### PR TITLE
fix: keep CLI device codes out of the GitHub OAuth code handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixes
 
+- Web: keep CLI device login codes out of the GitHub OAuth code handler — the device page no longer loses its prefilled code, bounces through a surprise GitHub redirect, or drops an active session; device links now use `user_code`.
 - API: keep successful rate-limit checks available when retention metadata writes contend, while preserving fail-closed enforcement for authoritative counter conflicts.
 - CLI: accept npm 12's package-keyed `npm pack --json` output when building ClawPacks while retaining compatibility with earlier npm array output.
 - Web/API: preserve JSON, SSR, and OG responses through the Convex proxy after the H3 response-wrapper update.

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -122,6 +122,7 @@ import type * as lib_skillSearchDigest from "../lib/skillSearchDigest.js";
 import type * as lib_skillSlugValidator from "../lib/skillSlugValidator.js";
 import type * as lib_skillStats from "../lib/skillStats.js";
 import type * as lib_skillSummary from "../lib/skillSummary.js";
+import type * as lib_skillTags from "../lib/skillTags.js";
 import type * as lib_skillZip from "../lib/skillZip.js";
 import type * as lib_skills_index from "../lib/skills/index.js";
 import type * as lib_skills_slugResolution from "../lib/skills/slugResolution.js";
@@ -288,6 +289,7 @@ declare const fullApi: ApiFromModules<{
   "lib/skillSlugValidator": typeof lib_skillSlugValidator;
   "lib/skillStats": typeof lib_skillStats;
   "lib/skillSummary": typeof lib_skillSummary;
+  "lib/skillTags": typeof lib_skillTags;
   "lib/skillZip": typeof lib_skillZip;
   "lib/skills/index": typeof lib_skills_index;
   "lib/skills/slugResolution": typeof lib_skills_slugResolution;

--- a/convex/cliDeviceAuth.ts
+++ b/convex/cliDeviceAuth.ts
@@ -197,6 +197,6 @@ function getVerificationUrl(siteUrlValue: string | undefined, userCode: string) 
   } catch {
     verificationUrl = new URL("/cli/device", "https://clawhub.ai");
   }
-  verificationUrl.searchParams.set("code", userCode);
+  verificationUrl.searchParams.set("user_code", userCode);
   return verificationUrl;
 }

