### PR TITLE
fix(security): handle artifact directory markers

### DIFF
--- a/scripts/security/run-codex-scan-worker.test.ts
+++ b/scripts/security/run-codex-scan-worker.test.ts
@@ -412,6 +412,51 @@ describe("run-codex-scan-worker diagnostics", () => {
     expect(metadata.target.files).toEqual([{ path: "SKILL.md", sha256: "abc123", size: 42 }]);
   });
 
+  it("materializes zero-byte directory markers with descendant files", async () => {
+    const workspace = await tempDir();
+
+    await writeArtifactWorkspace(
+      {
+        job: {
+          _id: "job-directory-marker",
+          hasMaliciousSignal: false,
+          leaseToken: "lease-secret",
+          source: "pre-publication",
+          targetKind: "skillVersion",
+          waitForVtUntil: 0,
+        },
+        target: {
+          files: [
+            {
+              path: "scripts",
+              sha256: "empty",
+              size: 0,
+              url: "data:application/octet-stream,",
+            },
+            {
+              path: "scripts/run.sh",
+              sha256: "script",
+              size: 18,
+              url: "data:text/plain,echo%20ready%0A",
+            },
+            {
+              path: "EMPTY",
+              sha256: "empty",
+              size: 0,
+              url: "data:application/octet-stream,",
+            },
+          ],
+        },
+      },
+      workspace,
+    );
+
+    expect(await readFile(join(workspace, "artifact", "scripts", "run.sh"), "utf8")).toBe(
+      "echo ready\n",
+    );
+    expect(await readFile(join(workspace, "artifact", "EMPTY"))).toHaveLength(0);
+  });
+
   it("omits signed artifact URLs from download failure errors", async () => {
     const unsafeLabels = unsafeFixtureLabels();
     const fetchMock = vi

--- a/scripts/security/run-codex-scan-worker.ts
+++ b/scripts/security/run-codex-scan-worker.ts
@@ -2,7 +2,7 @@ import { spawn } from "node:child_process";
 import { mkdirSync, readFileSync } from "node:fs";
 import { appendFile, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { basename, dirname, join, resolve } from "node:path";
+import { basename, dirname, join, resolve, sep } from "node:path";
 import { pathToFileURL } from "node:url";
 import { ConvexHttpClient } from "convex/browser";
 import { api } from "../../convex/_generated/api";
@@ -743,8 +743,19 @@ export async function writeArtifactWorkspace(job: ClaimedJob, workspace: string)
   };
   await writeFile(join(workspace, "metadata.json"), `${JSON.stringify(metadata, null, 2)}\n`);
 
-  for (const file of job.target.files ?? []) {
-    const out = safeOutputPath(workspace, file.path);
+  const files = (job.target.files ?? []).map((file) => ({
+    file,
+    out: safeOutputPath(workspace, file.path),
+  }));
+  for (const candidate of files) {
+    const isDirectoryMarker =
+      candidate.file.size === 0 &&
+      files.some(
+        (other) => other.out !== candidate.out && other.out.startsWith(`${candidate.out}${sep}`),
+      );
+    if (isDirectoryMarker) continue;
+
+    const { file, out } = candidate;
     await mkdir(dirname(out), { recursive: true });
     await writeFile(out, await download(file.url, { kind: "file", path: file.path }));
   }


### PR DESCRIPTION
## Summary

- treat zero-byte manifest entries as directory markers when another artifact path is nested beneath them
- preserve standalone zero-byte files and the existing fail-closed behavior for non-empty path collisions
- add regression coverage for a `scripts` marker plus `scripts/run.sh`

## Root cause

Some stored publish manifests contain archive-style directory marker entries such as `examples`, `scripts`, or `references`, followed by descendant files. The pre-publication worker materialized every entry as a file, so the later `mkdir(..., { recursive: true })` for a descendant failed with `EEXIST`. Those poison attempts were repeatedly reclaimed and failed within seconds.

This behavior originated with the artifact workspace materializer in #2290. The focused fix stays at that ownership boundary and skips an entry only when it is zero bytes and another validated output path proves it is an ancestor directory.

## Production evidence

- #3205's `rustok-wallet-tui@0.8.0` recovered without intervention and is now public; version `k970xpxnn4svm2zsar5d9hnqf18ayj12` resolves through the production query and the public API lists `0.8.0` as latest.
- The queue alert was real: the Axiom snapshot at July 21, 2026 6:54 AM PDT reported 35 pending, 30 ready, 19 scanner failures, and `oldestReadyAgeSeconds=296683`.
- A read-only production query at approximately 8:15 AM PDT reported 78 pending, all 78 ready, 19 scanner failures, zero active claims, and zero timeout-backed attempts.
- Workflow run https://github.com/openclaw/clawhub/actions/runs/29834604884 repeatedly encountered affected directory-marker artifacts.
- Separate runner capacity remains operational context: https://github.com/openclaw/clawhub/actions/runs/29838349752 was still queued without an assigned runner, while https://github.com/openclaw/clawhub/actions/runs/29842064346 was pending when checked. This PR does not change runner scheduling.

## Validation

- regression test failed on `origin/main` with the production `EEXIST` mechanism, then passed with this fix
- worker test suites: 42/42 passed
- `bun run ci:static`
- `bun run ci:unit` (377 test files passed, 1 skipped; 4,873 tests passed, 1 skipped)
- `bun run ci:types-build`
- autoreview clean: no accepted/actionable findings

No production data was modified and no recovery, moderation, deploy, or merge action was performed.

Fixes #3205.
