### PR TITLE
fix(build): use exported Monaco worker path

### DIFF
--- a/src/lib/monacoLoader.ts
+++ b/src/lib/monacoLoader.ts
@@ -1,6 +1,6 @@
 import { loader } from "@monaco-editor/react";
 import * as monaco from "monaco-editor";
-import editorWorker from "monaco-editor/esm/vs/editor/editor.worker?worker";
+import editorWorker from "monaco-editor/editor/editor.worker.js?worker";
 
 type MonacoWindow = Window &
   typeof globalThis & {


### PR DESCRIPTION
## Summary

- update the Monaco editor worker import to use the public subpath exported by `monaco-editor` 0.56.0
- restore production, Vercel, Playwright, and type/build jobs that all failed while resolving the old `esm/vs` internal path

## Root cause

PR #3185 upgraded `monaco-editor` from 0.55.1 to 0.56.0. Version 0.56.0 changed the package `exports` map from allowing arbitrary package-internal paths to mapping public subpaths into `esm/vs`. The existing import therefore resolved incorrectly and every build failed with:

```
Rolldown failed to resolve import "monaco-editor/esm/vs/editor/editor.worker?worker"
```

The last green `main` CI run was commit `ed9c8fdd`; the first failing run was the dependency bump at `5426fef8`.

## Validation

- `VITE_CONVEX_URL=https://example.invalid bun run build` (failed before the change, passed after)
- `bunx vitest run src/components/SkillDiffCard.test.tsx`
- `bun run ci:static`
- `bun run ci:types-build`
- `bun run ci:unit` (375 files passed, 4,819 tests passed)