--- a/convex/httpApi.handlers.test.ts
+++ b/convex/httpApi.handlers.test.ts
@@ -413,7 +413,7 @@ describe("httpApi handlers", () => {
     const result = {
       device_code: "device",
       user_code: "ABCD-2345",
-      verification_uri: "https://clawhub.ai/cli/device?code=ABCD-2345",
+      verification_uri: "https://clawhub.ai/cli/device?user_code=ABCD-2345",
       expires_in: 900,
       interval: 5,
     };

--- a/specs/auth-identity.md
+++ b/specs/auth-identity.md
@@ -2,6 +2,13 @@
 
 ClawHub uses Convex Auth with GitHub OAuth for production user sessions.
 
+## OAuth completion query parameter
+
+The app-level OAuth code handler consumes `?code=` on every route, so `code` is
+reserved for Convex Auth OAuth completion. Other flows must use a different query
+parameter; CLI device login uses `user_code`. As defense in depth, the handler
+explicitly ignores device-shaped codes (`XXXX-XXXX`).
+
 Security invariant: a GitHub OAuth account may link to a ClawHub user only through
 the auth-managed GitHub `providerAccountId`, which is the immutable GitHub
 numeric account id stored in `authAccounts`. Mutable GitHub usernames and OAuth

--- a/src/components/AppProviders.test.tsx
+++ b/src/components/AppProviders.test.tsx
@@ -70,6 +70,32 @@ describe("AuthCodeHandler", () => {
     expect(getAuthErrorSnapshot()).toBeNull();
   });
 
+  it("leaves CLI device user codes for the device route", async () => {
+    window.history.replaceState(null, "", "/cli/device?code=ABCD-2345");
+
+    render(<AuthCodeHandler />);
+
+    await waitFor(() => {
+      expect(signInMock).not.toHaveBeenCalled();
+    });
+    expect(`${window.location.pathname}${window.location.search}`).toBe(
+      "/cli/device?code=ABCD-2345",
+    );
+  });
+
+  it("still consumes long OAuth completion codes", async () => {
+    const code = "long-random-oauth-completion-code-1234567890";
+    signInMock.mockResolvedValue({ signingIn: true });
+    window.history.replaceState(null, "", `/sign-in?code=${code}`);
+
+    render(<AuthCodeHandler />);
+
+    await waitFor(() => {
+      expect(signInMock).toHaveBeenCalledWith(undefined, { code });
+    });
+    expect(`${window.location.pathname}${window.location.search}`).toBe("/sign-in");
+  });
+
   it("strips the auth code before waiting for code verification", async () => {
     signInMock.mockReturnValue(new Promise(() => {}));
     window.history.replaceState(

--- a/src/components/AppProviders.tsx
+++ b/src/components/AppProviders.tsx
@@ -9,6 +9,7 @@ import {
   normalizeAuthErrorMessage,
   routeToBannedAccountPage as navigateToBannedAccountPage,
 } from "../lib/authErrorMessage";
+import { isCliDeviceUserCode } from "../lib/cliDeviceCode";
 import { clearAuthError, setAuthError, useAuthError } from "../lib/useAuthError";
 import { AuthErrorMessage } from "./AuthErrorMessage";
 import { ClientOnly } from "./ClientOnly";
@@ -21,6 +22,8 @@ function getPendingAuthCode() {
   const url = new URL(window.location.href);
   const code = url.searchParams.get("code");
   if (!code) return null;
+  // Preserve legacy CLI device links; this code is not an OAuth completion.
+  if (isCliDeviceUserCode(code)) return null;
   const isRetry = url.searchParams.get("auth_retry") === "1";
   const retryUrl = new URL(window.location.href);
   retryUrl.searchParams.delete("code");

--- a/src/lib/cliDeviceCode.test.ts
+++ b/src/lib/cliDeviceCode.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { isCliDeviceUserCode } from "./cliDeviceCode";
+
+describe("isCliDeviceUserCode", () => {
+  it.each(["ABCD-2345", "abcd-2345", "  ABCD-2345  "])("accepts %j", (value) => {
+    expect(isCliDeviceUserCode(value)).toBe(true);
+  });
+
+  it.each([
+    "",
+    "ABCD2345",
+    "ABCD-234",
+    "ABCDE-2345",
+    "ABCI-2345",
+    "ABCO-2345",
+    "ABCD-0345",
+    "ABCD-1345",
+    "long-random-oauth-completion-code",
+  ])("rejects %j", (value) => {
+    expect(isCliDeviceUserCode(value)).toBe(false);
+  });
+});

--- a/src/lib/cliDeviceCode.ts
+++ b/src/lib/cliDeviceCode.ts
@@ -1,0 +1,4 @@
+// Device user codes must never be treated as OAuth completion codes.
+export function isCliDeviceUserCode(value: string): boolean {
+  return /^[A-HJ-NP-Z2-9]{4}-[A-HJ-NP-Z2-9]{4}$/i.test(value.trim());
+}

--- a/src/routes/cli/-device.test.tsx
+++ b/src/routes/cli/-device.test.tsx
@@ -1,16 +1,19 @@
 /* @vitest-environment jsdom */
 import { act, fireEvent, render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const approveMock = vi.fn();
 const denyMock = vi.fn();
 const useMutationMock = vi.fn();
+const { useSearchMock } = vi.hoisted(() => ({
+  useSearchMock: vi.fn(),
+}));
 
 vi.mock("@tanstack/react-router", () => ({
   createFileRoute: () => (config: { component: unknown }) => ({
     ...config,
-    useSearch: () => ({ code: "device-code" }),
+    useSearch: useSearchMock,
   }),
 }));
 
@@ -76,6 +79,39 @@ vi.mock("../../components/ui/label", () => ({
 const { CliDeviceAuth } = await import("./device");
 
 describe("CliDeviceAuth", () => {
+  beforeEach(() => {
+    approveMock.mockReset();
+    denyMock.mockReset();
+    useMutationMock.mockReset();
+    useSearchMock.mockReturnValue({ user_code: "ABCD-2345" });
+  });
+
+  it("prefills the code from user_code", () => {
+    useMutationMock.mockReturnValue(vi.fn());
+
+    render(<CliDeviceAuth />);
+
+    expect(screen.getByLabelText("Code")).toHaveProperty("value", "ABCD-2345");
+  });
+
+  it("prefills the code from a legacy device-shaped code param", () => {
+    useSearchMock.mockReturnValue({ code: "ABCD-2345" });
+    useMutationMock.mockReturnValue(vi.fn());
+
+    render(<CliDeviceAuth />);
+
+    expect(screen.getByLabelText("Code")).toHaveProperty("value", "ABCD-2345");
+  });
+
+  it("does not prefill an OAuth completion code from the legacy param", () => {
+    useSearchMock.mockReturnValue({ code: "long-random-oauth-completion-code-1234567890" });
+    useMutationMock.mockReturnValue(vi.fn());
+
+    render(<CliDeviceAuth />);
+
+    expect(screen.getByLabelText("Code")).toHaveProperty("value", "");
+  });
+
   it("allows only one device decision while the mutation is pending", async () => {
     let resolveApprove!: () => void;
     approveMock.mockImplementation(

--- a/src/routes/cli/device.tsx
+++ b/src/routes/cli/device.tsx
@@ -9,6 +9,7 @@ import { Button } from "../../components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "../../components/ui/card";
 import { Input } from "../../components/ui/input";
 import { Label } from "../../components/ui/label";
+import { isCliDeviceUserCode } from "../../lib/cliDeviceCode";
 import { useAuthStatus } from "../../lib/useAuthStatus";
 
 export const Route = createFileRoute("/cli/device")({
@@ -16,8 +17,11 @@ export const Route = createFileRoute("/cli/device")({
 });
 
 export function CliDeviceAuth() {
-  const search = Route.useSearch() as { code?: string };
-  const [code, setCode] = useState(search.code ?? "");
+  const search = Route.useSearch() as { user_code?: string; code?: string };
+  const legacyCode = search.code ?? "";
+  const [code, setCode] = useState(
+    search.user_code ?? (isCliDeviceUserCode(legacyCode) ? legacyCode : ""),
+  );
   const [status, setStatus] = useState<string | null>(null);
   const [pendingAction, setPendingAction] = useState<"approve" | "deny" | null>(null);
   const [isComplete, setIsComplete] = useState(false);


### PR DESCRIPTION
## Summary

Signing into ClawHub via `clawhub login` (CLI device flow) was broken: the global `AuthCodeHandler` consumes any `?code=` query param on any route as a GitHub OAuth completion code, and CLI device verification links used `/cli/device?code=XXXX-XXXX`. Reproduced live on production:

1. The device code is stripped from the URL before the device page reads it — the code input renders empty.
2. The failed code exchange (`signIn(undefined, { code })` returns `tokens: null`) makes the `@convex-dev/auth` client erase the current session — an actively signed-in user gets signed out.
3. The incomplete-sign-in retry then bounces the user through a surprise GitHub OAuth redirect.

Console evidence on prod: `[ClawHub auth] GitHub code sign-in did not create a session` on every `/cli/device?code=...` visit.

The collision has existed since the device flow shipped (`227cce18`, 2026-05-09); exposure grew when the device flow became the only CLI browser login path (`9fb09e07`). Plain web "Sign in with GitHub" was verified working on prod and is unchanged.

## Fix

- `convex/cliDeviceAuth.ts`: server-issued verification links now use `?user_code=`. CLI clients print the server-provided `verification_uri` verbatim, so released CLIs pick this up immediately with no client changes.
- `src/lib/cliDeviceCode.ts` (new): `isCliDeviceUserCode` shape guard (`XXXX-XXXX`, device-code alphabet).
- `src/components/AppProviders.tsx`: the OAuth code handler ignores device-shaped codes and leaves the URL untouched (defense in depth for stale `?code=` links).
- `src/routes/cli/device.tsx`: prefills from `user_code`; accepts the legacy `code` param only when it matches the device-code shape.
- `specs/auth-identity.md`: documents the invariant — `?code=` is reserved for OAuth completion on every route; other flows must use a different param name.
- Also includes a small `convex/_generated` refresh that was stale on main (missing `lib/skillTags` entries from an earlier merge).

## Tests

- `VITE_CONVEX_URL=https://example.invalid bunx vitest run src/lib/cliDeviceCode.test.ts src/components/AppProviders.test.tsx src/routes/cli/-device.test.tsx convex/httpApi.handlers.test.ts` — 71 passed. New regression cases: device-shaped `?code=` is not consumed and the URL is preserved; long OAuth codes still handled; device page prefill from `user_code`, legacy device-shaped `code`, and rejection of OAuth-style values.
- `bun run ci:static` — pass.
- `bun run ci:unit` — pass (one unrelated flaky failure in `scripts/security/run-prepublication-worker.test.ts` on the first run; passes in isolation and on rerun — see #3112).

## Live verification

Real browser against a real local instance (`http://localhost:3000`, Convex dev deployment `tame-koala-511`, DevPersonaFab `user` persona):

- Signed in, visited `/cli/device?code=ABCD-2345` (legacy shape): session survives, URL keeps the param, input prefilled, console clean — previously this signed the user out and emptied the page.
- `/cli/device?user_code=WXYZ-7789`: prefilled, session intact.
- Full end-to-end `clawhub login` against the local stack: CLI received a `user_code` verification link, browser Authorize succeeded, CLI printed `Authorized` and stored its token.
