### PR TITLE
fix: prevent and repair skill lineage cycles

### DIFF
--- a/convex/maintenance.test.ts
+++ b/convex/maintenance.test.ts
@@ -44,6 +44,10 @@ vi.mock("./_generated/api", () => ({
       repairLegacyPluginSkillSpectorBatchInternal: Symbol(
         "repairLegacyPluginSkillSpectorBatchInternal",
       ),
+      getSkillLineageCycleRepairPageInternal: Symbol("getSkillLineageCycleRepairPageInternal"),
+      inspectSkillLineageCycleInternal: Symbol("inspectSkillLineageCycleInternal"),
+      applySkillLineageCycleRepairInternal: Symbol("applySkillLineageCycleRepairInternal"),
+      repairSkillLineageCyclesInternal: Symbol("repairSkillLineageCyclesInternal"),
     },
     skills: {
       backfillLatestSkillModerationInternal: Symbol("skills.backfillLatestSkillModerationInternal"),
@@ -76,9 +80,12 @@ const {
   backfillSkillSummariesInternalHandler,
   backfillUserStatsInternalHandler,
   cleanupEmptySkillsInternalHandler,
+  applySkillLineageCycleRepairInternalHandler,
+  inspectSkillLineageCycleInternalHandler,
   nominateEmptySkillSpammersInternalHandler,
   repairLegacyPluginSkillSpectorBatchInternalHandler,
   repairLegacyPublisherOwnershipForUserHandler,
+  repairSkillLineageCyclesInternalHandler,
   resyncPluginCatalogMetadataDigestsBatchInternal,
   resyncPluginCatalogMetadataDigestsInternal,
   upsertSkillBadgeRecordInternal,
@@ -1550,6 +1557,204 @@ describe("maintenance fingerprint backfill", () => {
     expect(result.stats.fingerprintsInserted).toBe(0);
     expect(result.stats.fingerprintMismatches).toBe(0);
     expect(runMutation).not.toHaveBeenCalled();
+  });
+});
+
+function makeSkillLineageCycleDb(options?: { includeMergeAudit?: boolean }) {
+  const finalSkill = {
+    _id: "skills:final",
+    slug: "graincrawl",
+    canonicalSkillId: "skills:source",
+    forkOf: {
+      skillId: "skills:final",
+      kind: "duplicate",
+      at: 200,
+    },
+  };
+  const sourceSkill = {
+    _id: "skills:source",
+    slug: "archive-graincrawl",
+    canonicalSkillId: "skills:final",
+    forkOf: {
+      skillId: "skills:final",
+      kind: "duplicate",
+      at: 300,
+    },
+    softDeletedAt: 300,
+    moderationStatus: "hidden",
+    moderationReason: "owner.merged",
+  };
+  const patch = vi.fn();
+  const insert = vi.fn();
+  const get = vi.fn(async (id: string) => {
+    if (id === finalSkill._id) return finalSkill;
+    if (id === sourceSkill._id) return sourceSkill;
+    return null;
+  });
+  const query = vi.fn((table: string) => {
+    if (table !== "auditLogs") throw new Error(`Unexpected table: ${table}`);
+    return {
+      withIndex: (index: string) => {
+        if (index !== "by_target_action") throw new Error(`Unexpected index: ${index}`);
+        return {
+          order: () => ({
+            take: async () =>
+              options?.includeMergeAudit === false
+                ? []
+                : [
+                    {
+                      action: "skill.merge",
+                      targetType: "skill",
+                      targetId: sourceSkill._id,
+                      metadata: { targetSkillId: finalSkill._id },
+                      createdAt: sourceSkill.forkOf.at,
+                    },
+                  ],
+          }),
+        };
+      },
+    };
+  });
+
+  return {
+    db: { get, query, patch, insert },
+    finalSkill,
+    sourceSkill,
+    patch,
+    insert,
+  };
+}
+
+describe("maintenance skill lineage cycle repair", () => {
+  it("recognizes the exact malformed merge pair from its audit history", async () => {
+    const fixture = makeSkillLineageCycleDb();
+
+    const result = await inspectSkillLineageCycleInternalHandler(
+      fixture as never,
+      fixture.finalSkill._id as never,
+    );
+
+    expect(result).toEqual({
+      status: "repairable",
+      skillId: "skills:final",
+      slug: "graincrawl",
+      sourceSkillId: "skills:source",
+      sourceSlug: "archive-graincrawl",
+    });
+  });
+
+  it("leaves a self-reference untouched without matching merge history", async () => {
+    const fixture = makeSkillLineageCycleDb({ includeMergeAudit: false });
+
+    const result = await inspectSkillLineageCycleInternalHandler(
+      fixture as never,
+      fixture.finalSkill._id as never,
+    );
+
+    expect(result).toEqual({
+      status: "ambiguous",
+      skillId: "skills:final",
+      slug: "graincrawl",
+      reason: "missing_matching_merge_audit",
+      sourceSkillId: "skills:source",
+      sourceSlug: "archive-graincrawl",
+    });
+  });
+
+  it("clears only the final skill lineage and writes an audit record", async () => {
+    const fixture = makeSkillLineageCycleDb();
+
+    const result = await applySkillLineageCycleRepairInternalHandler(fixture as never, {
+      skillId: fixture.finalSkill._id as never,
+      sourceSkillId: fixture.sourceSkill._id as never,
+    });
+
+    expect(result).toEqual({ repaired: true });
+    expect(fixture.patch).toHaveBeenCalledTimes(1);
+    expect(fixture.patch).toHaveBeenCalledWith(
+      "skills:final",
+      expect.objectContaining({
+        canonicalSkillId: undefined,
+        forkOf: undefined,
+      }),
+    );
+    expect(fixture.insert).toHaveBeenCalledWith(
+      "auditLogs",
+      expect.objectContaining({
+        action: "skill.lineage_cycle.repair",
+        targetType: "skill",
+        targetId: "skills:final",
+        metadata: expect.objectContaining({
+          sourceSkillId: "skills:source",
+          previousCanonicalSkillId: "skills:source",
+          previousForkOf: fixture.finalSkill.forkOf,
+        }),
+      }),
+    );
+  });
+
+  it("defaults to preview and reports resumable progress", async () => {
+    const runQuery = vi.fn(async (endpoint: unknown) => {
+      if (endpoint === internal.maintenance.getSkillLineageCycleRepairPageInternal) {
+        return {
+          items: [{ skillId: "skills:final", slug: "graincrawl" }],
+          scanned: 200,
+          cursor: "next-page",
+          isDone: false,
+        };
+      }
+      if (endpoint === internal.maintenance.inspectSkillLineageCycleInternal) {
+        return {
+          status: "repairable",
+          skillId: "skills:final",
+          slug: "graincrawl",
+          sourceSkillId: "skills:source",
+          sourceSlug: "archive-graincrawl",
+        };
+      }
+      throw new Error(`Unexpected query endpoint: ${String(endpoint)}`);
+    });
+    const runMutation = vi.fn();
+
+    const result = await repairSkillLineageCyclesInternalHandler(
+      { runQuery, runMutation } as never,
+      { batchSize: 200, maxBatches: 1 },
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      dryRun: true,
+      confirmRequired: "repair-skill-lineage-cycles-2026-07-23",
+      cursor: "next-page",
+      isDone: false,
+      stats: {
+        skillsScanned: 200,
+        selfReferencesFound: 1,
+        repairable: 1,
+        ambiguous: 0,
+        repaired: 0,
+        changedBeforeApply: 0,
+      },
+      samples: [
+        {
+          status: "repairable",
+          skillId: "skills:final",
+          slug: "graincrawl",
+          sourceSkillId: "skills:source",
+          sourceSlug: "archive-graincrawl",
+        },
+      ],
+    });
+    expect(runMutation).not.toHaveBeenCalled();
+  });
+
+  it("requires the confirmation phrase before applying", async () => {
+    await expect(
+      repairSkillLineageCyclesInternalHandler(
+        { runQuery: vi.fn(), runMutation: vi.fn() } as never,
+        { dryRun: false },
+      ),
+    ).rejects.toThrow('Pass confirm="repair-skill-lineage-cycles-2026-07-23" to apply.');
   });
 });
 

--- a/convex/maintenance.ts
+++ b/convex/maintenance.ts
@@ -1,7 +1,7 @@
 import { ConvexError, v } from "convex/values";
 import { internal } from "./_generated/api";
 import type { Doc, Id } from "./_generated/dataModel";
-import type { ActionCtx, MutationCtx } from "./_generated/server";
+import type { ActionCtx, MutationCtx, QueryCtx } from "./_generated/server";
 import {
   action,
   internalAction,
@@ -45,6 +45,7 @@ const PUBLISHER_ABUSE_SIGNAL_SMOKE_OWNER_KEY =
   "smoke:publisher-abuse-hermit-digest:2026-07-03" as const;
 const PUBLISHER_ABUSE_SIGNAL_SMOKE_CONFIRM =
   "create-publisher-abuse-hermit-digest-smoke-2026-07-03" as const;
+const SKILL_LINEAGE_CYCLE_REPAIR_CONFIRM = "repair-skill-lineage-cycles-2026-07-23" as const;
 const legacyPluginSkillSpectorRepairFamilyValidator = v.union(
   v.literal("code-plugin"),
   v.literal("bundle-plugin"),
@@ -178,6 +179,73 @@ type PublisherAbuseSignalSmokeTarget = {
   sourcePublisherId: Id<"publishers"> | null;
   sourceUserId: Id<"users"> | null;
   sourcePublisherHandle: string | null;
+};
+
+type SkillLineageCycleRepairPageResult = {
+  items: Array<{
+    skillId: Id<"skills">;
+    slug: string;
+  }>;
+  scanned: number;
+  cursor: string | null;
+  isDone: boolean;
+};
+
+type SkillLineageCycleInspection =
+  | {
+      status: "repairable";
+      skillId: Id<"skills">;
+      slug: string;
+      sourceSkillId: Id<"skills">;
+      sourceSlug: string;
+    }
+  | {
+      status: "ambiguous";
+      skillId: Id<"skills">;
+      slug: string;
+      reason:
+        | "missing_skill"
+        | "no_self_reference"
+        | "multiple_linked_sources"
+        | "missing_source"
+        | "source_not_merged_into_skill"
+        | "missing_matching_merge_audit";
+      sourceSkillId?: Id<"skills">;
+      sourceSlug?: string;
+    };
+
+type SkillLineageCycleRepairStats = {
+  skillsScanned: number;
+  selfReferencesFound: number;
+  repairable: number;
+  ambiguous: number;
+  repaired: number;
+  changedBeforeApply: number;
+};
+
+export type SkillLineageCycleRepairArgs = {
+  cursor?: string;
+  dryRun?: boolean;
+  confirm?: string;
+  batchSize?: number;
+  maxBatches?: number;
+};
+
+export type SkillLineageCycleRepairResult = {
+  ok: true;
+  dryRun: boolean;
+  confirmRequired?: typeof SKILL_LINEAGE_CYCLE_REPAIR_CONFIRM;
+  cursor: string | null;
+  isDone: boolean;
+  stats: SkillLineageCycleRepairStats;
+  samples: Array<{
+    status: SkillLineageCycleInspection["status"] | "repaired" | "changed_before_apply";
+    skillId: Id<"skills">;
+    slug: string;
+    sourceSkillId?: Id<"skills">;
+    sourceSlug?: string;
+    reason?: Extract<SkillLineageCycleInspection, { status: "ambiguous" }>["reason"];
+  }>;
 };
 
 export const getSkillBackfillPageInternal = internalQuery({
@@ -2648,6 +2716,342 @@ export const backfillIsSuspiciousInternal = internalMutation({
 
     return { patched, isDone, scanned: page.length };
   },
+});
+
+export const getSkillLineageCycleRepairPageInternal = internalQuery({
+  args: {
+    cursor: v.optional(v.string()),
+    batchSize: v.optional(v.number()),
+  },
+  handler: async (ctx, args): Promise<SkillLineageCycleRepairPageResult> => {
+    const batchSize = clampInt(args.batchSize ?? DEFAULT_BATCH_SIZE, 1, MAX_BATCH_SIZE);
+    const { page, continueCursor, isDone } = await ctx.db
+      .query("skills")
+      .order("asc")
+      .paginate({ cursor: args.cursor ?? null, numItems: batchSize });
+
+    return {
+      items: page
+        .filter(
+          (skill) => skill.canonicalSkillId === skill._id || skill.forkOf?.skillId === skill._id,
+        )
+        .map((skill) => ({ skillId: skill._id, slug: skill.slug })),
+      scanned: page.length,
+      cursor: continueCursor,
+      isDone,
+    };
+  },
+});
+
+function parseSkillMergeTargetId(metadata: unknown): string | null {
+  if (typeof metadata !== "object" || metadata === null) return null;
+  const targetSkillId = (metadata as Record<string, unknown>).targetSkillId;
+  return typeof targetSkillId === "string" ? targetSkillId : null;
+}
+
+export async function inspectSkillLineageCycleInternalHandler(
+  ctx: Pick<QueryCtx | MutationCtx, "db">,
+  skillId: Id<"skills">,
+): Promise<SkillLineageCycleInspection> {
+  const skill = await ctx.db.get(skillId);
+  if (!skill) {
+    return {
+      status: "ambiguous",
+      skillId,
+      slug: "<missing>",
+      reason: "missing_skill",
+    };
+  }
+
+  const hasSelfReference =
+    skill.canonicalSkillId === skill._id || skill.forkOf?.skillId === skill._id;
+  if (!hasSelfReference) {
+    return {
+      status: "ambiguous",
+      skillId,
+      slug: skill.slug,
+      reason: "no_self_reference",
+    };
+  }
+
+  const linkedSourceIds = new Set(
+    [skill.canonicalSkillId, skill.forkOf?.skillId].filter((linkedId): linkedId is Id<"skills"> =>
+      Boolean(linkedId && linkedId !== skill._id),
+    ),
+  );
+  if (linkedSourceIds.size > 1) {
+    return {
+      status: "ambiguous",
+      skillId,
+      slug: skill.slug,
+      reason: "multiple_linked_sources",
+    };
+  }
+
+  let source: Doc<"skills"> | null = null;
+  const directSourceId = [...linkedSourceIds][0];
+  if (directSourceId) {
+    source = await ctx.db.get(directSourceId);
+  } else {
+    const [canonicalRefs, forkRefs] = await Promise.all([
+      ctx.db
+        .query("skills")
+        .withIndex("by_canonical", (q) => q.eq("canonicalSkillId", skill._id))
+        .take(3),
+      ctx.db
+        .query("skills")
+        .withIndex("by_fork_of", (q) => q.eq("forkOf.skillId", skill._id))
+        .take(3),
+    ]);
+    const reverseSources = new Map<Id<"skills">, Doc<"skills">>();
+    for (const related of [...canonicalRefs, ...forkRefs]) {
+      if (related._id !== skill._id) reverseSources.set(related._id, related);
+    }
+    const exactSources = [...reverseSources.values()].filter(
+      (related) =>
+        related.canonicalSkillId === skill._id &&
+        related.forkOf?.skillId === skill._id &&
+        related.forkOf.kind === "duplicate",
+    );
+    if (exactSources.length === 1) source = exactSources[0];
+    if (exactSources.length > 1) {
+      return {
+        status: "ambiguous",
+        skillId,
+        slug: skill.slug,
+        reason: "multiple_linked_sources",
+      };
+    }
+  }
+
+  if (!source) {
+    return {
+      status: "ambiguous",
+      skillId,
+      slug: skill.slug,
+      reason: "missing_source",
+      ...(directSourceId ? { sourceSkillId: directSourceId } : {}),
+    };
+  }
+
+  const sourceMatchesMergeState =
+    source.canonicalSkillId === skill._id &&
+    source.forkOf?.skillId === skill._id &&
+    source.forkOf.kind === "duplicate" &&
+    source.softDeletedAt !== undefined &&
+    source.moderationStatus === "hidden" &&
+    source.moderationReason === "owner.merged";
+  if (!sourceMatchesMergeState) {
+    return {
+      status: "ambiguous",
+      skillId,
+      slug: skill.slug,
+      reason: "source_not_merged_into_skill",
+      sourceSkillId: source._id,
+      sourceSlug: source.slug,
+    };
+  }
+
+  const mergeAuditLogs = await ctx.db
+    .query("auditLogs")
+    .withIndex("by_target_action", (q) =>
+      q.eq("targetType", "skill").eq("targetId", source._id).eq("action", "skill.merge"),
+    )
+    .order("desc")
+    .take(10);
+  const matchingAudit = mergeAuditLogs.some(
+    (log) =>
+      log.createdAt === source.forkOf?.at && parseSkillMergeTargetId(log.metadata) === skill._id,
+  );
+  if (!matchingAudit) {
+    return {
+      status: "ambiguous",
+      skillId,
+      slug: skill.slug,
+      reason: "missing_matching_merge_audit",
+      sourceSkillId: source._id,
+      sourceSlug: source.slug,
+    };
+  }
+
+  return {
+    status: "repairable",
+    skillId,
+    slug: skill.slug,
+    sourceSkillId: source._id,
+    sourceSlug: source.slug,
+  };
+}
+
+export const inspectSkillLineageCycleInternal = internalQuery({
+  args: { skillId: v.id("skills") },
+  handler: async (ctx, args): Promise<SkillLineageCycleInspection> =>
+    inspectSkillLineageCycleInternalHandler(ctx, args.skillId),
+});
+
+export async function applySkillLineageCycleRepairInternalHandler(
+  ctx: MutationCtx,
+  args: {
+    skillId: Id<"skills">;
+    sourceSkillId: Id<"skills">;
+  },
+): Promise<{ repaired: true } | { repaired: false; reason: "changed_before_apply" }> {
+  const inspection = await inspectSkillLineageCycleInternalHandler(ctx, args.skillId);
+  if (inspection.status !== "repairable" || inspection.sourceSkillId !== args.sourceSkillId) {
+    return {
+      repaired: false as const,
+      reason: "changed_before_apply" as const,
+    };
+  }
+
+  const skill = await ctx.db.get(args.skillId);
+  if (!skill) {
+    return {
+      repaired: false as const,
+      reason: "changed_before_apply" as const,
+    };
+  }
+
+  const now = Date.now();
+  await ctx.db.patch(skill._id, {
+    canonicalSkillId: undefined,
+    forkOf: undefined,
+    updatedAt: now,
+  });
+  await ctx.db.insert("auditLogs", {
+    action: "skill.lineage_cycle.repair",
+    targetType: "skill",
+    targetId: skill._id,
+    metadata: {
+      repairVersion: "skill-lineage-cycle-2026-07-23",
+      slug: skill.slug,
+      sourceSkillId: inspection.sourceSkillId,
+      sourceSlug: inspection.sourceSlug,
+      previousCanonicalSkillId: skill.canonicalSkillId,
+      previousForkOf: skill.forkOf,
+    },
+    createdAt: now,
+  });
+
+  return { repaired: true as const };
+}
+
+export const applySkillLineageCycleRepairInternal = internalMutation({
+  args: {
+    skillId: v.id("skills"),
+    sourceSkillId: v.id("skills"),
+  },
+  handler: applySkillLineageCycleRepairInternalHandler,
+});
+
+// This is a paired relationship repair, not a table-wide shape migration. It stays in
+// maintenance.ts so every write can revalidate both skill records and the merge audit.
+export async function repairSkillLineageCyclesInternalHandler(
+  ctx: ActionCtx,
+  args: SkillLineageCycleRepairArgs,
+): Promise<SkillLineageCycleRepairResult> {
+  const dryRun = args.dryRun !== false;
+  if (!dryRun && args.confirm !== SKILL_LINEAGE_CYCLE_REPAIR_CONFIRM) {
+    throw new ConvexError(`Pass confirm="${SKILL_LINEAGE_CYCLE_REPAIR_CONFIRM}" to apply.`);
+  }
+
+  const batchSize = clampInt(args.batchSize ?? DEFAULT_BATCH_SIZE, 1, MAX_BATCH_SIZE);
+  const maxBatches = clampInt(args.maxBatches ?? DEFAULT_MAX_BATCHES, 1, MAX_MAX_BATCHES);
+  const stats: SkillLineageCycleRepairStats = {
+    skillsScanned: 0,
+    selfReferencesFound: 0,
+    repairable: 0,
+    ambiguous: 0,
+    repaired: 0,
+    changedBeforeApply: 0,
+  };
+  const samples: SkillLineageCycleRepairResult["samples"] = [];
+  let cursor: string | null = args.cursor ?? null;
+  let isDone = false;
+
+  for (let batch = 0; batch < maxBatches; batch++) {
+    const page = (await ctx.runQuery(internal.maintenance.getSkillLineageCycleRepairPageInternal, {
+      cursor: cursor ?? undefined,
+      batchSize,
+    })) as SkillLineageCycleRepairPageResult;
+    cursor = page.cursor;
+    isDone = page.isDone;
+    stats.skillsScanned += page.scanned;
+    stats.selfReferencesFound += page.items.length;
+
+    for (const item of page.items) {
+      const inspection = (await ctx.runQuery(
+        internal.maintenance.inspectSkillLineageCycleInternal,
+        { skillId: item.skillId },
+      )) as SkillLineageCycleInspection;
+
+      if (inspection.status === "ambiguous") {
+        stats.ambiguous++;
+        if (samples.length < 200) samples.push(inspection);
+        continue;
+      }
+
+      stats.repairable++;
+      if (dryRun) {
+        if (samples.length < 200) samples.push(inspection);
+        continue;
+      }
+
+      const result = (await ctx.runMutation(
+        internal.maintenance.applySkillLineageCycleRepairInternal,
+        {
+          skillId: inspection.skillId,
+          sourceSkillId: inspection.sourceSkillId,
+        },
+      )) as { repaired: true } | { repaired: false; reason: "changed_before_apply" };
+      if (result.repaired) {
+        stats.repaired++;
+        if (samples.length < 200) {
+          samples.push({
+            status: "repaired",
+            skillId: inspection.skillId,
+            slug: inspection.slug,
+            sourceSkillId: inspection.sourceSkillId,
+            sourceSlug: inspection.sourceSlug,
+          });
+        }
+      } else {
+        stats.changedBeforeApply++;
+        if (samples.length < 200) {
+          samples.push({
+            status: "changed_before_apply",
+            skillId: inspection.skillId,
+            slug: inspection.slug,
+            sourceSkillId: inspection.sourceSkillId,
+            sourceSlug: inspection.sourceSlug,
+          });
+        }
+      }
+    }
+
+    if (isDone) break;
+  }
+
+  return {
+    ok: true,
+    dryRun,
+    ...(dryRun ? { confirmRequired: SKILL_LINEAGE_CYCLE_REPAIR_CONFIRM } : {}),
+    cursor,
+    isDone,
+    stats,
+    samples,
+  };
+}
+
+export const repairSkillLineageCyclesInternal = internalAction({
+  args: {
+    cursor: v.optional(v.string()),
+    dryRun: v.optional(v.boolean()),
+    confirm: v.optional(v.string()),
+    batchSize: v.optional(v.number()),
+    maxBatches: v.optional(v.number()),
+  },
+  handler: repairSkillLineageCyclesInternalHandler,
 });
 
 function isActiveLegacyPublisherRepairUser(

--- a/convex/skills.ownership.test.ts
+++ b/convex/skills.ownership.test.ts
@@ -899,6 +899,206 @@ describe("skills ownership", () => {
     );
   });
 
+  it("promotes an automatically detected duplicate target when merging its source into it", async () => {
+    const patch = vi.fn(async (_id: string, _value: unknown) => {});
+    const insert = vi.fn(async () => "auditLogs:1");
+    const skills = [
+      {
+        _id: "skills:source",
+        slug: "archive-demo",
+        displayName: "Archive Demo",
+        ownerUserId: "users:creator",
+        ownerPublisherId: "publishers:org",
+        moderationStatus: "active",
+        softDeletedAt: undefined,
+        statsDownloads: 0,
+        statsStars: 0,
+        statsInstallsCurrent: 0,
+        statsInstallsAllTime: 0,
+      },
+      {
+        _id: "skills:target",
+        slug: "demo",
+        displayName: "Demo",
+        ownerUserId: "users:creator",
+        ownerPublisherId: "publishers:org",
+        latestVersionId: "skillVersions:target",
+        canonicalSkillId: "skills:source",
+        forkOf: {
+          skillId: "skills:source",
+          kind: "duplicate",
+          at: 100,
+        },
+        moderationStatus: "active",
+        softDeletedAt: undefined,
+      },
+    ];
+
+    const result = await mergeOwnedSkillIntoCanonicalInternalHandler(
+      {
+        db: {
+          normalizeId: vi.fn(() => null),
+          system: {},
+          get: vi.fn(async (id: string) => {
+            if (id === "users:actor") return { _id: "users:actor", role: "user" };
+            if (id === "users:creator") {
+              return {
+                _id: "users:creator",
+                publishedSkills: 2,
+                totalDownloads: 0,
+                totalStars: 0,
+              };
+            }
+            if (id === "publishers:org") {
+              return {
+                _id: "publishers:org",
+                kind: "org",
+                handle: "team",
+                linkedUserId: undefined,
+              };
+            }
+            if (id === "skillVersions:target") return { _id: id, version: "1.0.0" };
+            return skills.find((skill) => skill._id === id) ?? null;
+          }),
+          query: vi.fn((table: string) => {
+            if (table === "skills") {
+              return {
+                withIndex: (name: string, build: (q: ReturnType<typeof chainEq>) => unknown) => {
+                  const constraints: Record<string, unknown> = {};
+                  build(chainEq(constraints));
+                  if (name === "by_slug") {
+                    return {
+                      take: async () =>
+                        skills.filter((skill) => skill.slug === constraints.slug).slice(0, 2),
+                      unique: async () =>
+                        skills.find((skill) => skill.slug === constraints.slug) ?? null,
+                    };
+                  }
+                  if (name === "by_owner_publisher_slug") {
+                    return {
+                      unique: async () =>
+                        skills.find(
+                          (skill) =>
+                            skill.ownerPublisherId === constraints.ownerPublisherId &&
+                            skill.slug === constraints.slug,
+                        ) ?? null,
+                    };
+                  }
+                  if (name === "by_canonical") {
+                    return {
+                      collect: async () =>
+                        skills.filter(
+                          (skill) => skill.canonicalSkillId === constraints.canonicalSkillId,
+                        ),
+                    };
+                  }
+                  if (name === "by_fork_of") {
+                    return {
+                      collect: async () =>
+                        skills.filter(
+                          (skill) => skill.forkOf?.skillId === constraints["forkOf.skillId"],
+                        ),
+                    };
+                  }
+                  throw new Error(`unexpected skills index ${name}`);
+                },
+              };
+            }
+            if (table === "publisherMembers") {
+              return {
+                withIndex: (name: string) => {
+                  if (name !== "by_publisher_user") {
+                    throw new Error(`unexpected publisherMembers index ${name}`);
+                  }
+                  return {
+                    unique: async () => ({
+                      _id: "publisherMembers:1",
+                      publisherId: "publishers:org",
+                      userId: "users:actor",
+                      role: "admin",
+                    }),
+                  };
+                },
+              };
+            }
+            if (table === "skillSlugAliases") {
+              return {
+                withIndex: (name: string, build: (q: ReturnType<typeof chainEq>) => unknown) => {
+                  const constraints: Record<string, unknown> = {};
+                  build(chainEq(constraints));
+                  if (name === "by_skill" || name === "by_owner_publisher") {
+                    return { take: async () => [] };
+                  }
+                  if (
+                    name === "by_slug" ||
+                    name === "by_owner_publisher_slug" ||
+                    name === "by_owner_slug"
+                  ) {
+                    return {
+                      take: async () => [],
+                      unique: async () => null,
+                    };
+                  }
+                  throw new Error(`unexpected skillSlugAliases index ${name}`);
+                },
+              };
+            }
+            if (table === "skillEmbeddings") {
+              return {
+                withIndex: (name: string) => {
+                  if (name !== "by_skill") {
+                    throw new Error(`unexpected skillEmbeddings index ${name}`);
+                  }
+                  return { collect: async () => [] };
+                },
+              };
+            }
+            throw new Error(`unexpected table ${table}`);
+          }),
+          patch,
+          insert,
+        },
+      } as never,
+      {
+        actorUserId: "users:actor",
+        sourceSlug: "archive-demo",
+        targetSlug: "demo",
+      },
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      sourceSlug: "archive-demo",
+      targetSlug: "demo",
+    });
+    expect(patch).toHaveBeenCalledWith(
+      "skills:target",
+      expect.objectContaining({
+        canonicalSkillId: undefined,
+        forkOf: undefined,
+      }),
+    );
+    const targetPatches = patch.mock.calls
+      .filter(([id]) => id === "skills:target")
+      .map(([, value]) => value as { canonicalSkillId?: string; forkOf?: { skillId?: string } });
+    expect(
+      targetPatches.some(
+        (value) =>
+          value.canonicalSkillId === "skills:target" || value.forkOf?.skillId === "skills:target",
+      ),
+    ).toBe(false);
+    expect(patch).toHaveBeenCalledWith(
+      "skills:source",
+      expect.objectContaining({
+        canonicalSkillId: "skills:target",
+        forkOf: expect.objectContaining({
+          skillId: "skills:target",
+          kind: "duplicate",
+        }),
+      }),
+    );
+  });
+
   it("preserves source-owner redirects when merging across owner namespaces", async () => {
     const patch = vi.fn(async () => {});
     const insert = vi.fn(async () => "auditLogs:1");

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -1438,6 +1438,7 @@ async function repointSkillRelationships(
     fromSkillId: Id<"skills">;
     toSkillId: Id<"skills">;
     toCanonicalSkillId: Id<"skills">;
+    skipSkillId?: Id<"skills">;
     targetVersion: Doc<"skillVersions"> | null;
     now: number;
   },
@@ -1447,6 +1448,7 @@ async function repointSkillRelationships(
     .withIndex("by_canonical", (q) => q.eq("canonicalSkillId", params.fromSkillId))
     .collect();
   for (const related of canonicalRefs) {
+    if (related._id === params.skipSkillId) continue;
     await ctx.db.patch(related._id, {
       canonicalSkillId: params.toCanonicalSkillId,
       updatedAt: params.now,
@@ -1458,6 +1460,7 @@ async function repointSkillRelationships(
     .withIndex("by_fork_of", (q) => q.eq("forkOf.skillId", params.fromSkillId))
     .collect();
   for (const related of forkRefs) {
+    if (related._id === params.skipSkillId) continue;
     await ctx.db.patch(related._id, {
       canonicalSkillId: params.toCanonicalSkillId,
       forkOf: related.forkOf
@@ -11201,7 +11204,17 @@ async function mergeOwnedSkillIntoCanonicalByActor(
   const targetLatestVersion = target.latestVersionId
     ? await ctx.db.get(target.latestVersionId)
     : null;
-  const targetCanonicalSkillId = target.canonicalSkillId ?? target._id;
+  const targetLineageIds = [target.canonicalSkillId, target.forkOf?.skillId].filter(
+    (skillId): skillId is Id<"skills"> => Boolean(skillId),
+  );
+  const targetReferencesSource = targetLineageIds.some((skillId) => skillId === source._id);
+  const targetReferencesAnotherSkill = targetLineageIds.some((skillId) => skillId !== source._id);
+  if (targetReferencesAnotherSkill) {
+    throw new ConvexError(
+      "Target skill must be canonical before merging. Merge into its canonical skill instead.",
+    );
+  }
+  const targetCanonicalSkillId = target._id;
 
   const targetAliases = await listSkillSlugAliasesForMerge(ctx, target._id);
   const targetAliasSlugs = new Set(targetAliases.map((alias) => alias.slug));
@@ -11301,10 +11314,19 @@ async function mergeOwnedSkillIntoCanonicalByActor(
     });
   }
 
+  if (targetReferencesSource) {
+    await ctx.db.patch(target._id, {
+      canonicalSkillId: undefined,
+      forkOf: undefined,
+      updatedAt: now,
+    });
+  }
+
   await repointSkillRelationships(ctx, {
     fromSkillId: source._id,
     toSkillId: target._id,
     toCanonicalSkillId: targetCanonicalSkillId,
+    skipSkillId: target._id,
     targetVersion: targetLatestVersion,
     now,
   });


### PR DESCRIPTION
## Summary
- prevent owner merges from turning an automatically detected duplicate target into a self-reference
- reject merge targets that already belong to an unrelated lineage
- add temporary, cursor-based maintenance tooling to preview and repair existing malformed pairs
- require exact archived-pair state plus the original `skill.merge` audit before any write
- default to preview mode, require `repair-skill-lineage-cycles-2026-07-23` for apply, and audit every repair

## Repair lifecycle
This uses `convex/maintenance.ts` instead of the migrations component because each write must validate two related skill records and their merge audit in one transaction. The action is resumable and idempotent. After merge and backend deploy, run the production preview to completion and present the results for explicit approval before applying. Remove the temporary maintenance functions in a cleanup PR after verified completion.

## Validation
- `bunx vitest run convex/skills.ownership.test.ts convex/maintenance.test.ts`
- `bunx convex codegen`
- `bun run ci:static`
- `bun run ci:unit`
- `bun run ci:types-build`
- `.agents/skills/autoreview/scripts/autoreview --mode local`

Local Convex codegen and TypeScript validation passed. A separate runtime invocation could not use the already-running local backend because it is owned by another checkout and immediately restores that checkout's function set; no production or shared-backend writes were performed.
