### PR TITLE
ci: retry transient GitHub package fixture failures

### DIFF
--- a/e2e/clawhub.e2e.test.ts
+++ b/e2e/clawhub.e2e.test.ts
@@ -838,7 +838,9 @@ describe("clawhub e2e", () => {
         "clawhub",
         "package",
         "publish",
-        "pwrdrvr/openclaw-codex-app-server",
+        "openclaw/openclaw",
+        "--source-path",
+        "extensions/cohere",
         "--dry-run",
         "--site",
         site,
@@ -854,41 +856,51 @@ describe("clawhub e2e", () => {
 
     expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
     expect(result.stdout).toMatch(/Dry run/i);
-    expect(result.stdout).toMatch(/openclaw-codex-app-server/);
+    expect(result.stdout).toMatch(/@openclaw\/cohere-provider/);
     expect(result.stdout).toMatch(/code-plugin/i);
     expect(result.stdout).toMatch(/openclaw\.plugin\.json/);
   }, 30_000);
 
-  it("package publish --dry-run --json from GitHub outputs valid JSON", async () => {
+  it("package publish --dry-run --json outputs valid JSON", async () => {
+    const root = await mkdtemp(join(tmpdir(), "clawhub-cli-dry-run-json-"));
     const registry = getRegistry();
     const site = getSite();
-    const result = spawnSync(
-      "bun",
-      [
-        "clawhub",
-        "package",
-        "publish",
-        "pwrdrvr/openclaw-codex-app-server",
-        "--dry-run",
-        "--json",
-        "--site",
-        site,
-        "--registry",
-        registry,
-      ],
-      {
-        cwd: process.cwd(),
-        env: { ...process.env, CLAWHUB_DISABLE_TELEMETRY: "1" },
-        encoding: "utf8",
-      },
-    );
+    try {
+      const plugin = await writeCodePluginFixture(root, "clawhub-json-dry-run");
+      const result = spawnSync(
+        "bun",
+        [
+          "clawhub",
+          "package",
+          "publish",
+          plugin,
+          "--dry-run",
+          "--json",
+          "--source-repo",
+          "openclaw/clawhub",
+          "--source-commit",
+          "0000000000000000000000000000000000000000",
+          "--site",
+          site,
+          "--registry",
+          registry,
+        ],
+        {
+          cwd: process.cwd(),
+          env: { ...process.env, CLAWHUB_DISABLE_TELEMETRY: "1" },
+          encoding: "utf8",
+        },
+      );
 
-    expect(result.status).toBe(0);
-    const output = JSON.parse(result.stdout.trim()) as Record<string, unknown>;
-    expect(String(output.name)).toMatch(/openclaw-codex-app-server/);
-    expect(output.family).toBe("code-plugin");
-    expect(Number(output.files)).toBeGreaterThan(0);
-    expect(output).not.toHaveProperty("releaseId");
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+      const output = JSON.parse(result.stdout.trim()) as Record<string, unknown>;
+      expect(output.name).toBe("clawhub-json-dry-run");
+      expect(output.family).toBe("code-plugin");
+      expect(Number(output.files)).toBeGreaterThan(0);
+      expect(output).not.toHaveProperty("releaseId");
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
   }, 30_000);
 
   it("package publish exits non-zero when Plugin Inspector hard errors block publish", async () => {

--- a/packages/clawhub/src/cli/commands/github.test.ts
+++ b/packages/clawhub/src/cli/commands/github.test.ts
@@ -6,7 +6,12 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { zipSync } from "fflate";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { fetchGitHubSource, resolveLocalGitInfo, resolveSourceInput } from "./github";
+import {
+  createGitHubRetryBudget,
+  fetchGitHubSource,
+  resolveLocalGitInfo,
+  resolveSourceInput,
+} from "./github";
 
 async function makeTmpDir() {
   return await mkdtemp(join(tmpdir(), "clawhub-github-test-"));
@@ -341,6 +346,421 @@ describe("github publish source helpers", () => {
       expect(await readFile(join(fetched.dir, "package.json"), "utf8")).toContain('"name":"demo"');
     } finally {
       await fetched.cleanup();
+      Object.defineProperty(globalThis, "fetch", {
+        value: originalFetch,
+        configurable: true,
+        writable: true,
+      });
+    }
+  });
+
+  it("retries transient GitHub repository lookup failures", async () => {
+    vi.useFakeTimers();
+    const archiveBytes = zipSync({
+      "repo-root/package.json": new TextEncoder().encode('{"name":"demo","version":"1.0.0"}\n'),
+      "repo-root/openclaw.plugin.json": new TextEncoder().encode(
+        '{"id":"demo","configSchema":{"type":"object"}}\n',
+      ),
+    });
+    const archiveBody = archiveBytes.buffer.slice(
+      archiveBytes.byteOffset,
+      archiveBytes.byteOffset + archiveBytes.byteLength,
+    ) as ArrayBuffer;
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockRejectedValueOnce(new TypeError("fetch failed"))
+      .mockResolvedValueOnce(new Response("temporarily unavailable", { status: 503 }))
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ default_branch: "main" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ sha: "0123456789abcdef0123456789abcdef01234567" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(archiveBody, {
+          status: 200,
+          headers: { "content-type": "application/zip" },
+        }),
+      );
+    const originalFetch = globalThis.fetch;
+    Object.defineProperty(globalThis, "fetch", {
+      value: fetchMock,
+      configurable: true,
+      writable: true,
+    });
+
+    try {
+      const fetchedPromise = fetchGitHubSource({
+        kind: "github",
+        owner: "owner",
+        repo: "repo",
+        path: ".",
+        url: "https://github.com/owner/repo",
+      });
+      await vi.runAllTimersAsync();
+      const fetched = await fetchedPromise;
+      await fetched.cleanup();
+
+      expect(fetchMock).toHaveBeenCalledTimes(5);
+      expect(fetched.source.ref).toBe("main");
+    } finally {
+      vi.useRealTimers();
+      Object.defineProperty(globalThis, "fetch", {
+        value: originalFetch,
+        configurable: true,
+        writable: true,
+      });
+    }
+  });
+
+  it("does not retry a missing GitHub repository", async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(new Response("not found", { status: 404 }));
+    const originalFetch = globalThis.fetch;
+    Object.defineProperty(globalThis, "fetch", {
+      value: fetchMock,
+      configurable: true,
+      writable: true,
+    });
+
+    try {
+      await expect(
+        fetchGitHubSource({
+          kind: "github",
+          owner: "owner",
+          repo: "missing",
+          path: ".",
+          url: "https://github.com/owner/missing",
+        }),
+      ).rejects.toThrow("GitHub repo not found: owner/missing");
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    } finally {
+      Object.defineProperty(globalThis, "fetch", {
+        value: originalFetch,
+        configurable: true,
+        writable: true,
+      });
+    }
+  });
+
+  it("honors a bounded GitHub rate-limit retry delay", async () => {
+    vi.useFakeTimers();
+    const archiveBytes = zipSync({
+      "repo-root/package.json": new TextEncoder().encode('{"name":"demo","version":"1.0.0"}\n'),
+      "repo-root/openclaw.plugin.json": new TextEncoder().encode(
+        '{"id":"demo","configSchema":{"type":"object"}}\n',
+      ),
+    });
+    const archiveBody = archiveBytes.buffer.slice(
+      archiveBytes.byteOffset,
+      archiveBytes.byteOffset + archiveBytes.byteLength,
+    ) as ArrayBuffer;
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        new Response("rate limited", {
+          status: 403,
+          headers: { "retry-after": "1" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ default_branch: "main" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ sha: "0123456789abcdef0123456789abcdef01234567" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(archiveBody, {
+          status: 200,
+          headers: { "content-type": "application/zip" },
+        }),
+      );
+    const originalFetch = globalThis.fetch;
+    Object.defineProperty(globalThis, "fetch", {
+      value: fetchMock,
+      configurable: true,
+      writable: true,
+    });
+
+    try {
+      const fetchedPromise = fetchGitHubSource({
+        kind: "github",
+        owner: "owner",
+        repo: "repo",
+        path: ".",
+        url: "https://github.com/owner/repo",
+      });
+      await vi.advanceTimersByTimeAsync(999);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(1);
+      const fetched = await fetchedPromise;
+      await fetched.cleanup();
+
+      expect(fetchMock).toHaveBeenCalledTimes(4);
+    } finally {
+      vi.useRealTimers();
+      Object.defineProperty(globalThis, "fetch", {
+        value: originalFetch,
+        configurable: true,
+        writable: true,
+      });
+    }
+  });
+
+  it("does not retry a GitHub rate limit beyond the bounded delay", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response("rate limited", {
+        status: 429,
+        headers: { "retry-after": "60" },
+      }),
+    );
+    const originalFetch = globalThis.fetch;
+    Object.defineProperty(globalThis, "fetch", {
+      value: fetchMock,
+      configurable: true,
+      writable: true,
+    });
+
+    try {
+      await expect(
+        fetchGitHubSource({
+          kind: "github",
+          owner: "owner",
+          repo: "repo",
+          path: ".",
+          url: "https://github.com/owner/repo",
+        }),
+      ).rejects.toThrow("GitHub repo lookup failed (429): owner/repo");
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    } finally {
+      Object.defineProperty(globalThis, "fetch", {
+        value: originalFetch,
+        configurable: true,
+        writable: true,
+      });
+    }
+  });
+
+  it("retries transient failures while reading a GitHub response body", async () => {
+    vi.useFakeTimers();
+    const archiveBytes = zipSync({
+      "repo-root/package.json": new TextEncoder().encode('{"name":"demo","version":"1.0.0"}\n'),
+      "repo-root/openclaw.plugin.json": new TextEncoder().encode(
+        '{"id":"demo","configSchema":{"type":"object"}}\n',
+      ),
+    });
+    const archiveBody = archiveBytes.buffer.slice(
+      archiveBytes.byteOffset,
+      archiveBytes.byteOffset + archiveBytes.byteLength,
+    ) as ArrayBuffer;
+    const failedBody = new ReadableStream({
+      start(controller) {
+        controller.error(new TypeError("connection reset"));
+      },
+    });
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response(failedBody, { status: 200 }))
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ default_branch: "main" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ sha: "0123456789abcdef0123456789abcdef01234567" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(archiveBody, {
+          status: 200,
+          headers: { "content-type": "application/zip" },
+        }),
+      );
+    const originalFetch = globalThis.fetch;
+    Object.defineProperty(globalThis, "fetch", {
+      value: fetchMock,
+      configurable: true,
+      writable: true,
+    });
+
+    try {
+      const fetchedPromise = fetchGitHubSource({
+        kind: "github",
+        owner: "owner",
+        repo: "repo",
+        path: ".",
+        url: "https://github.com/owner/repo",
+      });
+      await vi.runAllTimersAsync();
+      const fetched = await fetchedPromise;
+      await fetched.cleanup();
+
+      expect(fetchMock).toHaveBeenCalledTimes(4);
+    } finally {
+      vi.useRealTimers();
+      Object.defineProperty(globalThis, "fetch", {
+        value: originalFetch,
+        configurable: true,
+        writable: true,
+      });
+    }
+  });
+
+  it("enforces the GitHub rate-limit delay budget cumulatively", async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response("rate limited", {
+        status: 403,
+        headers: { "retry-after": "3" },
+      }),
+    );
+    const originalFetch = globalThis.fetch;
+    Object.defineProperty(globalThis, "fetch", {
+      value: fetchMock,
+      configurable: true,
+      writable: true,
+    });
+
+    try {
+      const fetchedPromise = fetchGitHubSource({
+        kind: "github",
+        owner: "owner",
+        repo: "repo",
+        path: ".",
+        url: "https://github.com/owner/repo",
+      });
+      const rejection = expect(fetchedPromise).rejects.toThrow(
+        "GitHub repo lookup failed (403): owner/repo",
+      );
+      await vi.advanceTimersByTimeAsync(3_000);
+      await rejection;
+
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+      Object.defineProperty(globalThis, "fetch", {
+        value: originalFetch,
+        configurable: true,
+        writable: true,
+      });
+    }
+  });
+
+  it("shares the GitHub rate-limit delay budget across source requests", async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        new Response("rate limited", {
+          status: 403,
+          headers: { "retry-after": "3" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ default_branch: "main" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response("rate limited", {
+          status: 403,
+          headers: { "retry-after": "3" },
+        }),
+      );
+    const originalFetch = globalThis.fetch;
+    Object.defineProperty(globalThis, "fetch", {
+      value: fetchMock,
+      configurable: true,
+      writable: true,
+    });
+
+    try {
+      const fetchedPromise = fetchGitHubSource({
+        kind: "github",
+        owner: "owner",
+        repo: "repo",
+        path: ".",
+        url: "https://github.com/owner/repo",
+      });
+      const rejection = expect(fetchedPromise).rejects.toThrow(
+        "GitHub ref not found: owner/repo@main",
+      );
+      await vi.advanceTimersByTimeAsync(3_000);
+      await rejection;
+
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+    } finally {
+      vi.useRealTimers();
+      Object.defineProperty(globalThis, "fetch", {
+        value: originalFetch,
+        configurable: true,
+        writable: true,
+      });
+    }
+  });
+
+  it("shares the GitHub rate-limit delay budget across URL resolution and fetch", async () => {
+    vi.useFakeTimers();
+    const retryBudget = createGitHubRetryBudget();
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        new Response("rate limited", {
+          status: 403,
+          headers: { "retry-after": "3" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ sha: "0123456789abcdef0123456789abcdef01234567" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response("rate limited", {
+          status: 403,
+          headers: { "retry-after": "3" },
+        }),
+      );
+    const originalFetch = globalThis.fetch;
+    Object.defineProperty(globalThis, "fetch", {
+      value: fetchMock,
+      configurable: true,
+      writable: true,
+    });
+
+    try {
+      const resolvedPromise = resolveSourceInput("https://github.com/owner/repo/tree/main", {
+        workdir: "/tmp",
+        retryBudget,
+      });
+      await vi.advanceTimersByTimeAsync(3_000);
+      const resolved = await resolvedPromise;
+      if (resolved.kind !== "github") throw new Error("Expected GitHub source");
+
+      await expect(fetchGitHubSource(resolved, retryBudget)).rejects.toThrow(
+        "GitHub ref not found: owner/repo@main",
+      );
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+    } finally {
+      vi.useRealTimers();
       Object.defineProperty(globalThis, "fetch", {
         value: originalFetch,
         configurable: true,

--- a/packages/clawhub/src/cli/commands/github.ts
+++ b/packages/clawhub/src/cli/commands/github.ts
@@ -7,6 +7,8 @@ import { unzipSync } from "fflate";
 const GITHUB_API = "https://api.github.com";
 const GITHUB_HOSTS = new Set(["github.com", "www.github.com"]);
 const ZIP_USER_AGENT = "clawhub/package-publish";
+const GITHUB_RETRY_DELAYS_MS = [250, 500];
+const GITHUB_MAX_RATE_LIMIT_DELAY_MS = 5_000;
 
 type ResolvedPublishSource =
   | {
@@ -30,6 +32,10 @@ type LocalGitInfo = {
   ref?: string;
 };
 
+type GitHubRetryBudget = {
+  remainingRateLimitDelayMs: number;
+};
+
 type FetchedGitHubSource = {
   dir: string;
   source: {
@@ -46,14 +52,18 @@ type FetchedGitHubSource = {
 
 export async function resolveSourceInput(
   input: string,
-  options: { workdir: string; localWorkdirs?: string[] },
+  options: {
+    workdir: string;
+    localWorkdirs?: string[];
+    retryBudget?: GitHubRetryBudget;
+  },
 ): Promise<ResolvedPublishSource> {
   const trimmed = input.trim();
   if (!trimmed) throw new Error("Path required");
   const localWorkdirs = normalizeLocalWorkdirs(options.workdir, options.localWorkdirs);
 
   if (trimmed.startsWith("https://")) {
-    return await parseGitHubUrl(trimmed);
+    return await parseGitHubUrl(trimmed, options.retryBudget ?? createGitHubRetryBudget());
   }
 
   const shorthand = parseGitHubShorthand(trimmed);
@@ -80,14 +90,22 @@ export async function resolveSourceInput(
 
 export async function fetchGitHubSource(
   source: Extract<ResolvedPublishSource, { kind: "github" }>,
+  retryBudget = createGitHubRetryBudget(),
 ) {
   const token = process.env.GITHUB_TOKEN?.trim() || undefined;
   const repo = `${source.owner}/${source.repo}`;
   const repoUrl = `https://github.com/${repo}`;
   const resolvedRef =
-    source.ref?.trim() || (await resolveDefaultBranch(source.owner, source.repo, token));
-  const commit = await resolveCommitSha(source.owner, source.repo, resolvedRef, token);
-  const archiveBytes = await downloadGitHubZip(source.owner, source.repo, commit, token);
+    source.ref?.trim() ||
+    (await resolveDefaultBranch(source.owner, source.repo, token, retryBudget));
+  const commit = await resolveCommitSha(source.owner, source.repo, resolvedRef, token, retryBudget);
+  const archiveBytes = await downloadGitHubZip(
+    source.owner,
+    source.repo,
+    commit,
+    token,
+    retryBudget,
+  );
   const entries = stripSingleTopLevelFolder(unzipSync(archiveBytes));
   const publishPath = normalizeRepoSubpath(source.path);
   const tempDir = await mkdtemp(join(tmpdir(), "clawhub-github-publish-"));
@@ -195,6 +213,7 @@ function parseGitHubShorthand(
 
 async function parseGitHubUrl(
   input: string,
+  retryBudget: GitHubRetryBudget,
 ): Promise<Extract<ResolvedPublishSource, { kind: "github" }>> {
   let url: URL;
   try {
@@ -221,7 +240,13 @@ async function parseGitHubUrl(
     };
   }
 
-  const { ref, path } = await resolveGitHubUrlRefAndPath(owner, repo, kind, segments.slice(3));
+  const { ref, path } = await resolveGitHubUrlRefAndPath(
+    owner,
+    repo,
+    kind,
+    segments.slice(3),
+    retryBudget,
+  );
 
   return {
     kind: "github",
@@ -276,54 +301,146 @@ function decodePathSegments(pathname: string) {
     });
 }
 
-async function resolveDefaultBranch(owner: string, repo: string, token?: string) {
-  const response = await fetch(`${GITHUB_API}/repos/${owner}/${repo}`, {
-    headers: buildGitHubHeaders(token),
-  });
-  if (!response.ok) throw new Error(`GitHub repo not found: ${owner}/${repo}`);
-  const parsed = (await response.json()) as { default_branch?: unknown };
+async function resolveDefaultBranch(
+  owner: string,
+  repo: string,
+  token: string | undefined,
+  retryBudget: GitHubRetryBudget,
+) {
+  const { response, body: parsed } = await fetchGitHub(
+    `${GITHUB_API}/repos/${owner}/${repo}`,
+    { headers: buildGitHubHeaders(token) },
+    async (githubResponse) => (await githubResponse.json()) as { default_branch?: unknown },
+    retryBudget,
+  );
+  if (!response.ok) {
+    if (response.status === 404) throw new Error(`GitHub repo not found: ${owner}/${repo}`);
+    throw new Error(`GitHub repo lookup failed (${response.status}): ${owner}/${repo}`);
+  }
   const defaultBranch =
-    typeof parsed.default_branch === "string" ? parsed.default_branch.trim() : "";
+    typeof parsed?.default_branch === "string" ? parsed.default_branch.trim() : "";
   if (!defaultBranch) throw new Error("GitHub repo default branch missing");
   return defaultBranch;
 }
 
-async function resolveCommitSha(owner: string, repo: string, ref: string, token?: string) {
-  const response = await fetch(
+async function resolveCommitSha(
+  owner: string,
+  repo: string,
+  ref: string,
+  token: string | undefined,
+  retryBudget: GitHubRetryBudget,
+) {
+  const { response, body: parsed } = await fetchGitHub(
     `${GITHUB_API}/repos/${owner}/${repo}/commits/${encodeURIComponent(ref)}`,
-    {
-      headers: buildGitHubHeaders(token),
-    },
+    { headers: buildGitHubHeaders(token) },
+    async (githubResponse) => (await githubResponse.json()) as { sha?: unknown },
+    retryBudget,
   );
   if (!response.ok) throw new Error(`GitHub ref not found: ${owner}/${repo}@${ref}`);
-  const parsed = (await response.json()) as { sha?: unknown };
-  const sha = typeof parsed.sha === "string" ? parsed.sha.trim().toLowerCase() : "";
+  const sha = typeof parsed?.sha === "string" ? parsed.sha.trim().toLowerCase() : "";
   if (!/^[a-f0-9]{40}$/.test(sha)) throw new Error("GitHub commit sha missing");
   return sha;
 }
 
-async function tryResolveCommitSha(owner: string, repo: string, ref: string, token?: string) {
-  const response = await fetch(
+async function tryResolveCommitSha(
+  owner: string,
+  repo: string,
+  ref: string,
+  token: string | undefined,
+  retryBudget: GitHubRetryBudget,
+) {
+  const { response, body: parsed } = await fetchGitHub(
     `${GITHUB_API}/repos/${owner}/${repo}/commits/${encodeURIComponent(ref)}`,
-    {
-      headers: buildGitHubHeaders(token),
-    },
+    { headers: buildGitHubHeaders(token) },
+    async (githubResponse) => (await githubResponse.json()) as { sha?: unknown },
+    retryBudget,
   );
   if (!response.ok) return null;
-  const parsed = (await response.json()) as { sha?: unknown };
-  const sha = typeof parsed.sha === "string" ? parsed.sha.trim().toLowerCase() : "";
+  const sha = typeof parsed?.sha === "string" ? parsed.sha.trim().toLowerCase() : "";
   return /^[a-f0-9]{40}$/.test(sha) ? sha : null;
 }
 
-async function downloadGitHubZip(owner: string, repo: string, ref: string, token?: string) {
-  const response = await fetch(
+async function downloadGitHubZip(
+  owner: string,
+  repo: string,
+  ref: string,
+  token: string | undefined,
+  retryBudget: GitHubRetryBudget,
+) {
+  const { response, body } = await fetchGitHub(
     `${GITHUB_API}/repos/${owner}/${repo}/zipball/${encodeURIComponent(ref)}`,
-    {
-      headers: buildGitHubHeaders(token),
-    },
+    { headers: buildGitHubHeaders(token) },
+    async (githubResponse) => new Uint8Array(await githubResponse.arrayBuffer()),
+    retryBudget,
   );
   if (!response.ok) throw new Error(`GitHub archive download failed: ${owner}/${repo}@${ref}`);
-  return new Uint8Array(await response.arrayBuffer());
+  if (!body) throw new Error("GitHub archive body missing");
+  return body;
+}
+
+async function fetchGitHub<T>(
+  input: string,
+  init: RequestInit,
+  readBody: (response: Response) => Promise<T>,
+  retryBudget: GitHubRetryBudget,
+) {
+  for (let attempt = 0; ; attempt += 1) {
+    const fallbackDelayMs = GITHUB_RETRY_DELAYS_MS[attempt];
+    try {
+      const response = await fetch(input, init);
+      if (response.ok) {
+        return { response, body: await readBody(response) };
+      }
+      if (fallbackDelayMs === undefined) return { response, body: undefined };
+      const retry = getGitHubRetry(response, fallbackDelayMs);
+      if (retry === null) return { response, body: undefined };
+      if (retry.rateLimited) {
+        if (retry.delayMs > retryBudget.remainingRateLimitDelayMs) {
+          return { response, body: undefined };
+        }
+        retryBudget.remainingRateLimitDelayMs -= retry.delayMs;
+      }
+      if (response.body) await response.body.cancel().catch(() => {});
+      await new Promise((done) => setTimeout(done, retry.delayMs));
+    } catch (error) {
+      if (fallbackDelayMs === undefined) throw error;
+      await new Promise((done) => setTimeout(done, fallbackDelayMs));
+    }
+  }
+}
+
+export function createGitHubRetryBudget(): GitHubRetryBudget {
+  return { remainingRateLimitDelayMs: GITHUB_MAX_RATE_LIMIT_DELAY_MS };
+}
+
+function getGitHubRetry(response: Response, fallbackDelayMs: number) {
+  const rateLimitDelayMs = getGitHubRateLimitDelayMs(response);
+  if (rateLimitDelayMs !== null) {
+    return { delayMs: rateLimitDelayMs, rateLimited: true };
+  }
+  if (response.status === 408 || (response.status >= 500 && response.status <= 599)) {
+    return { delayMs: fallbackDelayMs, rateLimited: false };
+  }
+  return null;
+}
+
+function getGitHubRateLimitDelayMs(response: Response) {
+  if (response.status !== 403 && response.status !== 429) return null;
+
+  const retryAfter = response.headers.get("retry-after");
+  if (retryAfter !== null) {
+    const retryAfterSeconds = Number(retryAfter);
+    if (Number.isFinite(retryAfterSeconds) && retryAfterSeconds >= 0) {
+      return retryAfterSeconds * 1_000;
+    }
+  }
+
+  if (response.headers.get("x-ratelimit-remaining") !== "0") return null;
+  const reset = response.headers.get("x-ratelimit-reset");
+  if (reset === null) return null;
+  const resetSeconds = Number(reset);
+  if (!Number.isFinite(resetSeconds) || resetSeconds <= 0) return null;
+  return Math.max(0, resetSeconds * 1_000 - Date.now());
 }
 
 function buildGitHubHeaders(token?: string) {
@@ -383,6 +500,7 @@ async function resolveGitHubUrlRefAndPath(
   repo: string,
   kind: "tree" | "blob",
   segments: string[],
+  retryBudget: GitHubRetryBudget,
 ) {
   if (segments.length === 0) throw new Error("Missing ref in GitHub URL");
 
@@ -394,7 +512,7 @@ async function resolveGitHubUrlRefAndPath(
     const ref = segments.slice(0, refSegmentCount).join("/");
     const pathRemainder = segments.slice(refSegmentCount).join("/");
     if (kind === "blob" && !pathRemainder) continue;
-    const commit = await tryResolveCommitSha(owner, repo, ref, token);
+    const commit = await tryResolveCommitSha(owner, repo, ref, token, retryBudget);
     if (!commit) continue;
     const path =
       kind === "blob"

--- a/packages/clawhub/src/cli/commands/packages.ts
+++ b/packages/clawhub/src/cli/commands/packages.ts
@@ -62,6 +62,7 @@ import {
   styleText,
 } from "../ui.js";
 import {
+  createGitHubRetryBudget,
   fetchGitHubSource,
   normalizeGitHubRepo,
   resolveLocalGitInfo,
@@ -2225,9 +2226,11 @@ async function preparePackagePublishPlan(
   sourceArg: string,
   options: PackagePublishOptions,
 ): Promise<PackagePublishPlan> {
+  const githubRetryBudget = createGitHubRetryBudget();
   const resolvedSource = await resolveSourceInput(sourceArg, {
     workdir: opts.workdir,
     localWorkdirs: [process.cwd(), opts.workdir],
+    retryBudget: githubRetryBudget,
   });
   const sourceForFetch = applyGitHubSourcePath(resolvedSource, options.sourcePath);
   let folder = sourceForFetch.kind === "local" ? sourceForFetch.path : "";
@@ -2248,7 +2251,7 @@ async function preparePackagePublishPlan(
       ? null
       : createCrabLoader(`Fetching ${sourceForFetch.owner}/${sourceForFetch.repo}`);
     try {
-      const fetched = await fetchGitHubSource(sourceForFetch);
+      const fetched = await fetchGitHubSource(sourceForFetch, githubRetryBudget);
       folder = fetched.dir;
       cleanup = fetched.cleanup;
       inferredSource = fetched.source;

--- a/specs/ci.md
+++ b/specs/ci.md
@@ -16,6 +16,10 @@ the short non-browser gates into one Blacksmith runner registration. The
 - `types-build` typechecks the app, schema package, and CLI package, then builds
   the app.
 - `e2e-http` runs the secretless HTTP and CLI end-to-end subset.
+  GitHub-backed package publish fixtures use bounded retries for network errors,
+  HTTP 408/5xx responses, and server-declared 403/429 rate limits whose retry
+  window fits the five-second CI budget. Longer rate limits and deterministic
+  client errors such as a missing repository fail immediately.
 
 The `static`, `unit`, `packages`, `types-build`, and `e2e-http` jobs are
 hosted-runner compatibility mirrors of `pr-gates` so existing branch protection
@@ -28,10 +32,10 @@ failing command.
   Convex backend with dev auth, then runs the chromium specs under
   `e2e/local-auth/`. Related low-risk specs are grouped so the matrix spends
   fewer Blacksmith runner registrations while keeping publish lifecycle checks
-  isolated for easier failure triage. The account cleanup and moderation/star
-  shards use 8-vCPU runners because their browser flows share the machine with
-  the local Convex backend; the remaining shards use 4-vCPU runners. The matrix
-  keeps `max-parallel: 3` to cap organization-level runner registrations.
+  isolated for easier failure triage. Every shard requests the
+  `blacksmith-16vcpu-ubuntu-2404` runner label and records actual CPU count,
+  load, cgroup CPU statistics, memory pressure, and free memory before and after
+  the test. The matrix runs at most eight shards concurrently.
 
 For local reproduction, run the matching `ci:*` package scripts. `bun run ci:pr`
 matches the non-browser PR gates. `bun run ci:playwright-smoke` assumes the


### PR DESCRIPTION
## Summary
- retry transient GitHub network and response-body failures plus HTTP 408/5xx responses
- honor short server-declared 403/429 rate-limit delays under one shared five-second package-publish budget
- keep deterministic failures such as confirmed 404s immediate and clearly reported
- use the canonical `openclaw/openclaw` Cohere extension for the live GitHub package fixture; keep JSON formatting coverage local so the large monorepo archive is downloaded only once
- document the current CI contract, including the local-auth hardening already merged in #3119 and #3140

## Root cause
The HTTP package-publish gate uses a live public GitHub repository. In the failure captured by #3112, the repository lookup failed transiently, the unchanged rerun passed, and the repository remained available. The CLI treated every failed lookup as a stable missing repository.

This fixes the owning GitHub fetch boundary rather than retrying the whole e2e test. The retry budget spans tree/blob ref resolution, repository lookup, commit resolution, and archive download, so retries cannot accumulate across phases. Stable client errors still fail without retry.

The live probe now uses the first-party `openclaw/openclaw` repository at `extensions/cohere`. The separate JSON-output case uses an isolated local code-plugin fixture, avoiding a second download of the OpenClaw monorepo archive while preserving output-format coverage.

The local-auth portion of #3112 was addressed separately by the merged synchronization/capacity work in #3119 and the concurrent under-five-minute lane in #3140. This PR closes the remaining HTTP failure mode.

## Validation
Exact head `873d15ab83b3134f43cba996074b3359e04c1fee`:
- focused GitHub/package tests: 104 passed
- focused first-party/live and local JSON fixture cases: 2 passed
- `bunx tsc -p packages/clawhub/tsconfig.json --noEmit`
- `bun run ci:unit`: 4,819 passed, 1 skipped
- `bun run ci:packages`: 364 CLI tests plus package artifact/type gates passed
- `bun run ci:e2e-http`: passed locally
- `bunx oxfmt --check e2e/clawhub.e2e.test.ts`
- autoreview: clean, no accepted/actionable findings (0.88)
- GitHub CI run 29788486880: `pr-gates`, all compatibility mirrors, smoke, all local-auth shards, CodeQL, and secret scanning passed

Closes #3112
