### PR TITLE
fix(security): prevent ClawScan timeout worker leaks

### DIFF
--- a/.github/workflows/security-scan-codex.yml
+++ b/.github/workflows/security-scan-codex.yml
@@ -64,7 +64,7 @@ jobs:
       CODEX_SECURITY_SCAN_MAX_JOBS: ${{ github.event.client_payload.max_jobs || inputs['max-jobs'] || '' }}
       CODEX_SECURITY_SCAN_MAX_RUNTIME_MINUTES: ${{ github.event.client_payload.max_runtime_minutes || inputs['max-runtime-minutes'] || '12' }}
       CODEX_SECURITY_SCAN_LANE: ${{ matrix.lane }}
-      CODEX_SECURITY_SCAN_CLAWSCAN_TIMEOUT_MS: ${{ vars.CODEX_SECURITY_SCAN_CLAWSCAN_TIMEOUT_MS || '240000' }}
+      CODEX_SECURITY_SCAN_CLAWSCAN_TIMEOUT_MS: ${{ vars.CODEX_SECURITY_SCAN_CLAWSCAN_TIMEOUT_MS || '900000' }}
       CODEX_SECURITY_SCAN_LEASE_MINUTES: "60"
       CODEX_SECURITY_SCAN_DIAGNOSTICS_DIR: codex-security-scan-diagnostics-${{ matrix.shard }}
       CODEX_SECURITY_SCAN_SHARD: ${{ matrix.shard }}

--- a/scripts/security/run-codex-scan-worker-clawscan.test.ts
+++ b/scripts/security/run-codex-scan-worker-clawscan.test.ts
@@ -7,7 +7,7 @@ import { join } from "node:path";
 import { promisify } from "node:util";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ClaimedJob } from "./run-codex-scan-worker";
-import { processJob } from "./run-codex-scan-worker";
+import { processJob, runClawScan } from "./run-codex-scan-worker";
 
 const tempDirs: string[] = [];
 const execFileAsync = promisify(execFile);
