### PR TITLE
fix: show one year instead of 12 months in relative timestamps

### DIFF
--- a/src/lib/timeAgo.test.ts
+++ b/src/lib/timeAgo.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { timeAgo } from "./timeAgo";
+
+const MINUTE = 60_000;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+
+const NOW = Date.UTC(2026, 5, 23, 12, 0, 0);
+
+function agoByDays(days: number) {
+  return timeAgo(NOW - days * DAY);
+}
+
+describe("timeAgo", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("reports sub-minute gaps as just now", () => {
+    expect(timeAgo(NOW)).toBe("just now");
+    expect(timeAgo(NOW - 59_999)).toBe("just now");
+  });
+
+  it("formats minutes and hours", () => {
+    expect(timeAgo(NOW - MINUTE)).toBe("1m ago");
+    expect(timeAgo(NOW - 59 * MINUTE)).toBe("59m ago");
+    expect(timeAgo(NOW - HOUR)).toBe("1h ago");
+    expect(timeAgo(NOW - 23 * HOUR)).toBe("23h ago");
+  });
+
+  it("formats days and weeks", () => {
+    expect(agoByDays(1)).toBe("1d ago");
+    expect(agoByDays(6)).toBe("6d ago");
+    expect(agoByDays(7)).toBe("1w ago");
+    expect(agoByDays(29)).toBe("4w ago");
+  });
+
+  it("formats months", () => {
+    expect(agoByDays(30)).toBe("1mo ago");
+    expect(agoByDays(60)).toBe("2mo ago");
+    expect(agoByDays(180)).toBe("6mo ago");
+  });
+
+  // Regression: 30-day months divided into a 365-day year yielded "12mo ago"
+  // for gaps of 360-364 days. Months must roll over into years at 12.
+  it("rolls the last days before a year over into years", () => {
+    expect(agoByDays(330)).toBe("11mo ago");
+    expect(agoByDays(359)).toBe("11mo ago");
+    expect(agoByDays(360)).toBe("1y ago");
+    expect(agoByDays(364)).toBe("1y ago");
+  });
+
+  it("formats years", () => {
+    expect(agoByDays(365)).toBe("1y ago");
+    expect(agoByDays(400)).toBe("1y ago");
+    expect(agoByDays(730)).toBe("2y ago");
+  });
+});

--- a/src/lib/timeAgo.ts
+++ b/src/lib/timeAgo.ts
@@ -3,7 +3,6 @@ const HOUR = 60 * MINUTE;
 const DAY = 24 * HOUR;
 const WEEK = 7 * DAY;
 const MONTH = 30 * DAY;
