### PR TITLE
fix: separate skill metrics by source

### DIFF
--- a/convex/githubSkillSync.test.ts
+++ b/convex/githubSkillSync.test.ts
@@ -1471,6 +1471,21 @@ description: Install from a GitHub-backed source.
         scanStatus: "clean",
         now,
       });
+      Object.assign(skill, {
+        statsDownloads: 41,
+        statsStars: 7,
+        statsInstallsCurrent: 3,
+        statsInstallsAllTime: 13,
+        statsSkillsShInstalls: 29,
+        statsGithubStars: 701,
+        stats: {
+          downloads: 41,
+          stars: 7,
+          installsCurrent: 3,
+          installsAllTime: 13,
+          versions: 0,
+        },
+      });
       expect(resolveInstallFromTables(tables, "demo-source")).toMatchObject({
         ok: true,
         installKind: "github",
@@ -1512,6 +1527,12 @@ description: Install from a GitHub-backed source.
         githubCurrentStatus: "present",
         githubScanStatus: "clean",
         moderationStatus: "active",
+        statsDownloads: 41,
+        statsStars: 7,
+        statsInstallsCurrent: 3,
+        statsInstallsAllTime: 13,
+        statsSkillsShInstalls: 29,
+        statsGithubStars: 701,
       });
       expect(skill.githubCurrentContentHash).toBe(commitAContentHash);
       expect(tables.githubSkillContents[0]).toMatchObject({
@@ -1562,6 +1583,14 @@ description: Install from a GitHub-backed source.
           contentHash: skill.githubCurrentContentHash,
         },
       });
+      expect(skill).toMatchObject({
+        statsDownloads: 41,
+        statsStars: 7,
+        statsInstallsCurrent: 3,
+        statsInstallsAllTime: 13,
+        statsSkillsShInstalls: 29,
+        statsGithubStars: 701,
+      });
 
       fakeGitHub.setSnapshot({
         commit: "c".repeat(40),
@@ -1583,6 +1612,12 @@ description: Install from a GitHub-backed source.
         softDeletedAt: 300,
         moderationStatus: "hidden",
         moderationReason: "github.upstream.removed",
+        statsDownloads: 41,
+        statsStars: 7,
+        statsInstallsCurrent: 3,
+        statsInstallsAllTime: 13,
+        statsSkillsShInstalls: 29,
+        statsGithubStars: 701,
       });
       expect(resolveInstallFromTables(tables, "demo-source")).toMatchObject({
         ok: false,
@@ -1611,6 +1646,12 @@ description: Install from a GitHub-backed source.
         githubScanStatus: "pending",
         moderationStatus: "active",
         moderationReason: "pending.scan",
+        statsDownloads: 41,
+        statsStars: 7,
+        statsInstallsCurrent: 3,
+        statsInstallsAllTime: 13,
+        statsSkillsShInstalls: 29,
+        statsGithubStars: 701,
       });
       expect(reappeared).not.toHaveProperty("softDeletedAt");
       expect(resolveInstallFromTables(tables, "demo-source")).toMatchObject({
@@ -2010,6 +2051,8 @@ description: Build HTML artifacts.
           statsStars: 11,
           statsInstallsCurrent: 5,
           statsInstallsAllTime: 23,
+          statsSkillsShInstalls: 47,
+          statsGithubStars: 901,
           stats: {
             downloads: 37,
             stars: 11,
@@ -2080,6 +2123,8 @@ description: Build HTML artifacts.
       statsStars: 11,
       statsInstallsCurrent: 5,
       statsInstallsAllTime: 23,
+      statsSkillsShInstalls: 47,
+      statsGithubStars: 901,
       githubPendingCandidateId: candidate?._id,
     });
     expect(pendingSkill).not.toHaveProperty("installKind");
@@ -2138,6 +2183,8 @@ description: Build HTML artifacts.
       statsStars: 11,
       statsInstallsCurrent: 5,
       statsInstallsAllTime: 23,
+      statsSkillsShInstalls: 47,
+      statsGithubStars: 901,
     });
     expect(tables.skills[0]).not.toHaveProperty("latestVersionId");
     expect(tables.skills[0]).not.toHaveProperty("githubPendingCandidateId");
@@ -2719,6 +2766,12 @@ description: Build HTML artifacts.
           githubCurrentStatus: "present",
           githubScanStatus: "pending",
           tags: {},
+          statsDownloads: 7,
+          statsStars: 3,
+          statsInstallsCurrent: 2,
+          statsInstallsAllTime: 5,
+          statsSkillsShInstalls: 17,
+          statsGithubStars: 321,
           stats: { downloads: 0, stars: 0, installsCurrent: 0, installsAllTime: 0, versions: 0 },
           createdAt: 1,
           updatedAt: 1,