@@ -979,6 +979,62 @@ echo "this should never complete"`,
       else process.env.CODEX_SECURITY_SCAN_CLAWSCAN_COMMAND = previousCommand;
       if (previousTimeout === undefined) delete process.env.CODEX_SECURITY_SCAN_CLAWSCAN_TIMEOUT_MS;
       else process.env.CODEX_SECURITY_SCAN_CLAWSCAN_TIMEOUT_MS = previousTimeout;
+    }
+  });
+
+  it("terminates the full ClawScan process tree on timeout", async () => {
+    const workspace = await tempDir();
+    await mkdir(join(workspace, "artifact"), { recursive: true });
+    const fakeClawScan = join(workspace, "fake-clawscan");
+    await writeFakeClawScanCommand(
+      fakeClawScan,
+      `(
+  trap '' TERM
+  exec >/dev/null 2>&1
+  while true; do sleep 1; done
+) &
+child_pid=$!
+printf '%s' "$child_pid" > "${workspace}/descendant.pid"
+wait "$child_pid"`,
+    );
+    const previousCommand = process.env.CODEX_SECURITY_SCAN_CLAWSCAN_COMMAND;
+    const previousTimeout = process.env.CODEX_SECURITY_SCAN_CLAWSCAN_TIMEOUT_MS;
+    process.env.CODEX_SECURITY_SCAN_CLAWSCAN_COMMAND = fakeClawScan;
+    process.env.CODEX_SECURITY_SCAN_CLAWSCAN_TIMEOUT_MS = "2000";
+    let descendantPid: number | undefined;
+
+    try {
+      await expect(
+        runClawScan(skillVersionJob("securityScanJobs:process-tree-timeout"), workspace, () => {}),
+      ).rejects.toThrow("timed out");
+
+      descendantPid = Number(await readFile(join(workspace, "descendant.pid"), "utf8"));
+      let descendantRunning = true;
+      for (let attempt = 0; attempt < 20; attempt += 1) {
+        try {
+          process.kill(descendantPid, 0);
+          await new Promise((resolvePromise) => setTimeout(resolvePromise, 25));
+        } catch {
+          descendantRunning = false;
+          break;
+        }
+      }
+      expect(descendantRunning).toBe(false);
+    } finally {
+      if (descendantPid) {
+        try {
+          process.kill(descendantPid, "SIGKILL");
+        } catch {
+          // The fixed worker has already terminated the descendant.
+        }
+      }
+      if (previousCommand === undefined) delete process.env.CODEX_SECURITY_SCAN_CLAWSCAN_COMMAND;
+      else process.env.CODEX_SECURITY_SCAN_CLAWSCAN_COMMAND = previousCommand;
+      if (previousTimeout === undefined) {
+        delete process.env.CODEX_SECURITY_SCAN_CLAWSCAN_TIMEOUT_MS;
+      } else {
+        process.env.CODEX_SECURITY_SCAN_CLAWSCAN_TIMEOUT_MS = previousTimeout;
+      }
     }
   });
 });

--- a/scripts/security/run-codex-scan-worker.ts
+++ b/scripts/security/run-codex-scan-worker.ts
@@ -856,16 +856,30 @@ async function runCommand(
     for (const name of options.omitEnv ?? []) delete env[name];
     const child = spawn(command, args, {
       cwd: options.cwd,
+      detached: process.platform !== "win32",
       env,
       stdio: ["pipe", "pipe", "pipe"],
     });
     let stdout = "";
     let stderr = "";
     let timedOut = false;
+    let forceKillTimeout: NodeJS.Timeout | undefined;
+    const killProcessTree = (signal: NodeJS.Signals) => {
+      if (process.platform !== "win32" && child.pid) {
+        try {
+          process.kill(-child.pid, signal);
+          return;
+        } catch {
+          // The process group may already have exited; fall back to the direct child.
+        }
+      }
+      child.kill(signal);
+    };
     const timeout = setTimeout(() => {
       timedOut = true;
-      child.kill("SIGTERM");
-      setTimeout(() => child.kill("SIGKILL"), 10_000).unref();
+      killProcessTree("SIGTERM");
+      forceKillTimeout = setTimeout(() => killProcessTree("SIGKILL"), 10_000);
+      forceKillTimeout.unref();
     }, options.timeoutMs);
     child.stdout.on("data", (chunk) => {
       stdout += String(chunk);
@@ -875,10 +889,14 @@ async function runCommand(
     });
     child.on("error", (error) => {
       clearTimeout(timeout);
+      if (timedOut) killProcessTree("SIGKILL");
+      if (forceKillTimeout) clearTimeout(forceKillTimeout);
       reject(error);
     });
     child.on("close", (code) => {
       clearTimeout(timeout);
+      if (timedOut) killProcessTree("SIGKILL");
+      if (forceKillTimeout) clearTimeout(forceKillTimeout);
       if (code === 0) resolvePromise({ stdout, stderr });
       else {
         reject(

--- a/scripts/security/security-scan-worker-workflow.test.ts
+++ b/scripts/security/security-scan-worker-workflow.test.ts
@@ -118,7 +118,7 @@ describe("security-scan-codex workflow", () => {
       "${{ github.event.client_payload.max_runtime_minutes || inputs['max-runtime-minutes'] || '12' }}",
     );
     expect(jobEnv.CODEX_SECURITY_SCAN_CLAWSCAN_TIMEOUT_MS).toBe(
-      "${{ vars.CODEX_SECURITY_SCAN_CLAWSCAN_TIMEOUT_MS || '240000' }}",
+      "${{ vars.CODEX_SECURITY_SCAN_CLAWSCAN_TIMEOUT_MS || '900000' }}",
     );
     expect(jobEnv).not.toHaveProperty("CODEX_SECURITY_SCAN_MODE");
     expect(jobEnv).not.toHaveProperty("CODEX_SECURITY_SCAN_TIMEOUT_MS");

--- a/specs/security-moderation.md
+++ b/specs/security-moderation.md
@@ -312,6 +312,12 @@ See also: [acceptable-usage.md](./acceptable-usage.md) for the marketplace polic
   kind and source runs through the same ClawScan profile and completion/failure
   contract. ClawScan failures use the existing failure/retry lifecycle; there
   is no per-job fallback or alternate legacy route.
+- On Unix runners, ClawScan commands run in isolated process groups. A timeout
+  must terminate the full process group so surviving scanner or judge
+  descendants cannot hold a worker slot after the timeout is recorded.
+- The production scan-worker timeout defaults to 15 minutes. Package-release
+  SkillSpector runs can validly exceed four minutes, so a lower timeout must not
+  be used as the normal capacity control.
 - A ClawScan judge result is complete only when ClawScan verifies
   a workspace-only inspection challenge and the SHA-256 of a required artifact
   file. Missing or mismatched inspection receipts fail the judge and use the


### PR DESCRIPTION
## Summary
- raise the production ClawScan worker deadline from 4 minutes to 15 minutes so valid package SkillSpector scans can finish
- run ClawScan in an isolated Unix process group and terminate the full tree on timeout
- add regression coverage for descendant cleanup and the workflow timeout contract
- record the timeout/process-group invariants in the security moderation spec

## Incident evidence
- Axiom monitor: https://app.axiom.co/openclaw-9pp0/monitors/view/0521Dzj4IdLkxNczm4
- Failed worker run: https://github.com/openclaw/clawhub/actions/runs/29928631669
- `shared-4` claimed 4 jobs, completed 1, failed 1, and left 2 retryable failures after three `clawscan timed out` results.
- Its redacted artifacts show the timed-out package SkillSpector scans actually completed in 277.6s, 366.1s, and 381.9s, all beyond the configured 240s deadline.
- The outer worker calls did not return at 240s; they lasted 394.8s, 501.4s, and 508.9s because descendant processes survived the direct-child timeout signal.
- At 2026-07-22 09:05:41 PDT, the production queue snapshot still showed 23 ready jobs and an oldest-ready age of 2,184 seconds while the newest worker run had all 10 jobs pending.

## Deduplication
No open issue or PR matched this shared-worker timeout/process-tree defect. Related fixes are narrower or address different causes:
- #3145 terminates process trees only in the prepublication worker.
- #3190 raises only the prepublication timeout.
- #3188 addresses worker concurrency.
- #3206 addresses artifact directory markers.

## Regression proof
On clean `origin/main` (`89f5e62e`):
- the process-tree regression fails because the TERM-resistant descendant remains alive
- the workflow contract fails because production still defaults to `240000`

On this branch:
- `bunx vitest run scripts/security/run-codex-scan-worker-clawscan.test.ts scripts/security/security-scan-worker-workflow.test.ts` (43 passed)
- `bun run ci:static`
- `bun run ci:unit` (384 files passed, 1 skipped; 5,024 tests passed, 1 skipped)
- `bun run ci:types-build`
- `actionlint .github/workflows/security-scan-codex.yml`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local` (clean, no actionable findings)

## Rollout note
This PR does not deploy anything. After a manual production deploy, verify that a fresh worker run starts on the self-hosted runners, timeout failures stop for legitimate long package scans, and oldest-ready age drains below the alert threshold.
