### PR TITLE
feat(moderation): rescan all signals from Signals tab

### DIFF
--- a/convex/publisherAbuseTemporalScan.test.ts
+++ b/convex/publisherAbuseTemporalScan.test.ts
@@ -1,7 +1,8 @@
 /* @vitest-environment node */
 import { describe, expect, it, vi } from "vitest";
 import type { Doc, Id } from "./_generated/dataModel";
-import type { MutationCtx } from "./_generated/server";
+import type { ActionCtx, MutationCtx } from "./_generated/server";
+import { assertModerator, requireUserFromAction } from "./lib/access";
 import {
   DEFAULT_PUBLISHER_ABUSE_MODEL_CONFIG,
   PUBLISHER_TEMPORAL_ABUSE_MODEL_VERSION,
@@ -10,14 +11,21 @@ import {
 import type { TemporalSkillCandidate } from "./publisherAbuse";
 import {
   advanceScheduledTemporalCandidatesInternalHandler,
+  getOrStartScheduledTemporalScanInternalHandler,
   markScheduledTemporalScanFailedInternalHandler,
   percentileIndex,
   pruneExpiredTemporalScanRowsInternalHandler,
   runScheduledTemporalPublisherAbuseScanInternalHandler,
+  startPublisherAbuseSignalScanHandler,
   storeScheduledTemporalScanPageInternalHandler,
   temporalBenchmarkFromRun,
   valueAtGlobalIndex,
 } from "./publisherAbuseTemporalScan";
+
+vi.mock("./lib/access", () => ({
+  assertModerator: vi.fn(),
+  requireUserFromAction: vi.fn(),
+}));
 
 function temporalScore(overrides: Partial<SkillTemporalAbuseScore> = {}): SkillTemporalAbuseScore {
   return {
@@ -83,6 +91,7 @@ function temporalRun(
     potentialBanCandidateCount: 0,
     sumLogPressure: 0,
     sumSquaredLogPressure: 0,
+    temporalPipelineKind: "signals",
     temporalMode: "current",
     temporalScanComplete: false,
     temporalPipelinePhase: "collecting",
@@ -96,6 +105,211 @@ function temporalRun(
 }
 
 describe("scheduled temporal publisher abuse scan", () => {
+  it("starts every signal check as a moderator-audited manual scan", async () => {
+    const runId = "publisherAbuseScoreRuns:manual-signals" as Id<"publisherAbuseScoreRuns">;
+    const actorUserId = "users:moderator" as Id<"users">;
+    vi.mocked(requireUserFromAction).mockResolvedValue({
+      userId: actorUserId,
+      user: { _id: actorUserId, role: "moderator" },
+    } as never);
+    const runMutation = vi
+      .fn()
+      .mockResolvedValueOnce({ runId, resumed: false })
+      .mockResolvedValueOnce({ applied: true });
+    const runQuery = vi
+      .fn()
+      .mockResolvedValueOnce(temporalRun({ _id: runId, trigger: "manual", actorUserId }))
+      .mockResolvedValueOnce({
+        benchmarkScores: [],
+        candidates: [],
+        cursor: "next-page",
+        isDone: false,
+        scannedSkills: 0,
+      });
+    const scheduler = { runAfter: vi.fn(async () => null) };
+
+    await expect(
+      startPublisherAbuseSignalScanHandler({
+        runMutation,
+        runQuery,
+        scheduler,
+      } as unknown as ActionCtx),
+    ).resolves.toEqual({
+      ok: true,
+      runId,
+      completed: false,
+      phase: "collecting",
+    });
+
+    expect(assertModerator).toHaveBeenCalledWith(
+      expect.objectContaining({ _id: actorUserId, role: "moderator" }),
+    );
+    expect(runMutation).toHaveBeenNthCalledWith(1, expect.anything(), {
+      trigger: "manual",
+      actorUserId,
+    });
+  });
+
+  it("does not start signal checks for non-moderators", async () => {
+    const actorUserId = "users:viewer" as Id<"users">;
+    vi.mocked(requireUserFromAction).mockResolvedValue({
+      userId: actorUserId,
+      user: { _id: actorUserId, role: "user" },
+    } as never);
+    vi.mocked(assertModerator).mockImplementationOnce(() => {
+      throw new Error("Forbidden");
+    });
+    const runMutation = vi.fn();
+
+    await expect(
+      startPublisherAbuseSignalScanHandler({ runMutation } as unknown as ActionCtx),
+    ).rejects.toThrow("Forbidden");
+    expect(runMutation).not.toHaveBeenCalled();
+  });
+
+  it("records the moderator on a new manual signal scan", async () => {
+    const actorUserId = "users:moderator" as Id<"users">;
+    const runId = "publisherAbuseScoreRuns:manual-signals" as Id<"publisherAbuseScoreRuns">;
+    const constraints: Record<string, unknown> = {};
+    const q = {
+      eq(field: string, value: unknown) {
+        constraints[field] = value;
+        return q;
+      },
+    };
+    const insert = vi.fn(async () => runId);
+    let queryCount = 0;
+    const ctx = {
+      db: {
+        query: vi.fn(() => ({
+          withIndex: vi.fn((indexName: string, build: (builder: typeof q) => unknown) => {
+            queryCount += 1;
+            if (queryCount === 1) {
+              expect(indexName).toBe("by_temporal_pipeline_kind_and_status_and_updated_at");
+              build(q);
+            } else {
+              expect(indexName).toBe("by_model_version_and_status_and_trigger_and_updated_at");
+            }
+            return {
+              order: vi.fn(() => ({ first: vi.fn(async () => null) })),
+            };
+          }),
+        })),
+        insert,
+      },
+    };
+
+    await expect(
+      getOrStartScheduledTemporalScanInternalHandler(ctx as unknown as MutationCtx, {
+        trigger: "manual",
+        actorUserId,
+      }),
+    ).resolves.toEqual({ runId, resumed: false });
+
+    expect(constraints).toEqual({
+      temporalPipelineKind: "signals",
+      status: "running",
+    });
+    expect(insert).toHaveBeenCalledWith(
+      "publisherAbuseScoreRuns",
+      expect.objectContaining({
+        trigger: "manual",
+        actorUserId,
+        temporalPipelineKind: "signals",
+      }),
+    );
+  });
+
+  it("does not take over an active cron scan when a moderator requests a rescan", async () => {
+    const actorUserId = "users:moderator" as Id<"users">;
+    const existing = temporalRun({ trigger: "cron", actorUserId: undefined });
+    const patch = vi.fn(async () => null);
+    const ctx = {
+      db: {
+        query: vi.fn(() => ({
+          withIndex: vi.fn(() => ({
+            order: vi.fn(() => ({ first: vi.fn(async () => existing) })),
+          })),
+        })),
+        patch,
+      },
+    };
+
+    await expect(
+      getOrStartScheduledTemporalScanInternalHandler(ctx as unknown as MutationCtx, {
+        trigger: "manual",
+        actorUserId,
+      }),
+    ).resolves.toEqual({ runId: existing._id, resumed: true });
+
+    expect(patch).not.toHaveBeenCalled();
+  });
+
+  it("does not launch a second worker for an already-running signal scan", async () => {
+    const existing = temporalRun({ trigger: "cron" });
+    const runMutation = vi.fn(async () => ({ runId: existing._id, resumed: true }));
+    const runQuery = vi.fn(async () => existing);
+    const scheduler = { runAfter: vi.fn(async () => null) };
+
+    await expect(
+      runScheduledTemporalPublisherAbuseScanInternalHandler(
+        { runMutation, runQuery, scheduler } as unknown as ActionCtx,
+        { trigger: "manual", actorUserId: "users:moderator" as Id<"users"> },
+      ),
+    ).resolves.toEqual({
+      ok: true,
+      runId: existing._id,
+      completed: false,
+      phase: "collecting",
+      alreadyRunning: true,
+    });
+
+    expect(runMutation).toHaveBeenCalledTimes(1);
+    expect(runQuery).toHaveBeenCalledTimes(1);
+    expect(scheduler.runAfter).not.toHaveBeenCalled();
+  });
+
+  it("reports an active scan that failed before the rescan state check", async () => {
+    const failed = temporalRun({
+      status: "failed",
+      errorMessage: "source page failed",
+    });
+    const runMutation = vi.fn().mockResolvedValueOnce({ runId: failed._id, resumed: true });
+    const runQuery = vi.fn(async () => failed);
+    const scheduler = { runAfter: vi.fn(async () => null) };
+
+    await expect(
+      runScheduledTemporalPublisherAbuseScanInternalHandler(
+        { runMutation, runQuery, scheduler } as unknown as ActionCtx,
+        { trigger: "manual", actorUserId: "users:moderator" as Id<"users"> },
+      ),
+    ).rejects.toThrow("source page failed");
+
+    expect(runMutation).toHaveBeenCalledTimes(1);
+    expect(scheduler.runAfter).not.toHaveBeenCalled();
+  });
+
+  it("does not fail an active scan when its read-only state check errors", async () => {
+    const existing = temporalRun();
+    const runMutation = vi.fn(async () => ({ runId: existing._id, resumed: true }));
+    const runQuery = vi.fn(async () => {
+      throw new Error("transient state read failure");
+    });
+
+    await expect(
+      runScheduledTemporalPublisherAbuseScanInternalHandler(
+        {
+          runMutation,
+          runQuery,
+          scheduler: { runAfter: vi.fn(async () => null) },
+        } as unknown as ActionCtx,
+        { trigger: "manual", actorUserId: "users:moderator" as Id<"users"> },
+      ),
+    ).rejects.toThrow("transient state read failure");
+
+    expect(runMutation).toHaveBeenCalledTimes(1);
+  });
+
   it("uses nearest-rank percentile indexes across bounded pages", () => {
     expect(percentileIndex(100, 0.5)).toBe(49);
     expect(percentileIndex(100, 0.95)).toBe(94);

--- a/convex/publisherAbuseTemporalScan.ts
+++ b/convex/publisherAbuseTemporalScan.ts
@@ -2,7 +2,8 @@ import { v } from "convex/values";
 import { internal } from "./_generated/api";
 import type { Doc, Id } from "./_generated/dataModel";
 import type { ActionCtx, MutationCtx, QueryCtx } from "./_generated/server";
-import { internalAction, internalMutation, internalQuery } from "./functions";
+import { action, internalAction, internalMutation, internalQuery } from "./functions";
+import { assertModerator, requireUserFromAction } from "./lib/access";
 import { toDayKey } from "./lib/leaderboards";
 import {
   classifySkillTemporalAbuseScore,
@@ -85,18 +86,32 @@ function isActiveScheduledTemporalRun(run: TemporalScanRun, now: number) {
   return run.status === "running" && now - run.startedAt < TEMPORAL_SCAN_RETENTION_MS;
 }
 
-export async function getOrStartScheduledTemporalScanInternalHandler(ctx: MutationCtx) {
+export async function getOrStartScheduledTemporalScanInternalHandler(
+  ctx: MutationCtx,
+  args: { trigger?: "cron" | "manual"; actorUserId?: Id<"users"> },
+) {
   const now = Date.now();
-  const existing = await ctx.db
+  const currentPipeline = await ctx.db
     .query("publisherAbuseScoreRuns")
-    .withIndex("by_model_version_and_status_and_trigger_and_updated_at", (q) =>
-      q
-        .eq("modelVersion", PUBLISHER_TEMPORAL_ABUSE_MODEL_VERSION)
-        .eq("status", "running")
-        .eq("trigger", "cron"),
+    .withIndex("by_temporal_pipeline_kind_and_status_and_updated_at", (q) =>
+      q.eq("temporalPipelineKind", "signals").eq("status", "running"),
     )
     .order("desc")
     .first();
+  const legacyCronPipeline = currentPipeline
+    ? null
+    : await ctx.db
+        .query("publisherAbuseScoreRuns")
+        .withIndex("by_model_version_and_status_and_trigger_and_updated_at", (q) =>
+          q
+            .eq("modelVersion", PUBLISHER_TEMPORAL_ABUSE_MODEL_VERSION)
+            .eq("status", "running")
+            .eq("trigger", "cron"),
+        )
+        .order("desc")
+        .first();
+  const existing =
+    currentPipeline ?? (legacyCronPipeline?.temporalPipelinePhase ? legacyCronPipeline : null);
   if (
     existing?.temporalPipelinePhase &&
     existing.temporalPipelinePhase !== "completed" &&
@@ -114,7 +129,9 @@ export async function getOrStartScheduledTemporalScanInternalHandler(ctx: Mutati
   const runId = await ctx.db.insert("publisherAbuseScoreRuns", {
     modelVersion: PUBLISHER_TEMPORAL_ABUSE_MODEL_VERSION,
     modelConfig: DEFAULT_PUBLISHER_ABUSE_MODEL_CONFIG,
-    trigger: "cron",
+    trigger: args.trigger ?? "cron",
+    ...(args.actorUserId ? { actorUserId: args.actorUserId } : {}),
+    temporalPipelineKind: "signals",
     status: "running",
     phase: "collecting",
     startedAt: now,
@@ -141,7 +158,10 @@ export async function getOrStartScheduledTemporalScanInternalHandler(ctx: Mutati
 }
 
 export const getOrStartScheduledTemporalScanInternal = internalMutation({
-  args: {},
+  args: {
+    trigger: v.optional(v.union(v.literal("cron"), v.literal("manual"))),
+    actorUserId: v.optional(v.id("users")),
+  },
   handler: getOrStartScheduledTemporalScanInternalHandler,
 });
 
@@ -521,6 +541,7 @@ type ScheduledTemporalScanResult =
       runId: Id<"publisherAbuseScoreRuns">;
       completed: false;
       phase: Exclude<TemporalScanRun["temporalPipelinePhase"], "completed">;
+      alreadyRunning?: true;
     };
 
 async function runScheduledTemporalPublisherAbuseScanStep(
@@ -679,14 +700,44 @@ async function runScheduledTemporalPublisherAbuseScanStep(
 
 export async function runScheduledTemporalPublisherAbuseScanInternalHandler(
   ctx: ActionCtx,
-  args: { runId?: Id<"publisherAbuseScoreRuns"> },
+  args: {
+    runId?: Id<"publisherAbuseScoreRuns">;
+    trigger?: "cron" | "manual";
+    actorUserId?: Id<"users">;
+  },
 ): Promise<ScheduledTemporalScanResult> {
-  const start: { runId: Id<"publisherAbuseScoreRuns"> } = args.runId
+  const start: { runId: Id<"publisherAbuseScoreRuns">; resumed?: boolean } = args.runId
     ? { runId: args.runId }
     : await ctx.runMutation(
         internal.publisherAbuseTemporalScan.getOrStartScheduledTemporalScanInternal,
-        {},
+        {
+          ...(args.trigger ? { trigger: args.trigger } : {}),
+          ...(args.actorUserId ? { actorUserId: args.actorUserId } : {}),
+        },
       );
+  if (start.resumed) {
+    const run: TemporalScanRun = await ctx.runQuery(
+      internal.publisherAbuseTemporalScan.getScheduledTemporalScanStateInternal,
+      { runId: start.runId },
+    );
+    if (run.status === "failed") {
+      throw new Error(run.errorMessage ?? "Signal scan failed before it could be resumed.");
+    }
+    if (
+      run.status === "completed" ||
+      !run.temporalPipelinePhase ||
+      run.temporalPipelinePhase === "completed"
+    ) {
+      return { ok: true, runId: run._id, completed: true };
+    }
+    return {
+      ok: true,
+      runId: run._id,
+      completed: false,
+      phase: run.temporalPipelinePhase,
+      alreadyRunning: true,
+    };
+  }
   try {
     return await runScheduledTemporalPublisherAbuseScanStep(ctx, start.runId);
   } catch (error) {
@@ -707,8 +758,28 @@ export async function runScheduledTemporalPublisherAbuseScanInternalHandler(
 }
 
 export const runScheduledTemporalPublisherAbuseScanInternal = internalAction({
-  args: { runId: v.optional(v.id("publisherAbuseScoreRuns")) },
+  args: {
+    runId: v.optional(v.id("publisherAbuseScoreRuns")),
+    trigger: v.optional(v.union(v.literal("cron"), v.literal("manual"))),
+    actorUserId: v.optional(v.id("users")),
+  },
   handler: runScheduledTemporalPublisherAbuseScanInternalHandler,
+});
+
+export async function startPublisherAbuseSignalScanHandler(
+  ctx: ActionCtx,
+): Promise<ScheduledTemporalScanResult> {
+  const { userId, user } = await requireUserFromAction(ctx);
+  assertModerator(user);
+  return await runScheduledTemporalPublisherAbuseScanInternalHandler(ctx, {
+    trigger: "manual",
+    actorUserId: userId,
+  });
+}
+
+export const startPublisherAbuseSignalScan = action({
+  args: {},
+  handler: startPublisherAbuseSignalScanHandler,
 });
 
 export async function pruneExpiredTemporalScanRowsInternalHandler(

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -2772,6 +2772,7 @@ const publisherAbuseScoreRuns = defineTable({
   sumSquaredLogPressure: v.number(),
   meanLogPressure: v.optional(v.number()),
   stdDevLogPressure: v.optional(v.number()),
+  temporalPipelineKind: v.optional(v.literal("signals")),
   temporalMode: v.optional(v.union(v.literal("current"), v.literal("backfill"))),
   temporalScanComplete: v.optional(v.boolean()),
   temporalPipelinePhase: v.optional(
@@ -2822,6 +2823,11 @@ const publisherAbuseScoreRuns = defineTable({
     "modelVersion",
     "status",
     "trigger",
+    "updatedAt",
+  ])
+  .index("by_temporal_pipeline_kind_and_status_and_updated_at", [
+    "temporalPipelineKind",
+    "status",
     "updatedAt",
   ])
   .index("by_model_status_phase_temporal_complete_started_at", [

--- a/specs/security-moderation.md
+++ b/specs/security-moderation.md
@@ -69,6 +69,9 @@ See also: [acceptable-usage.md](./acceptable-usage.md) for the marketplace polic
   resumes through percentile and classification phases. Temporary scan rows
   expire after seven days. A scheduled scan step that fails validation or throws
   must persist a terminal failed state instead of leaving a resumable running run.
+  Moderators can start this same full signal pipeline from the staff Signals tab.
+  New manual starts record the actor; requests made while a temporal scan is
+  already active return that run without starting a competing worker.
   Explicitly bounded manual scans remain diagnostic-only.
   The `review` label remains a calibration/manual-review signal. The
   `potential_ban_candidate` label is an

--- a/src/routes/-management.test.tsx
+++ b/src/routes/-management.test.tsx
@@ -994,6 +994,36 @@ describe("Management", () => {
     });
   });
 
+  it("runs every signal check from the Signals tab rescan control", async () => {
+    searchState = { view: "abuse", tab: "signals" };
+    const startScoreScan = vi.fn();
+    const startSignalScan = vi.fn(async () => ({
+      ok: true,
+      runId: "publisherAbuseScoreRuns:signals",
+      completed: false,
+      phase: "collecting",
+    }));
+    useActionMock.mockImplementation((action) => {
+      const name = getFunctionName(action);
+      if (name === "publisherAbuse:startPublisherAbuseScoreRun") return startScoreScan;
+      if (name === "publisherAbuseTemporalScan:startPublisherAbuseSignalScan") {
+        return startSignalScan;
+      }
+      return vi.fn();
+    });
+
+    render(<Management />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Rescan signals" }));
+    fireEvent.click(screen.getByRole("button", { name: "Run signal scan" }));
+
+    await waitFor(() => {
+      expect(startSignalScan).toHaveBeenCalledWith({});
+    });
+    expect(startScoreScan).not.toHaveBeenCalled();
+    expect(screen.getByText("Re-checks every active skill")).toBeTruthy();
+  });
+
   it("shows users as a separate management view", () => {
     searchState = { view: "users" };
 

--- a/src/routes/-management/AbusePage.tsx
+++ b/src/routes/-management/AbusePage.tsx
@@ -293,9 +293,11 @@ export function AbusePage({
           <div className="pa-rescan">
             <Button type="button" variant="outline" size="sm" onClick={onRefresh}>
               <RefreshCcw size={14} />
-              Run new scan
+              {tab === "signals" ? "Rescan signals" : "Run new scan"}
             </Button>
-            <span className="pa-rescan-hint">Re-scores every publisher</span>
+            <span className="pa-rescan-hint">
+              {tab === "signals" ? "Re-checks every active skill" : "Re-scores every publisher"}
+            </span>
           </div>
           <div className="pa-autoban" aria-label="Publisher abuse auto-ban">
             <span className={autobanEnabled ? "pa-autoban-status is-on" : "pa-autoban-status"}>

--- a/src/routes/management.tsx
+++ b/src/routes/management.tsx
@@ -287,6 +287,9 @@ export function Management() {
   const dismissPublisherAbuseSignal = useMutation(api.publisherAbuse.dismissPublisherAbuseSignal);
   const reopenPublisherAbuseSignal = useMutation(api.publisherAbuse.reopenPublisherAbuseSignal);
   const startPublisherAbuseScoreRun = useAction(api.publisherAbuse.startPublisherAbuseScoreRun);
+  const startPublisherAbuseSignalScan = useAction(
+    api.publisherAbuseTemporalScan.startPublisherAbuseSignalScan,
+  );
 
   const [selectedDuplicate, setSelectedDuplicate] = useState("");
   const [selectedOwner, setSelectedOwner] = useState<Id<"users"> | "">("");
@@ -869,6 +872,25 @@ export function Management() {
               }
             }}
             onRefresh={() => {
+              if (publisherAbuseTab === "signals") {
+                setConfirmRequest({
+                  title: "Rescan publisher abuse signals?",
+                  body: "Re-checks every active skill for all download/install signal types and refreshes the Signals tab. This can take a while.",
+                  confirmLabel: "Run signal scan",
+                  onConfirm: () => {
+                    void startPublisherAbuseSignalScan({})
+                      .then((result) =>
+                        toast.success(
+                          "alreadyRunning" in result && result.alreadyRunning
+                            ? "Signal scan is already running."
+                            : "Signal scan started.",
+                        ),
+                      )
+                      .catch((error) => toast.error(formatMutationError(error)));
+                  },
+                });
+                return;
+              }
               setConfirmRequest({
                 title: "Run a new abuse scan?",
                 body: "Re-scores every publisher in the catalog against the latest model. This normally runs automatically every few days; a manual run can take a while.",


### PR DESCRIPTION
## Summary
- show a **Rescan signals** action while the publisher-abuse Signals tab is active
- rerun every download/install signal across all active skills
- reuse an already-running full signal scan instead of launching a competing worker
- keep diagnostic temporal scans separate from the full signal pipeline

## Tests
- `bunx vitest run convex/publisherAbuseTemporalScan.test.ts src/routes/-management.test.tsx`
- `bun run ci:static`
- `bun run ci:unit`
- `bun run ci:types-build`
- `bunx tsc --noEmit`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