@@ -3010,6 +3063,12 @@ describe("applyGitHubSkillVerificationResultHandler", () => {
           githubCurrentStatus: "present",
           githubScanStatus: "pending",
           tags: {},
+          statsDownloads: 7,
+          statsStars: 3,
+          statsInstallsCurrent: 2,
+          statsInstallsAllTime: 5,
+          statsSkillsShInstalls: 17,
+          statsGithubStars: 321,
           stats: { downloads: 0, stars: 0, installsCurrent: 0, installsAllTime: 0, versions: 0 },
           moderationStatus: "hidden",
           moderationReason: "pending.scan",
@@ -3041,6 +3100,12 @@ describe("applyGitHubSkillVerificationResultHandler", () => {
     });
     expect(tables.skills[0]).toMatchObject({
       githubScanStatus: "pending",
+      statsDownloads: 7,
+      statsStars: 3,
+      statsInstallsCurrent: 2,
+      statsInstallsAllTime: 5,
+      statsSkillsShInstalls: 17,
+      statsGithubStars: 321,
     });
 
     const promoted = await applyGitHubSkillVerificationResultHandler({ db } as never, {

--- a/convex/lib/public.test.ts
+++ b/convex/lib/public.test.ts
@@ -59,7 +59,7 @@ describe("public skill mapping", () => {
 
     expect(mapped).not.toBeNull();
     expect(mapped?.stats).toEqual({
-      downloads: 20,
+      downloads: 12,
       stars: 3,
       installs: 7,
       versions: 0,
@@ -76,7 +76,7 @@ describe("public skill mapping", () => {
       }),
     );
 
-    expect(mapped?.stats.downloads).toBe(20);
+    expect(mapped?.stats.downloads).toBe(12);
     expect(mapped).not.toHaveProperty("statsSkillsShInstalls");
     expect(mapped).not.toHaveProperty("statsGithubStars");
   });

--- a/convex/lib/skillStats.test.ts
+++ b/convex/lib/skillStats.test.ts
@@ -32,8 +32,27 @@ describe("source-attributed skill metrics", () => {
     });
   });
 
-  it("adds skills.sh installs to public downloads without double-counting OpenClaw installs", () => {
-    expect(readPublicDownloads(skill)).toBe(49);
+  it("keeps public downloads scoped to ClawHub artifacts", () => {
+    expect(readPublicDownloads(skill)).toBe(40);
+  });
+
+  it("preserves unavailable external metrics instead of serializing them as zero", () => {
+    expect(
+      readSkillMetricSources({
+        statsDownloads: 4,
+        statsStars: 2,
+        statsInstallsCurrent: 1,
+        statsInstallsAllTime: 3,
+        stats: {},
+      }),
+    ).toEqual({
+      clawHubDownloads: 4,
+      skillsShInstalls: null,
+      openClawInstallsCurrent: 1,
+      openClawInstallsAllTime: 3,
+      githubStars: null,
+      bookmarks: 2,
+    });
   });
 
   it("builds a source-only refresh patch and preserves unknown GitHub popularity", () => {

--- a/convex/lib/skillStats.ts
+++ b/convex/lib/skillStats.ts
@@ -32,6 +32,10 @@ function nonNegativeCount(value: number | undefined): number {
   return Math.max(0, Math.trunc(value));
 }
 
+function optionalNonNegativeCount(value: number | undefined): number | null {
+  return value === undefined ? null : nonNegativeCount(value);
+}
+
 /**
  * Read the canonical value of a migrated stat field from a skill document.
  *
@@ -58,16 +62,16 @@ export function readCanonicalStat(
 export function readSkillMetricSources(skill: SkillStatReadable) {
   return {
     clawHubDownloads: readCanonicalStat(skill, "downloads"),
-    skillsShInstalls: nonNegativeCount(skill.statsSkillsShInstalls),
+    skillsShInstalls: optionalNonNegativeCount(skill.statsSkillsShInstalls),
     openClawInstallsCurrent: readCanonicalStat(skill, "installsCurrent"),
     openClawInstallsAllTime: readCanonicalStat(skill, "installsAllTime"),
-    githubStars: nonNegativeCount(skill.statsGithubStars),
+    githubStars: optionalNonNegativeCount(skill.statsGithubStars),
     bookmarks: readCanonicalStat(skill, "stars"),
   };
 }
 
 export function readPublicDownloads(skill: SkillStatReadable): number {
-  return readCanonicalStat(skill, "downloads") + nonNegativeCount(skill.statsSkillsShInstalls);
+  return readCanonicalStat(skill, "downloads");
 }
 
 export function buildExternalSkillMetricPatch(snapshot: ExternalSkillMetricSnapshot) {

--- a/convex/publishers.test.ts
+++ b/convex/publishers.test.ts
@@ -3194,7 +3194,7 @@ describe("publishers membership controls", () => {
     });
 
     expect(firstPage.page.map((item) => item.kind)).toEqual(["skill"]);
-    expect(firstPage.page[0]?.downloads).toBe(16);
+    expect(firstPage.page[0]?.downloads).toBe(10);
     expect(firstPage.continueCursor).toBe("1");
     expect(firstPage.isDone).toBe(false);
     expect(secondPage.page.map((item) => item.kind)).toEqual(["plugin"]);
@@ -3519,7 +3519,7 @@ describe("publishers membership controls", () => {
       skills: 1,
       packages: 1,
       installs: 12,
-      downloads: 58,
+      downloads: 50,
       stars: 3,
     });
   });

--- a/convex/skills.dashboard.test.ts
+++ b/convex/skills.dashboard.test.ts
@@ -240,7 +240,7 @@ describe("skills.listDashboardPaginated", () => {
     expect(result.page).toEqual([
       expect.objectContaining({
         slug: "slack",
-        stats: expect.objectContaining({ downloads: 20 }),
+        stats: expect.objectContaining({ downloads: 12 }),
         metricSources: {
           clawHubDownloads: 12,
           skillsShInstalls: 8,

--- a/convex/skills.packageCatalog.test.ts
+++ b/convex/skills.packageCatalog.test.ts
@@ -345,7 +345,7 @@ describe("skills package catalog queries", () => {
     ]);
   });
 
-  it("presents combined downloads without changing the native download index", async () => {
+  it("presents ClawHub downloads without changing the native download index", async () => {
     const indexNames: string[] = [];
     const result = await listPackageCatalogPageHandler(
       makeCtx(
@@ -370,7 +370,7 @@ describe("skills package catalog queries", () => {
     );
 
     expect(indexNames).toContain("by_active_stats_downloads");
-    expect(result.page[0]?.stats.downloads).toBe(20);
+    expect(result.page[0]?.stats.downloads).toBe(12);
   });
 
   it("normalizes and filters skill package catalog topics", async () => {

--- a/convex/skillsShCatalog.ts
+++ b/convex/skillsShCatalog.ts
@@ -38,10 +38,6 @@ const MAX_WRITES_PER_BATCH = 100;
 const MAX_SCAN_ADMISSIONS_PER_BATCH = 100;
 const MAX_SCAN_ADMISSIONS_PER_RUN = 500;
 const MAX_REAL_TEST_ADMISSIONS = 10;
-const CLEARED_EXTERNAL_SKILL_METRICS = {
-  statsSkillsShInstalls: undefined,
-  statsGithubStars: undefined,
-};
 const MAX_DETERMINISTIC_COMPLETIONS_PER_BATCH = 50;
 
 const fixtureIdValidator = v.union(
@@ -247,14 +243,16 @@ export const syncNativeSkillMetricsFromCatalogEntryInternal = internalMutation({
   handler: async (ctx, args) => {
     const [entry, skill] = await Promise.all([ctx.db.get(args.entryId), ctx.db.get(args.skillId)]);
     if (!entry || !skill) return { applied: false };
-    const patch =
-      entry.reconciliation?.kind === "exact-native" &&
-      entry.reconciliation.nativeSkillId === args.skillId
-        ? buildExternalSkillMetricPatch({
-            skillsShInstalls: entry.installs,
-            githubStars: entry.githubStars,
-          })
-        : CLEARED_EXTERNAL_SKILL_METRICS;
+    if (
+      entry.reconciliation?.kind !== "exact-native" ||
+      entry.reconciliation.nativeSkillId !== args.skillId
+    ) {
+      return { applied: false };
+    }
+    const patch = buildExternalSkillMetricPatch({
+      skillsShInstalls: entry.installs,
+      githubStars: entry.githubStars,
+    });
     const changed = Object.entries(patch).some(
       ([field, value]) => skill[field as keyof typeof skill] !== value,
     );
@@ -2473,7 +2471,7 @@ export const rollbackFixtureRunInternal = internalMutation({
     }
     const fixture = getSkillsShCatalogFixture(run.fixtureId);
     let deletedEntries = 0;
-    let nativeSkillsChanged = 0;
+    const nativeSkillsChanged = 0;
     for (let index = 0; index < fixture.length; index += 1) {
       const expected = normalizeIdentity(fixture.rowAt(index));
       const entry = await ctx.db
@@ -2495,21 +2493,6 @@ export const rollbackFixtureRunInternal = internalMutation({
         throw new ConvexError(
           `Controlled canary has retained scan history: ${expected.externalId}`,
         );
-      }
-      const nativeSkillId =
-        entry.reconciliation?.kind === "exact-native"
-          ? entry.reconciliation.nativeSkillId
-          : undefined;
-      if (nativeSkillId) {
-        const nativeSkill = await ctx.db.get(nativeSkillId);
-        if (
-          nativeSkill &&
-          (nativeSkill.statsSkillsShInstalls !== undefined ||
-            nativeSkill.statsGithubStars !== undefined)
-        ) {
-          await ctx.db.patch(nativeSkillId, CLEARED_EXTERNAL_SKILL_METRICS);
-          nativeSkillsChanged += 1;
-        }
       }
       await ctx.db.delete(entry._id);
       deletedEntries += 1;

--- a/convex/skillsShCatalogCanary.test.ts
+++ b/convex/skillsShCatalogCanary.test.ts
@@ -409,7 +409,7 @@ describe("skills.sh controlled hidden metadata canary", () => {
     });
   });
 
-  it("clears exact-native upstream metrics when the controlled entry is removed", async () => {
+  it("preserves exact-native upstream metric history when the controlled entry is removed", async () => {
     vi.useFakeTimers();
     useEnvironment(LOCAL_ENV);
     const t = convexTest(schema, modules);
@@ -440,12 +440,12 @@ describe("skills.sh controlled hidden metadata canary", () => {
 
     expect(rollback).toMatchObject({
       deletedEntries: 1,
-      nativeSkillsChanged: 1,
+      nativeSkillsChanged: 0,
     });
-    expect(native?.statsSkillsShInstalls).toBeUndefined();
-    expect(native?.statsGithubStars).toBeUndefined();
-    expect(digest?.statsSkillsShInstalls).toBeUndefined();
-    expect(digest?.statsGithubStars).toBeUndefined();
+    expect(native?.statsSkillsShInstalls).toBe(17);
+    expect(native?.statsGithubStars).toBe(321);
+    expect(digest?.statsSkillsShInstalls).toBe(17);
+    expect(digest?.statsGithubStars).toBe(321);
     expect(native).toMatchObject({
       statsDownloads: 143,
       statsStars: 5,
@@ -460,7 +460,7 @@ describe("skills.sh controlled hidden metadata canary", () => {
     });
   });
 
-  it("clears upstream metrics when an exact native match becomes a route collision", async () => {
+  it("preserves upstream metric history when an exact native match becomes a route collision", async () => {
     vi.useFakeTimers();
     useEnvironment(LOCAL_ENV);
     const t = convexTest(schema, modules);
@@ -495,10 +495,10 @@ describe("skills.sh controlled hidden metadata canary", () => {
       exactNativeMatches: 0,
       routeCollisions: 1,
     });
-    expect(native?.statsSkillsShInstalls).toBeUndefined();
-    expect(native?.statsGithubStars).toBeUndefined();
-    expect(digest?.statsSkillsShInstalls).toBeUndefined();
-    expect(digest?.statsGithubStars).toBeUndefined();
+    expect(native?.statsSkillsShInstalls).toBe(17);
+    expect(native?.statsGithubStars).toBe(321);
+    expect(digest?.statsSkillsShInstalls).toBe(17);
+    expect(digest?.statsGithubStars).toBe(321);
     expect(native).toMatchObject({
       statsDownloads: 143,
       stats: { downloads: 143 },

--- a/e2e/local-auth/skill-star-sync.pw.test.ts
+++ b/e2e/local-auth/skill-star-sync.pw.test.ts
@@ -69,7 +69,7 @@ async function expectHealthyStarPage(page: import("@playwright/test").Page, erro
   );
 }
 
-test("starring a skill survives refresh with the synchronized count", async ({
+test("bookmarking a skill survives refresh with the synchronized count", async ({
   page,
 }, testInfo) => {
   const errors = trackRuntimeErrors(page);
@@ -89,23 +89,26 @@ test("starring a skill survives refresh with the synchronized count", async ({
 
   await signInAsLocalPersona(page, "user");
   errors.length = 0;
-  const starButton = await gotoUntilStarButtonReady(page, buildSkillDetailHref(ownerHandle, slug));
+  const bookmarkButton = await gotoUntilStarButtonReady(
+    page,
+    buildSkillDetailHref(ownerHandle, slug),
+  );
   await expectLocalPersonaActive(page, "user");
 
-  await expect(starButton).toContainText("0");
+  await expect(bookmarkButton).toContainText("0");
 
-  await starButton.click();
+  await bookmarkButton.click();
 
-  const unstarButton = page.getByRole("button", { name: "Remove bookmark" });
-  await expect(unstarButton).toBeVisible({ timeout: 30_000 });
-  await expect(unstarButton).toContainText("1", { timeout: 30_000 });
+  const unbookmarkButton = page.getByRole("button", { name: "Unbookmark skill" });
+  await expect(unbookmarkButton).toBeVisible({ timeout: 30_000 });
+  await expect(unbookmarkButton).toContainText("1", { timeout: 30_000 });
 
   await page.reload({ waitUntil: "domcontentloaded" });
   await waitForHydration(page);
 
-  const refreshedUnstarButton = page.getByRole("button", { name: "Remove bookmark" });
-  await expect(refreshedUnstarButton).toBeVisible({ timeout: 30_000 });
-  await expect(refreshedUnstarButton).toContainText("1", { timeout: 30_000 });
+  const refreshedUnbookmarkButton = page.getByRole("button", { name: "Unbookmark skill" });
+  await expect(refreshedUnbookmarkButton).toBeVisible({ timeout: 30_000 });
+  await expect(refreshedUnbookmarkButton).toContainText("1", { timeout: 30_000 });
 
   await expectHealthyStarPage(page, errors);
 });

--- a/specs/download-metering.md
+++ b/specs/download-metering.md
@@ -30,27 +30,29 @@ for native ClawHub downloads still use the canonical skill download field:
 statsDownloads
 ```
 
-Skills mirrored from skills.sh store the upstream install count separately in
-`statsSkillsShInstalls`. Public skill Downloads are computed at serialization:
+Skills mirrored from skills.sh store the upstream lifetime install count
+separately in `statsSkillsShInstalls`. Public skill Downloads remain scoped to
+ClawHub artifact downloads:
 
 ```text
-native skill:        statsDownloads
-skills.sh indexed:   statsDownloads + statsSkillsShInstalls
+public Downloads:   statsDownloads
+skills.sh installs: statsSkillsShInstalls (lifetime)
 ```
 
-The combined value is never written back into `statsDownloads`. Existing
-historical ClawHub downloads remain intact, and search ranking continues to use
-the native field.
+These values are never combined into one Downloads counter. Existing historical
+ClawHub downloads remain intact, and canonical search gives lifetime downloads
+and skills.sh lifetime installs zero ranking weight.
 
 OpenClaw install telemetry remains in `statsInstallsCurrent` and
 `statsInstallsAllTime`; it is not added to public Downloads. GitHub popularity
 is stored in `statsGithubStars`. Existing `stars` rows and `statsStars` count
 ClawHub Bookmarks and retain those storage/API names for compatibility.
 
-Source refresh, adoption, content replacement, and GitHub synchronization may
-update source metadata or upstream counters, but must not reset or rewrite any
-other metric source. Publisher dashboards receive the source breakdown while
-ordinary public skill shapes expose only the combined Downloads value.
+Source refresh, adoption, content replacement, rollback, and GitHub
+synchronization may update source metadata or newer observations, but must not
+reset or rewrite any metric source. Publisher dashboards receive the attributed
+source breakdown; ordinary public skill shapes expose ClawHub artifact downloads
+as Downloads without manufacturing a cross-source total.
 
 ## Daily Package Graphs
 

--- a/specs/spec.md
+++ b/specs/spec.md
@@ -60,9 +60,10 @@ read_when:
 - `statsGithubStars`: upstream GitHub popularity.
 - `statsStars`: ClawHub Bookmarks; existing `stars` rows and API names remain for
   compatibility.
-- Public Downloads are `statsDownloads` for native-only skills and
-  `statsDownloads + statsSkillsShInstalls` for skills.sh-indexed skills.
-- Canonical mixed skill search never ranks by this combined presentation value.
+- Public Downloads are always `statsDownloads`; skills.sh lifetime installs are
+  independently attributed and never folded into Downloads.
+- Canonical mixed skill search gives lifetime Downloads and skills.sh lifetime
+  installs zero ranking weight.
   It uses lexical/semantic relevance first, then ClawHub-observed rolling
   60-day installs, rolling Bookmarks, and freshness for comparable matches.
 - `createdAt`, `updatedAt`

--- a/src/__tests__/header.test.tsx
+++ b/src/__tests__/header.test.tsx
@@ -754,7 +754,10 @@ describe("Header", () => {
     expect(profile.compareDocumentPosition(dashboard) & Node.DOCUMENT_POSITION_FOLLOWING).toBe(
       Node.DOCUMENT_POSITION_FOLLOWING,
     );
-    expect(screen.getByText("Bookmarks").closest("a")?.getAttribute("href")).toBe("/stars");
+    const bookmarksLink = screen.getByText("Bookmarks").closest("a");
+    expect(bookmarksLink?.getAttribute("href")).toBe("/stars");
+    expect(bookmarksLink?.querySelector(".lucide-bookmark")).toBeTruthy();
+    expect(bookmarksLink?.querySelector(".lucide-star")).toBeNull();
     expect(screen.getAllByText("Dashboard").length).toBeGreaterThan(0);
     expect(screen.getByText("Settings")).toBeTruthy();
   });

--- a/src/__tests__/skill-detail-page.test.tsx
+++ b/src/__tests__/skill-detail-page.test.tsx
@@ -1795,11 +1795,11 @@ describe("SkillDetailPage", () => {
     fireEvent.click(starButton);
 
     await waitFor(() => {
-      expect(screen.getByRole("button", { name: "Remove bookmark" }).textContent).toContain("9");
+      expect(screen.getByRole("button", { name: "Unbookmark skill" }).textContent).toContain("9");
     });
     expect(toggleStarMock).toHaveBeenCalledWith({ skillId });
 
-    fireEvent.click(screen.getByRole("button", { name: "Remove bookmark" }));
+    fireEvent.click(screen.getByRole("button", { name: "Unbookmark skill" }));
 
     await waitFor(() => {
       expect(screen.getByRole("button", { name: "Bookmark skill" }).textContent).toContain("8");
@@ -1869,7 +1869,7 @@ describe("SkillDetailPage", () => {
 
     render(<SkillDetailPage slug="weather" />);
 
-    expect((await screen.findByRole("button", { name: "Remove bookmark" })).textContent).toContain(
+    expect((await screen.findByRole("button", { name: "Unbookmark skill" })).textContent).toContain(
       "1",
     );
   });

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,6 +3,7 @@ import { Link, useLocation, useNavigate } from "@tanstack/react-router";
 import { useQuery } from "convex/react";
 import {
   ArrowRight,
+  Bookmark,
   ExternalLink,
   ChevronDown,
   Command,
@@ -15,7 +16,6 @@ import {
   Plus,
   Search,
   Settings,
-  Star,
   Sun,
   UserRound,
   X,
@@ -660,7 +660,7 @@ export default function Header() {
                   </DropdownMenuItem>
                   <DropdownMenuItem asChild>
                     <Link to="/stars" className="flex items-center gap-2">
-                      <Star size={14} aria-hidden="true" />
+                      <Bookmark size={14} aria-hidden="true" />
                       Bookmarks
                     </Link>
                   </DropdownMenuItem>

--- a/src/components/HomeListingSection.tsx
+++ b/src/components/HomeListingSection.tsx
@@ -2,6 +2,7 @@ import { Link } from "@tanstack/react-router";
 import { isPluginCategorySlug, isSkillCategorySlug } from "clawhub-schema";
 import {
   Binoculars,
+  Bookmark,
   CloudOff,
   Download,
   LayoutGrid,
@@ -10,7 +11,6 @@ import {
   Plus,
   Rows3,
   Search,
-  Star,
   X,
 } from "lucide-react";
 import {
@@ -247,7 +247,7 @@ function HomeListingSkillRow({ entry, showStats }: { entry: SkillPageEntry; show
       {showStats ? (
         <div className="home-v2-listing-row-stats" aria-label="Popularity">
           <span>
-            <Star size={13} aria-hidden="true" />
+            <Bookmark size={13} aria-hidden="true" />
             {formatCompactStat(entry.skill.stats?.stars ?? 0)}
           </span>
           <span>
@@ -363,7 +363,7 @@ function HomeListingSkillCard({ entry, showStats }: { entry: SkillPageEntry; sho
       {showStats ? (
         <div className="home-v2-listing-card-stats" aria-label="Popularity">
           <span>
-            <Star size={13} aria-hidden="true" />
+            <Bookmark size={13} aria-hidden="true" />
             {formatCompactStat(entry.skill.stats?.stars ?? 0)}
           </span>
           <span>

--- a/src/components/SkillHeader.test.tsx
+++ b/src/components/SkillHeader.test.tsx
@@ -497,7 +497,17 @@ describe("SkillHeader", () => {
       name: "Bookmark skill",
     });
     expect(starButton.className).toContain("skill-sidebar-star-action");
+    expect(starButton.querySelector(".lucide-bookmark")).toBeTruthy();
+    expect(starButton.querySelector(".lucide-star")).toBeNull();
     expect(container.querySelector(".skill-hero-title-row .skill-title-actions")).toBeNull();
+  });
+
+  it("presents the active bookmark control as an Unbookmark action", () => {
+    renderHeader({ isAuthenticated: true, isStarred: true });
+
+    const unbookmark = screen.getByRole("button", { name: "Unbookmark skill" });
+    expect(unbookmark.textContent).toContain("Unbookmark");
+    expect(unbookmark.querySelector(".lucide-bookmark")).toBeTruthy();
   });
 
   it("places Bookmark on the creator row on mobile detail layout", () => {

--- a/src/components/SkillHeader.tsx
+++ b/src/components/SkillHeader.tsx
@@ -1,7 +1,7 @@
 import { Link } from "@tanstack/react-router";
 import type { ClawdisSkillMetadata } from "clawhub-schema";
 import { PLATFORM_SKILL_LICENSE } from "clawhub-schema/licenseConstants";
-import { Flag, Settings, ShieldCheck, Star, Upload } from "lucide-react";
+import { Bookmark, Flag, Settings, ShieldCheck, Upload } from "lucide-react";
 import { useState, type ReactNode } from "react";
 import type { Doc, Id } from "../../convex/_generated/dataModel";
 import type { ActivityTrend } from "../lib/activityTrend";
@@ -212,14 +212,14 @@ export function SkillHeader({
         className="skill-sidebar-action-link skill-sidebar-star-action"
         onClick={isAuthenticated ? onToggleStar : onRequireSignIn}
         aria-pressed={Boolean(isAuthenticated && isStarred)}
-        aria-label={isStarred ? "Remove bookmark" : "Bookmark skill"}
+        aria-label={isStarred ? "Unbookmark skill" : "Bookmark skill"}
       >
-        <Star
+        <Bookmark
           size={14}
           aria-hidden="true"
           fill={isAuthenticated && isStarred ? "currentColor" : "none"}
         />
-        {isAuthenticated && isStarred ? "Bookmarked" : "Bookmark"}
+        {isAuthenticated && isStarred ? "Unbookmark" : "Bookmark"}
         <span className="skill-action-count">{formattedStats.stars}</span>
       </button>
     </SignedInActionTooltip>

--- a/src/components/SkillListItem.test.tsx
+++ b/src/components/SkillListItem.test.tsx
@@ -54,6 +54,8 @@ describe("SkillListItem", () => {
 
     expect(screen.getByText("@creator")).toBeTruthy();
     expect(container.querySelector(".skill-list-item-main img")).toBeNull();
+    expect(container.querySelector(".lucide-bookmark")).toBeTruthy();
+    expect(container.querySelector(".lucide-star")).toBeNull();
   });
 
   it("previews long names without displacing the creator identity", () => {

--- a/src/components/SkillListItem.tsx
+++ b/src/components/SkillListItem.tsx
@@ -1,5 +1,5 @@
 import { Link } from "@tanstack/react-router";
-import { Download, Star } from "lucide-react";
+import { Bookmark, Download } from "lucide-react";
 import { getSkillBadges } from "../lib/badges";
 import { getSkillCategoriesForSkill } from "../lib/categories";
 import { formatCompactStat } from "../lib/numberFormat";
@@ -71,7 +71,7 @@ export function SkillListItem({
           Updated {timeAgo(skill.updatedAt)}
         </span>
         <span className="skill-list-item-meta-item">
-          <Star size={14} aria-hidden="true" /> {formatCompactStat(skill.stats.stars)}
+          <Bookmark size={14} aria-hidden="true" /> {formatCompactStat(skill.stats.stars)}
         </span>
         <span className="skill-list-item-meta-item">
           <Download size={14} aria-hidden="true" /> {formatCompactStat(skill.stats.downloads)}

--- a/src/components/SkillRelatedSection.tsx
+++ b/src/components/SkillRelatedSection.tsx
@@ -1,4 +1,4 @@
-import { Download, Star } from "lucide-react";
+import { Bookmark, Download } from "lucide-react";
 import { BrowseCategoryIcon } from "../lib/browseCategoryIcons";
 import { buildSkillCategoryBrowseHref, type SkillCategory } from "../lib/categories";
 import { formatSkillStatsTriplet } from "../lib/numberFormat";
@@ -109,7 +109,7 @@ export function SkillRelatedSection({
                   {isCompact ? (
                     <span className="related-skill-stats" aria-label="Related skill stats">
                       <span className="related-skill-stat">
-                        <Star size={13} aria-hidden="true" />
+                        <Bookmark size={13} aria-hidden="true" />
                         {formattedStats.stars}
                       </span>
                       <span className="related-skill-stat">

--- a/src/components/SkillStats.tsx
+++ b/src/components/SkillStats.tsx
@@ -1,4 +1,4 @@
-import { Download, Star } from "lucide-react";
+import { Bookmark, Download } from "lucide-react";
 import { formatSkillStatsTriplet, type SkillStatsTriplet } from "../lib/numberFormat";
 
 export function SkillStatsTripletLine({ stats }: { stats: SkillStatsTriplet }) {
@@ -6,7 +6,7 @@ export function SkillStatsTripletLine({ stats }: { stats: SkillStatsTriplet }) {
   return (
     <span className="skill-stats-triplet">
       <span className="skill-stats-item">
-        <Star size={14} aria-hidden="true" />
+        <Bookmark size={14} aria-hidden="true" />
         {formatted.stars}
       </span>
       <span className="skill-stats-item">

--- a/src/components/UserBadge.tsx
+++ b/src/components/UserBadge.tsx
@@ -1,4 +1,4 @@
-import { Download, Package, Star } from "lucide-react";
+import { Bookmark, Download, Package } from "lucide-react";
 import { useEffect, useState } from "react";
 import { api } from "../../convex/_generated/api";
 import type { Id } from "../../convex/_generated/dataModel";
@@ -214,7 +214,7 @@ function UserStatsTooltipContent({
               className="flex items-center gap-1 text-fs-xs text-ink-soft"
               title="Bookmarks received"
             >
-              <Star size={12} />
+              <Bookmark size={12} />
               {formatCompactStat(stats.totalStars)}
             </span>
             <span

--- a/src/components/dashboard/DashboardCatalogView.test.tsx
+++ b/src/components/dashboard/DashboardCatalogView.test.tsx
@@ -15,7 +15,7 @@ const skill = {
   tags: {},
   badges: {},
   stats: {
-    downloads: 20,
+    downloads: 12,
     installsCurrent: 3,
     installsAllTime: 7,
     stars: 4,
@@ -42,18 +42,47 @@ const item: DashboardCatalogItem = {
   data: skill,
   updatedAt: skill.updatedAt,
   installs: 7,
-  downloads: 20,
+  downloads: 12,
 };
 
 describe("DashboardCatalogView", () => {
-  it("lets publishers inspect the source breakdown behind combined downloads", () => {
+  it("lets publishers inspect independently attributed metric sources", () => {
     render(
       <DashboardCatalogView items={[item]} view="list" ownerHandle="owner" canManage={true} />,
     );
 
     expect(
       screen.getByTitle(
-        "20 downloads: 12 ClawHub downloads + 8 skills.sh installs. 7 OpenClaw installs; 99 GitHub stars; 4 bookmarks.",
+        "12 ClawHub downloads. 8 skills.sh lifetime installs; 99 GitHub stars. 7 OpenClaw installs; 4 bookmarks.",
+      ),
+    ).toBeTruthy();
+  });
+
+  it("distinguishes unavailable external metrics from zero", () => {
+    render(
+      <DashboardCatalogView
+        items={[
+          {
+            ...item,
+            data: {
+              ...skill,
+              metricSources: {
+                ...skill.metricSources!,
+                skillsShInstalls: null,
+                githubStars: null,
+              },
+            },
+          },
+        ]}
+        view="list"
+        ownerHandle="owner"
+        canManage={true}
+      />,
+    );
+
+    expect(
+      screen.getByTitle(
+        "12 ClawHub downloads. skills.sh lifetime installs unavailable; GitHub stars unavailable. 7 OpenClaw installs; 4 bookmarks.",
       ),
     ).toBeTruthy();
   });

--- a/src/components/dashboard/DashboardCatalogView.tsx
+++ b/src/components/dashboard/DashboardCatalogView.tsx
@@ -227,7 +227,15 @@ function skillMetricSourceLabel(skill: DashboardSkill) {
   const sources = skill.metricSources;
   const downloads = skill.stats?.downloads ?? 0;
   if (!sources) return metricLabel(downloads, "download");
-  return `${metricLabel(downloads, "download")}: ${sources.clawHubDownloads} ClawHub downloads + ${sources.skillsShInstalls} skills.sh installs. ${sources.openClawInstallsAllTime} OpenClaw installs; ${sources.githubStars} GitHub stars; ${sources.bookmarks} bookmarks.`;
+  const externalMetrics = [
+    sources.skillsShInstalls === null
+      ? "skills.sh lifetime installs unavailable"
+      : `${sources.skillsShInstalls} skills.sh lifetime installs`,
+    sources.githubStars === null
+      ? "GitHub stars unavailable"
+      : `${sources.githubStars} GitHub stars`,
+  ];
+  return `${sources.clawHubDownloads} ClawHub downloads. ${externalMetrics.join("; ")}. ${sources.openClawInstallsAllTime} OpenClaw installs; ${sources.bookmarks} bookmarks.`;
 }
 
 function visibilityIcon(label: string) {

--- a/src/components/dashboard/types.ts
+++ b/src/components/dashboard/types.ts
@@ -30,10 +30,10 @@ export type DashboardSkill = Pick<
   settingsHref?: string;
   metricSources?: {
     clawHubDownloads: number;
-    skillsShInstalls: number;
+    skillsShInstalls: number | null;
     openClawInstallsCurrent: number;
     openClawInstallsAllTime: number;
-    githubStars: number;
+    githubStars: number | null;
     bookmarks: number;
   };
   pendingReview?: boolean;

--- a/src/routes/-management/AbusePage.tsx
+++ b/src/routes/-management/AbusePage.tsx
@@ -712,7 +712,10 @@ export function AbusePage({
                       label="Total installs"
                       value={selectedScore?.totalInstalls}
                     />
-                    <PublisherAbuseMetric label="Total stars" value={selectedScore?.totalStars} />
+                    <PublisherAbuseMetric
+                      label="Total bookmarks"
+                      value={selectedScore?.totalStars}
+                    />
                     <PublisherAbuseMetric
                       label="Total downloads"
                       value={selectedScore?.totalDownloads}
@@ -725,7 +728,7 @@ export function AbusePage({
                       ratio
                     />
                     <PublisherAbuseMetric
-                      label="Stars / skill"
+                      label="Bookmarks / skill"
                       value={selectedScore?.starsPerSkill}
                       ratio
                     />
@@ -1793,7 +1796,7 @@ function formatReasonCode(reason: string) {
     .replace("High / Catalog / Volume", "High Catalog Volume")
     .replace("Extreme / Volume / Low / Engagement", "Extreme Volume, Low Engagement")
     .replace("Low / Installs / Per / Skill", "Low Installs / Skill")
-    .replace("Low / Stars / Per / Skill", "Low Stars / Skill")
+    .replace("Low / Stars / Per / Skill", "Low Bookmarks / Skill")
     .replace("Low / Downloads / Per / Skill", "Low Downloads / Skill")
     .replace("Temporal / Download / Spike / Flat / Installs", "Temporal Spike, Flat Installs")
     .replace(
@@ -1807,13 +1810,13 @@ function describeReasonCode(reason: string) {
     return "Publisher has an unusually high number of skills compared to peers.";
   }
   if (reason === "extreme_volume_low_engagement") {
-    return "Very high catalog volume with extremely low engagement across installs, stars, and downloads.";
+    return "Very high catalog volume with extremely low engagement across installs, bookmarks, and downloads.";
   }
   if (reason === "low_installs_per_skill") {
     return "Installs per skill are far below the platform median.";
   }
   if (reason === "low_stars_per_skill") {
-    return "Stars per skill are far below the platform median.";
+    return "Bookmarks per skill are far below the platform median.";
   }
   if (reason === "low_downloads_per_skill") {
     return "Downloads per skill are far below the platform median.";

--- a/src/routes/-stars.test.tsx
+++ b/src/routes/-stars.test.tsx
@@ -85,10 +85,12 @@ describe("Stars", () => {
       return undefined;
     });
 
-    render(<Stars />);
+    const { container } = render(<Stars />);
 
     expect(screen.getByText("Sign in to see your bookmarks")).toBeTruthy();
     expect(screen.getByRole("button", { name: /sign in/i })).toBeTruthy();
+    expect(container.querySelector(".lucide-bookmark")).toBeTruthy();
+    expect(container.querySelector(".lucide-star")).toBeNull();
   });
 
   it("shows skeleton while loading", () => {
@@ -125,10 +127,13 @@ describe("Stars", () => {
       return [makeSkill({ _id: "skill_1", slug: "test-skill", displayName: "Test Skill" })];
     });
 
-    render(<Stars />);
+    const { container } = render(<Stars />);
 
     expect(screen.getByRole("heading", { name: "Test Skill" })).toBeTruthy();
-    expect(screen.getByLabelText("Remove bookmark for Test Skill")).toBeTruthy();
+    const removeBookmark = screen.getByLabelText("Unbookmark Test Skill");
+    expect(removeBookmark.querySelector(".lucide-bookmark")).toBeTruthy();
+    expect(removeBookmark.querySelector(".lucide-star")).toBeNull();
+    expect(container.querySelectorAll(".lucide-star")).toHaveLength(0);
     expect(screen.getByText("Your bookmarks")).toBeTruthy();
   });
 
@@ -140,7 +145,7 @@ describe("Stars", () => {
     });
 
     render(<Stars />);
-    const unstarBtn = screen.getByLabelText("Remove bookmark for Test Skill");
+    const unstarBtn = screen.getByLabelText("Unbookmark Test Skill");
     fireEvent.click(unstarBtn);
 
     expect(toggleStarMock).toHaveBeenCalledWith({ skillId: "skill_1" });

--- a/src/routes/stars.tsx
+++ b/src/routes/stars.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { useMutation, useQuery } from "convex/react";
-import { ArrowDownUp, LayoutGrid, List, Star } from "lucide-react";
+import { ArrowDownUp, Bookmark, LayoutGrid, List } from "lucide-react";
 import { startTransition, useOptimistic } from "react";
 import { toast } from "sonner";
 import { api } from "../../convex/_generated/api";
@@ -82,8 +82,8 @@ export function Stars() {
       startTransition(() => {
         updateOptimisticSkills({ type: "restore", skill });
       });
-      console.error("Failed to remove skill bookmark:", err);
-      toast.error("Unable to remove this bookmark. Please try again.");
+      console.error("Failed to unbookmark skill:", err);
+      toast.error("Unable to unbookmark this skill. Please try again.");
     });
   };
 
@@ -94,7 +94,7 @@ export function Stars() {
   if (!isAuthenticated || !me) {
     return (
       <SignInPrompt
-        icon={Star}
+        icon={Bookmark}
         title="Sign in to see your bookmarks"
         description="Bookmark skills for quick access later."
       />
@@ -171,7 +171,7 @@ export function Stars() {
 
       {skills.length === 0 ? (
         <EmptyState
-          icon={Star}
+          icon={Bookmark}
           title="No bookmarks yet"
           description="Browse skills and bookmark your favorites."
           action={{ label: "Browse skills", href: "/skills" }}
@@ -198,10 +198,10 @@ export function Stars() {
                     e.stopPropagation();
                     handleUnstar(skill);
                   }}
-                  aria-label={`Remove bookmark for ${skill.displayName}`}
+                  aria-label={`Unbookmark ${skill.displayName}`}
                   className="stars-card-unstar text-[color:var(--gold)] hover:text-status-error-fg"
                 >
-                  <Star className="h-4 w-4 fill-current" />
+                  <Bookmark className="h-4 w-4 fill-current" />
                 </Button>
               </div>
             );
@@ -220,10 +220,10 @@ export function Stars() {
                   e.stopPropagation();
                   handleUnstar(skill);
                 }}
-                aria-label={`Remove bookmark for ${skill.displayName}`}
+                aria-label={`Unbookmark ${skill.displayName}`}
                 className="absolute right-3 top-1/2 -translate-y-1/2 text-[color:var(--gold)] hover:text-status-error-fg"
               >
-                <Star className="h-4 w-4 fill-current" />
+                <Bookmark className="h-4 w-4 fill-current" />
               </Button>
             </div>
           ))}

--- a/src/routes/user/$handle.tsx
+++ b/src/routes/user/$handle.tsx
@@ -11,13 +11,13 @@ import { usePaginatedQuery, useQuery } from "convex/react";
 import {
   ArrowRight,
   ArrowUpRight,
+  Bookmark,
   Building2,
   Download,
   Flag,
   MoreHorizontal,
   Plus,
   Search,
-  Star,
   type LucideIcon,
 } from "lucide-react";
 import { useEffect, useLayoutEffect, useMemo, useRef, useState, type ReactNode } from "react";
@@ -286,7 +286,7 @@ export function buildPublisherStatCards(
       key: "stars",
       value: formatCompactStat(publisher.stats.stars),
       label: "bookmarks",
-      icon: Star,
+      icon: Bookmark,
     },
   ];
 }


### PR DESCRIPTION
## Summary

- keep ClawHub artifact downloads, OpenClaw installs, Bookmarks, skills.sh lifetime installs, and GitHub stars independently attributed
- serialize missing external metrics as `null` instead of fabricating zero, and label every source in publisher dashboards
- preserve source observations across exact-native route drift, rollback, stale callbacks, refresh, removal/reappearance, and Hosted-to-GitHub promotion
- retain the completed Bookmark terminology/icon correction while keeping imported GitHub stars as stars

Closes [CLAW-561](https://linear.app/my-openclaw/issue/CLAW-561/06-separate-github-popularity-from-clawhub-bookmarks).

## Contract

Public `Downloads` now means ClawHub artifact downloads only. skills.sh lifetime installs and GitHub stars remain separately attributed and have no canonical search-ranking weight. The existing skills.sh Trending contract remains rank/order plus observation time; no exact 24-hour install count is fabricated.

## Validation

- focused metric serializer, lifecycle, sync, package-catalog, publisher, and dashboard suites: green
- `bun run ci:static`
- `VITE_CONVEX_URL=https://example.invalid bun run ci:unit` — 5,638 passed, 2 skipped; coverage green
- `bun run ci:types-build`
- `bun run ci:packages`
- `bun run ci:e2e-http`
- autoreview on the final local diff: clean, no accepted/actionable findings
- real seeded ClawHub owner dashboard verified in the Codex in-app browser at `http://127.0.0.1:18143/dashboard`; preview left running

No production deployment, hidden staging, production data mutation, scan, schedule, release, or rollout activation was performed.
