### PR TITLE
feat: make owner version deletion reversible

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -51,6 +51,7 @@ import type * as leaderboards from "../leaderboards.js";
 import type * as lib_access from "../lib/access.js";
 import type * as lib_apiTokenAuth from "../lib/apiTokenAuth.js";
 import type * as lib_artifactModeration from "../lib/artifactModeration.js";
+import type * as lib_artifactText from "../lib/artifactText.js";
 import type * as lib_badges from "../lib/badges.js";
 import type * as lib_batching from "../lib/batching.js";
 import type * as lib_catalogClassification from "../lib/catalogClassification.js";
@@ -221,6 +222,7 @@ declare const fullApi: ApiFromModules<{
   "lib/access": typeof lib_access;
   "lib/apiTokenAuth": typeof lib_apiTokenAuth;
   "lib/artifactModeration": typeof lib_artifactModeration;
+  "lib/artifactText": typeof lib_artifactText;
   "lib/badges": typeof lib_badges;
   "lib/batching": typeof lib_batching;
   "lib/catalogClassification": typeof lib_catalogClassification;

--- a/convex/devSeed.ts
+++ b/convex/devSeed.ts
@@ -4486,11 +4486,11 @@ description: Disposable local-auth version deletion fixture skill.
 
 # ${args.skillDisplayName}
 
-This fixture proves one-way owner deletion of an older skill version.
+This fixture proves reversible owner withdrawal of an older skill version.
 `;
     const pluginReadme = `# ${args.packageDisplayName}
 
-This fixture proves one-way owner deletion of an older plugin release.
+This fixture proves reversible owner withdrawal of an older plugin release.
 `;
     const [skillStorageId, pluginReadmeStorageId] = await Promise.all([
       ctx.storage.store(new Blob([skillMd], { type: "text/markdown" })),
@@ -4855,6 +4855,14 @@ export const getVersionDeletionFixtureState: ReturnType<typeof rawInternalMutati
           q.eq("targetType", "packageRelease").eq("targetId", args.olderPackageReleaseId),
         )
         .take(10);
+      const skillDigest = await ctx.db
+        .query("skillSearchDigest")
+        .withIndex("by_skill", (q) => q.eq("skillId", args.skillId))
+        .unique();
+      const packageDigest = await ctx.db
+        .query("packageSearchDigest")
+        .withIndex("by_package", (q) => q.eq("packageId", args.packageId))
+        .unique();
 
       return {
         ok: true as const,
@@ -4863,6 +4871,9 @@ export const getVersionDeletionFixtureState: ReturnType<typeof rawInternalMutati
         skillLatestTagVersionId: skill?.tags.latest ?? null,
         skillLatestSummaryVersion: skill?.latestVersionSummary?.version ?? null,
         skillStatsVersions: skill?.stats.versions ?? null,
+        skillDigestLatestVersionId: skillDigest?.latestVersionId ?? null,
+        skillDigestLatestSummaryVersion: skillDigest?.latestVersionSummary?.version ?? null,
+        skillDigestTags: skillDigest?.tags ?? null,
         skillActiveVersions: skillActiveVersions.map((version) => version.version),
         olderSkillVersion: versionDeletionRowState(olderSkillVersion),
         latestSkillVersion: versionDeletionRowState(latestSkillVersion),
@@ -4871,7 +4882,9 @@ export const getVersionDeletionFixtureState: ReturnType<typeof rawInternalMutati
         packageLatestTagReleaseId: pkg?.tags.latest ?? null,
         packageLatestSummaryVersion: pkg?.latestVersionSummary?.version ?? null,
         packageStatsVersions: pkg?.stats.versions ?? null,
+        packageDigestLatestVersion: packageDigest?.latestVersion ?? null,
         packageActiveVersions: packageActiveReleases.map((release) => release.version),
+        olderPackageDistTags: olderPackageRelease?.distTags ?? null,
         olderPackageRelease: versionDeletionRowState(olderPackageRelease),
         latestPackageRelease: versionDeletionRowState(latestPackageRelease),
         packageAuditActions: packageAuditLogs.map((log) => log.action),

--- a/convex/httpApiV1.handlers.test.ts
+++ b/convex/httpApiV1.handlers.test.ts
@@ -7640,6 +7640,68 @@ describe("httpApiV1 handlers", () => {
     expect(await response.text()).toBe(message);
   });
 
+  it("restores an exact owner-withdrawn skill version", async () => {
+    vi.mocked(requireApiTokenUser).mockResolvedValue({
+      userId: "users:1",
+      user: { handle: "p" },
+    } as never);
+    const runMutation = vi.fn(async (_mutation: unknown, args: Record<string, unknown>) => {
+      if (isRateLimitArgs(args)) return okRate();
+      return { ok: true, skillId: "skills:1", versionId: "skillVersions:1" };
+    });
+
+    const response = await __handlers.skillsPostRouterV1Handler(
+      makeCtx({ runMutation }),
+      new Request(
+        "https://example.com/api/v1/skills/demo/versions/1.2.3/restore?ownerHandle=openclaw",
+        {
+          method: "POST",
+          headers: { Authorization: "Bearer clh_test" },
+          body: JSON.stringify({ ownerHandle: "openclaw" }),
+        },
+      ),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      skillId: "skills:1",
+      versionId: "skillVersions:1",
+    });
+    expect(runMutation).toHaveBeenCalledWith(
+      (internal as unknown as { skills: Record<string, unknown> }).skills
+        .restoreOwnedVersionForUserInternal,
+      {
+        actorUserId: "users:1",
+        slug: "demo",
+        version: "1.2.3",
+        ownerHandle: "openclaw",
+      },
+    );
+  });
+
+  it("maps non-owner skill version restore to forbidden", async () => {
+    vi.mocked(requireApiTokenUser).mockResolvedValue({
+      userId: "users:stranger",
+      user: { handle: "stranger" },
+    } as never);
+    const runMutation = vi.fn(async (_mutation: unknown, args: Record<string, unknown>) => {
+      if (isRateLimitArgs(args)) return okRate();
+      throw new Error("Forbidden");
+    });
+
+    const response = await __handlers.skillsPostRouterV1Handler(
+      makeCtx({ runMutation }),
+      new Request("https://example.com/api/v1/skills/demo/versions/1.2.3/restore", {
+        method: "POST",
+        headers: { Authorization: "Bearer clh_test" },
+      }),
+    );
+
+    expect(response.status).toBe(403);
+    expect(await response.text()).toBe("Forbidden");
+  });
+
   it("skill hard-delete dry-runs through the admin-only API", async () => {
     const generated_token_reference = "hard-delete-skill:@openclaw/demo:skills:1";
     vi.mocked(requireApiTokenUser).mockResolvedValue({
@@ -15852,6 +15914,69 @@ describe("httpApiV1 handlers", () => {
 
     expect(response.status).toBe(400);
     expect(await response.text()).toBe(message);
+  });
+
+  it("restores an exact owner-withdrawn package release", async () => {
+    vi.mocked(requireApiTokenUser).mockResolvedValue({
+      userId: "users:1",
+      user: { _id: "users:1", handle: "p" },
+    } as never);
+    const runMutation = vi.fn(async (_mutation: unknown, args: Record<string, unknown>) => {
+      if (isRateLimitArgs(args)) return okRate();
+      return { ok: true, packageId: "packages:1", releaseId: "packageReleases:1" };
+    });
+
+    const response = await __handlers.packagesPostRouterV1Handler(
+      makeCtx({ runMutation }),
+      new Request(
+        "https://example.com/api/v1/packages/%40openclaw%2Fdemo-plugin/versions/1.2.3/restore",
+        {
+          method: "POST",
+          headers: { Authorization: "Bearer clh_test" },
+        },
+      ),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      packageId: "packages:1",
+      releaseId: "packageReleases:1",
+    });
+    expect(runMutation).toHaveBeenCalledWith(
+      (internal as unknown as { packages: Record<string, unknown> }).packages
+        .restoreOwnedReleaseForUserInternal,
+      {
+        actorUserId: "users:1",
+        name: "@openclaw/demo-plugin",
+        version: "1.2.3",
+      },
+    );
+  });
+
+  it("maps non-owner package release restore to forbidden", async () => {
+    vi.mocked(requireApiTokenUser).mockResolvedValue({
+      userId: "users:stranger",
+      user: { _id: "users:stranger", handle: "stranger" },
+    } as never);
+    const runMutation = vi.fn(async (_mutation: unknown, args: Record<string, unknown>) => {
+      if (isRateLimitArgs(args)) return okRate();
+      throw new Error("Forbidden");
+    });
+
+    const response = await __handlers.packagesPostRouterV1Handler(
+      makeCtx({ runMutation }),
+      new Request(
+        "https://example.com/api/v1/packages/%40openclaw%2Fdemo-plugin/versions/1.2.3/restore",
+        {
+          method: "POST",
+          headers: { Authorization: "Bearer clh_test" },
+        },
+      ),
+    );
+
+    expect(response.status).toBe(403);
+    expect(await response.text()).toBe("Forbidden");
   });
 
   it("undeletes a package", async () => {

--- a/convex/httpApiV1/packagesV1.ts
+++ b/convex/httpApiV1/packagesV1.ts
@@ -124,6 +124,7 @@ const internalRefs = internal as unknown as {
     transferPackageOwnerForUserInternal: unknown;
     deleteTrustedPublisherForUserInternal: unknown;
     deleteOwnedReleaseForUserInternal: unknown;
+    restoreOwnedReleaseForUserInternal: unknown;
     getReleasesByIdsInternal: unknown;
     getReleaseByPackageAndVersionInternal: unknown;
     getReleaseByIdInternal: unknown;
@@ -3050,6 +3051,33 @@ export async function packagesPostRouterV1Handler(ctx: ActionCtx, request: Reque
       return json({ ok: true }, 200, rate.headers);
     } catch (error) {
       return softDeleteErrorToResponse("package", error, rate.headers);
+    }
+  }
+
+  if (
+    packageSegments[0] === "versions" &&
+    packageSegments[1] &&
+    packageSegments[2] === "restore" &&
+    packageSegments.length === 3
+  ) {
+    const rate = await applyRateLimit(ctx, request, "write");
+    if (!rate.ok) return rate.response;
+    const auth = await requireApiTokenUserOrResponse(ctx, request, rate.headers);
+    if (!auth.ok) return auth.response;
+
+    try {
+      const result = await runMutationRef(
+        ctx,
+        internalRefs.packages.restoreOwnedReleaseForUserInternal,
+        {
+          actorUserId: auth.userId,
+          name: packageName,
+          version: packageSegments[1],
+        },
+      );
+      return json(result, 200, rate.headers);
+    } catch (error) {
+      return packageOperationErrorToResponse(error, rate.headers, "Package version restore failed");
     }
   }
 

--- a/convex/httpApiV1/skillsV1.ts
+++ b/convex/httpApiV1/skillsV1.ts
@@ -351,6 +351,7 @@ const internalRefs = internal as unknown as {
   };
   skills: {
     deleteOwnedVersionForUserInternal: unknown;
+    restoreOwnedVersionForUserInternal: unknown;
     revokeSkillVersionForUserInternal: unknown;
     getSecurityVerdictTargetInternal: unknown;
     getVerifyTargetBySlugInternal: unknown;
@@ -3317,6 +3318,34 @@ export async function skillsPostRouterV1Handler(ctx: ActionCtx, request: Request
       return json(result, 200, rate.headers);
     } catch (error) {
       return softDeleteErrorToResponse("skill", error, rate.headers);
+    }
+  }
+
+  if (
+    segments.length === 4 &&
+    segments[1] === "versions" &&
+    segments[2] &&
+    segments[3] === "restore"
+  ) {
+    try {
+      const { userId } = await requireApiTokenUser(ctx, request);
+      const body = await readOptionalJson(request);
+      const ownerHandle =
+        optionalStringField(body, "ownerHandle") ?? getOwnerHandleParam(new URL(request.url));
+      const result = await runMutationRef(
+        ctx,
+        internalRefs.skills.restoreOwnedVersionForUserInternal,
+        {
+          actorUserId: userId,
+          slug,
+          version: segments[2],
+          ...(ownerHandle ? { ownerHandle } : {}),
+        },
+      );
+      return json(result, 200, rate.headers);
+    } catch (error) {
+      if (error instanceof SyntaxError) return text("Invalid JSON", 400, rate.headers);
+      return skillVersionDeleteErrorToResponse(error, rate.headers);
     }
   }
 

--- a/convex/packages.public.test.ts
+++ b/convex/packages.public.test.ts
@@ -50,6 +50,7 @@ import {
   listPublicPage,
   listPageForViewerInternal,
   listVersions,
+  listVersionsForManager,
   updateReleaseLlmAnalysisInternal,
   updateReleaseStaticScanInternal,
   applyAccountDeletionToOwnedPackagesBatchInternal,
@@ -206,6 +207,19 @@ const listVersionsHandler = (
     },
     {
       page: Array<{ version: string }>;
+      isDone: boolean;
+      continueCursor: string;
+    }
+  >
+)._handler;
+const listVersionsForManagerHandler = (
+  listVersionsForManager as unknown as WrappedHandler<
+    {
+      name: string;
+      paginationOpts: { cursor: string | null; numItems: number };
+    },
+    {
+      page: Array<{ version: string; softDeletedAt?: number; ownerDeletedAt?: number }>;
       isDone: boolean;
       continueCursor: string;
     }
@@ -13231,6 +13245,91 @@ describe("packages public queries", () => {
     );
 
     expect(result).toBeNull();
+  });
+
+  it("paginates owner-withdrawn releases with explicit restore markers", async () => {
+    vi.mocked(getAuthUserId).mockResolvedValue("users:owner" as never);
+    const indexNames: string[] = [];
+    const filters = new Map<string, unknown>();
+    const paginate = vi.fn().mockResolvedValue({
+      page: [
+        {
+          _id: "packageReleases:withdrawn",
+          packageId: "packages:demo",
+          version: "0.8.0",
+          changelog: "Withdrawn release",
+          distTags: [],
+          files: [],
+          integritySha256: "sha256:withdrawn",
+          compatibility: null,
+          verification: null,
+          createdBy: "users:owner",
+          publishActor: { kind: "user", userId: "users:owner" },
+          createdAt: 1,
+          softDeletedAt: 123,
+          ownerDeletedAt: 123,
+          ownerDeletedBy: "users:owner",
+        },
+      ],
+      isDone: true,
+      continueCursor: "",
+    });
+    const ctx = {
+      db: {
+        get: vi.fn(async (id: string) => (id === "users:owner" ? { _id: id, role: "user" } : null)),
+        query: vi.fn((table: string) => {
+          if (table === "packages") {
+            return {
+              withIndex: vi.fn(() => ({
+                unique: vi.fn().mockResolvedValue(makePackageDoc()),
+              })),
+            };
+          }
+          if (table === "packageReleases") {
+            return {
+              withIndex: vi.fn(
+                (
+                  index: string,
+                  buildQuery?: (q: { eq: (field: string, value: unknown) => unknown }) => unknown,
+                ) => {
+                  indexNames.push(index);
+                  const query = {
+                    eq(field: string, value: unknown) {
+                      filters.set(field, value);
+                      return query;
+                    },
+                  };
+                  buildQuery?.(query);
+                  return { order: vi.fn(() => ({ paginate })) };
+                },
+              ),
+            };
+          }
+          throw new Error(`Unexpected table ${table}`);
+        }),
+      },
+    } as never;
+
+    const result = await listVersionsForManagerHandler(ctx, {
+      name: "demo-plugin",
+      paginationOpts: { cursor: null, numItems: 20 },
+    });
+
+    expect(result.page).toEqual([
+      expect.objectContaining({
+        version: "0.8.0",
+        softDeletedAt: 123,
+        ownerDeletedAt: 123,
+      }),
+    ]);
+    expect(indexNames).toEqual(["by_package_owner_deleted_created"]);
+    expect(filters).toEqual(
+      new Map<string, unknown>([
+        ["packageId", "packages:demo"],
+        ["ownerDeletedBy", "users:owner"],
+      ]),
+    );
+    expect(paginate).toHaveBeenCalledWith({ cursor: null, numItems: 20 });
   });
 
   it("allows direct package owners to delete versions", async () => {

--- a/convex/packages.ts
+++ b/convex/packages.ts
@@ -1222,6 +1222,14 @@ function toPublicPackageRelease(release: Doc<"packageReleases">) {
   };
 }
 
+function toManagerPackageRelease(release: Doc<"packageReleases">) {
+  return {
+    ...toPublicPackageRelease(release),
+    softDeletedAt: release.softDeletedAt,
+    ownerDeletedAt: release.ownerDeletedAt,
+  };
+}
+
 async function paginatePublishedPackageReleases(
   ctx: QueryCtx,
   packageId: Id<"packages">,
@@ -3031,6 +3039,48 @@ export const listVersionsForViewerInternal = internalQuery({
     return {
       ...result,
       page: result.page.map(toPublicPackageRelease),
+    };
+  },
+});
+
+export const listVersionsForManager = query({
+  args: {
+    name: v.string(),
+    paginationOpts: paginationOptsValidator,
+  },
+  handler: async (ctx, args) => {
+    const viewerUserId = await getOptionalViewerUserId(ctx);
+    if (!viewerUserId) return { page: [], isDone: true, continueCursor: "" };
+    const actor = await ctx.db.get(viewerUserId);
+    if (!actor || actor.deletedAt || actor.deactivatedAt) {
+      return { page: [], isDone: true, continueCursor: "" };
+    }
+
+    const pkg = await getPackageByNormalizedName(ctx, normalizePackageName(args.name));
+    if (
+      !pkg ||
+      pkg.softDeletedAt ||
+      pkg.family === "skill" ||
+      isPackageBlockedFromPublic(pkg.scanStatus)
+    ) {
+      return { page: [], isDone: true, continueCursor: "" };
+    }
+    if (!(await viewerCanManagePackageOwner(ctx, pkg, viewerUserId))) {
+      return { page: [], isDone: true, continueCursor: "" };
+    }
+
+    const result = await ctx.db
+      .query("packageReleases")
+      .withIndex("by_package_owner_deleted_created", (q) =>
+        q.eq("packageId", pkg._id).eq("ownerDeletedBy", actor._id),
+      )
+      .order("desc")
+      .paginate(args.paginationOpts);
+    return {
+      ...result,
+      page: result.page
+        .filter((release) => isPackageReleaseRestorableByOwner(release, pkg._id, actor._id))
+        .map(toManagerPackageRelease),
     };
   },
 });
@@ -6006,6 +6056,106 @@ export const deleteOwnedRelease = mutation({
   handler: async (ctx, args) => {
     const { user } = await requireUser(ctx);
     return await deleteOwnedPackageReleaseForActor(ctx, user, args);
+  },
+});
+
+function isPackageReleaseRestorableByOwner(
+  release: Doc<"packageReleases"> | null | undefined,
+  packageId: Id<"packages">,
+  actorUserId: Id<"users">,
+): release is Doc<"packageReleases"> {
+  return Boolean(
+    release &&
+    release.packageId === packageId &&
+    release.softDeletedAt !== undefined &&
+    release.ownerDeletedAt !== undefined &&
+    release.softDeletedAt === release.ownerDeletedAt &&
+    release.ownerDeletedBy === actorUserId &&
+    resolvePackageReleaseScanStatus(release) !== "malicious" &&
+    release.manualModeration?.state !== "quarantined" &&
+    release.manualModeration?.state !== "revoked",
+  );
+}
+
+export async function restoreOwnedPackageReleaseForActor(
+  ctx: MutationCtx,
+  actor: Doc<"users">,
+  args: { name: string; version: string },
+) {
+  const normalizedName = normalizePackageName(args.name);
+  const pkg = await getPackageByNormalizedName(ctx, normalizedName);
+  if (!pkg || pkg.softDeletedAt || isPackageBlockedFromPublic(pkg.scanStatus)) {
+    throw new ConvexError("This package is unavailable and its releases cannot be restored.");
+  }
+  if (pkg.family === "skill") {
+    throw new ConvexError("Skill packages must use the skills restore flow.");
+  }
+
+  await assertCanManageOwnedResource(ctx, {
+    actor,
+    ownerUserId: pkg.ownerUserId,
+    ownerPublisherId: pkg.ownerPublisherId,
+    allowedPublisherRoles: ["admin"],
+  });
+
+  const release = await ctx.db
+    .query("packageReleases")
+    .withIndex("by_package_version", (q) => q.eq("packageId", pkg._id).eq("version", args.version))
+    .unique();
+  if (!isPackageReleaseRestorableByOwner(release, pkg._id, actor._id)) {
+    throw new ConvexError(
+      "This package release was not withdrawn by this owner and cannot be restored.",
+    );
+  }
+
+  const now = Date.now();
+  await ctx.db.patch(release._id, {
+    softDeletedAt: undefined,
+    ownerDeletedAt: undefined,
+    ownerDeletedBy: undefined,
+    distTags: [],
+  });
+  await ctx.db.insert("auditLogs", {
+    actorUserId: actor._id,
+    action: "package.release.restore",
+    targetType: "packageRelease",
+    targetId: release._id,
+    metadata: {
+      packageId: pkg._id,
+      name: pkg.name,
+      version: release.version,
+    },
+    createdAt: now,
+  });
+
+  return { ok: true as const, packageId: pkg._id, releaseId: release._id };
+}
+
+export const restoreOwnedReleaseForUserInternal = internalMutation({
+  args: {
+    actorUserId: v.id("users"),
+    name: v.string(),
+    version: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const actor = await ctx.db.get(args.actorUserId);
+    if (!actor || actor.deletedAt || actor.deactivatedAt) throw new ConvexError("Unauthorized");
+
+    const version = args.version.trim();
+    if (!version) throw new ConvexError("Version required");
+
+    return await restoreOwnedPackageReleaseForActor(ctx, actor, {
+      name: args.name,
+      version,
+    });
+  },
+});
+
+export const restoreOwnedRelease = mutation({
+  args: { name: v.string(), version: v.string() },
+  handler: async (ctx, args) => {
+    const { user } = await requireUser(ctx);
+    return await restoreOwnedPackageReleaseForActor(ctx, user, args);
   },
 });
 

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1114,6 +1114,7 @@ const skillVersions = defineTable({
   .index("by_skill", ["skillId"])
   .index("by_skill_version", ["skillId", "version"])
   .index("by_skill_active_created", ["skillId", "softDeletedAt", "createdAt"])
+  .index("by_skill_owner_deleted_created", ["skillId", "ownerDeletedBy", "createdAt"])
   .index("by_active_created", ["softDeletedAt", "createdAt"])
   .index("by_active_vt_status_created", ["softDeletedAt", "vtAnalysis.status", "createdAt"])
   .index("by_sha256hash", ["sha256hash"])
@@ -1761,6 +1762,7 @@ const packageReleases = defineTable({
 })
   .index("by_package", ["packageId"])
   .index("by_package_active_created", ["packageId", "softDeletedAt", "createdAt"])
+  .index("by_package_owner_deleted_created", ["packageId", "ownerDeletedBy", "createdAt"])
   .index("by_active_created", ["softDeletedAt", "createdAt"])
   .index("by_package_version", ["packageId", "version"])
   .index("by_sha256hash", ["sha256hash"]);

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -2282,6 +2282,13 @@ function toPublicSkillVersion(
   };
 }
 
+function toManagerSkillVersion(version: Doc<"skillVersions">) {
+  return {
+    ...toPublicSkillVersion(version)!,
+    ownerDeletedAt: version.ownerDeletedAt,
+  };
+}
+
 function toPublicGitHubSkillScan(
   scan: Doc<"githubSkillScans"> | null | undefined,
   version: string | undefined,
@@ -7613,6 +7620,45 @@ export const listVersions = query({
   },
 });
 
+export const listWithdrawnVersionsForManager = query({
+  args: {
+    skillId: v.id("skills"),
+    paginationOpts: paginationOptsValidator,
+  },
+  handler: async (ctx, args) => {
+    const authUserId = await getAuthUserId(ctx);
+    if (!authUserId) return { page: [], isDone: true, continueCursor: "" };
+    const actor = await ctx.db.get(authUserId);
+    if (!actor || actor.deletedAt || actor.deactivatedAt) {
+      return { page: [], isDone: true, continueCursor: "" };
+    }
+
+    const skill = await ctx.db.get(args.skillId);
+    if (
+      !skill ||
+      skill.softDeletedAt ||
+      (skill.moderationStatus ?? "active") !== "active" ||
+      !(await canManageSkillOwnerForActor(ctx, actor, skill))
+    ) {
+      return { page: [], isDone: true, continueCursor: "" };
+    }
+
+    const result = await ctx.db
+      .query("skillVersions")
+      .withIndex("by_skill_owner_deleted_created", (q) =>
+        q.eq("skillId", skill._id).eq("ownerDeletedBy", actor._id),
+      )
+      .order("desc")
+      .paginate(args.paginationOpts);
+    return {
+      ...result,
+      page: result.page
+        .filter((version) => isSkillVersionRestorableByOwner(version, skill._id, actor._id))
+        .map(toManagerSkillVersion),
+    };
+  },
+});
+
 export const listVersionsPage = query({
   args: {
     skillId: v.id("skills"),
@@ -9748,6 +9794,130 @@ export const deleteOwnedVersionForUserInternal = internalMutation({
   },
   handler: async (ctx, args) => {
     return await deleteOwnedSkillVersionForUser(ctx, args);
+  },
+});
+
+function isSkillVersionRestorableByOwner(
+  version: Doc<"skillVersions"> | null | undefined,
+  skillId: Id<"skills">,
+  actorUserId: Id<"users">,
+): version is Doc<"skillVersions"> {
+  return Boolean(
+    version &&
+    version.skillId === skillId &&
+    version.softDeletedAt !== undefined &&
+    version.ownerDeletedAt !== undefined &&
+    version.softDeletedAt === version.ownerDeletedAt &&
+    version.ownerDeletedBy === actorUserId &&
+    !version.manualRevocation &&
+    !isKnownMaliciousSkillVersion(version),
+  );
+}
+
+export async function restoreOwnedSkillVersionForActor(
+  ctx: MutationCtx,
+  actor: Doc<"users">,
+  args: { versionId: Id<"skillVersions"> },
+) {
+  const version = await ctx.db.get(args.versionId);
+  if (!version) throw new ConvexError("Forbidden");
+
+  const skill = await ctx.db.get(version.skillId);
+  if (!skill) throw new ConvexError("Forbidden");
+
+  await assertCanManageOwnedResource(ctx, {
+    actor,
+    ownerUserId: skill.ownerUserId,
+    ownerPublisherId: skill.ownerPublisherId,
+    allowedPublisherRoles: ["admin"],
+  });
+
+  if (skill.softDeletedAt || (skill.moderationStatus ?? "active") !== "active") {
+    throw new ConvexError("This skill is unavailable and its versions cannot be restored.");
+  }
+  if (!isSkillVersionRestorableByOwner(version, skill._id, actor._id)) {
+    throw new ConvexError(
+      "This skill version was not withdrawn by this owner and cannot be restored.",
+    );
+  }
+
+  const now = Date.now();
+  await ctx.db.patch(version._id, {
+    softDeletedAt: undefined,
+    ownerDeletedAt: undefined,
+    ownerDeletedBy: undefined,
+  });
+  await ctx.db.insert("auditLogs", {
+    actorUserId: actor._id,
+    action: "skill.version.restore",
+    targetType: "skillVersion",
+    targetId: version._id,
+    metadata: {
+      skillId: skill._id,
+      slug: skill.slug,
+      version: version.version,
+    },
+    createdAt: now,
+  });
+
+  return { ok: true as const, skillId: skill._id, versionId: version._id };
+}
+
+export async function restoreOwnedSkillVersionForUser(
+  ctx: MutationCtx,
+  args: {
+    actorUserId: Id<"users">;
+    slug: string;
+    version: string;
+    ownerHandle?: string;
+  },
+) {
+  const actor = await ctx.db.get(args.actorUserId);
+  if (!actor || actor.deletedAt || actor.deactivatedAt) throw new ConvexError("Unauthorized");
+
+  const slug = args.slug.trim().toLowerCase();
+  if (!slug) throw new ConvexError("Slug required");
+  const version = args.version.trim();
+  if (!version) throw new ConvexError("Version required");
+  const ownerHandle = args.ownerHandle?.trim().replace(/^@+/, "") || undefined;
+
+  const resolved = await resolveSkillBySlugOrAliasForOwner(ctx, slug, ownerHandle);
+  const skill = resolved.skill;
+  if (!skill) throw new ConvexError("Skill not found");
+
+  await assertCanManageOwnedResource(ctx, {
+    actor,
+    ownerUserId: skill.ownerUserId,
+    ownerPublisherId: skill.ownerPublisherId,
+    allowedPublisherRoles: ["admin"],
+  });
+
+  const skillVersion = await ctx.db
+    .query("skillVersions")
+    .withIndex("by_skill_version", (q) => q.eq("skillId", skill._id).eq("version", version))
+    .unique();
+  if (!skillVersion) throw new ConvexError("Skill version not found");
+
+  return await restoreOwnedSkillVersionForActor(ctx, actor, { versionId: skillVersion._id });
+}
+
+export const restoreOwnedVersionForUserInternal = internalMutation({
+  args: {
+    actorUserId: v.id("users"),
+    slug: v.string(),
+    version: v.string(),
+    ownerHandle: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    return await restoreOwnedSkillVersionForUser(ctx, args);
+  },
+});
+
+export const restoreOwnedVersion = mutation({
+  args: { versionId: v.id("skillVersions") },
+  handler: async (ctx, args) => {
+    const { user } = await requireUser(ctx);
+    return await restoreOwnedSkillVersionForActor(ctx, user, args);
   },
 });
 

--- a/convex/skills.versions.public.test.ts
+++ b/convex/skills.versions.public.test.ts
@@ -21,6 +21,7 @@ const {
   listHighlightedPublic,
   listVersions,
   listVersionsPage,
+  listWithdrawnVersionsForManager,
   listWithLatest,
 } = await import("./skills");
 
@@ -59,6 +60,13 @@ const listVersionsPageHandler = (
     skillId: string;
     cursor?: string;
     limit?: number;
+  }>
+)._handler;
+
+const listWithdrawnVersionsForManagerHandler = (
+  listWithdrawnVersionsForManager as unknown as WrappedHandler<{
+    skillId: string;
+    paginationOpts: { cursor: string | null; numItems: number };
   }>
 )._handler;
 
@@ -523,7 +531,7 @@ describe("public skill version queries", () => {
     },
   );
 
-  it("shows active pending version history to owners through the bounded active index", async () => {
+  it("keeps owner version history within the requested active-version limit", async () => {
     const version = makeVersion();
     const pendingVersion = {
       ...makeVersion(),
@@ -574,10 +582,10 @@ describe("public skill version queries", () => {
 
     const result = (await listVersionsHandler(ctx, {
       skillId: "skills:1",
-      limit: 50,
+      limit: 1,
     } as never)) as Array<{ version: string }>;
 
-    expect(result.map((item) => item.version)).toEqual(["2.0.0", "1.0.0"]);
+    expect(result.map((item) => item.version)).toEqual(["2.0.0"]);
     expect(indexNames).toEqual(["by_skill_active_created"]);
     expect(filters).toEqual(
       new Map<string, unknown>([
@@ -585,7 +593,86 @@ describe("public skill version queries", () => {
         ["softDeletedAt", undefined],
       ]),
     );
-    expect(take).toHaveBeenCalledWith(50);
+    expect(take).toHaveBeenCalledOnce();
+    expect(take).toHaveBeenCalledWith(1);
+  });
+
+  it("paginates owner-withdrawn versions through the owner provenance index", async () => {
+    const withdrawnVersion = {
+      ...makeVersion(),
+      softDeletedAt: 123,
+      ownerDeletedAt: 123,
+      ownerDeletedBy: "users:owner",
+    };
+    const indexNames: string[] = [];
+    const filters = new Map<string, unknown>();
+    const paginate = vi.fn().mockResolvedValue({
+      page: [withdrawnVersion],
+      isDone: true,
+      continueCursor: "",
+    });
+    vi.mocked(getAuthUserId).mockResolvedValue("users:owner" as never);
+    const ctx = {
+      db: {
+        get: vi.fn(async (id: string) => {
+          if (id === "users:owner") return { _id: id, role: "user" };
+          if (id === "skills:1") {
+            return {
+              _id: id,
+              ownerUserId: "users:owner",
+              ownerPublisherId: undefined,
+              softDeletedAt: undefined,
+              moderationStatus: "active",
+            };
+          }
+          return null;
+        }),
+        query: vi.fn((table: string) => {
+          if (table !== "skillVersions") throw new Error(`Unexpected table ${table}`);
+          return {
+            withIndex: vi.fn(
+              (
+                index: string,
+                buildQuery?: (q: { eq: (field: string, value: unknown) => unknown }) => unknown,
+              ) => {
+                indexNames.push(index);
+                const query = {
+                  eq(field: string, value: unknown) {
+                    filters.set(field, value);
+                    return query;
+                  },
+                };
+                buildQuery?.(query);
+                return { order: vi.fn(() => ({ paginate })) };
+              },
+            ),
+          };
+        }),
+      },
+    } as never;
+
+    const result = (await listWithdrawnVersionsForManagerHandler(ctx, {
+      skillId: "skills:1",
+      paginationOpts: { cursor: null, numItems: 20 },
+    } as never)) as {
+      page: Array<{ version: string; softDeletedAt?: number; ownerDeletedAt?: number }>;
+    };
+
+    expect(result.page).toEqual([
+      expect.objectContaining({
+        version: "1.0.0",
+        softDeletedAt: 123,
+        ownerDeletedAt: 123,
+      }),
+    ]);
+    expect(indexNames).toEqual(["by_skill_owner_deleted_created"]);
+    expect(filters).toEqual(
+      new Map<string, unknown>([
+        ["skillId", "skills:1"],
+        ["ownerDeletedBy", "users:owner"],
+      ]),
+    );
+    expect(paginate).toHaveBeenCalledWith({ cursor: null, numItems: 20 });
   });
 
   it("keeps soft-deleted versions from consuming an ordinary viewer's limit", async () => {

--- a/convex/versionDeletion.test.ts
+++ b/convex/versionDeletion.test.ts
@@ -1202,6 +1202,168 @@ describe("owner skill version deletion", () => {
   });
 });
 
+describe("owner skill version restore", () => {
+  it("exports the public mutation contract", () => {
+    expect(skillsModule.restoreOwnedVersion).toBeTypeOf("function");
+  });
+
+  it("restores only the owner tombstone and audits without changing latest or search metadata", async () => {
+    const restoreOwned = getDeletionHelper<{ versionId: string }>(
+      skillsModule,
+      "restoreOwnedSkillVersionForActor",
+    );
+    const withdrawn = makeSkillVersion("skillVersions:v1", "1.0.0", {
+      softDeletedAt: 30,
+      ownerDeletedAt: 30,
+      ownerDeletedBy: "users:owner",
+    });
+    const { actors, audits, ctx, digest, patches, skill, versions } = makeSkillDeletionCtx({
+      versions: [withdrawn, makeSkillVersion("skillVersions:v2", "2.0.0")],
+    });
+    const parentBefore = structuredClone(skill);
+    const digestBefore = structuredClone(digest);
+    const artifactBefore = structuredClone(versions[0]);
+
+    await expect(
+      restoreOwned(ctx, actors["users:owner"], { versionId: "skillVersions:v1" }),
+    ).resolves.toMatchObject({
+      ok: true,
+      skillId: "skills:demo",
+      versionId: "skillVersions:v1",
+    });
+
+    expect(patches).toContainEqual({
+      id: "skillVersions:v1",
+      patch: {
+        softDeletedAt: undefined,
+        ownerDeletedAt: undefined,
+        ownerDeletedBy: undefined,
+      },
+    });
+    expect(versions[0]).toEqual({
+      ...artifactBefore,
+      softDeletedAt: undefined,
+      ownerDeletedAt: undefined,
+      ownerDeletedBy: undefined,
+    });
+    expect(skill).toEqual(parentBefore);
+    expect(digest).toEqual(digestBefore);
+    expect(audits).toContainEqual(
+      expect.objectContaining({
+        actorUserId: "users:owner",
+        action: "skill.version.restore",
+        targetType: "skillVersion",
+        targetId: "skillVersions:v1",
+        metadata: {
+          skillId: "skills:demo",
+          slug: "demo",
+          version: "1.0.0",
+        },
+      }),
+    );
+  });
+
+  it("requires the same owner actor who withdrew the version", async () => {
+    const restoreOwned = getDeletionHelper<{ versionId: string }>(
+      skillsModule,
+      "restoreOwnedSkillVersionForActor",
+    );
+    const { actors, audits, ctx, patches } = makeSkillDeletionCtx({
+      skill: {
+        ...makeSkillDeletionCtx({}).skill,
+        ownerPublisherId: "publishers:org",
+      },
+      versions: [
+        makeSkillVersion("skillVersions:v1", "1.0.0", {
+          softDeletedAt: 30,
+          ownerDeletedAt: 30,
+          ownerDeletedBy: "users:owner",
+        }),
+      ],
+      membership: {
+        publisherId: "publishers:org",
+        userId: "users:org-admin",
+        role: "admin",
+      },
+    });
+
+    await expect(
+      restoreOwned(ctx, actors["users:org-admin"], { versionId: "skillVersions:v1" }),
+    ).rejects.toThrow(/not withdrawn by this owner/i);
+    expect(patches).toEqual([]);
+    expect(audits).toEqual([]);
+  });
+
+  it.each([
+    [
+      "manually revoked",
+      {
+        manualRevocation: {
+          reason: "confirmed compromise",
+          reviewerUserId: "users:moderator",
+          revokedAt: 31,
+        },
+      },
+    ],
+    [
+      "malicious",
+      {
+        llmAnalysis: {
+          status: "malicious",
+          checkedAt: 31,
+        },
+      },
+    ],
+  ])("does not restore an owner-withdrawn version that is %s", async (_label, state) => {
+    const restoreOwned = getDeletionHelper<{ versionId: string }>(
+      skillsModule,
+      "restoreOwnedSkillVersionForActor",
+    );
+    const { actors, audits, ctx, patches } = makeSkillDeletionCtx({
+      versions: [
+        makeSkillVersion("skillVersions:v1", "1.0.0", {
+          softDeletedAt: 30,
+          ownerDeletedAt: 30,
+          ownerDeletedBy: "users:owner",
+          ...state,
+        }),
+      ],
+    });
+
+    await expect(
+      restoreOwned(ctx, actors["users:owner"], { versionId: "skillVersions:v1" }),
+    ).rejects.toThrow(/cannot be restored/i);
+    expect(patches).toEqual([]);
+    expect(audits).toEqual([]);
+  });
+
+  it("does not restore through an unavailable parent skill", async () => {
+    const restoreOwned = getDeletionHelper<{ versionId: string }>(
+      skillsModule,
+      "restoreOwnedSkillVersionForActor",
+    );
+    const { actors, audits, ctx, patches } = makeSkillDeletionCtx({
+      skill: {
+        ...makeSkillDeletionCtx({}).skill,
+        moderationStatus: "hidden",
+      },
+      versions: [
+        makeSkillVersion("skillVersions:v1", "1.0.0", {
+          softDeletedAt: 30,
+          ownerDeletedAt: 30,
+          ownerDeletedBy: "users:owner",
+        }),
+      ],
+    });
+
+    await expect(
+      restoreOwned(ctx, actors["users:owner"], { versionId: "skillVersions:v1" }),
+    ).rejects.toThrow(/skill is unavailable/i);
+    expect(patches).toEqual([]);
+    expect(audits).toEqual([]);
+  });
+});
+
 describe("owner package release deletion", () => {
   it("exports the public mutation contract", () => {
     expect(packagesModule.deleteOwnedRelease).toBeTypeOf("function");
@@ -1723,5 +1885,194 @@ describe("owner package release deletion", () => {
       deleteOwned(ctx, actors["users:owner"], { name: "demo-plugin", version: "2.0.0" }),
     ).rejects.toThrow(/skills deletion flow/i);
     expect(patches).toEqual([]);
+  });
+});
+
+describe("owner package release restore", () => {
+  it("exports the public mutation contract", () => {
+    expect(packagesModule.restoreOwnedRelease).toBeTypeOf("function");
+  });
+
+  it("restores only the retained release, clears dist-tags, and preserves package/search metadata", async () => {
+    const restoreOwned = getDeletionHelper<{ name: string; version: string }>(
+      packagesModule,
+      "restoreOwnedPackageReleaseForActor",
+    );
+    const withdrawn = makePackageRelease("packageReleases:v1", "1.0.0", {
+      softDeletedAt: 30,
+      ownerDeletedAt: 30,
+      ownerDeletedBy: "users:owner",
+      distTags: ["stable", "legacy"],
+    });
+    const { actors, audits, ctx, digest, patches, pkg, releases } = makePackageDeletionCtx({
+      releases: [withdrawn, makePackageRelease("packageReleases:v2", "2.0.0")],
+    });
+    const parentBefore = structuredClone(pkg);
+    const digestBefore = structuredClone(digest);
+    const artifactBefore = structuredClone(releases[0]);
+
+    await expect(
+      restoreOwned(ctx, actors["users:owner"], {
+        name: "demo-plugin",
+        version: "1.0.0",
+      }),
+    ).resolves.toMatchObject({
+      ok: true,
+      packageId: "packages:demo",
+      releaseId: "packageReleases:v1",
+    });
+
+    expect(patches).toContainEqual({
+      id: "packageReleases:v1",
+      patch: {
+        softDeletedAt: undefined,
+        ownerDeletedAt: undefined,
+        ownerDeletedBy: undefined,
+        distTags: [],
+      },
+    });
+    expect(releases[0]).toEqual({
+      ...artifactBefore,
+      softDeletedAt: undefined,
+      ownerDeletedAt: undefined,
+      ownerDeletedBy: undefined,
+      distTags: [],
+    });
+    expect(pkg).toEqual(parentBefore);
+    expect(digest).toEqual(digestBefore);
+    expect(audits).toContainEqual(
+      expect.objectContaining({
+        actorUserId: "users:owner",
+        action: "package.release.restore",
+        targetType: "packageRelease",
+        targetId: "packageReleases:v1",
+        metadata: {
+          packageId: "packages:demo",
+          name: "demo-plugin",
+          version: "1.0.0",
+        },
+      }),
+    );
+  });
+
+  it("requires the same owner actor who withdrew the release", async () => {
+    const restoreOwned = getDeletionHelper<{ name: string; version: string }>(
+      packagesModule,
+      "restoreOwnedPackageReleaseForActor",
+    );
+    const { actors, audits, ctx, patches } = makePackageDeletionCtx({
+      pkg: {
+        ...makePackageDeletionCtx({}).pkg,
+        ownerPublisherId: "publishers:org",
+      },
+      releases: [
+        makePackageRelease("packageReleases:v1", "1.0.0", {
+          softDeletedAt: 30,
+          ownerDeletedAt: 30,
+          ownerDeletedBy: "users:owner",
+        }),
+      ],
+      membership: {
+        publisherId: "publishers:org",
+        userId: "users:org-admin",
+        role: "admin",
+      },
+    });
+
+    await expect(
+      restoreOwned(ctx, actors["users:org-admin"], {
+        name: "demo-plugin",
+        version: "1.0.0",
+      }),
+    ).rejects.toThrow(/not withdrawn by this owner/i);
+    expect(patches).toEqual([]);
+    expect(audits).toEqual([]);
+  });
+
+  it.each([
+    [
+      "quarantined",
+      {
+        manualModeration: {
+          state: "quarantined",
+          reason: "security review",
+          reviewerUserId: "users:moderator",
+          reviewedAt: 31,
+        },
+      },
+    ],
+    [
+      "revoked",
+      {
+        manualModeration: {
+          state: "revoked",
+          reason: "confirmed compromise",
+          reviewerUserId: "users:moderator",
+          reviewedAt: 31,
+        },
+      },
+    ],
+    [
+      "malicious",
+      {
+        llmAnalysis: {
+          status: "malicious",
+          checkedAt: 31,
+        },
+      },
+    ],
+  ])("does not restore an owner-withdrawn release that is %s", async (_label, state) => {
+    const restoreOwned = getDeletionHelper<{ name: string; version: string }>(
+      packagesModule,
+      "restoreOwnedPackageReleaseForActor",
+    );
+    const { actors, audits, ctx, patches } = makePackageDeletionCtx({
+      releases: [
+        makePackageRelease("packageReleases:v1", "1.0.0", {
+          softDeletedAt: 30,
+          ownerDeletedAt: 30,
+          ownerDeletedBy: "users:owner",
+          ...state,
+        }),
+      ],
+    });
+
+    await expect(
+      restoreOwned(ctx, actors["users:owner"], {
+        name: "demo-plugin",
+        version: "1.0.0",
+      }),
+    ).rejects.toThrow(/cannot be restored/i);
+    expect(patches).toEqual([]);
+    expect(audits).toEqual([]);
+  });
+
+  it("does not restore through an unavailable parent package", async () => {
+    const restoreOwned = getDeletionHelper<{ name: string; version: string }>(
+      packagesModule,
+      "restoreOwnedPackageReleaseForActor",
+    );
+    const { actors, audits, ctx, patches } = makePackageDeletionCtx({
+      pkg: {
+        ...makePackageDeletionCtx({}).pkg,
+        scanStatus: "malicious",
+      },
+      releases: [
+        makePackageRelease("packageReleases:v1", "1.0.0", {
+          softDeletedAt: 30,
+          ownerDeletedAt: 30,
+          ownerDeletedBy: "users:owner",
+        }),
+      ],
+    });
+
+    await expect(
+      restoreOwned(ctx, actors["users:owner"], {
+        name: "demo-plugin",
+        version: "1.0.0",
+      }),
+    ).rejects.toThrow(/package is unavailable/i);
+    expect(patches).toEqual([]);
+    expect(audits).toEqual([]);
   });
 });

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -311,10 +311,10 @@ Notes:
 - Without `--version`, soft-delete a skill (owner, moderator, or admin).
 - Calls `DELETE /api/v1/skills/{slug}`.
 - Owner-initiated soft deletes reserve the slug for 30 days; the command prints the expiry time.
-- `--version <version>` permanently deletes one owned non-latest version through a fail-closed,
-  version-specific route.
-  Deleted versions cannot be restored or republished. Publish a replacement before deleting the
-  current latest version. Platform staff do not bypass ownership for this version-only flow.
+- `--version <version>` withdraws one owned non-latest version through a fail-closed,
+  version-specific route. The version number remains reserved and cannot be republished with
+  different contents. Publish a replacement before deleting the current latest version. Platform
+  staff do not bypass ownership for this version-only flow.
 - `--reason <text>` records a moderation note on a whole-skill soft-delete and audit log.
 - `--note <text>` is an alias for `--reason`.
 - `--yes` skips confirmation.
@@ -322,8 +322,10 @@ Notes:
 ### `undelete <skill>`
 
 - Restore a hidden skill (owner, moderator, or admin).
-- There is no version undelete; permanently deleted versions cannot be restored.
 - Calls `POST /api/v1/skills/{slug}/undelete`.
+- `--version <version>` restores only the exact retained artifact previously withdrawn by the same
+  owner actor. It does not make the restored version latest or recreate removed tags.
+- Version restore calls `POST /api/v1/skills/{slug}/versions/{version}/restore`.
 - `--reason <text>` records a moderation note on the skill and audit log.
 - `--note <text>` is an alias for `--reason`.
 - `--yes` skips confirmation.
@@ -483,15 +485,15 @@ If validation reports a package, manifest, SDK import, or artifact finding, see
 ### `package delete <name>`
 
 - Without `--version`, soft-deletes a package and all releases.
-- `--version <version>` permanently deletes one owned non-latest release through a fail-closed,
-  version-specific route.
-  Deleted versions cannot be restored or republished. Publish a replacement before deleting the
-  current latest version. This version-only flow requires the package owner or an org publisher
-  admin; platform staff do not bypass package ownership.
+- `--version <version>` withdraws one owned non-latest release through a fail-closed,
+  version-specific route. The version number remains reserved and cannot be republished with
+  different contents. Publish a replacement before deleting the current latest version. This
+  version-only flow requires the package owner or an org publisher admin; platform staff do not
+  bypass package ownership.
 - Whole-package soft-delete requires the package owner, an org publisher owner/admin, platform
   moderator, or platform admin.
 - Flags:
-  - `--version <version>`: permanently delete one non-latest version.
+  - `--version <version>`: withdraw one non-latest version.
   - `--yes`: skip confirmation.
   - `--json`: machine-readable output.
 
@@ -505,11 +507,14 @@ clawhub package delete @openclaw/example-plugin --version 1.2.3 --yes
 ### `package undelete <name>`
 
 - Restores a soft-deleted package and releases.
-- There is no version undelete; permanently deleted versions cannot be restored.
 - Requires the package owner, an org publisher owner/admin, platform moderator,
   or platform admin.
 - Calls `POST /api/v1/packages/{name}/undelete`.
+- `--version <version>` restores only the exact retained release previously withdrawn by the same
+  owner actor. It does not make the release latest or recreate removed package tags/dist-tags.
+- Version restore calls `POST /api/v1/packages/{name}/versions/{version}/restore`.
 - Flags:
+  - `--version <version>`: restore one owner-withdrawn release.
   - `--yes`: skip confirmation.
   - `--json`: machine-readable output.
 

--- a/e2e/local-auth/version-delete.pw.test.ts
+++ b/e2e/local-auth/version-delete.pw.test.ts
@@ -1,6 +1,6 @@
 import { spawnSync } from "node:child_process";
 import { readFileSync } from "node:fs";
-import { expect, test } from "@playwright/test";
+import { expect, type APIRequestContext, type APIResponse, test } from "@playwright/test";
 import { buildSkillDetailHref } from "../../src/lib/ownerRoute";
 import { buildPluginDetailHref } from "../../src/lib/pluginRoutes";
 import {
@@ -103,6 +103,9 @@ type VersionDeletionFixtureState = {
   skillLatestTagVersionId: string | null;
   skillLatestSummaryVersion: string | null;
   skillStatsVersions: number | null;
+  skillDigestLatestVersionId: string | null;
+  skillDigestLatestSummaryVersion: string | null;
+  skillDigestTags: Record<string, string> | null;
   skillActiveVersions: string[];
   olderSkillVersion: {
     exists: boolean;
@@ -121,7 +124,9 @@ type VersionDeletionFixtureState = {
   packageLatestTagReleaseId: string | null;
   packageLatestSummaryVersion: string | null;
   packageStatsVersions: number | null;
+  packageDigestLatestVersion: string | null;
   packageActiveVersions: string[];
+  olderPackageDistTags: string[] | null;
   olderPackageRelease: {
     exists: boolean;
     softDeletedAt: number | null;
@@ -136,6 +141,114 @@ type VersionDeletionFixtureState = {
   };
   packageAuditActions: string[];
 };
+
+type PublicVersionSurfaceState = {
+  skillListVersions: string[];
+  skillExactStatus: number;
+  skillDownloadStatus: number;
+  skillSearchVersion: string | null;
+  packageListVersions: string[];
+  packageExactStatus: number;
+  packageDownloadStatus: number;
+  packageLatestVersion: string | null;
+  packageTags: Record<string, unknown> | null;
+  packageSearchVersion: string | null;
+};
+
+function convexSiteUrl() {
+  const value = process.env.VITE_CONVEX_SITE_URL;
+  if (!value) throw new Error("VITE_CONVEX_SITE_URL is required");
+  return value.replace(/\/$/u, "");
+}
+
+async function getWithRetry(request: APIRequestContext, url: string): Promise<APIResponse> {
+  let lastResponse: APIResponse | null = null;
+  for (let attempt = 1; attempt <= 8; attempt += 1) {
+    lastResponse = await request.get(url);
+    if (lastResponse.status() < 500) return lastResponse;
+    await new Promise((resolve) => setTimeout(resolve, attempt * 500));
+  }
+  if (!lastResponse) throw new Error(`No response from ${url}`);
+  return lastResponse;
+}
+
+async function getPublicVersionSurfaceState(
+  request: APIRequestContext,
+  fixture: VersionDeletionFixture,
+): Promise<PublicVersionSurfaceState> {
+  const site = convexSiteUrl();
+  const owner = encodeURIComponent(fixture.handle);
+  const slug = encodeURIComponent(fixture.skillSlug);
+  const packageName = encodeURIComponent(fixture.packageName);
+  const skillListResponse = await getWithRetry(
+    request,
+    `${site}/api/v1/skills/${slug}/versions?ownerHandle=${owner}`,
+  );
+  const skillExactResponse = await getWithRetry(
+    request,
+    `${site}/api/v1/skills/${slug}/versions/${OLDER_VERSION}?ownerHandle=${owner}`,
+  );
+  const skillDownloadResponse = await getWithRetry(
+    request,
+    `${site}/api/v1/download?slug=${slug}&ownerHandle=${owner}&version=${OLDER_VERSION}`,
+  );
+  const skillSearchResponse = await getWithRetry(
+    request,
+    `${site}/api/v1/packages/search?q=${slug}&family=skill`,
+  );
+  const packageListResponse = await getWithRetry(
+    request,
+    `${site}/api/v1/packages/${packageName}/versions`,
+  );
+  const packageExactResponse = await getWithRetry(
+    request,
+    `${site}/api/v1/packages/${packageName}/versions/${OLDER_VERSION}`,
+  );
+  const packageDownloadResponse = await getWithRetry(
+    request,
+    `${site}/api/v1/packages/${packageName}/download?version=${OLDER_VERSION}`,
+  );
+  const packageDetailResponse = await getWithRetry(
+    request,
+    `${site}/api/v1/packages/${packageName}`,
+  );
+  const packageSearchResponse = await getWithRetry(
+    request,
+    `${site}/api/v1/packages/search?q=${packageName}&family=code-plugin`,
+  );
+  const skillList = (await skillListResponse.json()) as { items?: Array<{ version?: string }> };
+  const skillSearch = (await skillSearchResponse.json()) as {
+    results?: Array<{ package?: { name?: string; latestVersion?: string | null } }>;
+  };
+  const packageList = (await packageListResponse.json()) as {
+    items?: Array<{ version?: string }>;
+  };
+  const packageDetail = (await packageDetailResponse.json()) as {
+    package?: {
+      latestVersion?: string | null;
+      tags?: Record<string, unknown>;
+    } | null;
+  };
+  const packageSearch = (await packageSearchResponse.json()) as {
+    results?: Array<{ package?: { name?: string; latestVersion?: string | null } }>;
+  };
+  return {
+    skillListVersions: skillList.items?.flatMap((item) => item.version ?? []) ?? [],
+    skillExactStatus: skillExactResponse.status(),
+    skillDownloadStatus: skillDownloadResponse.status(),
+    skillSearchVersion:
+      skillSearch.results?.find((result) => result.package?.name === fixture.skillSlug)?.package
+        ?.latestVersion ?? null,
+    packageListVersions: packageList.items?.flatMap((item) => item.version ?? []) ?? [],
+    packageExactStatus: packageExactResponse.status(),
+    packageDownloadStatus: packageDownloadResponse.status(),
+    packageLatestVersion: packageDetail.package?.latestVersion ?? null,
+    packageTags: packageDetail.package?.tags ?? null,
+    packageSearchVersion:
+      packageSearch.results?.find((result) => result.package?.name === fixture.packageName)?.package
+        ?.latestVersion ?? null,
+  };
+}
 
 function seedVersionDeletionFixture(args: {
   skillSlug: string;
@@ -212,13 +325,23 @@ async function expectDeleteDialog(page: Parameters<typeof expectNoFatalErrorUi>[
     dialog.getByRole("heading", { name: `Delete version ${OLDER_VERSION}?` }),
   ).toBeVisible({ timeout: 30_000 });
   await expect(dialog).toContainText(
-    `Deletion is permanent. Version ${OLDER_VERSION} cannot be restored or republished, and the version number remains reserved. Recovery is publishing a new version.`,
+    "This withdraws the version from public use. You can restore the exact retained artifact later, but the version number remains reserved and cannot be republished with different contents.",
   );
   await expect(dialog.getByRole("button", { name: "Delete version" })).toBeVisible({
     timeout: 30_000,
   });
-  await expect(dialog.getByRole("button", { name: /restore/i })).toHaveCount(0);
   await expect(dialog).toHaveAttribute("data-state", "open");
+  return dialog;
+}
+
+async function expectRestoreDialog(page: Parameters<typeof expectNoFatalErrorUi>[0]) {
+  const dialog = page.getByRole("dialog");
+  await expect(
+    dialog.getByRole("heading", { name: `Restore version ${OLDER_VERSION}?` }),
+  ).toBeVisible({ timeout: 30_000 });
+  await expect(dialog).toContainText(
+    "This restores the exact retained artifact. It will not become latest or regain removed tags automatically.",
+  );
   return dialog;
 }
 
@@ -289,6 +412,18 @@ async function confirmDeleteDialog(page: Parameters<typeof expectNoFatalErrorUi>
   throw lastError;
 }
 
+async function restoreOlderVersion(page: Parameters<typeof expectNoFatalErrorUi>[0]) {
+  const restoreButton = page.getByRole("button", { name: `Restore version ${OLDER_VERSION}` });
+  await expect(restoreButton).toBeVisible({ timeout: 30_000 });
+  await restoreButton.click();
+  const dialog = await expectRestoreDialog(page);
+  await dialog.getByRole("button", { name: "Restore version" }).click();
+  await expect(dialog).toHaveCount(0);
+  await expect(page.getByRole("button", { name: `Delete version ${OLDER_VERSION}` })).toBeVisible({
+    timeout: 30_000,
+  });
+}
+
 async function expectVersionsList(page: Parameters<typeof expectNoFatalErrorUi>[0]) {
   let lastError: unknown;
   for (let attempt = 1; attempt <= 4; attempt += 1) {
@@ -327,13 +462,13 @@ async function expectVersionsList(page: Parameters<typeof expectNoFatalErrorUi>[
 
 async function expectPublicVersionsList(page: Parameters<typeof expectNoFatalErrorUi>[0]) {
   await ensureVersionsTab(page);
-  await expect(versionToggle(page, OLDER_VERSION)).toHaveCount(0);
+  await expect(versionToggle(page, OLDER_VERSION)).toBeVisible();
   await expect(versionToggle(page, LATEST_VERSION)).toBeVisible();
   await expect(page.getByRole("button", { name: /delete version/i })).toHaveCount(0);
   await expect(page.getByRole("button", { name: /restore/i })).toHaveCount(0);
 }
 
-test("owners can permanently delete individual non-latest skill and plugin versions", async ({
+test("owners can withdraw and restore individual non-latest skill and plugin versions", async ({
   baseURL,
   browser,
   page,
@@ -354,7 +489,7 @@ test("owners can permanently delete individual non-latest skill and plugin versi
   expect(fixture.publisherPublishedSkills).toBeGreaterThanOrEqual(1);
   expect(fixture.publisherPublishedPackages).toBeGreaterThanOrEqual(1);
   console.log(
-    `CLAW-333 fixture ${JSON.stringify({
+    `CLAW-575 fixture ${JSON.stringify({
       appUrl: testInfo.project.use.baseURL,
       handle: fixture.handle,
       packageName: fixture.packageName,
@@ -368,6 +503,9 @@ test("owners can permanently delete individual non-latest skill and plugin versi
     skillLatestTagVersionId: fixture.latestSkillVersionId,
     skillLatestSummaryVersion: LATEST_VERSION,
     skillStatsVersions: 2,
+    skillDigestLatestVersionId: fixture.latestSkillVersionId,
+    skillDigestLatestSummaryVersion: LATEST_VERSION,
+    skillDigestTags: { latest: fixture.latestSkillVersionId },
     skillActiveVersions: [LATEST_VERSION, OLDER_VERSION],
     olderSkillVersion: {
       exists: true,
@@ -386,7 +524,9 @@ test("owners can permanently delete individual non-latest skill and plugin versi
     packageLatestTagReleaseId: fixture.latestPackageReleaseId,
     packageLatestSummaryVersion: LATEST_VERSION,
     packageStatsVersions: 2,
+    packageDigestLatestVersion: LATEST_VERSION,
     packageActiveVersions: [LATEST_VERSION, OLDER_VERSION],
+    olderPackageDistTags: [],
     olderPackageRelease: {
       exists: true,
       softDeletedAt: null,
@@ -427,12 +567,33 @@ test("owners can permanently delete individual non-latest skill and plugin versi
   await confirmDeleteDialog(page);
   await expect(skillDialog).toHaveCount(0);
   await ensureVersionsTab(page);
-  await expect(versionToggle(page, OLDER_VERSION)).toHaveCount(0);
+  await expect(versionToggle(page, OLDER_VERSION)).toBeVisible();
   await expect(versionToggle(page, LATEST_VERSION)).toBeVisible();
-  await expect(page.getByRole("button", { name: /restore/i })).toHaveCount(0);
+  await expect(
+    page.getByRole("button", { name: `Restore version ${OLDER_VERSION}` }),
+  ).toBeVisible();
   await page.screenshot({
     path: testInfo.outputPath("skill-version-delete-after.png"),
     fullPage: true,
+  });
+  expect(await getPublicVersionSurfaceState(page.request, fixture)).toMatchObject({
+    skillListVersions: [LATEST_VERSION],
+    skillExactStatus: 404,
+    skillDownloadStatus: 410,
+    skillSearchVersion: LATEST_VERSION,
+    packageLatestVersion: LATEST_VERSION,
+    packageSearchVersion: LATEST_VERSION,
+  });
+  await restoreOlderVersion(page);
+  await page.screenshot({
+    path: testInfo.outputPath("skill-version-restore-after.png"),
+    fullPage: true,
+  });
+  expect(await getPublicVersionSurfaceState(page.request, fixture)).toMatchObject({
+    skillListVersions: [LATEST_VERSION, OLDER_VERSION],
+    skillExactStatus: 200,
+    skillDownloadStatus: 200,
+    skillSearchVersion: LATEST_VERSION,
   });
 
   await page.goto(pluginDetailHref, {
@@ -457,12 +618,35 @@ test("owners can permanently delete individual non-latest skill and plugin versi
   await confirmDeleteDialog(page);
   await expect(packageDialog).toHaveCount(0);
   await ensureVersionsTab(page);
-  await expect(versionToggle(page, OLDER_VERSION)).toHaveCount(0);
+  await expect(versionToggle(page, OLDER_VERSION)).toBeVisible();
   await expect(versionToggle(page, LATEST_VERSION)).toBeVisible();
-  await expect(page.getByRole("button", { name: /restore/i })).toHaveCount(0);
+  await expect(
+    page.getByRole("button", { name: `Restore version ${OLDER_VERSION}` }),
+  ).toBeVisible();
   await page.screenshot({
     path: testInfo.outputPath("plugin-version-delete-after.png"),
     fullPage: true,
+  });
+  expect(await getPublicVersionSurfaceState(page.request, fixture)).toMatchObject({
+    packageListVersions: [LATEST_VERSION],
+    packageExactStatus: 404,
+    packageDownloadStatus: 404,
+    packageLatestVersion: LATEST_VERSION,
+    packageTags: { latest: LATEST_VERSION },
+    packageSearchVersion: LATEST_VERSION,
+  });
+  await restoreOlderVersion(page);
+  await page.screenshot({
+    path: testInfo.outputPath("plugin-version-restore-after.png"),
+    fullPage: true,
+  });
+  expect(await getPublicVersionSurfaceState(page.request, fixture)).toMatchObject({
+    packageListVersions: [LATEST_VERSION, OLDER_VERSION],
+    packageExactStatus: 200,
+    packageDownloadStatus: 200,
+    packageLatestVersion: LATEST_VERSION,
+    packageTags: { latest: LATEST_VERSION },
+    packageSearchVersion: LATEST_VERSION,
   });
 
   await expect
@@ -475,12 +659,15 @@ test("owners can permanently delete individual non-latest skill and plugin versi
       skillLatestTagVersionId: fixture.latestSkillVersionId,
       skillLatestSummaryVersion: LATEST_VERSION,
       skillStatsVersions: 2,
-      skillActiveVersions: [LATEST_VERSION],
+      skillDigestLatestVersionId: fixture.latestSkillVersionId,
+      skillDigestLatestSummaryVersion: LATEST_VERSION,
+      skillDigestTags: { latest: fixture.latestSkillVersionId },
+      skillActiveVersions: [LATEST_VERSION, OLDER_VERSION],
       olderSkillVersion: {
         exists: true,
-        softDeletedAt: expect.any(Number),
-        ownerDeletedAt: expect.any(Number),
-        ownerDeletedBy: fixture.userId,
+        softDeletedAt: null,
+        ownerDeletedAt: null,
+        ownerDeletedBy: null,
       },
       latestSkillVersion: {
         exists: true,
@@ -488,17 +675,19 @@ test("owners can permanently delete individual non-latest skill and plugin versi
         ownerDeletedAt: null,
         ownerDeletedBy: null,
       },
-      skillAuditActions: ["skill.version.delete"],
+      skillAuditActions: ["skill.version.delete", "skill.version.restore"],
       packageLatestReleaseId: fixture.latestPackageReleaseId,
       packageLatestTagReleaseId: fixture.latestPackageReleaseId,
       packageLatestSummaryVersion: LATEST_VERSION,
       packageStatsVersions: 2,
-      packageActiveVersions: [LATEST_VERSION],
+      packageDigestLatestVersion: LATEST_VERSION,
+      packageActiveVersions: [LATEST_VERSION, OLDER_VERSION],
+      olderPackageDistTags: [],
       olderPackageRelease: {
         exists: true,
-        softDeletedAt: expect.any(Number),
-        ownerDeletedAt: expect.any(Number),
-        ownerDeletedBy: fixture.userId,
+        softDeletedAt: null,
+        ownerDeletedAt: null,
+        ownerDeletedBy: null,
       },
       latestPackageRelease: {
         exists: true,
@@ -506,15 +695,11 @@ test("owners can permanently delete individual non-latest skill and plugin versi
         ownerDeletedAt: null,
         ownerDeletedBy: null,
       },
-      packageAuditActions: ["package.release.delete"],
+      packageAuditActions: ["package.release.delete", "package.release.restore"],
     });
   const finalState = getVersionDeletionFixtureState(fixture);
-  expect(finalState.olderSkillVersion.softDeletedAt).toBe(
-    finalState.olderSkillVersion.ownerDeletedAt,
-  );
-  expect(finalState.olderPackageRelease.softDeletedAt).toBe(
-    finalState.olderPackageRelease.ownerDeletedAt,
-  );
+  expect(finalState.olderSkillVersion.softDeletedAt).toBeNull();
+  expect(finalState.olderPackageRelease.softDeletedAt).toBeNull();
 
   if (!baseURL) throw new Error("Playwright base URL was not available");
   const publicContext = await browser.newContext({ baseURL });

--- a/packages/clawhub/src/cli.ts
+++ b/packages/clawhub/src/cli.ts
@@ -431,11 +431,11 @@ registerCommand(scanCmd, ["scan", "download"])
   });
 
 registerCommand(program, ["delete"])
-  .description("Soft-delete a skill or permanently delete one version")
+  .description("Soft-delete a skill or withdraw one version")
   .argument("<skill>", "Skill ref")
   .option(
     "--version <version>",
-    "Permanently delete one version; cannot be restored or republished; publish a replacement first if deleting the current latest version",
+    "Withdraw one non-latest version; the retained artifact can be restored, but the version number remains reserved",
   )
   .option("--reason <text>", "Whole-skill moderation note/reason")
   .option("--note <text>", "Alias for --reason")
@@ -457,8 +457,12 @@ registerCommand(program, ["hide"])
   });
 
 registerCommand(program, ["undelete"])
-  .description("Restore one of your hidden skills")
+  .description("Restore a hidden skill or an owner-withdrawn version")
   .argument("<skill>", "Skill to restore")
+  .option(
+    "--version <version>",
+    "Restore the exact retained version without changing latest or tags",
+  )
   .option("--reason <text>", "Moderation note/reason")
   .option("--note <text>", "Alias for --reason")
   .option("--yes", "Skip confirmation")
@@ -628,11 +632,11 @@ registerCommand(packageCmd, ["package", "validate"])
   });
 
 registerCommand(packageCmd, ["package", "delete"])
-  .description("Soft-delete a package or permanently delete one version")
+  .description("Soft-delete a package or withdraw one version")
   .argument("<name>", "Package name")
   .option(
     "--version <version>",
-    "Permanently delete one version; cannot be restored or republished; publish a replacement first if deleting the current latest version",
+    "Withdraw one non-latest version; the retained artifact can be restored, but the version number remains reserved",
   )
   .option("--yes", "Skip confirmation")
   .option("--json", "Output JSON")
@@ -642,8 +646,12 @@ registerCommand(packageCmd, ["package", "delete"])
   });
 
 registerCommand(packageCmd, ["package", "undelete"])
-  .description("Restore a soft-deleted package and releases")
+  .description("Restore a soft-deleted package or an owner-withdrawn release")
   .argument("<name>", "Package name")
+  .option(
+    "--version <version>",
+    "Restore the exact retained release without changing latest or dist-tags",
+  )
   .option("--yes", "Skip confirmation")
   .option("--json", "Output JSON")
   .action(async (name, options) => {

--- a/packages/clawhub/src/cli.version-delete.test.ts
+++ b/packages/clawhub/src/cli.version-delete.test.ts
@@ -44,7 +44,7 @@ function runCli(args: string[], env: NodeJS.ProcessEnv) {
 }
 
 describe("version delete CLI registration", () => {
-  it("shows permanent --version help only on skill and package delete", () => {
+  it("documents reversible version withdrawal and restore", () => {
     const skillDelete = runCliSync(["delete", "--help"]);
     const skillUndelete = runCliSync(["undelete", "--help"]);
     const packageDelete = runCliSync(["package", "delete", "--help"]);
@@ -54,16 +54,19 @@ describe("version delete CLI registration", () => {
       const help = result.stdout.replace(/\s+/g, " ");
       expect(result.status).toBe(0);
       expect(help).toContain("--version <version>");
-      expect(help).toContain("cannot be restored or republished");
-      expect(help).toContain("publish a replacement first");
+      expect(help).toContain("retained artifact can be restored");
+      expect(help).toContain("version number remains reserved");
     }
-    expect(skillUndelete.status).toBe(0);
-    expect(skillUndelete.stdout).not.toContain("--version <version>");
-    expect(packageUndelete.status).toBe(0);
-    expect(packageUndelete.stdout).not.toContain("--version <version>");
+    for (const result of [skillUndelete, packageUndelete]) {
+      const help = result.stdout.replace(/\s+/g, " ");
+      expect(result.status).toBe(0);
+      expect(help).toContain("--version <version>");
+      expect(help).toContain("exact retained");
+      expect(help).toContain("without changing latest");
+    }
   });
 
-  it("parses and forwards skill and package delete versions to HTTP requests", async () => {
+  it("forwards skill and package version delete and restore requests", async () => {
     const requests: Array<{ body: unknown; method: string | undefined; url: string | undefined }> =
       [];
     const server = createServer(async (request, response) => {
@@ -108,9 +111,30 @@ describe("version delete CLI registration", () => {
         ],
         env,
       );
+      const skillRestoreResult = await runCli(
+        ["--registry", registry, "--no-input", "undelete", "demo", "--version", "1.2.3", "--yes"],
+        env,
+      );
+      const packageRestoreResult = await runCli(
+        [
+          "--registry",
+          registry,
+          "--no-input",
+          "package",
+          "undelete",
+          "@openclaw/demo",
+          "--version",
+          "2.3.4",
+          "--yes",
+          "--json",
+        ],
+        env,
+      );
 
       expect(skillResult).toMatchObject({ code: 0 });
       expect(packageResult).toMatchObject({ code: 0 });
+      expect(skillRestoreResult).toMatchObject({ code: 0 });
+      expect(packageRestoreResult).toMatchObject({ code: 0 });
       expect(requests).toEqual([
         {
           method: "DELETE",
@@ -121,6 +145,16 @@ describe("version delete CLI registration", () => {
           method: "DELETE",
           url: "/api/v1/packages/%40openclaw%2Fdemo/versions/2.3.4",
           body: { version: "2.3.4" },
+        },
+        {
+          method: "POST",
+          url: "/api/v1/skills/demo/versions/1.2.3/restore",
+          body: { version: "1.2.3" },
+        },
+        {
+          method: "POST",
+          url: "/api/v1/packages/%40openclaw%2Fdemo/versions/2.3.4/restore",
+          body: {},
         },
       ]);
     } finally {

--- a/packages/clawhub/src/cli/commands/delete.test.ts
+++ b/packages/clawhub/src/cli/commands/delete.test.ts
@@ -77,14 +77,17 @@ describe("delete/undelete", () => {
     expect(httpMocks.apiRequest.mock.calls[0]?.[1]).not.toHaveProperty("retryCount");
   });
 
-  it("confirms that skill version deletion is permanent", async () => {
+  it("confirms that skill version deletion is a reversible withdrawal", async () => {
     httpMocks.apiRequest.mockResolvedValueOnce({ ok: true });
 
     await cmdDeleteSkill(makeGlobalOpts(), "demo", { version: "1.2.3" }, true);
 
     expect(uiMocks.promptConfirm).toHaveBeenCalledWith(expect.stringContaining("version 1.2.3"));
     expect(uiMocks.promptConfirm).toHaveBeenCalledWith(
-      expect.stringContaining("cannot be restored or republished"),
+      expect.stringContaining("exact retained artifact can be restored"),
+    );
+    expect(uiMocks.promptConfirm).toHaveBeenCalledWith(
+      expect.stringContaining("version number remains reserved"),
     );
     expect(uiMocks.promptConfirm).toHaveBeenCalledWith(
       expect.stringContaining("publish a replacement first"),
@@ -189,6 +192,38 @@ describe("delete/undelete", () => {
       expect.objectContaining({ method: "POST", path: "/api/v1/skills/demo/undelete" }),
       expect.anything(),
     );
+  });
+
+  it("restores an owner-withdrawn skill version without retrying", async () => {
+    httpMocks.apiRequest.mockResolvedValueOnce({ ok: true });
+    await cmdUndeleteSkill(
+      makeGlobalOpts(),
+      "@Alice/Demo",
+      { yes: true, version: " 1.2.3 " },
+      false,
+    );
+    expect(httpMocks.apiRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        method: "POST",
+        path: "/api/v1/skills/demo/versions/1.2.3/restore",
+        body: { ownerHandle: "alice", version: "1.2.3" },
+        retryCount: 0,
+      }),
+      expect.anything(),
+    );
+  });
+
+  it("rejects whole-skill moderation reasons on version restore", async () => {
+    await expect(
+      cmdUndeleteSkill(
+        makeGlobalOpts(),
+        "demo",
+        { yes: true, version: "1.2.3", reason: "reviewed" },
+        false,
+      ),
+    ).rejects.toThrow(/whole-skill restoration/i);
+    expect(httpMocks.apiRequest).not.toHaveBeenCalled();
   });
 
   it("passes a moderation reason on undelete", async () => {

--- a/packages/clawhub/src/cli/commands/delete.ts
+++ b/packages/clawhub/src/cli/commands/delete.ts
@@ -106,37 +106,47 @@ export async function cmdDeleteSkill(
 export async function cmdUndeleteSkill(
   opts: GlobalOpts,
   slugArg: string,
-  options: SkillActionOptions,
+  options: SkillDeleteOptions,
   inputAllowed: boolean,
   labels: SkillActionLabels = undeleteLabels,
 ) {
   const ref = parseSkillRef(slugArg);
   const slug = ref.slug;
   const reason = normalizeReason(options);
+  const version = normalizeVersion(options.version);
+  if (version && reason) fail("--reason/--note apply only to whole-skill restoration");
   const allowPrompt = isInteractive() && inputAllowed !== false;
 
   if (!options.yes) {
     if (!allowPrompt) fail("Pass --yes (no input)");
-    const ok = await promptConfirm(formatPrompt(labels, formatSkillRef(ref)));
+    const ok = await promptConfirm(
+      version
+        ? `Restore ${formatSkillRef(ref)} version ${version}? (restores the exact retained artifact; does not make it latest or restore tags)`
+        : formatPrompt(labels, formatSkillRef(ref)),
+    );
     if (!ok) return undefined;
   }
 
   const token = await requireAuthToken();
   const registry = await getRegistry(opts, { cache: true });
-  const spinner = createCrabLoader(`${labels.progress} ${formatSkillRef(ref)}`);
+  const target = version ? `${formatSkillRef(ref)} version ${version}` : formatSkillRef(ref);
+  const spinner = createCrabLoader(`${labels.progress} ${target}`);
   try {
-    const body = buildBody(reason, ref.ownerHandle);
+    const body = buildBody(reason, ref.ownerHandle, version);
     const result = await apiRequest(
       registry,
       {
         method: "POST",
-        path: `${ApiRoutes.skills}/${encodeURIComponent(slug)}/undelete`,
+        path: version
+          ? `${ApiRoutes.skills}/${encodeURIComponent(slug)}/versions/${encodeURIComponent(version)}/restore`
+          : `${ApiRoutes.skills}/${encodeURIComponent(slug)}/undelete`,
         token,
         body,
+        ...(version ? { retryCount: 0 } : {}),
       },
       ApiV1DeleteResponseSchema,
     );
-    spinner.succeed(`OK. ${labels.past} ${formatSkillRef(ref)}`);
+    spinner.succeed(`OK. ${labels.past} ${target}`);
     return parseArk(ApiV1DeleteResponseSchema, result, "Undelete response");
   } catch (error) {
     spinner.fail(formatError(error));
@@ -225,7 +235,7 @@ function normalizeVersion(value: string | undefined) {
 
 function formatPrompt(labels: SkillActionLabels, slug: string, version?: string) {
   if (version) {
-    return `${labels.verb} ${slug} version ${version}? (permanent; cannot be restored or republished; publish a replacement first if deleting the current latest version)`;
+    return `${labels.verb} ${slug} version ${version}? (withdraws public access; the exact retained artifact can be restored, but the version number remains reserved; publish a replacement first if deleting the current latest version)`;
   }
   const suffix = labels.promptSuffix ? ` (${labels.promptSuffix})` : "";
   return `${labels.verb} ${slug}?${suffix}`;

--- a/packages/clawhub/src/cli/commands/packages.test.ts
+++ b/packages/clawhub/src/cli/commands/packages.test.ts
@@ -3344,14 +3344,17 @@ describe("package commands", () => {
     expect(httpMocks.apiRequest.mock.calls[0]?.[1]).not.toHaveProperty("retryCount");
   });
 
-  it("confirms that package version deletion is permanent", async () => {
+  it("confirms that package version deletion is a reversible withdrawal", async () => {
     httpMocks.apiRequest.mockResolvedValueOnce({ ok: true });
 
     await cmdDeletePackage(makeOpts(), "@openclaw/zalo", { version: "1.2.3" }, true);
 
     expect(uiMocks.promptConfirm).toHaveBeenCalledWith(expect.stringContaining("version 1.2.3"));
     expect(uiMocks.promptConfirm).toHaveBeenCalledWith(
-      expect.stringContaining("cannot be restored or republished"),
+      expect.stringContaining("exact retained artifact can be restored"),
+    );
+    expect(uiMocks.promptConfirm).toHaveBeenCalledWith(
+      expect.stringContaining("version number remains reserved"),
     );
     expect(uiMocks.promptConfirm).toHaveBeenCalledWith(
       expect.stringContaining("publish a replacement first"),
@@ -3412,6 +3415,28 @@ describe("package commands", () => {
         method: "POST",
         path: "/api/v1/packages/%40openclaw%2Fzalo/undelete",
         token: "tkn",
+      }),
+      expect.anything(),
+    );
+  });
+
+  it("restores an owner-withdrawn package release without retrying", async () => {
+    httpMocks.apiRequest.mockResolvedValueOnce({ ok: true });
+
+    await cmdUndeletePackage(
+      makeOpts(),
+      "@openclaw/zalo",
+      { yes: true, version: " 1.2.3 " },
+      false,
+    );
+
+    expect(httpMocks.apiRequest).toHaveBeenCalledWith(
+      "https://clawhub.ai",
+      expect.objectContaining({
+        method: "POST",
+        path: "/api/v1/packages/%40openclaw%2Fzalo/versions/1.2.3/restore",
+        token: "tkn",
+        retryCount: 0,
       }),
       expect.anything(),
     );

--- a/packages/clawhub/src/cli/commands/packages.ts
+++ b/packages/clawhub/src/cli/commands/packages.ts
@@ -233,7 +233,7 @@ type PackageDeleteOptions = {
   version?: string;
 };
 
-type PackageUndeleteOptions = Omit<PackageDeleteOptions, "version">;
+type PackageUndeleteOptions = PackageDeleteOptions;
 
 type PackageTransferOptions = {
   to: string;
@@ -1324,7 +1324,7 @@ export async function cmdDeletePackage(
     if (!isInteractive() || inputAllowed === false) fail("Pass --yes (no input)");
     const ok = await promptConfirm(
       version
-        ? `Delete ${name} version ${version}? (permanent; cannot be restored or republished; publish a replacement first if deleting the current latest version)`
+        ? `Delete ${name} version ${version}? (withdraws public access; the exact retained artifact can be restored, but the version number remains reserved; publish a replacement first if deleting the current latest version)`
         : `Delete ${name}? (soft delete package and all releases)`,
     );
     if (!ok) return undefined;
@@ -1373,27 +1373,36 @@ export async function cmdUndeletePackage(
 ) {
   const name = nameArg.trim();
   if (!name) fail("Package name required");
+  const version = normalizeDeleteVersion(options.version);
 
   if (!options.yes) {
     if (!isInteractive() || inputAllowed === false) fail("Pass --yes (no input)");
-    const ok = await promptConfirm(`Restore ${name}? (restore package and releases)`);
+    const ok = await promptConfirm(
+      version
+        ? `Restore ${name} version ${version}? (restores the exact retained artifact; does not make it latest or restore tags or dist-tags)`
+        : `Restore ${name}? (restore package and releases)`,
+    );
     if (!ok) return undefined;
   }
 
   const token = await requireAuthToken();
   const registry = await getRegistry(opts, { cache: true });
-  const spinner = createCrabLoader(`Restoring ${name}`);
+  const target = version ? `${name} version ${version}` : name;
+  const spinner = createCrabLoader(`Restoring ${target}`);
   try {
     const result = await apiRequest(
       registry,
       {
         method: "POST",
-        path: `${ApiRoutes.packages}/${encodeURIComponent(name)}/undelete`,
+        path: version
+          ? `${ApiRoutes.packages}/${encodeURIComponent(name)}/versions/${encodeURIComponent(version)}/restore`
+          : `${ApiRoutes.packages}/${encodeURIComponent(name)}/undelete`,
         token,
+        ...(version ? { retryCount: 0 } : {}),
       },
       ApiV1DeleteResponseSchema,
     );
-    spinner.succeed(`OK. Restored ${name}`);
+    spinner.succeed(`OK. Restored ${target}`);
     if (options.json) {
       console.log(JSON.stringify(result, null, 2));
     }

--- a/src/__tests__/package-detail-route.test.tsx
+++ b/src/__tests__/package-detail-route.test.tsx
@@ -101,6 +101,11 @@ vi.mock("convex/react", () => ({
   useConvex: () => convexClientMock,
   useQuery: (...args: unknown[]) => useQueryMock(...args),
   useMutation: (...args: unknown[]) => useMutationMock(...args),
+  usePaginatedQuery: () => ({
+    results: [],
+    status: "Exhausted",
+    loadMore: vi.fn(),
+  }),
 }));
 
 vi.mock("../lib/useAuthStatus", () => ({

--- a/src/__tests__/skill-detail-page.test.tsx
+++ b/src/__tests__/skill-detail-page.test.tsx
@@ -52,6 +52,11 @@ vi.mock("convex/react", () => ({
   useConvex: () => convexClientMock,
   useQuery: (...args: unknown[]) => useQueryMock(...args),
   useMutation: (...args: unknown[]) => useMutationMock(...args),
+  usePaginatedQuery: () => ({
+    results: [],
+    status: "Exhausted",
+    loadMore: vi.fn(),
+  }),
   useAction: () => getReadmeMock,
 }));
 

--- a/src/__tests__/version-delete-ui.test.tsx
+++ b/src/__tests__/version-delete-ui.test.tsx
@@ -5,14 +5,18 @@ import { getFunctionName } from "convex/server";
 import { toast } from "sonner";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Doc, Id } from "../../convex/_generated/dataModel";
-import { PluginVersionsPanel } from "../components/PluginVersionsPanel";
+import { PLUGIN_VERSIONS_PAGE_SIZE, PluginVersionsPanel } from "../components/PluginVersionsPanel";
 import { SkillVersionsPanel } from "../components/SkillVersionsPanel";
 import { fetchPackageVersions } from "../lib/packageApi";
 
 const useMutationMock = vi.fn();
+const useQueryMock = vi.fn();
+const usePaginatedQueryMock = vi.fn();
 
 vi.mock("convex/react", () => ({
   useMutation: (...args: unknown[]) => useMutationMock(...args),
+  useQuery: (...args: unknown[]) => useQueryMock(...args),
+  usePaginatedQuery: (...args: unknown[]) => usePaginatedQueryMock(...args),
 }));
 
 vi.mock("sonner", () => ({
@@ -28,6 +32,8 @@ vi.mock("../lib/packageApi", () => ({
 
 const latestSkillVersionId = "skillVersions:latest" as Id<"skillVersions">;
 const olderSkillVersionId = "skillVersions:older" as Id<"skillVersions">;
+const skillId = "skills:weather" as Id<"skills">;
+const otherSkillId = "skills:other-weather" as Id<"skills">;
 const otherLatestSkillVersionId = "skillVersions:other-latest" as Id<"skillVersions">;
 const otherOlderSkillVersionId = "skillVersions:other-older" as Id<"skillVersions">;
 
@@ -109,15 +115,18 @@ function makeSkillVersionsPanel({
   versions = skillVersions,
   latestVersionId = latestSkillVersionId,
   canDeleteVersions = true,
+  panelSkillId = skillId,
   skillSlug = "weather",
 }: {
   versions?: Doc<"skillVersions">[];
   latestVersionId?: Id<"skillVersions">;
   canDeleteVersions?: boolean;
+  panelSkillId?: Id<"skills">;
   skillSlug?: string;
 } = {}) {
   return (
     <SkillVersionsPanel
+      skillId={panelSkillId}
       versions={versions}
       latestVersionId={latestVersionId}
       canDeleteVersions={canDeleteVersions}
@@ -154,12 +163,20 @@ function renderPluginVersions({
   };
 }
 
-function expectIrreversibleConfirmation(version: string) {
+function expectWithdrawalConfirmation(version: string) {
   expect(screen.getByRole("heading", { name: `Delete version ${version}?` })).toBeTruthy();
-  expect(screen.getByText(/deletion is permanent/i)).toBeTruthy();
-  expect(screen.getByText(/cannot be restored or republished/i)).toBeTruthy();
+  expect(screen.getByText(/withdraws the version from public use/i)).toBeTruthy();
+  expect(screen.getByText(/restore the exact retained artifact later/i)).toBeTruthy();
   expect(screen.getByText(/version number remains reserved/i)).toBeTruthy();
-  expect(screen.getByText(/recovery is publishing a new version/i)).toBeTruthy();
+  expect(screen.getByText(/cannot be republished with different contents/i)).toBeTruthy();
+}
+
+function expectRestoreConfirmation(version: string) {
+  expect(screen.getByRole("heading", { name: `Restore version ${version}?` })).toBeTruthy();
+  expect(screen.getByText(/restores the exact retained artifact/i)).toBeTruthy();
+  expect(
+    screen.getByText(/will not become latest or regain removed tags automatically/i),
+  ).toBeTruthy();
 }
 
 function getVersionRowButton(version: string) {
@@ -180,6 +197,14 @@ function getVersionRowButton(version: string) {
 describe("version Delete UI", () => {
   beforeEach(() => {
     useMutationMock.mockReset();
+    useQueryMock.mockReset();
+    useQueryMock.mockReturnValue(undefined);
+    usePaginatedQueryMock.mockReset();
+    usePaginatedQueryMock.mockReturnValue({
+      results: [],
+      status: "Exhausted",
+      loadMore: vi.fn(),
+    });
     vi.mocked(fetchPackageVersions).mockReset();
     vi.mocked(toast.error).mockReset();
     vi.mocked(toast.success).mockReset();
@@ -187,8 +212,13 @@ describe("version Delete UI", () => {
 
   it("lets a skill owner confirm deletion of a non-latest version", async () => {
     const deleteOwnedVersion = vi.fn().mockResolvedValue({ ok: true });
+    const restoreOwnedVersion = vi.fn().mockResolvedValue({ ok: true });
     useMutationMock.mockImplementation((mutation) =>
-      getFunctionName(mutation) === "skills:deleteOwnedVersion" ? deleteOwnedVersion : vi.fn(),
+      getFunctionName(mutation) === "skills:deleteOwnedVersion"
+        ? deleteOwnedVersion
+        : getFunctionName(mutation) === "skills:restoreOwnedVersion"
+          ? restoreOwnedVersion
+          : vi.fn(),
     );
 
     renderSkillVersions();
@@ -196,15 +226,26 @@ describe("version Delete UI", () => {
     expect(screen.getByText("Latest")).toBeTruthy();
     expect(screen.queryByRole("button", { name: "Delete version 2.0.0" })).toBeNull();
     fireEvent.click(screen.getByRole("button", { name: "Delete version 1.0.0" }));
-    expectIrreversibleConfirmation("1.0.0");
+    expectWithdrawalConfirmation("1.0.0");
 
     fireEvent.click(screen.getByRole("button", { name: "Delete version" }));
 
     await waitFor(() => {
       expect(deleteOwnedVersion).toHaveBeenCalledWith({ versionId: olderSkillVersionId });
-      expect(screen.queryByText("Older skill release")).toBeNull();
+      expect(getVersionRowButton("1.0.0")).toBeTruthy();
+      expect(screen.getByRole("button", { name: "Restore version 1.0.0" })).toBeTruthy();
       expect(getVersionRowButton("2.0.0")).toBeTruthy();
       expect(toast.success).toHaveBeenCalledWith("Deleted version 1.0.0.");
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Restore version 1.0.0" }));
+    expectRestoreConfirmation("1.0.0");
+    fireEvent.click(screen.getByRole("button", { name: "Restore version" }));
+
+    await waitFor(() => {
+      expect(restoreOwnedVersion).toHaveBeenCalledWith({ versionId: olderSkillVersionId });
+      expect(screen.getByRole("button", { name: "Delete version 1.0.0" })).toBeTruthy();
+      expect(toast.success).toHaveBeenCalledWith("Restored version 1.0.0.");
     });
   });
 
@@ -216,12 +257,13 @@ describe("version Delete UI", () => {
     const { rerender } = renderSkillVersions();
 
     fireEvent.click(screen.getByRole("button", { name: "Delete version 1.0.0" }));
-    expectIrreversibleConfirmation("1.0.0");
+    expectWithdrawalConfirmation("1.0.0");
 
     rerender(
       makeSkillVersionsPanel({
         versions: otherSkillVersions.slice(0, 1),
         latestVersionId: otherLatestSkillVersionId,
+        panelSkillId: otherSkillId,
         skillSlug: "other-skill",
       }),
     );
@@ -252,11 +294,12 @@ describe("version Delete UI", () => {
       makeSkillVersionsPanel({
         versions: otherSkillVersions,
         latestVersionId: otherLatestSkillVersionId,
+        panelSkillId: otherSkillId,
         skillSlug: "other-skill",
       }),
     );
     fireEvent.click(screen.getByRole("button", { name: "Delete version 2.5.0" }));
-    expectIrreversibleConfirmation("2.5.0");
+    expectWithdrawalConfirmation("2.5.0");
 
     resolveDelete({ ok: true });
 
@@ -264,6 +307,41 @@ describe("version Delete UI", () => {
       expect(screen.getByRole("heading", { name: "Delete version 2.5.0?" })).toBeTruthy();
     });
     expect(toast.success).not.toHaveBeenCalled();
+  });
+
+  it("cannot restore a pending version after navigating to a different same-slug skill", () => {
+    const restoreOwnedVersion = vi.fn().mockResolvedValue({ ok: true });
+    useMutationMock.mockImplementation((mutation) =>
+      getFunctionName(mutation) === "skills:restoreOwnedVersion" ? restoreOwnedVersion : vi.fn(),
+    );
+    usePaginatedQueryMock.mockReturnValue({
+      results: [
+        {
+          ...skillVersions[1],
+          softDeletedAt: 4,
+          ownerDeletedAt: 4,
+        },
+      ],
+      status: "Exhausted",
+      loadMore: vi.fn(),
+    });
+    const { rerender } = renderSkillVersions();
+
+    fireEvent.click(screen.getByRole("button", { name: "Restore version 1.0.0" }));
+    expectRestoreConfirmation("1.0.0");
+
+    rerender(
+      makeSkillVersionsPanel({
+        versions: otherSkillVersions,
+        latestVersionId: otherLatestSkillVersionId,
+        panelSkillId: otherSkillId,
+        skillSlug: "weather",
+      }),
+    );
+
+    expect(screen.queryByRole("heading", { name: "Restore version 1.0.0?" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Restore version" })).toBeNull();
+    expect(restoreOwnedVersion).not.toHaveBeenCalled();
   });
 
   it("hides skill Delete actions without owner capability", () => {
@@ -291,7 +369,7 @@ describe("version Delete UI", () => {
       },
     ] as Doc<"skillVersions">[];
 
-    render(makeSkillVersionsPanel({ versions: unavailableVersions }));
+    render(makeSkillVersionsPanel({ versions: unavailableVersions, canDeleteVersions: false }));
 
     expect(getVersionRowButton("1.0.0")).toBeTruthy();
     expect(getVersionRowButton("0.9.0")).toBeTruthy();
@@ -302,6 +380,32 @@ describe("version Delete UI", () => {
         .getAllByRole("link", { name: /Download version v/ })
         .map((link) => new URL((link as HTMLAnchorElement).href).searchParams.get("version")),
     ).toEqual(["2.0.0"]);
+  });
+
+  it("shows owner-withdrawn skill versions returned by the paginated manager query", () => {
+    useMutationMock.mockReturnValue(vi.fn());
+    usePaginatedQueryMock.mockImplementation((query) =>
+      getFunctionName(query) === "skills:listWithdrawnVersionsForManager"
+        ? {
+            results: [
+              {
+                ...skillVersions[1],
+                _id: "skillVersions:withdrawn" as Id<"skillVersions">,
+                version: "0.8.0",
+                softDeletedAt: 4,
+                ownerDeletedAt: 4,
+              },
+            ],
+            status: "Exhausted",
+            loadMore: vi.fn(),
+          }
+        : { results: [], status: "Exhausted", loadMore: vi.fn() },
+    );
+
+    renderSkillVersions();
+
+    expect(screen.getByRole("button", { name: "Restore version 0.8.0" })).toBeTruthy();
+    expect(screen.queryByRole("link", { name: "Download version v0.8.0" })).toBeNull();
   });
 
   it("keeps Download version and Delete actions on active skill version rows", () => {
@@ -326,6 +430,7 @@ describe("version Delete UI", () => {
 
     render(
       <SkillVersionsPanel
+        skillId={skillId}
         versions={skillVersions}
         latestVersionId={olderSkillVersionId}
         latestTaggedVersionId={latestSkillVersionId}
@@ -365,15 +470,20 @@ describe("version Delete UI", () => {
 
   it("lets a plugin owner confirm deletion and refresh route metadata", async () => {
     const deleteOwnedRelease = vi.fn().mockResolvedValue({ ok: true });
+    const restoreOwnedRelease = vi.fn().mockResolvedValue({ ok: true });
     useMutationMock.mockImplementation((mutation) =>
-      getFunctionName(mutation) === "packages:deleteOwnedRelease" ? deleteOwnedRelease : vi.fn(),
+      getFunctionName(mutation) === "packages:deleteOwnedRelease"
+        ? deleteOwnedRelease
+        : getFunctionName(mutation) === "packages:restoreOwnedRelease"
+          ? restoreOwnedRelease
+          : vi.fn(),
     );
     const { onVersionDeleted } = renderPluginVersions();
 
     expect(screen.getAllByText(/latest/i).length).toBeGreaterThan(0);
     expect(screen.queryByRole("button", { name: "Delete version 2.0.0" })).toBeNull();
     fireEvent.click(screen.getByRole("button", { name: "Delete version 1.0.0" }));
-    expectIrreversibleConfirmation("1.0.0");
+    expectWithdrawalConfirmation("1.0.0");
 
     fireEvent.click(screen.getByRole("button", { name: "Delete version" }));
 
@@ -383,10 +493,25 @@ describe("version Delete UI", () => {
         version: "1.0.0",
       });
     });
-    expect(screen.queryByRole("button", { name: /v1\.0\.0/ })).toBeNull();
+    expect(getVersionRowButton("1.0.0")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Restore version 1.0.0" })).toBeTruthy();
     expect(getVersionRowButton("2.0.0")).toBeTruthy();
     expect(onVersionDeleted).toHaveBeenCalledTimes(1);
     expect(toast.success).toHaveBeenCalledWith("Deleted version 1.0.0.");
+
+    fireEvent.click(screen.getByRole("button", { name: "Restore version 1.0.0" }));
+    expectRestoreConfirmation("1.0.0");
+    fireEvent.click(screen.getByRole("button", { name: "Restore version" }));
+
+    await waitFor(() => {
+      expect(restoreOwnedRelease).toHaveBeenCalledWith({
+        name: "demo-plugin",
+        version: "1.0.0",
+      });
+      expect(screen.getByRole("button", { name: "Delete version 1.0.0" })).toBeTruthy();
+      expect(toast.success).toHaveBeenCalledWith("Restored version 1.0.0.");
+    });
+    expect(onVersionDeleted).toHaveBeenCalledTimes(2);
   });
 
   it("ignores a plugin deletion response after navigating to another plugin", async () => {
@@ -461,6 +586,55 @@ describe("version Delete UI", () => {
 
     expect(screen.getAllByText(/latest/i).length).toBeGreaterThan(0);
     expect(screen.queryByRole("button", { name: /Delete version/ })).toBeNull();
+  });
+
+  it("shows persisted owner-withdrawn plugin releases with Restore after reload", () => {
+    useMutationMock.mockReturnValue(vi.fn());
+    usePaginatedQueryMock.mockImplementation((query) =>
+      getFunctionName(query) === "packages:listVersionsForManager"
+        ? {
+            results: [
+              {
+                version: "0.8.0",
+                createdAt: 0,
+                changelog: "Persisted withdrawn release",
+                distTags: [],
+                softDeletedAt: 4,
+                ownerDeletedAt: 4,
+              },
+            ],
+            status: "Exhausted",
+            loadMore: vi.fn(),
+          }
+        : { results: [], status: "Exhausted", loadMore: vi.fn() },
+    );
+
+    renderPluginVersions();
+
+    expect(screen.getByRole("button", { name: "Restore version 0.8.0" })).toBeTruthy();
+    expect(screen.queryByRole("link", { name: "Download .zip for v0.8.0" })).toBeNull();
+  });
+
+  it("shows manager pagination when a filtered plugin page has no visible releases", () => {
+    useMutationMock.mockReturnValue(vi.fn());
+    const loadMore = vi.fn();
+    usePaginatedQueryMock.mockReturnValue({
+      results: [],
+      status: "CanLoadMore",
+      loadMore,
+    });
+
+    render(
+      <PluginVersionsPanel
+        packageName="demo-plugin"
+        versions={{ items: [], nextCursor: null }}
+        latestVersion={null}
+        canDeleteVersions
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Load more" }));
+    expect(loadMore).toHaveBeenCalledWith(PLUGIN_VERSIONS_PAGE_SIZE);
   });
 
   it("treats the plugin latest dist-tag as current when route metadata is stale", () => {

--- a/src/components/PluginVersionsPanel.tsx
+++ b/src/components/PluginVersionsPanel.tsx
@@ -1,5 +1,5 @@
 import type { ApiV1PackageVersionListResponse } from "clawhub-schema";
-import { useMutation } from "convex/react";
+import { useMutation, usePaginatedQuery } from "convex/react";
 import { Download } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
@@ -12,8 +12,14 @@ import { Button } from "./ui/button";
 import { VersionChangelog } from "./VersionChangelog";
 import { VersionDeleteDialog } from "./VersionDeleteDialog";
 import { VersionReleaseRow } from "./VersionReleaseRow";
+import { VersionRestoreDialog } from "./VersionRestoreDialog";
 
 export const PLUGIN_VERSIONS_PAGE_SIZE = 20;
+
+type PluginVersionItem = ApiV1PackageVersionListResponse["items"][number] & {
+  softDeletedAt?: number;
+  ownerDeletedAt?: number;
+};
 
 type PluginVersionsPanelProps = {
   packageName: string;
@@ -34,6 +40,17 @@ function buildPluginDownloadHref(packageName: string, version: string) {
   return `${convexSiteUrl}/api/v1/packages/${packagePath}/download?${params.toString()}`;
 }
 
+function mergePluginVersions(...groups: PluginVersionItem[][]) {
+  return [
+    ...new Map(
+      groups
+        .flat()
+        .sort((a, b) => b.createdAt - a.createdAt)
+        .map((release) => [release.version, release]),
+    ).values(),
+  ];
+}
+
 export function PluginVersionsPanel({
   packageName,
   versions,
@@ -48,16 +65,32 @@ export function PluginVersionsPanel({
   const isLoading = versions === undefined;
   const isUnavailable = versions === null;
   const deleteOwnedRelease = useMutation(api.packages.deleteOwnedRelease);
-  const [releases, setReleases] = useState(versions?.items ?? []);
+  const restoreOwnedRelease = useMutation(api.packages.restoreOwnedRelease);
+  const {
+    results: managerVersionResults,
+    status: managerVersionsStatus,
+    loadMore: loadMoreManagerVersions,
+  } = usePaginatedQuery(
+    api.packages.listVersionsForManager,
+    canDeleteVersions ? { name: packageName } : "skip",
+    { initialNumItems: PLUGIN_VERSIONS_PAGE_SIZE },
+  );
+  const managerVersions = managerVersionResults as PluginVersionItem[];
+  const [releases, setReleases] = useState<PluginVersionItem[]>(versions?.items ?? []);
   const [nextCursor, setNextCursor] = useState(versions?.nextCursor ?? null);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
   const [loadMoreError, setLoadMoreError] = useState<string | null>(null);
   const [deletingVersion, setDeletingVersion] = useState<string | null>(null);
+  const [restoringVersion, setRestoringVersion] = useState<string | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
+  const [isRestoring, setIsRestoring] = useState(false);
+  const [withdrawnVersions, setWithdrawnVersions] = useState<Set<string>>(() => new Set());
+  const [restoredVersions, setRestoredVersions] = useState<Set<string>>(() => new Set());
   const [expandedVersions, setExpandedVersions] = useState<Set<string>>(() => new Set());
   const loadMoreInFlightRef = useRef(false);
   const loadMoreAbortControllerRef = useRef<AbortController | null>(null);
   const requestGenerationRef = useRef(0);
+  const visibleReleases = mergePluginVersions(releases, managerVersions);
 
   useEffect(() => {
     loadMoreAbortControllerRef.current?.abort();
@@ -68,7 +101,11 @@ export function PluginVersionsPanel({
     setIsLoadingMore(false);
     setLoadMoreError(null);
     setDeletingVersion(null);
+    setRestoringVersion(null);
     setIsDeleting(false);
+    setIsRestoring(false);
+    setWithdrawnVersions(new Set());
+    setRestoredVersions(new Set());
     setExpandedVersions(new Set());
     return () => loadMoreAbortControllerRef.current?.abort();
   }, [packageName, versions]);
@@ -86,7 +123,10 @@ export function PluginVersionsPanel({
   };
 
   const loadMore = async () => {
-    if (!nextCursor || loadMoreInFlightRef.current) return;
+    const canLoadMoreManagerVersions = managerVersionsStatus === "CanLoadMore";
+    if ((!nextCursor && !canLoadMoreManagerVersions) || loadMoreInFlightRef.current) return;
+    if (canLoadMoreManagerVersions) loadMoreManagerVersions(PLUGIN_VERSIONS_PAGE_SIZE);
+    if (!nextCursor) return;
     const cursor = nextCursor;
     const requestGeneration = requestGenerationRef.current;
     const controller = new AbortController();
@@ -101,7 +141,7 @@ export function PluginVersionsPanel({
         signal: controller.signal,
       });
       if (requestGeneration !== requestGenerationRef.current) return;
-      setReleases((current) => [...current, ...page.items]);
+      setReleases((current) => mergePluginVersions(current, page.items));
       setNextCursor(page.nextCursor);
     } catch {
       if (requestGeneration !== requestGenerationRef.current || controller.signal.aborted) return;
@@ -125,7 +165,12 @@ export function PluginVersionsPanel({
     try {
       await deleteOwnedRelease({ name: packageName, version });
       if (requestGeneration !== requestGenerationRef.current) return;
-      setReleases((current) => current.filter((release) => release.version !== version));
+      setWithdrawnVersions((current) => new Set(current).add(version));
+      setRestoredVersions((current) => {
+        const next = new Set(current);
+        next.delete(version);
+        return next;
+      });
       toast.success(`Deleted version ${version}.`);
       setDeletingVersion(null);
       void (async () => {
@@ -140,6 +185,41 @@ export function PluginVersionsPanel({
       toast.error(getUserFacingConvexError(error, "Version could not be deleted. Try again."));
     } finally {
       if (requestGeneration === requestGenerationRef.current) setIsDeleting(false);
+    }
+  };
+
+  const handleRestore = async () => {
+    if (!restoringVersion) return;
+    const requestGeneration = requestGenerationRef.current;
+    const version = restoringVersion;
+    const restoredRelease = visibleReleases.find((release) => release.version === version);
+    setIsRestoring(true);
+    try {
+      await restoreOwnedRelease({ name: packageName, version });
+      if (requestGeneration !== requestGenerationRef.current) return;
+      setWithdrawnVersions((current) => {
+        const next = new Set(current);
+        next.delete(version);
+        return next;
+      });
+      setRestoredVersions((current) => new Set(current).add(version));
+      if (restoredRelease) {
+        setReleases((current) => mergePluginVersions(current, [restoredRelease]));
+      }
+      toast.success(`Restored version ${version}.`);
+      setRestoringVersion(null);
+      void (async () => {
+        try {
+          await onVersionDeleted?.();
+        } catch {
+          // Local state already reflects the restore; a later route refresh can retry metadata.
+        }
+      })();
+    } catch (error) {
+      if (requestGeneration !== requestGenerationRef.current) return;
+      toast.error(getUserFacingConvexError(error, "Version could not be restored. Try again."));
+    } finally {
+      if (requestGeneration === requestGenerationRef.current) setIsRestoring(false);
     }
   };
 
@@ -170,7 +250,10 @@ export function PluginVersionsPanel({
               <p className="empty-state-body">Try again later.</p>
             )}
           </div>
-        ) : releases.length > 0 || nextCursor ? (
+        ) : visibleReleases.length > 0 ||
+          nextCursor ||
+          managerVersionsStatus === "CanLoadMore" ||
+          managerVersionsStatus === "LoadingMore" ? (
           <div className="skill-versions-scroll">
             <div className="skill-versions-list skill-versions-list-plugins">
               <div
@@ -186,9 +269,13 @@ export function PluginVersionsPanel({
                 </span>
                 <span className="skill-versions-col-expand" />
               </div>
-              {releases.map((release) => {
+              {visibleReleases.map((release) => {
                 const hasLatestTag = release.distTags?.includes("latest");
                 const isLatest = release.version === latestVersion || hasLatestTag;
+                const isWithdrawn =
+                  !restoredVersions.has(release.version) &&
+                  (withdrawnVersions.has(release.version) ||
+                    (release.softDeletedAt !== undefined && release.ownerDeletedAt !== undefined));
                 const isExpanded = expandedVersions.has(release.version);
                 const changelogId = `version-changelog-${release.version}`;
                 return (
@@ -226,18 +313,20 @@ export function PluginVersionsPanel({
                     }
                     actions={
                       <>
-                        <a
-                          href={buildPluginDownloadHref(packageName, release.version)}
-                          className="skill-version-release-download"
-                          aria-label={`Download .zip for v${release.version}`}
-                        >
-                          <Download
-                            className="skill-version-release-download-icon"
-                            size={14}
-                            aria-hidden="true"
-                          />
-                        </a>
-                        {canDeleteVersions && !isLatest ? (
+                        {!isWithdrawn ? (
+                          <a
+                            href={buildPluginDownloadHref(packageName, release.version)}
+                            className="skill-version-release-download"
+                            aria-label={`Download .zip for v${release.version}`}
+                          >
+                            <Download
+                              className="skill-version-release-download-icon"
+                              size={14}
+                              aria-hidden="true"
+                            />
+                          </a>
+                        ) : null}
+                        {canDeleteVersions && !isWithdrawn && !isLatest ? (
                           <Button
                             type="button"
                             variant="destructive"
@@ -246,6 +335,17 @@ export function PluginVersionsPanel({
                             onClick={() => setDeletingVersion(release.version)}
                           >
                             Delete
+                          </Button>
+                        ) : null}
+                        {canDeleteVersions && isWithdrawn ? (
+                          <Button
+                            type="button"
+                            variant="outline"
+                            size="sm"
+                            aria-label={`Restore version ${release.version}`}
+                            onClick={() => setRestoringVersion(release.version)}
+                          >
+                            Restore
                           </Button>
                         ) : null}
                       </>
@@ -261,13 +361,15 @@ export function PluginVersionsPanel({
                 {loadMoreError}
               </p>
             ) : null}
-            {nextCursor ? (
+            {nextCursor ||
+            managerVersionsStatus === "CanLoadMore" ||
+            managerVersionsStatus === "LoadingMore" ? (
               <div className="mt-3 flex justify-center">
                 <Button
                   type="button"
                   variant="outline"
                   size="sm"
-                  loading={isLoadingMore}
+                  loading={isLoadingMore || managerVersionsStatus === "LoadingMore"}
                   onClick={() => void loadMore()}
                 >
                   Load more
@@ -287,6 +389,14 @@ export function PluginVersionsPanel({
         onCancel={() => setDeletingVersion(null)}
         onConfirm={() => {
           void handleDelete();
+        }}
+      />
+      <VersionRestoreDialog
+        version={restoringVersion}
+        isRestoring={isRestoring}
+        onCancel={() => setRestoringVersion(null)}
+        onConfirm={() => {
+          void handleRestore();
         }}
       />
     </>

--- a/src/components/SkillDetailTabs.test.tsx
+++ b/src/components/SkillDetailTabs.test.tsx
@@ -11,6 +11,11 @@ const useMutationMock = vi.fn();
 
 vi.mock("convex/react", () => ({
   useMutation: (...args: unknown[]) => useMutationMock(...args),
+  usePaginatedQuery: () => ({
+    results: [],
+    status: "Exhausted",
+    loadMore: vi.fn(),
+  }),
 }));
 
 beforeEach(() => {

--- a/src/components/SkillDetailTabs.tsx
+++ b/src/components/SkillDetailTabs.tsx
@@ -368,6 +368,7 @@ export function SkillDetailTabs({
       {showArchiveTabs && activeTab === "versions" ? (
         <div role="tabpanel" id="skill-tabpanel-versions" aria-labelledby="skill-tab-versions">
           <SkillVersionsPanel
+            skillId={skill._id}
             versions={versions}
             latestVersionId={latestVersionId}
             latestTaggedVersionId={skill.tags.latest ?? null}

--- a/src/components/SkillVersionsPanel.tsx
+++ b/src/components/SkillVersionsPanel.tsx
@@ -1,4 +1,4 @@
-import { useMutation } from "convex/react";
+import { useMutation, usePaginatedQuery } from "convex/react";
 import { Download } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
@@ -12,8 +12,10 @@ import { Button } from "./ui/button";
 import { VersionChangelog } from "./VersionChangelog";
 import { VersionDeleteDialog } from "./VersionDeleteDialog";
 import { VersionReleaseRow } from "./VersionReleaseRow";
+import { VersionRestoreDialog } from "./VersionRestoreDialog";
 
 type SkillVersionsPanelProps = {
+  skillId: Id<"skills">;
   versions: Doc<"skillVersions">[] | undefined;
   latestVersionId: Id<"skillVersions"> | null;
   latestTaggedVersionId?: Id<"skillVersions"> | null;
@@ -24,6 +26,17 @@ type SkillVersionsPanelProps = {
   suppressScanResults: boolean;
   suppressedMessage: string | null;
 };
+
+function mergeSkillVersions(...groups: Doc<"skillVersions">[][]) {
+  return [
+    ...new Map(
+      groups
+        .flat()
+        .sort((a, b) => b.createdAt - a.createdAt)
+        .map((version) => [version._id, version]),
+    ).values(),
+  ];
+}
 
 function buildVersionDownloadHref(
   convexSiteUrl: string,
@@ -39,6 +52,7 @@ function buildVersionDownloadHref(
 }
 
 export function SkillVersionsPanel({
+  skillId,
   versions,
   latestVersionId,
   latestTaggedVersionId = null,
@@ -50,22 +64,43 @@ export function SkillVersionsPanel({
 }: SkillVersionsPanelProps) {
   const convexSiteUrl = getRuntimeEnv("VITE_CONVEX_SITE_URL") ?? "https://clawhub.ai";
   const deleteOwnedVersion = useMutation(api.skills.deleteOwnedVersion);
+  const restoreOwnedVersion = useMutation(api.skills.restoreOwnedVersion);
+  const {
+    results: managerVersionResults,
+    status: managerVersionsStatus,
+    loadMore: loadMoreManagerVersions,
+  } = usePaginatedQuery(
+    api.skills.listWithdrawnVersionsForManager,
+    canDeleteVersions ? { skillId } : "skip",
+    { initialNumItems: 20 },
+  );
   const [deletingVersion, setDeletingVersion] = useState<Doc<"skillVersions"> | null>(null);
+  const [restoringVersion, setRestoringVersion] = useState<Doc<"skillVersions"> | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
-  const [removedVersionIds, setRemovedVersionIds] = useState<Set<Id<"skillVersions">>>(
+  const [isRestoring, setIsRestoring] = useState(false);
+  const [withdrawnVersionIds, setWithdrawnVersionIds] = useState<Set<Id<"skillVersions">>>(
+    () => new Set(),
+  );
+  const [restoredVersionIds, setRestoredVersionIds] = useState<Set<Id<"skillVersions">>>(
     () => new Set(),
   );
   const [expandedVersionIds, setExpandedVersionIds] = useState<Set<string>>(() => new Set());
   const deleteContextIdRef = useRef(0);
-  const visibleVersions = (versions ?? []).filter((version) => !removedVersionIds.has(version._id));
+  const visibleVersions = mergeSkillVersions(
+    versions ?? [],
+    managerVersionResults as Doc<"skillVersions">[],
+  );
 
   useEffect(() => {
     deleteContextIdRef.current += 1;
     setDeletingVersion(null);
+    setRestoringVersion(null);
     setIsDeleting(false);
-    setRemovedVersionIds(new Set());
+    setIsRestoring(false);
+    setWithdrawnVersionIds(new Set());
+    setRestoredVersionIds(new Set());
     setExpandedVersionIds(new Set());
-  }, [skillSlug]);
+  }, [skillId]);
 
   const toggleVersion = (versionId: string) => {
     setExpandedVersionIds((current) => {
@@ -87,7 +122,12 @@ export function SkillVersionsPanel({
     try {
       await deleteOwnedVersion({ versionId: version._id });
       if (deleteContextIdRef.current !== deleteContextId) return;
-      setRemovedVersionIds((current) => new Set(current).add(version._id));
+      setWithdrawnVersionIds((current) => new Set(current).add(version._id));
+      setRestoredVersionIds((current) => {
+        const next = new Set(current);
+        next.delete(version._id);
+        return next;
+      });
       toast.success(`Deleted version ${version.version}.`);
       setDeletingVersion(null);
     } catch (error) {
@@ -95,6 +135,30 @@ export function SkillVersionsPanel({
       toast.error(getUserFacingConvexError(error, "Version could not be deleted. Try again."));
     } finally {
       if (deleteContextIdRef.current === deleteContextId) setIsDeleting(false);
+    }
+  };
+
+  const handleRestore = async () => {
+    if (!restoringVersion) return;
+    const restoreContextId = deleteContextIdRef.current;
+    const version = restoringVersion;
+    setIsRestoring(true);
+    try {
+      await restoreOwnedVersion({ versionId: version._id });
+      if (deleteContextIdRef.current !== restoreContextId) return;
+      setWithdrawnVersionIds((current) => {
+        const next = new Set(current);
+        next.delete(version._id);
+        return next;
+      });
+      setRestoredVersionIds((current) => new Set(current).add(version._id));
+      toast.success(`Restored version ${version.version}.`);
+      setRestoringVersion(null);
+    } catch (error) {
+      if (deleteContextIdRef.current !== restoreContextId) return;
+      toast.error(getUserFacingConvexError(error, "Version could not be restored. Try again."));
+    } finally {
+      if (deleteContextIdRef.current === restoreContextId) setIsRestoring(false);
     }
   };
 
@@ -121,8 +185,14 @@ export function SkillVersionsPanel({
             {visibleVersions.map((version) => {
               const isLatest =
                 version._id === latestVersionId || version._id === latestTaggedVersionId;
+              const isWithdrawn =
+                !restoredVersionIds.has(version._id) &&
+                (withdrawnVersionIds.has(version._id) ||
+                  (version.softDeletedAt !== undefined && version.ownerDeletedAt !== undefined));
               const isAvailable =
-                version.softDeletedAt === undefined && version.ownerDeletedAt === undefined;
+                !isWithdrawn &&
+                version.softDeletedAt === undefined &&
+                version.ownerDeletedAt === undefined;
               const isExpanded = expandedVersionIds.has(version._id);
               const isAutoChangelog = version.changelogSource === "auto";
               const changelogId = `version-changelog-${version._id}`;
@@ -180,6 +250,17 @@ export function SkillVersionsPanel({
                           Delete
                         </Button>
                       ) : null}
+                      {canDeleteVersions && isWithdrawn ? (
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="sm"
+                          aria-label={`Restore version ${version.version}`}
+                          onClick={() => setRestoringVersion(version)}
+                        >
+                          Restore
+                        </Button>
+                      ) : null}
                     </>
                   }
                   onToggle={() => toggleVersion(version._id)}
@@ -188,6 +269,20 @@ export function SkillVersionsPanel({
               );
             })}
           </div>
+          {canDeleteVersions &&
+          (managerVersionsStatus === "CanLoadMore" || managerVersionsStatus === "LoadingMore") ? (
+            <div className="mt-3 flex justify-center">
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                loading={managerVersionsStatus === "LoadingMore"}
+                onClick={() => loadMoreManagerVersions(20)}
+              >
+                Load more
+              </Button>
+            </div>
+          ) : null}
         </div>
       </div>
       <VersionDeleteDialog
@@ -196,6 +291,14 @@ export function SkillVersionsPanel({
         onCancel={() => setDeletingVersion(null)}
         onConfirm={() => {
           void handleDelete();
+        }}
+      />
+      <VersionRestoreDialog
+        version={restoringVersion?.version ?? null}
+        isRestoring={isRestoring}
+        onCancel={() => setRestoringVersion(null)}
+        onConfirm={() => {
+          void handleRestore();
         }}
       />
     </>

--- a/src/components/VersionRestoreDialog.tsx
+++ b/src/components/VersionRestoreDialog.tsx
@@ -8,41 +8,40 @@ import {
   DialogTitle,
 } from "./ui/dialog";
 
-type VersionDeleteDialogProps = {
+type VersionRestoreDialogProps = {
   version: string | null;
-  isDeleting: boolean;
+  isRestoring: boolean;
   onCancel: () => void;
   onConfirm: () => void;
 };
 
-export function VersionDeleteDialog({
+export function VersionRestoreDialog({
   version,
-  isDeleting,
+  isRestoring,
   onCancel,
   onConfirm,
-}: VersionDeleteDialogProps) {
+}: VersionRestoreDialogProps) {
   return (
     <Dialog
       open={version !== null}
       onOpenChange={(open) => {
-        if (!open && !isDeleting) onCancel();
+        if (!open && !isRestoring) onCancel();
       }}
     >
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Delete version {version}?</DialogTitle>
+          <DialogTitle>Restore version {version}?</DialogTitle>
           <DialogDescription>
-            This withdraws the version from public use. You can restore the exact retained artifact
-            later, but the version number remains reserved and cannot be republished with different
-            contents.
+            This restores the exact retained artifact. It will not become latest or regain removed
+            tags automatically.
           </DialogDescription>
         </DialogHeader>
         <DialogFooter>
-          <Button variant="ghost" onClick={onCancel} disabled={isDeleting}>
+          <Button variant="ghost" onClick={onCancel} disabled={isRestoring}>
             Cancel
           </Button>
-          <Button variant="destructive" loading={isDeleting} onClick={onConfirm}>
-            Delete version
+          <Button loading={isRestoring} onClick={onConfirm}>
+            Restore version
           </Button>
         </DialogFooter>
       </DialogContent>


### PR DESCRIPTION
## Summary

- let an owner restore only the exact retained skill version or plugin release that the same actor previously withdrew
- add compatible Convex, HTTP, CLI, and Versions UI restore surfaces while keeping duplicate version publishing rejected
- preserve latest pointers, parent metadata, skill tags, package tags, and plugin dist-tags; restored historical releases return without dist-tags
- keep moderator, security, malware, ban, parent-unavailable, latest-version, and only-version protections owner-irreversible
- add restore audit events and coverage for public lists, exact-version reads/downloads, search digests, and package metadata

## Validation

- `VITE_CONVEX_URL=https://example.invalid bunx vitest run convex/versionDeletion.test.ts convex/packages.public.test.ts convex/skills.versions.public.test.ts convex/httpApiV1.handlers.test.ts src/__tests__/version-delete-ui.test.tsx src/__tests__/skill-detail-page.test.tsx src/__tests__/package-detail-route.test.tsx src/components/SkillDetailTabs.test.tsx` (860 passed)
- `(cd packages/clawhub && bunx vitest run src/cli.version-delete.test.ts src/cli/commands/delete.test.ts src/cli/commands/packages.test.ts)` (97 passed)
- `bun run ci:static`
- `bun run ci:unit` (4,865 passed, 1 skipped)
- `bun run ci:types-build`
- `bun run ci:packages`
- `bun run ci:e2e-http`
- `bun run test:pw:local-auth -- --project=chromium e2e/local-auth/version-delete.pw.test.ts` (passed on retry after a local Convex fixture setup timeout; skill and plugin delete/restore flows completed with public API assertions and screenshots)
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` (clean)
