### PR TITLE
fix: double prepublication worker shards

### DIFF
--- a/.github/workflows/prepublication-publish-checks.yml
+++ b/.github/workflows/prepublication-publish-checks.yml
@@ -57,9 +57,9 @@ jobs:
     environment: Production
     strategy:
       fail-fast: false
-      max-parallel: 2
+      max-parallel: 4
       matrix:
-        shard: ${{ fromJSON(github.event_name == 'workflow_dispatch' && inputs['attempt-id'] != '' && '[0]' || '[0,1]') }}
+        shard: ${{ fromJSON(github.event_name == 'workflow_dispatch' && inputs['attempt-id'] != '' && '[0]' || '[0,1,2,3]') }}
     env:
       CONVEX_URL: ${{ vars.CONVEX_URL || vars.VITE_CONVEX_URL || 'https://wry-manatee-359.convex.cloud' }}
       PREPUBLICATION_CHECK_LIMIT: ${{ inputs['batch-limit'] || '4' }}

--- a/scripts/security/prepublication-worker-workflow.test.ts
+++ b/scripts/security/prepublication-worker-workflow.test.ts
@@ -96,9 +96,9 @@ describe("pre-publication publish worker workflow", () => {
     expect(job["runs-on"]).toBe("${{ inputs.runner || 'blacksmith-8vcpu-ubuntu-2404' }}");
     expect(job["timeout-minutes"]).toBe(25);
     expect(job.strategy?.matrix?.shard).toBe(
-      "${{ fromJSON(github.event_name == 'workflow_dispatch' && inputs['attempt-id'] != '' && '[0]' || '[0,1]') }}",
+      "${{ fromJSON(github.event_name == 'workflow_dispatch' && inputs['attempt-id'] != '' && '[0]' || '[0,1,2,3]') }}",
     );
-    expect(job.strategy?.["max-parallel"]).toBe(2);
+    expect(job.strategy?.["max-parallel"]).toBe(4);
     expect(job.env).toMatchObject({
       CONVEX_URL:
         "${{ vars.CONVEX_URL || vars.VITE_CONVEX_URL || 'https://wry-manatee-359.convex.cloud' }}",


### PR DESCRIPTION
## Summary
- expand normal pre-publication runs from two worker shards to four
- allow all four shards to run in parallel
- preserve single-shard targeted attempt recovery

## Validation
- `bunx vitest run scripts/security/prepublication-worker-workflow.test.ts`
- `bun run ci:static`
- autoreview clean
