### PR TITLE
fix: isolate ClawScan worker shard concurrency

### DIFF
--- a/.github/workflows/security-scan-codex.yml
+++ b/.github/workflows/security-scan-codex.yml
@@ -24,16 +24,15 @@ on:
 permissions:
   contents: read
 
-concurrency:
-  group: clawhub-security-scan
-  cancel-in-progress: false
-
 jobs:
   codex-security-scan:
     name: Codex security scan ${{ matrix.lane }} shard ${{ matrix.shard }}
     runs-on: blacksmith-16vcpu-ubuntu-2404
     timeout-minutes: 40
     environment: Production
+    concurrency:
+      group: clawhub-security-scan-${{ matrix.shard }}
+      cancel-in-progress: false
     strategy:
       fail-fast: false
       max-parallel: 10

--- a/scripts/security/security-scan-worker-workflow.test.ts
+++ b/scripts/security/security-scan-worker-workflow.test.ts
@@ -32,8 +32,16 @@ describe("security-scan-codex workflow", () => {
     const workflow = parseYaml(
       await readFile(".github/workflows/security-scan-codex.yml", "utf8"),
     ) as {
+      concurrency?: {
+        "cancel-in-progress"?: boolean;
+        group?: string;
+      };
       jobs: {
         "codex-security-scan": {
+          concurrency?: {
+            "cancel-in-progress"?: boolean;
+            group?: string;
+          };
           env?: Record<string, unknown>;
           steps: WorkflowStep[];
           strategy?: {
@@ -81,6 +89,11 @@ describe("security-scan-codex workflow", () => {
     expect(workflow.on?.workflow_dispatch).toBeDefined();
     expect(workflow.on?.repository_dispatch?.types).toEqual(["clawhub-security-scan"]);
     expect(workflow.on?.schedule).toBeUndefined();
+    expect(workflow.concurrency).toBeUndefined();
+    expect(workflow.jobs["codex-security-scan"].concurrency).toEqual({
+      group: "clawhub-security-scan-${{ matrix.shard }}",
+      "cancel-in-progress": false,
+    });
     expect(workflow.jobs["codex-security-scan"].strategy?.["max-parallel"]).toBe(10);
     expect(workflow.jobs["codex-security-scan"].strategy?.matrix?.include).toEqual([
       { lane: "priority", shard: "priority-0" },

--- a/specs/security-moderation.md
+++ b/specs/security-moderation.md
@@ -311,7 +311,9 @@ See also: [acceptable-usage.md](./acceptable-usage.md) for the marketplace polic
   Convex emits the narrowly typed `clawhub-security-scan`
   `repository_dispatch` event using the production GitHub App. Event-driven
   dispatch stays disabled until that installation is verified to have Contents
-  write permission.
+  write permission. GitHub Actions concurrency is scoped per worker shard so a
+  delayed runner allocation cannot block every shard; each shard still keeps at
+  most one running and one pending drain wave.
 - Queue source priority is `manual`, `backfill`, `publish`, `vt-update`, then
   `bulk-rescan`. A later VirusTotal update may make a waiting publish job
   claimable immediately, but it must not demote that job from publish priority.


### PR DESCRIPTION
## Summary

- scope GitHub Actions concurrency to each ClawScan worker matrix shard
- prevent a delayed Blacksmith allocation for one drain wave from blocking every shard
- retain bounded execution per shard: at most one running and one pending job
- add workflow regression coverage and record the invariant in the security/moderation spec

## Root cause

The ClawScan ready queue stopped draining while workflow run [29707560904](https://github.com/openclaw/clawhub/actions/runs/29707560904) waited about three hours for Blacksmith runners. Workflow-wide concurrency (`clawhub-security-scan`) held the gate for all later dispatches, so subsequent 15-minute drain waves were repeatedly cancelled/replaced before any shard could start.

Axiom showed 14-16 continuously ready jobs during that interval, with oldest-ready age reaching 10,936 seconds, followed by immediate draining once the matrix workers started. OCC claim failures were absent during the stall. This change addresses that proven global scheduling blockage; it does not treat unrelated ClawScan timeout or SkillSpector failures as the cause.

Related incident reports: #3186, #3183, #3182, #3175.

## Validation

- `bunx vitest run scripts/security/security-scan-worker-workflow.test.ts` (red before fix, 1 passed after)
- focused security worker suite (28 passed)
- `actionlint .github/workflows/security-scan-codex.yml`
- `bun run ci:static`
- `VITE_CONVEX_URL=https://example.invalid bun run ci:unit` (373 files passed, 4,809 tests passed, coverage thresholds met)
- `.agents/skills/autoreview/scripts/autoreview --mode local` (clean, no accepted/actionable findings)
- `git diff --check`

## Operations

No production data, moderation state, deployment, or runtime configuration was changed.
