### PR TITLE
fix(ui): show stats on trending cards

### DIFF
--- a/src/__tests__/home-listing-section.test.tsx
+++ b/src/__tests__/home-listing-section.test.tsx
@@ -498,7 +498,7 @@ describe("HomeListingSection", () => {
                 slug: "trending-skill",
                 displayName: "Trending Skill",
                 summary: "Hot this week.",
-                stats: { installs: 999 },
+                stats: { stars: 12, downloads: 340, installs: 999 },
               },
               ownerHandle: "builder",
             },
@@ -534,7 +534,7 @@ describe("HomeListingSection", () => {
       expect(convexQueryMock).toHaveBeenCalledWith("skills:listPublicTrendingPage", { limit: 20 });
       expect(screen.getByText("Trending Skill")).toBeTruthy();
     });
-    expect(screen.queryByText("Popularity")).toBeNull();
+    expect(screen.getByLabelText("Popularity").textContent).toBe("12340");
     expect(screen.queryByText("999")).toBeNull();
   });
 

--- a/src/components/HomeListingSection.tsx
+++ b/src/components/HomeListingSection.tsx
@@ -431,7 +431,7 @@ export function HomeListingSection({ initialListing = null }: HomeListingSection
       : plugins;
   const activeStatus = isSearchMode ? searchStatus : status;
   const isEmpty = activeStatus === "idle" && activeItems.length === 0;
-  const showSkillStats = !(kind === "skills" && tab === "trending" && !isSearchMode);
+  const showSkillStats = true;
   const showListingMore =
     activeStatus === "idle" && (activeItems.length > visibleCount || listingHasMore);
 


### PR DESCRIPTION
## Summary
- show star and download stats on homepage Trending skill cards, matching Top
- keep install counts hidden from the card presentation
- add a regression assertion for Trending popularity stats

## Validation
- `bun run test src/__tests__/home-listing-section.test.tsx`
- `bun run ci:static`
- `bun run ci:unit`
- `bun run ci:types-build`
- autoreview: clean
- local browser proof at `http://127.0.0.1:3002/` in desktop and mobile layouts
