### PR TITLE
fix: owner-qualified skill reports for ambiguous slugs

### DIFF
--- a/convex/httpApiV1.handlers.test.ts
+++ b/convex/httpApiV1.handlers.test.ts
@@ -3519,6 +3519,53 @@ describe("httpApiV1 handlers", () => {
     );
   });
 
+  it("skill report forwards owner query/body and skillId for ambiguous slugs", async () => {
+    vi.mocked(requireApiTokenUser).mockResolvedValue({
+      userId: "users:reporter",
+      user: { _id: "users:reporter", role: "user" },
+    } as never);
+    const runMutation = vi.fn(async (_mutation: unknown, args: Record<string, unknown>) => {
+      if (isRateLimitArgs(args)) return okRate();
+      return {
+        ok: true,
+        reported: true,
+        alreadyReported: false,
+        reportId: "skillReports:2",
+        skillId: "skills:owner-scoped",
+        reportCount: 1,
+      };
+    });
+
+    const response = await __handlers.skillsPostRouterV1Handler(
+      makeCtx({ runMutation }),
+      new Request(
+        "https://example.com/api/v1/skills/wp-multi-tool/report?owner=kingaiwork",
+        {
+          method: "POST",
+          headers: { Authorization: "Bearer clh_test" },
+          body: JSON.stringify({
+            reason: "impersonation",
+            ownerHandle: "kingaiwork",
+            skillId: "skills:owner-scoped",
+          }),
+        },
+      ),
+    );
+
+    expect(response.status).toBe(200);
+    expect(runMutation).toHaveBeenCalledWith(
+      (internal as unknown as { skills: Record<string, unknown> }).skills
+        .reportSkillForUserInternal,
+      {
+        actorUserId: "users:reporter",
+        slug: "wp-multi-tool",
+        reason: "impersonation",
+        ownerHandle: "kingaiwork",
+        skillId: "skills:owner-scoped",
+      },
+    );
+  });
+
   it("skill report triage posts moderator decisions", async () => {
     vi.mocked(requireApiTokenUser).mockResolvedValue({
       userId: "users:moderator",

--- a/convex/httpApiV1.handlers.test.ts
+++ b/convex/httpApiV1.handlers.test.ts
@@ -3519,7 +3519,7 @@ describe("httpApiV1 handlers", () => {
     );
   });
 
-  it("skill report forwards owner query/body and skillId for ambiguous slugs", async () => {
+  it("skill report forwards owner query for ambiguous slugs", async () => {
     vi.mocked(requireApiTokenUser).mockResolvedValue({
       userId: "users:reporter",
       user: { _id: "users:reporter", role: "user" },
@@ -3538,18 +3538,13 @@ describe("httpApiV1 handlers", () => {
 
     const response = await __handlers.skillsPostRouterV1Handler(
       makeCtx({ runMutation }),
-      new Request(
-        "https://example.com/api/v1/skills/wp-multi-tool/report?owner=kingaiwork",
-        {
-          method: "POST",
-          headers: { Authorization: "Bearer clh_test" },
-          body: JSON.stringify({
-            reason: "impersonation",
-            ownerHandle: "kingaiwork",
-            skillId: "skills:owner-scoped",
-          }),
-        },
-      ),
+      new Request("https://example.com/api/v1/skills/wp-multi-tool/report?owner=kingaiwork", {
+        method: "POST",
+        headers: { Authorization: "Bearer clh_test" },
+        body: JSON.stringify({
+          reason: "impersonation",
+        }),
+      }),
     );
 
     expect(response.status).toBe(200);
@@ -3561,7 +3556,6 @@ describe("httpApiV1 handlers", () => {
         slug: "wp-multi-tool",
         reason: "impersonation",
         ownerHandle: "kingaiwork",
-        skillId: "skills:owner-scoped",
       },
     );
   });

--- a/convex/httpApiV1/skillsV1.ts
+++ b/convex/httpApiV1/skillsV1.ts
@@ -3165,12 +3165,20 @@ export async function skillsPostRouterV1Handler(ctx: ActionCtx, request: Request
     if (!parsed.ok) return parsed.response;
     const reason = typeof parsed.payload.reason === "string" ? parsed.payload.reason : "";
     const version = typeof parsed.payload.version === "string" ? parsed.payload.version : undefined;
+    const url = new URL(request.url);
+    const ownerHandle =
+      optionalStringField(parsed.payload, "ownerHandle") ??
+      optionalStringField(parsed.payload, "owner") ??
+      getOwnerHandleParam(url);
+    const skillIdRaw = optionalStringField(parsed.payload, "skillId");
     try {
       const result = await runMutationRef(ctx, internalRefs.skills.reportSkillForUserInternal, {
         actorUserId: auth.userId,
         slug,
         reason,
         ...(version ? { version } : {}),
+        ...(ownerHandle ? { ownerHandle } : {}),
+        ...(skillIdRaw ? { skillId: skillIdRaw as Id<"skills"> } : {}),
       });
       return json(result, 200, rate.headers);
     } catch (error) {

--- a/convex/httpApiV1/skillsV1.ts
+++ b/convex/httpApiV1/skillsV1.ts
@@ -3170,7 +3170,6 @@ export async function skillsPostRouterV1Handler(ctx: ActionCtx, request: Request
       optionalStringField(parsed.payload, "ownerHandle") ??
       optionalStringField(parsed.payload, "owner") ??
       getOwnerHandleParam(url);
-    const skillIdRaw = optionalStringField(parsed.payload, "skillId");
     try {
       const result = await runMutationRef(ctx, internalRefs.skills.reportSkillForUserInternal, {
         actorUserId: auth.userId,
@@ -3178,7 +3177,6 @@ export async function skillsPostRouterV1Handler(ctx: ActionCtx, request: Request
         reason,
         ...(version ? { version } : {}),
         ...(ownerHandle ? { ownerHandle } : {}),
-        ...(skillIdRaw ? { skillId: skillIdRaw as Id<"skills"> } : {}),
       });
       return json(result, 200, rate.headers);
     } catch (error) {

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -4376,28 +4376,21 @@ export const reportSkillForUserInternal = internalMutation({
     version: v.optional(v.string()),
     // Owner qualifier for ambiguous slugs (mirrors GET /skills/{slug}?owner=).
     ownerHandle: v.optional(v.string()),
-    // Direct id path used by the signed-in web dialog; also works for ambiguous slugs.
-    skillId: v.optional(v.id("skills")),
   },
   handler: async (ctx, args) => {
     const actor = await ctx.db.get(args.actorUserId);
     if (!actor || actor.deletedAt || actor.deactivatedAt) throw new ConvexError("Unauthorized");
 
-    let skill: Doc<"skills"> | null = null;
-    if (args.skillId) {
-      skill = await ctx.db.get(args.skillId);
-    } else {
-      const ownerHandle = args.ownerHandle?.trim().replace(/^@+/, "") || undefined;
-      const resolved = await resolveSkillBySlugOrAliasForOwner(ctx, args.slug, ownerHandle);
-      if (resolved.ambiguous) {
-        // Prefer the same guidance used by other slug-only endpoints instead of
-        // collapsing collisions into a misleading "Skill not found".
-        throw new ConvexError(
-          "Slug is used by multiple publishers. Use an owner-qualified skill URL.",
-        );
-      }
-      skill = resolved.skill;
+    const ownerHandle = args.ownerHandle?.trim().replace(/^@+/, "") || undefined;
+    const resolved = await resolveSkillBySlugOrAliasForOwner(ctx, args.slug, ownerHandle);
+    if (resolved.ambiguous) {
+      // Prefer the same guidance used by other slug-only endpoints instead of
+      // collapsing collisions into a misleading "Skill not found".
+      throw new ConvexError(
+        "Slug is used by multiple publishers. Use an owner-qualified skill URL.",
+      );
     }
+    const skill = resolved.skill;
     if (!skill || skill.softDeletedAt || skill.moderationStatus === "removed") {
       throw new ConvexError("Skill not found");
     }

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -4374,13 +4374,30 @@ export const reportSkillForUserInternal = internalMutation({
     slug: v.string(),
     reason: v.string(),
     version: v.optional(v.string()),
+    // Owner qualifier for ambiguous slugs (mirrors GET /skills/{slug}?owner=).
+    ownerHandle: v.optional(v.string()),
+    // Direct id path used by the signed-in web dialog; also works for ambiguous slugs.
+    skillId: v.optional(v.id("skills")),
   },
   handler: async (ctx, args) => {
     const actor = await ctx.db.get(args.actorUserId);
     if (!actor || actor.deletedAt || actor.deactivatedAt) throw new ConvexError("Unauthorized");
 
-    const resolved = await resolveSkillBySlugOrAlias(ctx, args.slug);
-    const skill = resolved.skill;
+    let skill: Doc<"skills"> | null = null;
+    if (args.skillId) {
+      skill = await ctx.db.get(args.skillId);
+    } else {
+      const ownerHandle = args.ownerHandle?.trim().replace(/^@+/, "") || undefined;
+      const resolved = await resolveSkillBySlugOrAliasForOwner(ctx, args.slug, ownerHandle);
+      if (resolved.ambiguous) {
+        // Prefer the same guidance used by other slug-only endpoints instead of
+        // collapsing collisions into a misleading "Skill not found".
+        throw new ConvexError(
+          "Slug is used by multiple publishers. Use an owner-qualified skill URL.",
+        );
+      }
+      skill = resolved.skill;
+    }
     if (!skill || skill.softDeletedAt || skill.moderationStatus === "removed") {
       throw new ConvexError("Skill not found");
     }


### PR DESCRIPTION
## Summary
- Fixes skill listing reports for ambiguous slugs (SECURITY.md: report handling).
- `POST /api/v1/skills/{slug}/report` now accepts `owner` / `ownerHandle` from the query or JSON body, matching GET disambiguation.
- Bare-slug collisions now return the standard message (`Slug is used by multiple publishers. Use an owner-qualified skill URL.`) instead of misleading `Skill not found`.
- Keeps the URL slug plus owner qualifier authoritative; the endpoint does not accept a conflicting direct skill ID.

Fixes #3111

## Test plan
- [x] `VITE_CONVEX_URL=https://example.invalid bunx vitest run convex/httpApiV1.handlers.test.ts -t "skill report"` (4 passed)
- [x] Authenticated local Convex duplicate-slug proof:
  - merge base `aaa73625ed41`: owner-qualified and bare requests both returned `400 Skill not found`
  - PR head `34ef2ade`: owner-qualified request returned `200` and persisted the requested publisher's exact skill ID; bare request returned `400` with owner-qualified guidance
- [x] `bun run ci:unit` (4,799 passed, 1 skipped)
- [x] `bun run ci:types-build`
- [x] `bun run ci:static`
- [x] `$autoreview` (clean; no actionable findings)

## Notes
Maintainer follow-up `34ef2ade` removed the unnecessary HTTP `skillId` override so the report target cannot disagree with the route.
