### PR TITLE
fix(security): extend prepublication ClawScan timeout

### DIFF
--- a/.github/workflows/prepublication-publish-checks.yml
+++ b/.github/workflows/prepublication-publish-checks.yml
@@ -69,7 +69,7 @@ jobs:
       PREPUBLICATION_CHECK_KIND: ${{ inputs.kind || '' }}
       PREPUBLICATION_CHECK_SLUG: ${{ inputs.slug || '' }}
       PREPUBLICATION_CHECK_VERSION: ${{ inputs.version || '' }}
-      PREPUBLICATION_CLAWSCAN_TIMEOUT_MS: ${{ vars.PREPUBLICATION_CLAWSCAN_TIMEOUT_MS || '240000' }}
+      PREPUBLICATION_CLAWSCAN_TIMEOUT_MS: ${{ vars.PREPUBLICATION_CLAWSCAN_TIMEOUT_MS || '900000' }}
       PREPUBLICATION_TRUFFLEHOG_IMAGE: ${{ vars.PREPUBLICATION_TRUFFLEHOG_IMAGE || 'ghcr.io/trufflesecurity/trufflehog:3.95.6@sha256:96f8429082cb2d4ae73b1096dcdb2f5aa139881d97042b0c5e5fa226a392e056' }}
       PREPUBLICATION_WORKER_ID: "github-actions:${{ github.run_id }}:${{ github.run_attempt }}:${{ matrix.shard }}"
     steps:

--- a/scripts/security/prepublication-worker-workflow.test.ts
+++ b/scripts/security/prepublication-worker-workflow.test.ts
@@ -103,7 +103,7 @@ describe("pre-publication publish worker workflow", () => {
       CONVEX_URL:
         "${{ vars.CONVEX_URL || vars.VITE_CONVEX_URL || 'https://wry-manatee-359.convex.cloud' }}",
       PREPUBLICATION_CLAWSCAN_TIMEOUT_MS:
-        "${{ vars.PREPUBLICATION_CLAWSCAN_TIMEOUT_MS || '240000' }}",
+        "${{ vars.PREPUBLICATION_CLAWSCAN_TIMEOUT_MS || '900000' }}",
       PREPUBLICATION_CHECK_ATTEMPT_ID: "${{ inputs['attempt-id'] || '' }}",
       PREPUBLICATION_CHECK_LIMIT: "${{ inputs['batch-limit'] || '4' }}",
       PREPUBLICATION_CHECK_KIND: "${{ inputs.kind || '' }}",

--- a/scripts/security/run-prepublication-worker.test.ts
+++ b/scripts/security/run-prepublication-worker.test.ts
@@ -6,6 +6,7 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { Id } from "../../convex/_generated/dataModel";
 import {
+  DEFAULT_PREPUBLICATION_CLAWSCAN_TIMEOUT_MS,
   claimBatchDrainedQueue,
   claimPrePublicationAttempt,
   claimPrePublicationBatch,
@@ -63,6 +64,10 @@ const attempt = {
 };
 
 describe("pre-publication worker", () => {
+  it("allows production ClawScan runs up to 15 minutes by default", () => {
+    expect(DEFAULT_PREPUBLICATION_CLAWSCAN_TIMEOUT_MS).toBe(900_000);
+  });
+
   it("treats empty scheduled recovery flags as absent", () => {
     expect(
       parseArgs(

--- a/scripts/security/run-prepublication-worker.ts
+++ b/scripts/security/run-prepublication-worker.ts
@@ -361,9 +361,13 @@ export async function runNativeTruffleHog(workspace: string): Promise<TruffleHog
   };
 }
 
+export const DEFAULT_PREPUBLICATION_CLAWSCAN_TIMEOUT_MS = 15 * 60 * 1000;
+
 function clawScanTimeoutMs() {
   const parsed = Number(process.env.PREPUBLICATION_CLAWSCAN_TIMEOUT_MS);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : 240_000;
+  return Number.isFinite(parsed) && parsed > 0
+    ? parsed
+    : DEFAULT_PREPUBLICATION_CLAWSCAN_TIMEOUT_MS;
 }
 
 function clawScanCommand() {


### PR DESCRIPTION
## Summary

- raise the pre-publication ClawScan timeout from 240 seconds to 900 seconds
- keep the workflow and worker fallback defaults aligned
- add focused regression coverage for the production timeout

## RCA evidence

- production currently has 42 attempts in `pending_checks`; 36 record `clawscan timed out`
- an exact local reconstruction of affected `clawseccheck@3.54.0` took 287 seconds; SkillSpector alone took 270 seconds
- the former 240-second cap therefore kills otherwise completing scans

## Validation

- `node_modules/.bin/vitest run scripts/security/run-prepublication-worker.test.ts scripts/security/prepublication-worker-workflow.test.ts` (23/23)
- `bun run ci:static`
- autoreview clean: no accepted/actionable findings
- full unit suite: 4,809 passed, one unrelated existing mobile package-detail test timed out
- types/build reached the existing Monaco worker-resolution failure

Part of #3186.
