### PR TITLE
fix: allow transfers to replace owned redirects

### DIFF
--- a/convex/skills.ownerMigration.test.ts
+++ b/convex/skills.ownerMigration.test.ts
@@ -61,10 +61,12 @@ type OrgMigrationFixture = {
     get: ReturnType<typeof vi.fn>;
     query: ReturnType<typeof vi.fn>;
     patch: ReturnType<typeof vi.fn>;
+    delete: ReturnType<typeof vi.fn>;
     insert: ReturnType<typeof vi.fn>;
     normalizeId: ReturnType<typeof vi.fn>;
   };
   patchCalls: Array<{ id: string; value: Record<string, unknown> }>;
+  deleteCalls: string[];
   insertCalls: Array<{ table: string; value: Record<string, unknown> }>;
 };
 
@@ -87,10 +89,12 @@ function createMigrationFixture(params: {
   sourcePersonalLinkedUserId?: string | null;
   duplicateGlobalSlug?: boolean;
   destinationDuplicateSkill?: boolean;
+  destinationRedirect?: boolean;
   skillOverrides?: Record<string, unknown>;
 }): OrgMigrationFixture {
   const now = Date.now();
   const patchCalls: Array<{ id: string; value: Record<string, unknown> }> = [];
+  const deleteCalls: string[] = [];
   const insertCalls: Array<{ table: string; value: Record<string, unknown> }> = [];
 
   const db = {
@@ -328,7 +332,18 @@ function createMigrationFixture(params: {
       }
       if (table === "skillSlugAliases") {
         return {
-          withIndex: (name: string) => {
+          withIndex: (
+            name: string,
+            build?: (q: { eq: (field: string, value: string) => unknown }) => unknown,
+          ) => {
+            const constraints: Record<string, string> = {};
+            const q = {
+              eq: (field: string, value: string) => {
+                constraints[field] = value;
+                return q;
+              },
+            };
+            build?.(q);
             if (name === "by_skill") {
               return { collect: async () => [] };
             }
@@ -336,7 +351,20 @@ function createMigrationFixture(params: {
               return { unique: async () => null, take: async () => [] };
             }
             if (name === "by_owner_publisher_slug" || name === "by_owner_slug") {
-              return { unique: async () => null };
+              return {
+                unique: async () =>
+                  params.destinationRedirect &&
+                  constraints.ownerPublisherId === "publishers:org" &&
+                  constraints.slug === "nano"
+                    ? {
+                        _id: "skillSlugAliases:destination-redirect",
+                        slug: "nano",
+                        skillId: "skills:renamed-destination",
+                        ownerUserId: "users:caller",
+                        ownerPublisherId: "publishers:org",
+                      }
+                    : null,
+              };
             }
             throw new Error(`unexpected skillSlugAliases index ${name}`);
           },
@@ -382,6 +410,9 @@ function createMigrationFixture(params: {
     patch: vi.fn(async (id: string, value: Record<string, unknown>) => {
       patchCalls.push({ id, value });
     }),
+    delete: vi.fn(async (id: string) => {
+      deleteCalls.push(id);
+    }),
     insert: vi.fn(async (table: string, value: Record<string, unknown>) => {
       insertCalls.push({ table, value });
       return `${table}:inserted`;
@@ -389,7 +420,7 @@ function createMigrationFixture(params: {
     normalizeId: vi.fn(),
   };
 
-  return { db, patchCalls, insertCalls };
+  return { db, patchCalls, deleteCalls, insertCalls };
 }
 
 describe("skills.insertVersion owner migration", () => {
@@ -756,6 +787,41 @@ describe("skills.insertVersion owner migration", () => {
         table: "skillVersions",
       }),
     );
+  });
+
+  it("replaces a destination-owned redirect during explicit owner migration", async () => {
+    const fixture = createMigrationFixture({
+      skillSource: "caller-personal",
+      destinationRedirect: true,
+      sourceMemberships: [
+        {
+          _id: "publisherMembers:orgAdminCaller",
+          publisherId: "publishers:org",
+          userId: "users:caller",
+          role: "admin",
+        },
+      ],
+    });
+
+    await expect(
+      insertVersionHandler(
+        { db: fixture.db } as never,
+        buildPublishArgs({
+          migrateOwner: true,
+          sourceOwnerPublisherId: "publishers:personalCaller",
+        }) as never,
+      ),
+    ).rejects.toThrow(SENTINEL_BAIL_MESSAGE);
+
+    expect(fixture.deleteCalls).toEqual(["skillSlugAliases:destination-redirect"]);
+    expect(fixture.patchCalls.filter((p) => p.id === "skills:1")).toHaveLength(1);
+    const migrationAudit = fixture.insertCalls.find(
+      (call) => call.table === "auditLogs" && call.value.action === "skill.ownership.migrate",
+    );
+    expect(migrationAudit?.value.metadata).toMatchObject({
+      replacedDestinationAliasId: "skillSlugAliases:destination-redirect",
+      replacedDestinationAliasSkillId: "skills:renamed-destination",
+    });
   });
 
   it("classifies explicit migrations as blocked when preflight sees a destination slug collision", async () => {

--- a/convex/skills.ownership.test.ts
+++ b/convex/skills.ownership.test.ts
@@ -1304,6 +1304,7 @@ describe("skills ownership", () => {
 
   it("allows publisher admins to move a skill into an org they administer", async () => {
     const patch = vi.fn(async () => {});
+    const deleteDoc = vi.fn(async () => {});
     const insert = vi.fn(async () => "auditLogs:1");
     const skill = {
       _id: "skills:source",
@@ -1425,10 +1426,10 @@ describe("skills ownership", () => {
                     unique: async () =>
                       name === "by_owner_publisher_slug" &&
                       constraints.ownerPublisherId === "publishers:org" &&
-                      constraints.slug === "source-namespace-redirect"
+                      constraints.slug === "portable"
                         ? {
                             _id: "skillSlugAliases:destination-conflict",
-                            slug: "source-namespace-redirect",
+                            slug: "portable",
                             skillId: "skills:destination",
                             ownerUserId: "users:actor",
                             ownerPublisherId: "publishers:org",
@@ -1451,6 +1452,7 @@ describe("skills ownership", () => {
             throw new Error(`unexpected table ${table}`);
           }),
           patch,
+          delete: deleteDoc,
           insert,
         },
       } as never,
@@ -1478,6 +1480,7 @@ describe("skills ownership", () => {
     );
     expect(patch).not.toHaveBeenCalledWith("skillSlugAliases:old", expect.anything());
     expect(patch).not.toHaveBeenCalledWith("skillSlugAliases:source-owned", expect.anything());
+    expect(deleteDoc).toHaveBeenCalledWith("skillSlugAliases:destination-conflict");
     expect(patch).toHaveBeenCalledWith(
       "skillSearchDigest:source",
       expect.objectContaining({
@@ -1485,6 +1488,16 @@ describe("skills ownership", () => {
         ownerPublisherId: "publishers:org",
         ownerHandle: "team",
         ownerKind: "org",
+      }),
+    );
+    expect(insert).toHaveBeenCalledWith(
+      "auditLogs",
+      expect.objectContaining({
+        action: "skill.owner.transfer",
+        metadata: expect.objectContaining({
+          replacedDestinationAliasId: "skillSlugAliases:destination-conflict",
+          replacedDestinationAliasSkillId: "skills:destination",
+        }),
       }),
     );
   });

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -11317,30 +11317,17 @@ async function canManagePublisherDestination(
   return Boolean(membership && isPublisherRoleAllowed(membership.role, ["admin"]));
 }
 
-async function assertCanTransferSkillSlugToPublisher(
+async function getDestinationSkillSlugAliasToReplace(
   ctx: MutationCtx,
   skill: Doc<"skills">,
   destinationPublisher: Doc<"publishers">,
 ) {
-  const transferredSlugs = new Set([skill.slug]);
-
-  for (const slug of transferredSlugs) {
-    const existingSkill = await getSkillBySlugForPublisher(ctx, slug, destinationPublisher);
-    if (existingSkill && existingSkill._id !== skill._id) {
-      throw new ConvexError(buildDestinationSkillExistsMessage(destinationPublisher, slug));
-    }
-
-    const existingAlias = await getSkillSlugAliasBySlugForPublisher(
-      ctx,
-      slug,
-      destinationPublisher,
-    );
-    if (existingAlias && existingAlias.skillId !== skill._id) {
-      throw new ConvexError(
-        `Destination owner @${destinationPublisher.handle} already has a redirect for skill "${slug}". Rename or merge before transferring ownership.`,
-      );
-    }
+  const existingSkill = await getSkillBySlugForPublisher(ctx, skill.slug, destinationPublisher);
+  if (existingSkill && existingSkill._id !== skill._id) {
+    throw new ConvexError(buildDestinationSkillExistsMessage(destinationPublisher, skill.slug));
   }
+
+  return getSkillSlugAliasBySlugForPublisher(ctx, skill.slug, destinationPublisher);
 }
 
 export const transferSkillOwnerForUserInternal = internalMutation({
@@ -11408,9 +11395,16 @@ export const transferSkillOwnerForUserInternal = internalMutation({
       throw new ConvexError("Destination owner user not found");
     }
 
-    await assertCanTransferSkillSlugToPublisher(ctx, skill, destinationPublisher);
+    const replacedDestinationAlias = await getDestinationSkillSlugAliasToReplace(
+      ctx,
+      skill,
+      destinationPublisher,
+    );
 
     const now = Date.now();
+    if (replacedDestinationAlias) {
+      await ctx.db.delete(replacedDestinationAlias._id);
+    }
     await transferSkillOwnershipAndEmbeddings(ctx, {
       skill,
       ownerUserId: nextOwner._id,
@@ -11438,6 +11432,8 @@ export const transferSkillOwnerForUserInternal = internalMutation({
         nextOwnerUserId: nextOwner._id,
         nextOwnerPublisherId: destinationPublisher._id,
         reason: args.reason || undefined,
+        replacedDestinationAliasId: replacedDestinationAlias?._id,
+        replacedDestinationAliasSkillId: replacedDestinationAlias?.skillId,
       },
       createdAt: now,
     });
@@ -12367,7 +12363,11 @@ export const insertVersion = internalMutation({
         userId,
         allowed: ["admin"],
       });
-      await assertCanTransferSkillSlugToPublisher(ctx, skill, ownerPublisher);
+      const replacedDestinationAlias = await getDestinationSkillSlugAliasToReplace(
+        ctx,
+        skill,
+        ownerPublisher,
+      );
 
       const previousOwnerPublisherId = skill.ownerPublisherId;
       const previousOwnerUserId = skill.ownerUserId;
@@ -12380,6 +12380,9 @@ export const insertVersion = internalMutation({
         updatedAt: now,
       };
 
+      if (replacedDestinationAlias) {
+        await ctx.db.delete(replacedDestinationAlias._id);
+      }
       await transferSkillOwnershipAndEmbeddings(ctx, {
         skill,
         ownerPublisherId,
@@ -12402,6 +12405,8 @@ export const insertVersion = internalMutation({
             ownerPublisherId,
             ownerUserId: userId,
           },
+          replacedDestinationAliasId: replacedDestinationAlias?._id,
+          replacedDestinationAliasSkillId: replacedDestinationAlias?.skillId,
         },
         createdAt: now,
       });

--- a/specs/orgs.md
+++ b/specs/orgs.md
@@ -322,10 +322,14 @@ migration.
   must include `migrateOwner: true`
 - owner migration requires admin or owner access on both the current publisher
   and the destination publisher
+- explicit owner migration may replace the destination publisher's exact-slug
+  historical redirect; a live destination skill with that slug remains a hard
+  collision
 - migration preserves the skill id, versions, stats, forks, aliases,
   search digest identity, and audit history
-- migration writes a `skill.ownership.migrate` audit event; the new version's
-  `createdBy` remains the publishing actor
+- migration writes a `skill.ownership.migrate` audit event, including any
+  replaced destination redirect; the new version's `createdBy` remains the
+  publishing actor
 
 ### Packages
 


### PR DESCRIPTION
## Summary

- allow an explicitly authorized skill ownership transfer to replace the destination publisher's exact-slug historical redirect
- preserve the hard collision when the destination already has a live skill with that slug
- record replaced redirect IDs in existing transfer and owner-migration audit events
- document the redirect replacement invariant

Closes #3178.

## Root cause

The shared ownership-migration guard treated a destination-owned historical alias as a permanent slug collision. That blocked both direct transfer and `publishVersion` owner migration even after the actor had explicitly selected the destination and passed source/destination authorization checks.

## Validation

- Red/green regression tests for direct transfer and explicit owner migration
- `bunx vitest run convex/skills.ownership.test.ts convex/skills.ownerMigration.test.ts --reporter=dot` (38 passed)
- `bun run ci:static`
- `bun run ci:unit` (373 files passed, 4,810 tests passed, coverage thresholds passed)
- `bunx tsc --noEmit`
- `bunx tsc -p packages/schema/tsconfig.json --noEmit`
- `bunx tsc -p packages/clawhub/tsconfig.json --noEmit`
- `bun run --cwd packages/clawhub-admin typecheck`
- `bunx convex dev --configure existing --team amantus --project clawdhub --dev-deployment local --once` (local deployment function/schema push passed)
- `.agents/skills/autoreview/scripts/autoreview --mode local` (clean; no actionable findings)

## Build caveat

`bun run ci:types-build` passed all TypeScript checks but its final Vite build failed resolving the existing current-main import `monaco-editor/esm/vs/editor/editor.worker?worker` from `src/lib/monacoLoader.ts`. This PR does not touch the frontend, Monaco loader, dependencies, or lockfile.