-const YEAR = 365 * DAY;
 
 export function timeAgo(timestamp: number): string {
   const diff = Date.now() - timestamp;
@@ -24,10 +23,11 @@ export function timeAgo(timestamp: number): string {
     const w = Math.floor(diff / WEEK);
     return `${w}w ago`;
   }
-  if (diff < YEAR) {
-    const m = Math.floor(diff / MONTH);
-    return `${m}mo ago`;
-  }
-  const y = Math.floor(diff / YEAR);
-  return `${y}y ago`;
+  // Derive years from whole 30-day months rather than from a separate 365-day
+  // year: dividing a 365-day year by 30-day months leaves a 360-364 day gap
+  // that rendered as "12mo ago". Matches formatRelativeUpdatedAt in
+  // routes/user/$handle.tsx.
+  const months = Math.floor(diff / MONTH);
+  if (months < 12) return `${months}mo ago`;
+  return `${Math.floor(months / 12)}y ago`;
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where listings last updated between 360 and 364 days ago displayed
"Updated 12mo ago" instead of "Updated 1y ago".

`timeAgo` measures months as 30 days but years as 365 days. Those two units do not
tile: 360-364 days still divides into twelve whole 30-day months while remaining
below the 365-day year threshold, so the month branch renders a twelve-month value
that should already have rolled over into years.

The affected surfaces are the skill list rows, skill header, browse results, plugin
detail page, dashboard catalog and needs-attention views, and the GitHub sync
timestamp in settings.

## Why This Change Was Made

The repository already contains the intended semantics. `formatRelativeUpdatedAt`
in `src/routes/user/$handle.tsx` derives years from whole months and caps the month
branch at 11:

```ts
const months = Math.floor(days / 30);
if (months < 12) return `${months}mo ago`;
return `${Math.floor(months / 12)}y ago`;
```

`timeAgo` is now aligned with that rule, so the two relative-time renderers agree at
the one-year boundary. Deriving years from months also removes the unit mismatch at
its source rather than special-casing the twelve-month output.

Non-goals, kept out to hold the change to one concern:

- Consolidating `timeAgo` and `formatRelativeUpdatedAt` into a single helper. They
  are now consistent; merging them is a separate refactor.
- Making the 30-day month calendar-aware.
- Future-dated timestamps. Both functions already render those as "just now", so
  clamping the difference would be a no-op here.

## User Impact

Relative timestamps no longer show a twelve-month value. A listing that has not been
updated for just under a year now reads "1y ago", matching what the publisher profile
route has always shown for the same listing.

## Evidence

Added `src/lib/timeAgo.test.ts`, which had no test coverage before this change even
though `src/lib/**` is inside the `vitest.config.ts` coverage `include` list.

The new boundary case fails on the parent commit and passes with the fix:

```
$ bunx vitest run src/lib/timeAgo.test.ts        # before the fix
FAIL  src/lib/timeAgo.test.ts > timeAgo > rolls the last days before a year over into years
AssertionError: expected '12mo ago' to be '1y ago'
 ❯ src/lib/timeAgo.test.ts:54:28
     54|     expect(agoByDays(360)).toBe("1y ago");

Test Files  1 failed (1)
     Tests  1 failed | 5 passed (6)

$ bunx vitest run src/lib/timeAgo.test.ts        # with the fix
Test Files  1 passed (1)
     Tests  6 passed (6)
```

The other five cases pass on both sides, so the existing minute, hour, day, week and
month branches are unchanged.

Rendered `SkillListItem` output, reading `.skill-list-item-meta-item.is-updated` from
the mounted component with the clock fixed at 2026-06-23T12:00:00Z:

| updatedAt | before | after |
| --- | --- | --- |
| now - 330 days | Updated 11mo ago | Updated 11mo ago |
| now - 359 days | Updated 11mo ago | Updated 11mo ago |
| now - 360 days | Updated 12mo ago | Updated 1y ago |
| now - 364 days | Updated 12mo ago | Updated 1y ago |
| now - 365 days | Updated 1y ago | Updated 1y ago |
| now - 400 days | Updated 1y ago | Updated 1y ago |
| now - 730 days | Updated 2y ago | Updated 2y ago |

Regression check on the consumers and on the sibling renderer:

```
$ bunx vitest run src/lib/timeAgo.test.ts src/components/SkillListItem.test.tsx \
    src/__tests__/user-profile-route.test.tsx
Test Files  3 passed (3)
     Tests  29 passed (29)
```

Gates run locally on Windows:

- `bun run format:check -- src/lib/timeAgo.ts src/lib/timeAgo.test.ts` — clean
- `bun run lint` — clean
- `bunx tsc --noEmit -p tsconfig.json` — clean
- `bun run deadcode:ci` — clean
- `bun run ci:unit` — 4722 passed. The 22 failures are pre-existing on this platform
  and unrelated to this change: they are `spawn bun ENOENT` in the worker and
  security-dataset suites plus the design-contract and management route suites. I
  confirmed they fail identically on the unmodified parent commit, so I have left
  them alone. CI on Linux is the authoritative signal here.

The Vercel preview check will need OpenClaw Foundation team authorization, as with
other fork pull requests.
