### PR TITLE
fix(ui): default homepage catalog to list view

### DIFF
--- a/src/__tests__/home-listing-section.test.tsx
+++ b/src/__tests__/home-listing-section.test.tsx
@@ -135,7 +135,7 @@ describe("HomeListingSection", () => {
     });
   });
 
-  it("renders Featured plugins as cards by default", async () => {
+  it("renders Featured plugins as a list by default", async () => {
     render(<HomeListingSection initialListing={initialPluginListing()} />);
 
     const contentTypeButtons = screen
@@ -151,7 +151,7 @@ describe("HomeListingSection", () => {
     expect(screen.getByRole("tab", { name: "Featured" }).getAttribute("aria-selected")).toBe(
       "true",
     );
-    expect(screen.getByRole("button", { name: "Grid view" }).getAttribute("aria-pressed")).toBe(
+    expect(screen.getByRole("button", { name: "List view" }).getAttribute("aria-pressed")).toBe(
       "true",
     );
     expect(screen.getAllByRole("tab").map((tab) => tab.textContent)).toEqual([
@@ -162,7 +162,7 @@ describe("HomeListingSection", () => {
     expect(screen.queryByRole("tab", { name: "New" })).toBeNull();
     expect(screen.queryByRole("tab", { name: "Official" })).toBeNull();
     expect(screen.getByText("Demo Plugin")).toBeTruthy();
-    expect(document.querySelector(".home-v2-listing-grid")).toBeTruthy();
+    expect(document.querySelector(".home-v2-listing-list")).toBeTruthy();
     expect(document.querySelector(".marketplace-icon-image")?.getAttribute("src")).toBe(
       featuredPlugin.icon,
     );

--- a/src/components/HomeListingSection.tsx
+++ b/src/components/HomeListingSection.tsx
@@ -377,7 +377,7 @@ export function HomeListingSection({ initialListing = null }: HomeListingSection
 
   const [kind, setKind] = useState<ListingKind>(initialListing?.kind ?? "plugins");
   const [tab, setTab] = useState<ListingTab>(initialListing?.tab ?? "featured");
-  const [view, setView] = useState<ListingView>("grid");
+  const [view, setView] = useState<ListingView>("list");
   const [categorySlugs, setCategorySlugs] = useState<string[]>([]);
   const [visibleCount, setVisibleCount] = useState(LISTING_PAGE_SIZE);
   const [fetchLimit, setFetchLimit] = useState(LISTING_PAGE_SIZE);


### PR DESCRIPTION
## Summary
- default the homepage catalog to list view
- preserve grid as an explicit user-selectable layout
- update regression coverage for the initial layout state

## Validation
- `bun run test -- src/__tests__/home-listing-section.test.tsx`
- `bun run ci:static`
- `bun run ci:unit`
- `bunx tsc -p packages/schema/tsconfig.json --noEmit`
- `bunx tsc -p packages/clawhub/tsconfig.json --noEmit`
- `.agents/skills/autoreview/scripts/autoreview --mode local`

## Visual proof
Verified against `http://localhost:3002/` with local Convex fixture data: the homepage catalog renders plugin rows and the List view control is selected on first load.
