### PR TITLE
feat: generalize GitHub Skill Sync engine

### DIFF
--- a/convex/githubSkillSources.test.ts
+++ b/convex/githubSkillSources.test.ts
@@ -171,6 +171,17 @@ describe("githubSkillSources.deleteForPublisherHandler", () => {
           contentHash: "hash-other-source",
         },
       ],
+      githubSkillCandidates: [
+        {
+          _id: "githubSkillCandidates:hosted",
+          skillId: "skills:hosted-candidate",
+          githubSourceId: "githubSkillSources:matt",
+          githubPath: "skills/hosted-candidate",
+          githubCommit: "c".repeat(40),
+          githubContentHash: "hash-hosted-candidate",
+          scanStatus: "pending",
+        },
+      ],
       skills: [
         {
           _id: "skills:github",
@@ -212,6 +223,16 @@ describe("githubSkillSources.deleteForPublisherHandler", () => {
           softDeletedAt: undefined,
         },
         {
+          _id: "skills:hosted-candidate",
+          slug: "hosted-candidate",
+          displayName: "Hosted Candidate",
+          ownerPublisherId: "publishers:openclaw",
+          latestVersionId: "skillVersions:hosted",
+          githubPendingCandidateId: "githubSkillCandidates:hosted",
+          softDeletedAt: undefined,
+          updatedAt: 2,
+        },
+        {
           _id: "skills:other-source",
           slug: "other-source",
           displayName: "Other Source",
@@ -247,6 +268,7 @@ describe("githubSkillSources.deleteForPublisherHandler", () => {
     );
     expect(tables.githubSkillSources).toHaveLength(0);
     expect(tables.githubSkillContents).toHaveLength(0);
+    expect(tables.githubSkillCandidates).toHaveLength(0);
     expect(tables.githubSkillScans).toHaveLength(2);
     expect(scheduler.runAfter).toHaveBeenCalledWith(0, expect.anything(), {
       sourceId: "githubSkillSources:matt",
@@ -280,6 +302,14 @@ describe("githubSkillSources.deleteForPublisherHandler", () => {
     expect(tables.skills.find((skill) => skill._id === "skills:direct")).toMatchObject({
       softDeletedAt: undefined,
     });
+    expect(tables.skills.find((skill) => skill._id === "skills:hosted-candidate")).toMatchObject({
+      latestVersionId: "skillVersions:hosted",
+      softDeletedAt: undefined,
+      updatedAt: 123,
+    });
+    expect(
+      tables.skills.find((skill) => skill._id === "skills:hosted-candidate"),
+    ).not.toHaveProperty("githubPendingCandidateId");
     expect(tables.skills.find((skill) => skill._id === "skills:other-source")).toMatchObject({
       githubCurrentStatus: "present",
       softDeletedAt: undefined,

--- a/convex/githubSkillSources.ts
+++ b/convex/githubSkillSources.ts
@@ -190,6 +190,20 @@ export async function deleteForPublisherHandler(
   for (const content of contents) {
     await ctx.db.delete(content._id);
   }
+  const candidates = await ctx.db
+    .query("githubSkillCandidates")
+    .withIndex("by_github_source", (q) => q.eq("githubSourceId", args.sourceId))
+    .collect();
+  for (const candidate of candidates) {
+    const skill = await ctx.db.get(candidate.skillId);
+    if (skill?.githubPendingCandidateId === candidate._id) {
+      await ctx.db.patch(skill._id, {
+        githubPendingCandidateId: undefined,
+        updatedAt: now,
+      });
+    }
+    await ctx.db.delete(candidate._id);
+  }
   await ctx.scheduler.runAfter(0, internal.githubSkillSources.cleanupDeletedSourceScansInternal, {
     sourceId: args.sourceId,
   });

--- a/convex/githubSkillSync.test.ts
+++ b/convex/githubSkillSync.test.ts
@@ -9,8 +9,10 @@ import {
   configurePublicGitHubSkillSourceHandler,
   listSourcesForSyncHandler,
   recordGitHubSkillSourceSyncAttemptHandler,
+  revokeGitHubSkillSourceAuthorizationHandler,
   resolveOwnerUserIdForPublisherHandler,
   syncGitHubSkillSourcesHandler,
+  upsertGitHubSkillCandidateContentHandler,
   upsertGitHubSkillContentHandler,
   verifyGitHubSkillHandler,
 } from "./githubSkillSync";
@@ -78,6 +80,11 @@ function createDb(initial: Record<string, Row[]> = {}) {
         }
       }
     },
+    delete: async (id: string) => {
+      const table = id.split(":")[0] ?? "";
+      const index = list(table).findIndex((candidate) => candidate._id === id);
+      if (index >= 0) list(table).splice(index, 1);
+    },
     query: (table: string) => ({
       withIndex: (_indexName: string, build?: (q: ReturnType<typeof chainEq>) => unknown) => {
         const constraints: Record<string, unknown> = {};
@@ -141,7 +148,9 @@ function createFakeGitHubSkillsRepo() {
     ) {
       return new Response(
         JSON.stringify({
+          id: 100,
           full_name: repo,
+          owner: { id: 200 },
           private: false,
           visibility: "public",
           default_branch: defaultBranch,
@@ -347,7 +356,6 @@ describe("configurePublicGitHubSkillSourceHandler", () => {
       return {
         ownerUserId: "users:publisher-owner",
         existingSource: null,
-        official: true,
       };
     });
     const runMutation = vi.fn(async () => ({ ok: true, stats: { discovered: 1 } }));
@@ -356,7 +364,9 @@ describe("configurePublicGitHubSkillSourceHandler", () => {
       .mockResolvedValueOnce({
         ok: true,
         json: async () => ({
+          id: 101,
           full_name: "SomeoneElse/public-skills",
+          owner: { id: 201 },
           private: false,
           visibility: "public",
           default_branch: "main",
@@ -372,6 +382,18 @@ describe("configurePublicGitHubSkillSourceHandler", () => {
         headers: new Headers({ "content-length": String(zip.byteLength) }),
         body: null,
         arrayBuffer: async () => zip.buffer.slice(zip.byteOffset, zip.byteOffset + zip.byteLength),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          id: 101,
+          full_name: "SomeoneElse/public-skills",
+          owner: { id: 201 },
+          private: false,
+          visibility: "public",
+          default_branch: "main",
+          disabled: false,
+        }),
       });
 
     const result = await configurePublicGitHubSkillSourceHandler(
@@ -424,7 +446,6 @@ describe("configurePublicGitHubSkillSourceHandler", () => {
     const runQuery = vi.fn(async () => ({
       ownerUserId: "users:publisher-owner",
       existingSource: null,
-      official: true,
     }));
     const runMutation = vi.fn(async () => ({ ok: true, stats: { discovered: 1 } }));
     const fetchMock = vi
@@ -432,7 +453,9 @@ describe("configurePublicGitHubSkillSourceHandler", () => {
       .mockResolvedValueOnce({
         ok: true,
         json: async () => ({
+          id: 102,
           full_name: "aws/agent-toolkit-for-aws",
+          owner: { id: 202 },
           private: false,
           visibility: "public",
           default_branch: "main",
@@ -448,6 +471,18 @@ describe("configurePublicGitHubSkillSourceHandler", () => {
         headers: new Headers({ "content-length": String(zip.byteLength) }),
         body: null,
         arrayBuffer: async () => zip.buffer.slice(zip.byteOffset, zip.byteOffset + zip.byteLength),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          id: 102,
+          full_name: "aws/agent-toolkit-for-aws",
+          owner: { id: 202 },
+          private: false,
+          visibility: "public",
+          default_branch: "main",
+          disabled: false,
+        }),
       });
 
     await expect(
@@ -491,7 +526,6 @@ describe("configurePublicGitHubSkillSourceHandler", () => {
     const runQuery = vi.fn(async () => ({
       ownerUserId: "users:publisher-owner",
       existingSource: null,
-      official: true,
     }));
     const runMutation = vi.fn();
     const fetchMock = vi
@@ -499,7 +533,9 @@ describe("configurePublicGitHubSkillSourceHandler", () => {
       .mockResolvedValueOnce({
         ok: true,
         json: async () => ({
+          id: 103,
           full_name: "aws/agent-toolkit-for-aws",
+          owner: { id: 203 },
           private: false,
           visibility: "public",
           default_branch: "main",
@@ -541,17 +577,17 @@ describe("configurePublicGitHubSkillSourceHandler", () => {
     expect(runMutation).not.toHaveBeenCalled();
   });
 
-  it("rejects non-official publishers before fetching skill contents", async () => {
-    const runQuery = vi.fn(async () => ({
-      ownerUserId: "users:publisher-owner",
-      existingSource: null,
-      official: false,
-    }));
+  it("rejects repositories that do not match the publisher's immutable GitHub owner", async () => {
+    const runQuery = vi.fn(async () => {
+      throw new ConvexError("Repository ownership does not match the selected publisher.");
+    });
     const runMutation = vi.fn();
     const fetchMock = vi.fn().mockResolvedValueOnce({
       ok: true,
       json: async () => ({
+        id: 104,
         full_name: "SomeoneElse/public-skills",
+        owner: { id: 204 },
         private: false,
         visibility: "public",
         default_branch: "main",
@@ -571,9 +607,71 @@ describe("configurePublicGitHubSkillSourceHandler", () => {
           userId: "users:actor" as never,
         },
       ),
-    ).rejects.toThrow(/official publishers/i);
+    ).rejects.toThrow(/ownership does not match/i);
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(runMutation).not.toHaveBeenCalled();
+  });
+
+  it("rejects a repository transfer that occurs while the source snapshot is fetched", async () => {
+    const zip = zipSync({
+      "skills-main/skills/html/SKILL.md": new TextEncoder().encode("# HTML\n"),
+    });
+    const runQuery = vi.fn(async () => ({
+      ownerUserId: "users:publisher-owner",
+      existingSource: null,
+    }));
+    const runMutation = vi.fn();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          id: 105,
+          full_name: "patrick-erichsen/skills",
+          owner: { id: 205 },
+          private: false,
+          visibility: "public",
+          default_branch: "main",
+          disabled: false,
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ sha: "1".repeat(40) }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: new Headers({ "content-length": String(zip.byteLength) }),
+        body: null,
+        arrayBuffer: async () => zip.buffer.slice(zip.byteOffset, zip.byteOffset + zip.byteLength),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          id: 105,
+          full_name: "someone-else/skills",
+          owner: { id: 999 },
+          private: false,
+          visibility: "public",
+          default_branch: "main",
+          disabled: false,
+        }),
+      });
+
+    await expect(
+      configurePublicGitHubSkillSourceHandler(
+        { runQuery, runMutation, auth: { getUserIdentity: vi.fn() } } as never,
+        {
+          ownerPublisherId: "publishers:local" as never,
+          repo: "patrick-erichsen/skills",
+        },
+        fetchMock as never,
+        { userId: "users:actor" as never },
+      ),
+    ).rejects.toThrow(/authorization no longer matches/i);
+
+    expect(fetchMock).toHaveBeenCalledTimes(4);
     expect(runMutation).not.toHaveBeenCalled();
   });
 
@@ -765,7 +863,9 @@ describe("syncGitHubSkillSourcesHandler", () => {
         isDone: true,
       })
       .mockResolvedValueOnce("users:nvidia");
-    const runMutation = vi.fn(async () => ({ ok: true }));
+    const runMutation = vi.fn(async (_ref: unknown, _args: Record<string, unknown>) => ({
+      ok: true,
+    }));
     const fetchMock = vi.fn().mockResolvedValueOnce({
       ok: true,
       json: async () => ({
@@ -792,6 +892,45 @@ describe("syncGitHubSkillSourcesHandler", () => {
       expect.anything(),
       expect.objectContaining({ snapshot: expect.anything() }),
     );
+  });
+
+  it("revokes a generic source when GitHub reports the repository missing", async () => {
+    const runQuery = vi
+      .fn()
+      .mockResolvedValueOnce({
+        sources: [
+          {
+            _id: "githubSkillSources:patrick",
+            repo: "patrick-erichsen/skills",
+            ownerPublisherId: "publishers:patrick",
+            githubRepositoryId: "100",
+            githubOwnerId: "200",
+            defaultBranch: "main",
+          },
+        ],
+        continueCursor: null,
+        isDone: true,
+      })
+      .mockResolvedValueOnce("users:patrick");
+    const runMutation = vi.fn(async (_ref: unknown, _args: Record<string, unknown>) => ({
+      ok: true,
+    }));
+    const fetchMock = vi.fn().mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+    });
+
+    await expect(
+      syncGitHubSkillSourcesHandler({ runQuery, runMutation } as never, {}, fetchMock as never),
+    ).resolves.toMatchObject({ ok: true, synced: 0, errors: 1 });
+
+    expect(getFunctionName(runMutation.mock.calls[0]?.[0] as never)).toBe(
+      "githubSkillSync:revokeGitHubSkillSourceAuthorizationInternal",
+    );
+    expect(runMutation.mock.calls[0]?.[1]).toMatchObject({
+      sourceId: "githubSkillSources:patrick",
+      error: expect.stringMatching(/public GitHub repo/i),
+    });
   });
 });
 
@@ -963,14 +1102,36 @@ description: Install from a GitHub-backed source.
         }
         if ("skillId" in args) {
           const skill = tables.skills?.find((row) => row._id === args.skillId);
-          const source =
-            skill && typeof skill.githubSourceId === "string"
-              ? tables.githubSkillSources?.find((row) => row._id === skill.githubSourceId)
+          const candidate =
+            skill && typeof skill.githubPendingCandidateId === "string"
+              ? tables.githubSkillCandidates?.find(
+                  (row) => row._id === skill.githubPendingCandidateId,
+                )
               : null;
-          return skill && source ? { skill, source } : null;
+          const source =
+            skill && typeof (candidate?.githubSourceId ?? skill.githubSourceId) === "string"
+              ? tables.githubSkillSources?.find(
+                  (row) => row._id === (candidate?.githubSourceId ?? skill.githubSourceId),
+                )
+              : null;
+          if (!skill || !source) return null;
+          if (candidate && candidate.githubContentHash === args.contentHash) {
+            return {
+              skill: {
+                ...skill,
+                githubPath: candidate.githubPath,
+                githubCurrentCommit: candidate.githubCommit,
+                githubCurrentContentHash: candidate.githubContentHash,
+                githubCurrentStatus: "present",
+              },
+              source,
+              candidateId: candidate._id,
+            };
+          }
+          return { skill, source };
         }
         if ("sourceId" in args) {
-          return (tables.skills ?? []).flatMap((skill) => {
+          const currentTargets = (tables.skills ?? []).flatMap((skill) => {
             if (
               skill.githubSourceId !== args.sourceId ||
               skill.installKind !== "github" ||
@@ -988,6 +1149,15 @@ description: Install from a GitHub-backed source.
               },
             ];
           });
+          const candidateTargets = (tables.githubSkillCandidates ?? [])
+            .filter((candidate) => candidate.githubSourceId === args.sourceId)
+            .map((candidate) => ({
+              skillId: candidate.skillId,
+              githubPath: candidate.githubPath,
+              githubCurrentContentHash: candidate.githubContentHash,
+              candidateId: candidate._id,
+            }));
+          return [...currentTargets, ...candidateTargets];
         }
         if ("batchSize" in args || "cursor" in args || Object.keys(args).length === 0) {
           return await listSourcesForSyncHandler({ db } as never, args);
@@ -1035,6 +1205,22 @@ description: Install from a GitHub-backed source.
           );
         }
         if ("discovered" in args && "commit" in args) {
+          if ("candidateId" in args) {
+            const candidate = tables.githubSkillCandidates?.find(
+              (row) => row._id === args.candidateId,
+            );
+            if (candidate) {
+              Object.assign(candidate, {
+                skillMarkdownPath: (args.discovered as Record<string, unknown>).skillMarkdownPath,
+                skillMarkdown: (args.discovered as Record<string, unknown>).skillMarkdown,
+                skillCardMarkdownPath: (args.discovered as Record<string, unknown>)
+                  .skillCardMarkdownPath,
+                skillCardMarkdown: (args.discovered as Record<string, unknown>).skillCardMarkdown,
+                updatedAt: now,
+              });
+            }
+            return { ok: true };
+          }
           return await upsertGitHubSkillContentHandler(
             { db } as never,
             {
@@ -1079,6 +1265,8 @@ description: Install from a GitHub-backed source.
       expect(tables.githubSkillSources[0]).toMatchObject({
         repo: fakeGitHub.repo,
         ownerPublisherId: "publishers:openclaw",
+        githubRepositoryId: "100",
+        githubOwnerId: "200",
         defaultBranch: "main",
         displayManifestStatus: "ok",
       });
@@ -1189,20 +1377,26 @@ description: Install from a GitHub-backed source.
       });
       skill = getSkill(tables, "demo-source");
       expect(skill).toMatchObject({
-        githubCurrentCommit: "b".repeat(40),
+        githubCurrentCommit: "a".repeat(40),
         githubCurrentStatus: "present",
-        githubScanStatus: "pending",
+        githubScanStatus: "clean",
         moderationStatus: "active",
       });
-      expect(skill.githubCurrentContentHash).not.toBe(commitAContentHash);
+      expect(skill.githubCurrentContentHash).toBe(commitAContentHash);
       expect(tables.githubSkillContents[0]).toMatchObject({
-        skillMarkdown: expect.stringContaining("# Demo Source B"),
+        skillMarkdown: expect.stringContaining("# Demo Source A"),
+        githubCommit: "a".repeat(40),
+      });
+      const candidate = tables.githubSkillCandidates[0];
+      expect(candidate).toMatchObject({
+        skillId: skill._id,
         githubCommit: "b".repeat(40),
+        skillMarkdown: expect.stringContaining("# Demo Source B"),
+        scanStatus: "pending",
       });
       expect(resolveInstallFromTables(tables, "demo-source")).toMatchObject({
-        ok: false,
-        reason: "github_verification_pending",
-        status: 423,
+        ok: true,
+        github: { commit: "a".repeat(40), contentHash: commitAContentHash },
       });
 
       now = 210;
@@ -1211,22 +1405,22 @@ description: Install from a GitHub-backed source.
           actionCtx as never,
           {
             skillId: skill._id as never,
-            contentHash: skill.githubCurrentContentHash as string,
+            contentHash: candidate.githubContentHash as string,
           },
           fakeGitHub.fetcher as never,
         ),
       ).resolves.toMatchObject({ ok: true, queued: true });
       expect(resolveInstallFromTables(tables, "demo-source")).toMatchObject({
-        ok: false,
-        reason: "github_verification_pending",
-        status: 423,
+        ok: true,
+        github: { commit: "a".repeat(40), contentHash: commitAContentHash },
       });
       await applyGitHubSkillVerificationResultHandler({ db } as never, {
         skillId: skill._id as never,
-        contentHash: skill.githubCurrentContentHash as string,
+        contentHash: candidate.githubContentHash as string,
         scanStatus: "clean",
         now,
       });
+      skill = getSkill(tables, "demo-source");
       expect(resolveInstallFromTables(tables, "demo-source")).toMatchObject({
         ok: true,
         installKind: "github",
@@ -1252,7 +1446,7 @@ description: Install from a GitHub-backed source.
 
       skill = getSkill(tables, "demo-source");
       expect(skill).toMatchObject({
-        githubCurrentCommit: "c".repeat(40),
+        githubCurrentCommit: "b".repeat(40),
         githubCurrentStatus: "missing",
         githubRemovedAt: 300,
         softDeletedAt: 300,
@@ -1263,6 +1457,48 @@ description: Install from a GitHub-backed source.
         ok: false,
         reason: "github_upstream_removed",
         status: 410,
+      });
+
+      fakeGitHub.setSnapshot({
+        commit: "d".repeat(40),
+        entries: githubRepoEntriesForSkill(`---
+name: Demo Source
+description: Install from a GitHub-backed source.
+---
+
+# Demo Source D
+`),
+      });
+      now = 400;
+      await syncGitHubSkillSourcesHandler(actionCtx as never, {}, fakeGitHub.fetcher as never);
+
+      const reappeared = getSkill(tables, "demo-source");
+      expect(reappeared).toMatchObject({
+        _id: skill._id,
+        githubCurrentCommit: "d".repeat(40),
+        githubCurrentStatus: "present",
+        githubScanStatus: "pending",
+        moderationStatus: "active",
+        moderationReason: "pending.scan",
+      });
+      expect(reappeared).not.toHaveProperty("softDeletedAt");
+      expect(resolveInstallFromTables(tables, "demo-source")).toMatchObject({
+        ok: false,
+        reason: "github_verification_pending",
+        status: 423,
+      });
+      await applyGitHubSkillVerificationResultHandler({ db } as never, {
+        skillId: reappeared._id as never,
+        contentHash: reappeared.githubCurrentContentHash as string,
+        scanStatus: "clean",
+        now: 410,
+      });
+      expect(resolveInstallFromTables(tables, "demo-source")).toMatchObject({
+        ok: true,
+        github: {
+          commit: "d".repeat(40),
+          contentHash: reappeared.githubCurrentContentHash,
+        },
       });
     } finally {
       consoleLog.mockRestore();
@@ -1320,6 +1556,473 @@ describe("resolveOwnerUserIdForPublisherHandler", () => {
 });
 
 describe("applyGitHubSkillSourceSyncHandler", () => {
+  it("preserves an intentional soft delete when source content changes", async () => {
+    const snapshot = await buildGitHubSkillSourceSnapshot({
+      repo: "patrick-erichsen/skills",
+      defaultBranch: "main",
+      commit: "4".repeat(40),
+      entries: { "skills/html/SKILL.md": new TextEncoder().encode("# HTML\n") },
+    });
+    const { db, tables } = createDb({
+      publishers: [
+        {
+          _id: "publishers:patrick",
+          kind: "user",
+          handle: "patrick",
+          linkedUserId: "users:patrick",
+        },
+      ],
+      githubSkillSources: [
+        {
+          _id: "githubSkillSources:patrick",
+          repo: "patrick-erichsen/skills",
+          ownerPublisherId: "publishers:patrick",
+          githubRepositoryId: "100",
+          githubOwnerId: "200",
+          createdAt: 1,
+          updatedAt: 1,
+        },
+      ],
+      skills: [
+        {
+          _id: "skills:html",
+          slug: "html",
+          displayName: "HTML",
+          ownerUserId: "users:patrick",
+          ownerPublisherId: "publishers:patrick",
+          installKind: "github",
+          githubSourceId: "githubSkillSources:patrick",
+          githubPath: "skills/html",
+          githubCurrentCommit: "3".repeat(40),
+          githubCurrentContentHash: "old-hash",
+          githubCurrentStatus: "present",
+          githubScanStatus: "clean",
+          softDeletedAt: 50,
+          moderationStatus: "hidden",
+          moderationReason: "staff.hidden",
+          tags: {},
+          stats: {
+            downloads: 0,
+            stars: 0,
+            installsCurrent: 0,
+            installsAllTime: 0,
+            versions: 0,
+            comments: 0,
+          },
+          createdAt: 1,
+          updatedAt: 50,
+        },
+      ],
+    });
+
+    await applyGitHubSkillSourceSyncHandler({ db } as never, {
+      sourceId: "githubSkillSources:patrick" as never,
+      repo: "patrick-erichsen/skills",
+      ownerUserId: "users:patrick" as never,
+      ownerPublisherId: "publishers:patrick" as never,
+      githubRepositoryId: "100",
+      githubOwnerId: "200",
+      snapshot,
+      now: 100,
+    });
+
+    expect(tables.skills[0]).toMatchObject({
+      softDeletedAt: 50,
+      moderationStatus: "hidden",
+      moderationReason: "staff.hidden",
+      githubCurrentCommit: "3".repeat(40),
+      githubCurrentContentHash: "old-hash",
+    });
+    expect(tables.githubSkillCandidates ?? []).toEqual([]);
+
+    await applyGitHubSkillSourceSyncHandler({ db } as never, {
+      sourceId: "githubSkillSources:patrick" as never,
+      repo: "patrick-erichsen/skills",
+      ownerUserId: "users:patrick" as never,
+      ownerPublisherId: "publishers:patrick" as never,
+      githubRepositoryId: "100",
+      githubOwnerId: "200",
+      snapshot: { ...snapshot, skills: [] },
+      now: 110,
+    });
+    expect(tables.skills[0]).toMatchObject({
+      softDeletedAt: 50,
+      githubRemovedAt: 110,
+      githubCurrentStatus: "missing",
+    });
+
+    await applyGitHubSkillSourceSyncHandler({ db } as never, {
+      sourceId: "githubSkillSources:patrick" as never,
+      repo: "patrick-erichsen/skills",
+      ownerUserId: "users:patrick" as never,
+      ownerPublisherId: "publishers:patrick" as never,
+      githubRepositoryId: "100",
+      githubOwnerId: "200",
+      snapshot,
+      now: 120,
+    });
+    expect(tables.skills[0]).toMatchObject({
+      softDeletedAt: 50,
+      githubRemovedAt: 110,
+      githubCurrentStatus: "missing",
+      moderationStatus: "hidden",
+    });
+  });
+
+  it("revokes transferred sources and cancels their pending candidates", async () => {
+    const { db, tables } = createDb({
+      githubSkillSources: [
+        {
+          _id: "githubSkillSources:patrick",
+          repo: "patrick-erichsen/skills",
+          authorizationStatus: "active",
+          createdAt: 1,
+          updatedAt: 1,
+        },
+      ],
+      githubSkillCandidates: [
+        {
+          _id: "githubSkillCandidates:html",
+          skillId: "skills:html",
+          githubSourceId: "githubSkillSources:patrick",
+          githubPath: "skills/html",
+          githubCommit: "5".repeat(40),
+          githubContentHash: "next-hash",
+          scanStatus: "pending",
+        },
+      ],
+      skills: [
+        {
+          _id: "skills:html",
+          slug: "html",
+          displayName: "HTML",
+          ownerUserId: "users:patrick",
+          installKind: "github",
+          githubSourceId: "githubSkillSources:patrick",
+          githubPath: "skills/html",
+          githubCurrentCommit: "4".repeat(40),
+          githubCurrentContentHash: "current-hash",
+          githubCurrentStatus: "present",
+          githubScanStatus: "clean",
+          githubPendingCandidateId: "githubSkillCandidates:html",
+          moderationStatus: "active",
+          moderationFlags: [],
+          isSuspicious: false,
+          tags: {},
+          stats: {
+            downloads: 0,
+            stars: 0,
+            installsCurrent: 0,
+            installsAllTime: 0,
+            versions: 0,
+            comments: 0,
+          },
+          createdAt: 1,
+          updatedAt: 1,
+        },
+      ],
+    });
+
+    await revokeGitHubSkillSourceAuthorizationHandler({ db } as never, {
+      sourceId: "githubSkillSources:patrick" as never,
+      error: "GitHub repository authorization no longer matches.",
+      now: 200,
+    });
+
+    expect(tables.githubSkillCandidates).toEqual([]);
+    expect(tables.githubSkillSources[0]).toMatchObject({
+      authorizationStatus: "revoked",
+      authorizationCheckedAt: 200,
+      lastSyncStatus: "failed",
+    });
+    expect(tables.skills[0]).toMatchObject({
+      githubCurrentStatus: "missing",
+      githubRemovedAt: 200,
+      softDeletedAt: 200,
+      moderationStatus: "hidden",
+      moderationReason: "github.authorization.revoked",
+    });
+    expect(tables.skills[0]).not.toHaveProperty("githubPendingCandidateId");
+  });
+
+  it("promotes a candidate after caching content for an exact reusable clean scan", async () => {
+    const snapshot = await buildGitHubSkillSourceSnapshot({
+      repo: "patrick-erichsen/skills",
+      defaultBranch: "main",
+      commit: "3".repeat(40),
+      entries: {
+        "skills/html/SKILL.md": new TextEncoder().encode("# HTML reusable\n"),
+      },
+    });
+    const contentHash = snapshot.skills[0]?.contentHash ?? "";
+    const { db, tables } = createDb({
+      publishers: [
+        {
+          _id: "publishers:patrick",
+          kind: "user",
+          handle: "patrick",
+          displayName: "Patrick",
+          linkedUserId: "users:patrick",
+          createdAt: 1,
+          updatedAt: 1,
+        },
+      ],
+      skills: [
+        {
+          _id: "skills:html",
+          slug: "html",
+          displayName: "HTML Hosted",
+          ownerUserId: "users:patrick",
+          ownerPublisherId: "publishers:patrick",
+          latestVersionId: "skillVersions:html-v1",
+          tags: {},
+          stats: {
+            downloads: 0,
+            stars: 0,
+            installsCurrent: 0,
+            installsAllTime: 0,
+            versions: 1,
+            comments: 0,
+          },
+          moderationStatus: "active",
+          moderationFlags: [],
+          isSuspicious: false,
+          createdAt: 5,
+          updatedAt: 10,
+        },
+      ],
+      githubSkillScans: [
+        {
+          _id: "githubSkillScans:html",
+          skillId: "skills:html",
+          githubSourceId: "githubSkillSources:old",
+          contentHash,
+          commit: "1".repeat(40),
+          path: "skills/html",
+          status: "clean",
+          createdAt: 20,
+          updatedAt: 20,
+        },
+      ],
+    });
+    const scheduler = { runAfter: vi.fn(async () => undefined) };
+
+    await applyGitHubSkillSourceSyncHandler({ db, scheduler } as never, {
+      repo: "patrick-erichsen/skills",
+      ownerUserId: "users:patrick" as never,
+      ownerPublisherId: "publishers:patrick" as never,
+      githubRepositoryId: "100",
+      githubOwnerId: "200",
+      snapshot,
+      now: 100,
+    });
+
+    const candidate = tables.githubSkillCandidates[0];
+    expect(candidate).toMatchObject({ scanStatus: "clean", githubContentHash: contentHash });
+    expect(scheduler.runAfter).not.toHaveBeenCalled();
+
+    await upsertGitHubSkillCandidateContentHandler({ db } as never, {
+      candidateId: candidate?._id as never,
+      discovered: snapshot.skills[0]!,
+      commit: snapshot.commit,
+      now: 110,
+    });
+
+    expect(tables.githubSkillCandidates).toEqual([]);
+    expect(tables.skills[0]).toMatchObject({
+      _id: "skills:html",
+      installKind: "github",
+      githubCurrentCommit: snapshot.commit,
+      githubCurrentContentHash: contentHash,
+      githubScanStatus: "clean",
+    });
+  });
+
+  it("promotes a Hosted Skill in place only after the exact GitHub candidate passes scanning", async () => {
+    const snapshot = await buildGitHubSkillSourceSnapshot({
+      repo: "patrick-erichsen/skills",
+      defaultBranch: "main",
+      commit: "2".repeat(40),
+      entries: {
+        "skills/html/SKILL.md": new TextEncoder().encode(`---
+name: HTML
+description: Build HTML artifacts.
+---
+
+# HTML
+`),
+      },
+    });
+    const { db, tables } = createDb({
+      publishers: [
+        {
+          _id: "publishers:patrick",
+          kind: "user",
+          handle: "patrick",
+          displayName: "Patrick",
+          linkedUserId: "users:patrick",
+          createdAt: 1,
+          updatedAt: 1,
+        },
+      ],
+      skills: [
+        {
+          _id: "skills:html",
+          slug: "html",
+          displayName: "HTML Hosted",
+          ownerUserId: "users:patrick",
+          ownerPublisherId: "publishers:patrick",
+          latestVersionId: "skillVersions:html-v1",
+          latestVersionSummary: { version: "1.0.0", createdAt: 10 },
+          tags: { latest: "1.0.0" },
+          statsDownloads: 37,
+          statsStars: 11,
+          statsInstallsCurrent: 5,
+          statsInstallsAllTime: 23,
+          stats: {
+            downloads: 37,
+            stars: 11,
+            installsCurrent: 5,
+            installsAllTime: 23,
+            versions: 1,
+            comments: 0,
+          },
+          moderationStatus: "active",
+          moderationFlags: [],
+          isSuspicious: false,
+          createdAt: 5,
+          updatedAt: 10,
+        },
+      ],
+      skillVersions: [
+        {
+          _id: "skillVersions:html-v1",
+          skillId: "skills:html",
+          version: "1.0.0",
+          createdAt: 10,
+        },
+      ],
+      bookmarks: [
+        {
+          _id: "bookmarks:html",
+          skillId: "skills:html",
+          userId: "users:reader",
+          createdAt: 20,
+        },
+      ],
+      auditLogs: [
+        {
+          _id: "auditLogs:html",
+          targetId: "skills:html",
+          action: "skill.publish",
+          createdAt: 10,
+        },
+      ],
+      globalStats: [
+        {
+          _id: "globalStats:default",
+          key: "default",
+          activeSkillsCount: 1,
+          updatedAt: 1,
+        },
+      ],
+    });
+    const scheduler = { runAfter: vi.fn(async () => undefined) };
+
+    const applied = await applyGitHubSkillSourceSyncHandler({ db, scheduler } as never, {
+      repo: "patrick-erichsen/skills",
+      ownerUserId: "users:patrick" as never,
+      ownerPublisherId: "publishers:patrick" as never,
+      githubRepositoryId: "100",
+      githubOwnerId: "200",
+      snapshot,
+      now: 100,
+    });
+
+    expect(applied.stats).toMatchObject({ changed: 1, inserted: 0, conflicts: 0 });
+    const pendingSkill = tables.skills[0];
+    const candidate = tables.githubSkillCandidates[0];
+    expect(pendingSkill).toMatchObject({
+      _id: "skills:html",
+      latestVersionId: "skillVersions:html-v1",
+      statsDownloads: 37,
+      statsStars: 11,
+      statsInstallsCurrent: 5,
+      statsInstallsAllTime: 23,
+      githubPendingCandidateId: candidate?._id,
+    });
+    expect(pendingSkill).not.toHaveProperty("installKind");
+    expect(candidate).toMatchObject({
+      skillId: "skills:html",
+      githubPath: "skills/html",
+      githubCommit: "2".repeat(40),
+      githubContentHash: snapshot.skills[0]?.contentHash,
+      scanStatus: "pending",
+    });
+
+    Object.assign(candidate ?? {}, {
+      skillMarkdownPath: snapshot.skills[0]?.skillMarkdownPath,
+      skillMarkdown: snapshot.skills[0]?.skillMarkdown,
+    });
+    Object.assign(pendingSkill ?? {}, {
+      softDeletedAt: 105,
+      moderationStatus: "hidden",
+      moderationReason: "staff.hidden",
+    });
+    await expect(
+      applyGitHubSkillVerificationResultHandler({ db } as never, {
+        skillId: "skills:html" as never,
+        contentHash: snapshot.skills[0]?.contentHash ?? "",
+        scanStatus: "clean",
+        now: 106,
+      }),
+    ).resolves.toMatchObject({ skipped: "skill-no-longer-eligible" });
+    expect(tables.skills[0]).toMatchObject({
+      latestVersionId: "skillVersions:html-v1",
+      softDeletedAt: 105,
+      moderationStatus: "hidden",
+      moderationReason: "staff.hidden",
+    });
+    expect(tables.skills[0]).not.toHaveProperty("installKind");
+
+    delete pendingSkill?.softDeletedAt;
+    delete pendingSkill?.moderationReason;
+    Object.assign(pendingSkill ?? {}, { moderationStatus: "active" });
+    await applyGitHubSkillVerificationResultHandler({ db } as never, {
+      skillId: "skills:html" as never,
+      contentHash: snapshot.skills[0]?.contentHash ?? "",
+      scanStatus: "clean",
+      now: 110,
+    });
+
+    expect(tables.skills).toHaveLength(1);
+    expect(tables.skills[0]).toMatchObject({
+      _id: "skills:html",
+      createdAt: 5,
+      installKind: "github",
+      githubPath: "skills/html",
+      githubCurrentCommit: "2".repeat(40),
+      githubScanStatus: "clean",
+      statsDownloads: 37,
+      statsStars: 11,
+      statsInstallsCurrent: 5,
+      statsInstallsAllTime: 23,
+    });
+    expect(tables.skills[0]).not.toHaveProperty("latestVersionId");
+    expect(tables.skills[0]).not.toHaveProperty("githubPendingCandidateId");
+    expect(tables.githubSkillCandidates).toEqual([]);
+    expect(tables.skillVersions).toEqual([
+      expect.objectContaining({ _id: "skillVersions:html-v1", skillId: "skills:html" }),
+    ]);
+    expect(tables.bookmarks).toEqual([
+      expect.objectContaining({ _id: "bookmarks:html", skillId: "skills:html" }),
+    ]);
+    expect(tables.auditLogs).toEqual([
+      expect.objectContaining({ _id: "auditLogs:html", targetId: "skills:html" }),
+    ]);
+    expect(tables.skillVersions).toHaveLength(1);
+  });
+
   it("queues a full scan and blocks legacy clean GitHub skills without a durable result", async () => {
     const snapshot = await buildGitHubSkillSourceSnapshot({
       repo: "NVIDIA/skills",

--- a/convex/githubSkillSync.ts
+++ b/convex/githubSkillSync.ts
@@ -7,12 +7,14 @@ import { action, internalMutation, internalQuery } from "./functions";
 import { assertAdmin, requireUserFromAction } from "./lib/access";
 import { decodeBoundedUtf8Text } from "./lib/artifactText";
 import { buildGitHubApiHeaders } from "./lib/githubAuth";
+import { getGitHubProviderAccountId } from "./lib/githubIdentity";
 import {
   fetchGitHubZipBytes,
   type GitHubImportUrl,
   resolveGitHubCommit,
   stripGitHubZipRoot,
 } from "./lib/githubImport";
+import { GITHUB_ORG_MEMBERSHIP_VERIFICATION_MAX_AGE_MS } from "./lib/githubOrgMemberships";
 import {
   buildGitHubSkillSourceSnapshot,
   buildGitHubSkillSyncPlan,
@@ -26,14 +28,18 @@ import {
 import { adjustGlobalPublicSkillsCount, getPublicSkillVisibilityDelta } from "./lib/globalStats";
 import { runStaticModerationScan } from "./lib/moderationEngine";
 import { Events, logErrorEvent, logEvent } from "./lib/observabilityEvents";
-import { isOfficialPublisher } from "./lib/officialPublishers";
 import { requirePublisherRole } from "./lib/publishers";
 import {
   assertGenericGitHubSkillSyncEnabled,
   assertGitHubSkillSyncRuntimeEnabled,
   getRuntimeRolloutCapabilities,
+  isLegacyNvidiaSkillSource,
 } from "./lib/rolloutCapabilities";
 import { isMacJunkPath, parseFrontmatter } from "./lib/skills";
+import {
+  getSkillBySlugForPublisher,
+  getSkillSlugAliasBySlugForPublisher,
+} from "./lib/skills/slugResolution";
 import { chunkSkillScanRequestFiles } from "./lib/skillScanRequestFiles";
 import { syncSkillSearchDigestForSkill } from "./lib/skillSearchDigest";
 import { assertValidSkillSlug } from "./lib/skillSlugValidator";
@@ -51,7 +57,7 @@ const MAX_SOURCE_SYNC_BATCH_SIZE = 50;
 
 type SourceForSync = Pick<
   Doc<"githubSkillSources">,
-  "_id" | "repo" | "ownerPublisherId" | "defaultBranch"
+  "_id" | "repo" | "ownerPublisherId" | "githubRepositoryId" | "githubOwnerId" | "defaultBranch"
 >;
 
 type SourceForSyncPage = {
@@ -117,6 +123,8 @@ type SyncDryRunResult = {
 };
 
 type GitHubRepoMetadata = {
+  repositoryId?: string;
+  ownerId?: string;
   repo: string;
   defaultBranch: string;
 };
@@ -124,7 +132,6 @@ type GitHubRepoMetadata = {
 type GitHubSkillSourceSetupContext = {
   ownerUserId: Id<"users">;
   existingSource: SourceForSync | null;
-  official: boolean;
 };
 
 type GitHubSkillVerificationTarget = {
@@ -135,6 +142,7 @@ type GitHubSkillVerificationTarget = {
     githubCurrentStatus: "present";
   };
   source: Pick<Doc<"githubSkillSources">, "_id" | "repo" | "defaultBranch">;
+  candidateId?: Id<"githubSkillCandidates">;
 };
 
 type GitHubSkillVerificationResult = {
@@ -155,6 +163,7 @@ type GitHubSkillContentTarget = {
   skillId: Id<"skills">;
   githubPath: string;
   githubCurrentContentHash: string;
+  candidateId?: Id<"githubSkillCandidates">;
 };
 
 const displayManifestStatusValidator = v.union(
@@ -288,11 +297,17 @@ export async function listSourcesForSyncHandler(
 export const listGitHubSkillContentTargetsInternal = internalQuery({
   args: { sourceId: v.id("githubSkillSources") },
   handler: async (ctx, args): Promise<GitHubSkillContentTarget[]> => {
-    const skills = await ctx.db
-      .query("skills")
-      .withIndex("by_github_source", (q) => q.eq("githubSourceId", args.sourceId))
-      .collect();
-    return skills.flatMap((skill) => {
+    const [skills, candidates] = await Promise.all([
+      ctx.db
+        .query("skills")
+        .withIndex("by_github_source", (q) => q.eq("githubSourceId", args.sourceId))
+        .collect(),
+      ctx.db
+        .query("githubSkillCandidates")
+        .withIndex("by_github_source", (q) => q.eq("githubSourceId", args.sourceId))
+        .collect(),
+    ]);
+    const currentTargets = skills.flatMap((skill) => {
       if (
         skill.installKind !== "github" ||
         skill.githubCurrentStatus !== "present" ||
@@ -309,6 +324,13 @@ export const listGitHubSkillContentTargetsInternal = internalQuery({
         },
       ];
     });
+    const candidateTargets = candidates.map((candidate) => ({
+      skillId: candidate.skillId,
+      githubPath: candidate.githubPath,
+      githubCurrentContentHash: candidate.githubContentHash,
+      candidateId: candidate._id,
+    }));
+    return [...currentTargets, ...candidateTargets];
   },
 });
 
@@ -329,6 +351,8 @@ export const getPublicGitHubSkillSourceSetupContextInternal = internalQuery({
     ownerPublisherId: v.id("publishers"),
     actorUserId: v.id("users"),
     repo: v.string(),
+    githubRepositoryId: v.string(),
+    githubOwnerId: v.string(),
   },
   handler: async (ctx, args): Promise<GitHubSkillSourceSetupContext> => {
     const { publisher } = await requirePublisherRole(ctx, {
@@ -336,12 +360,52 @@ export const getPublicGitHubSkillSourceSetupContextInternal = internalQuery({
       userId: args.actorUserId,
       allowed: ["admin"],
     });
-    const official = await isOfficialPublisher(ctx, publisher);
+    if (publisher.kind === "user") {
+      if (publisher.linkedUserId !== args.actorUserId) throw new ConvexError("Forbidden");
+      const providerId = normalizeGitHubNumericId(
+        await getGitHubProviderAccountId(ctx, args.actorUserId),
+      );
+      if (!providerId || providerId !== args.githubOwnerId) {
+        throw new ConvexError("Repository ownership does not match the selected publisher.");
+      }
+    } else {
+      const publisherOwnerId = normalizeGitHubNumericId(publisher.githubOrgId);
+      if (
+        !publisherOwnerId ||
+        !publisher.githubVerifiedAt ||
+        publisherOwnerId !== args.githubOwnerId
+      ) {
+        throw new ConvexError("Repository ownership does not match the selected publisher.");
+      }
+      const membership = await ctx.db
+        .query("githubOrgMemberships")
+        .withIndex("by_user_and_github_org", (q) =>
+          q.eq("userId", args.actorUserId).eq("githubOrgId", publisherOwnerId),
+        )
+        .unique();
+      if (
+        !membership ||
+        membership.role !== "admin" ||
+        Date.now() - membership.syncedAt > GITHUB_ORG_MEMBERSHIP_VERIFICATION_MAX_AGE_MS
+      ) {
+        throw new ConvexError("Reconnect GitHub to verify current organization admin access.");
+      }
+    }
     const repo = normalizeRepo(args.repo);
-    const existingSource = await ctx.db
+    const sourceByRepo = await ctx.db
       .query("githubSkillSources")
       .withIndex("by_repo", (q) => q.eq("repo", repo))
       .unique();
+    const sourceByRepositoryId = await ctx.db
+      .query("githubSkillSources")
+      .withIndex("by_github_repository_id", (q) =>
+        q.eq("githubRepositoryId", args.githubRepositoryId),
+      )
+      .unique();
+    if (sourceByRepo && sourceByRepositoryId && sourceByRepo._id !== sourceByRepositoryId._id) {
+      throw new ConvexError("GitHub repository identity conflicts with an existing source.");
+    }
+    const existingSource = sourceByRepositoryId ?? sourceByRepo;
     if (
       existingSource?.ownerPublisherId &&
       existingSource.ownerPublisherId !== args.ownerPublisherId
@@ -349,7 +413,7 @@ export const getPublicGitHubSkillSourceSetupContextInternal = internalQuery({
       throw new ConvexError("GitHub repo is already configured for another publisher.");
     }
     const ownerUserId = await resolveOwnerUserIdForPublisher(ctx, args.ownerPublisherId);
-    return { ownerUserId, existingSource, official };
+    return { ownerUserId, existingSource };
   },
 });
 
@@ -385,23 +449,112 @@ export const recordGitHubSkillSourceSyncAttemptInternal = internalMutation({
   handler: recordGitHubSkillSourceSyncAttemptHandler,
 });
 
+export async function revokeGitHubSkillSourceAuthorizationHandler(
+  ctx: MutationCtx,
+  args: { sourceId: Id<"githubSkillSources">; error: string; now?: number },
+) {
+  const source = await ctx.db.get(args.sourceId);
+  if (!source || isLegacyNvidiaSkillSource(source.repo)) {
+    return { ok: true as const, skipped: "missing-or-legacy-source" as const };
+  }
+  const now = args.now ?? Date.now();
+  const candidates = await ctx.db
+    .query("githubSkillCandidates")
+    .withIndex("by_github_source", (q) => q.eq("githubSourceId", source._id))
+    .collect();
+  for (const candidate of candidates) {
+    const skill = await ctx.db.get(candidate.skillId);
+    if (skill?.githubPendingCandidateId === candidate._id) {
+      await ctx.db.patch(skill._id, {
+        githubPendingCandidateId: undefined,
+        updatedAt: now,
+      });
+    }
+    await ctx.db.delete(candidate._id);
+  }
+
+  const skills = await ctx.db
+    .query("skills")
+    .withIndex("by_github_source", (q) => q.eq("githubSourceId", source._id))
+    .collect();
+  let blockedSkills = 0;
+  for (const skill of skills) {
+    if (skill.installKind !== "github") continue;
+    const previousSkill = { ...skill };
+    const removedAt = skill.githubRemovedAt ?? now;
+    const patch = {
+      githubCurrentStatus: "missing" as const,
+      githubCurrentCheckedAt: now,
+      githubRemovedAt: removedAt,
+      githubPendingCandidateId: undefined,
+      softDeletedAt: skill.softDeletedAt ?? removedAt,
+      moderationStatus: "hidden" as const,
+      moderationReason: "github.authorization.revoked",
+      moderationVerdict: undefined,
+      moderationFlags: [],
+      isSuspicious: false,
+      updatedAt: now,
+    };
+    await ctx.db.patch(skill._id, patch);
+    const nextSkill = { ...previousSkill, ...patch };
+    await syncSkillSearchDigestForSkill(ctx, nextSkill);
+    await adjustGlobalPublicCountForSkillChange(ctx, previousSkill, nextSkill, now);
+    blockedSkills += 1;
+  }
+
+  await ctx.db.patch(source._id, {
+    authorizationStatus: "revoked",
+    authorizationCheckedAt: now,
+    authorizationError: args.error,
+    lastSyncStatus: "failed",
+    lastSyncError: args.error,
+    lastSyncErrorAt: now,
+    updatedAt: now,
+  });
+  return { ok: true as const, revoked: true as const, blockedSkills };
+}
+
+export const revokeGitHubSkillSourceAuthorizationInternal = internalMutation({
+  args: {
+    sourceId: v.id("githubSkillSources"),
+    error: v.string(),
+    now: v.optional(v.number()),
+  },
+  handler: revokeGitHubSkillSourceAuthorizationHandler,
+});
+
 export const getGitHubSkillVerificationTargetInternal = internalQuery({
   args: { skillId: v.id("skills"), contentHash: v.string() },
   handler: async (ctx, args): Promise<GitHubSkillVerificationTarget | null> => {
     const skill = await ctx.db.get(args.skillId);
-    if (
-      !skill ||
-      skill.installKind !== "github" ||
-      skill.githubCurrentStatus !== "present" ||
-      !skill.githubCurrentCommit ||
-      !skill.githubCurrentContentHash ||
-      skill.githubCurrentContentHash !== args.contentHash ||
-      !skill.githubSourceId ||
-      !skill.githubPath
-    ) {
-      return null;
-    }
-    const source = await ctx.db.get(skill.githubSourceId);
+    if (!skill) return null;
+    const candidate = skill.githubPendingCandidateId
+      ? await ctx.db.get(skill.githubPendingCandidateId)
+      : null;
+    const exact =
+      candidate?.githubContentHash === args.contentHash
+        ? {
+            sourceId: candidate.githubSourceId,
+            path: candidate.githubPath,
+            commit: candidate.githubCommit,
+            contentHash: candidate.githubContentHash,
+            candidateId: candidate._id,
+          }
+        : skill.installKind === "github" &&
+            skill.githubCurrentStatus === "present" &&
+            skill.githubCurrentCommit &&
+            skill.githubCurrentContentHash === args.contentHash &&
+            skill.githubSourceId &&
+            skill.githubPath
+          ? {
+              sourceId: skill.githubSourceId,
+              path: skill.githubPath,
+              commit: skill.githubCurrentCommit,
+              contentHash: skill.githubCurrentContentHash,
+            }
+          : null;
+    if (!exact) return null;
+    const source = await ctx.db.get(exact.sourceId);
     if (!source) return null;
     return {
       skill: {
@@ -409,16 +562,17 @@ export const getGitHubSkillVerificationTargetInternal = internalQuery({
         slug: skill.slug,
         displayName: skill.displayName,
         summary: skill.summary,
-        githubPath: skill.githubPath,
-        githubCurrentCommit: skill.githubCurrentCommit,
-        githubCurrentContentHash: skill.githubCurrentContentHash,
-        githubCurrentStatus: skill.githubCurrentStatus,
+        githubPath: exact.path,
+        githubCurrentCommit: exact.commit,
+        githubCurrentContentHash: exact.contentHash,
+        githubCurrentStatus: "present",
       },
       source: {
         _id: source._id,
         repo: source.repo,
         defaultBranch: source.defaultBranch,
       },
+      ...(exact.candidateId ? { candidateId: exact.candidateId } : {}),
     };
   },
 });
@@ -428,6 +582,8 @@ export type ApplyGitHubSkillSourceSyncArgs = {
   repo: string;
   ownerUserId: Id<"users">;
   ownerPublisherId?: Id<"publishers">;
+  githubRepositoryId?: string;
+  githubOwnerId?: string;
   snapshot: GitHubSkillSourceMetadataSnapshot;
   now?: number;
 };
@@ -438,6 +594,13 @@ export async function applyGitHubSkillSourceSyncHandler(
 ): Promise<SyncOneResult> {
   const now = args.now ?? Date.now();
   const repo = normalizeRepo(args.repo);
+  if (!isLegacyNvidiaSkillSource(repo)) {
+    return await applyGenericGitHubSkillSourceSyncHandler(ctx, {
+      ...args,
+      repo,
+      now,
+    });
+  }
   const existingSource = args.sourceId
     ? await ctx.db.get(args.sourceId)
     : await ctx.db
@@ -681,6 +844,458 @@ export async function applyGitHubSkillSourceSyncHandler(
   };
 }
 
+async function applyGenericGitHubSkillSourceSyncHandler(
+  ctx: MutationCtx,
+  args: ApplyGitHubSkillSourceSyncArgs & { repo: string; now: number },
+): Promise<SyncOneResult> {
+  if (!args.ownerPublisherId || !args.githubRepositoryId || !args.githubOwnerId) {
+    throw new ConvexError("GitHub Skill Sync requires immutable repository authorization.");
+  }
+  const existingSource = args.sourceId
+    ? await ctx.db.get(args.sourceId)
+    : ((await ctx.db
+        .query("githubSkillSources")
+        .withIndex("by_github_repository_id", (q) =>
+          q.eq("githubRepositoryId", args.githubRepositoryId),
+        )
+        .unique()) ??
+      (await ctx.db
+        .query("githubSkillSources")
+        .withIndex("by_repo", (q) => q.eq("repo", args.repo))
+        .unique()));
+  if (
+    existingSource?.ownerPublisherId &&
+    existingSource.ownerPublisherId !== args.ownerPublisherId
+  ) {
+    throw new ConvexError("GitHub source is already configured for another publisher.");
+  }
+  if (
+    existingSource?.githubRepositoryId &&
+    existingSource.githubRepositoryId !== args.githubRepositoryId
+  ) {
+    throw new ConvexError("GitHub repository identity changed.");
+  }
+  if (existingSource?.githubOwnerId && existingSource.githubOwnerId !== args.githubOwnerId) {
+    throw new ConvexError("GitHub repository owner identity changed.");
+  }
+
+  const sourceId =
+    existingSource?._id ??
+    (await ctx.db.insert("githubSkillSources", {
+      repo: args.repo,
+      ownerPublisherId: args.ownerPublisherId,
+      githubRepositoryId: args.githubRepositoryId,
+      githubOwnerId: args.githubOwnerId,
+      authorizationStatus: "active",
+      authorizationCheckedAt: args.now,
+      createdAt: args.now,
+      updatedAt: args.now,
+    }));
+  const publisher = await ctx.db.get(args.ownerPublisherId);
+  if (!publisher || publisher.deletedAt || publisher.deactivatedAt) {
+    throw new ConvexError("GitHub source owner publisher not found.");
+  }
+  await ctx.db.patch(sourceId, {
+    repo: args.repo,
+    ownerPublisherId: args.ownerPublisherId,
+    githubRepositoryId: args.githubRepositoryId,
+    githubOwnerId: args.githubOwnerId,
+    authorizationStatus: "active",
+    authorizationCheckedAt: args.now,
+    authorizationError: undefined,
+    defaultBranch: args.snapshot.defaultBranch,
+    lastSyncStatus: "ok",
+    lastSyncError: undefined,
+    lastSyncErrorAt: undefined,
+    displayManifestKind: "skills.sh",
+    displayManifestHash: args.snapshot.manifestHash,
+    displayManifestCommit: args.snapshot.commit,
+    displayManifestFetchedAt: args.now,
+    displayManifestStatus: args.snapshot.manifestStatus,
+    displayManifest: args.snapshot.manifest,
+    updatedAt: args.now,
+  });
+
+  const sourceSkills = await ctx.db
+    .query("skills")
+    .withIndex("by_github_source", (q) => q.eq("githubSourceId", sourceId))
+    .collect();
+  const sourceCandidates = await ctx.db
+    .query("githubSkillCandidates")
+    .withIndex("by_github_source", (q) => q.eq("githubSourceId", sourceId))
+    .collect();
+  const sourceSkillByPath = new Map(
+    sourceSkills.flatMap((skill) => (skill.githubPath ? [[skill.githubPath, skill] as const] : [])),
+  );
+  const sourceSkillBySlug = new Map(sourceSkills.map((skill) => [skill.slug, skill]));
+  const matchedSkillIds = new Set<Id<"skills">>();
+  const matchedCandidateIds = new Set<Id<"githubSkillCandidates">>();
+  const issues: GitHubSkillSourceSyncIssue[] = [];
+  const invalidSkills: NonNullable<SyncOneResult["invalidSkills"]> = [];
+  const stats = {
+    discovered: args.snapshot.skills.length,
+    inserted: 0,
+    changed: 0,
+    unchanged: 0,
+    removed: 0,
+    conflicts: 0,
+    invalid: 0,
+    revived: 0,
+  };
+
+  for (const discovered of args.snapshot.skills) {
+    try {
+      assertValidSkillSlug(discovered.slug);
+    } catch (error) {
+      const message = getErrorMessage(error);
+      invalidSkills.push({
+        slug: discovered.slug,
+        path: discovered.path,
+        displayName: discovered.displayName,
+        error: message,
+      });
+      issues.push({
+        slug: discovered.slug,
+        path: discovered.path,
+        displayName: discovered.displayName,
+        kind: "invalid_slug",
+        severity: "error",
+        message,
+      });
+      stats.invalid += 1;
+      continue;
+    }
+
+    let skill =
+      sourceSkillByPath.get(discovered.path) ?? sourceSkillBySlug.get(discovered.slug) ?? null;
+    if (!skill) {
+      const [destination, alias] = await Promise.all([
+        getSkillBySlugForPublisher(ctx, discovered.slug, publisher),
+        getSkillSlugAliasBySlugForPublisher(ctx, discovered.slug, publisher),
+      ]);
+      if (alias && (!destination || alias.skillId !== destination._id)) {
+        issues.push(
+          githubSkillSyncConflictIssue(
+            discovered,
+            "Destination slug is already reserved by another skill redirect.",
+            publisher.handle,
+          ),
+        );
+        stats.conflicts += 1;
+        continue;
+      }
+      skill = destination;
+    }
+
+    if (!skill) {
+      const moderation = githubBackedSkillModeration("pending");
+      const skillId = await ctx.db.insert("skills", {
+        slug: discovered.slug,
+        displayName: discovered.displayName,
+        summary: discovered.summary,
+        ownerUserId: args.ownerUserId,
+        ownerPublisherId: args.ownerPublisherId,
+        installKind: "github",
+        githubSourceId: sourceId,
+        githubPath: discovered.path,
+        githubHasSkillCard: Boolean(discovered.skillCardMarkdownPath),
+        githubCurrentCommit: args.snapshot.commit,
+        githubCurrentContentHash: discovered.contentHash,
+        githubCurrentStatus: "present",
+        githubCurrentCheckedAt: args.now,
+        githubScanStatus: "pending",
+        latestVersionSummary: latestGitHubVersionSummary(discovered.upstreamVersion, args.now),
+        tags: {},
+        statsDownloads: 0,
+        statsStars: 0,
+        statsInstallsCurrent: 0,
+        statsInstallsAllTime: 0,
+        stats: {
+          downloads: 0,
+          stars: 0,
+          installsCurrent: 0,
+          installsAllTime: 0,
+          versions: 0,
+          comments: 0,
+        },
+        ...moderation,
+        createdAt: args.now,
+        updatedAt: args.now,
+      });
+      const insertedSkill = await ctx.db.get(skillId);
+      if (insertedSkill) {
+        await syncSkillSearchDigestForSkill(ctx, insertedSkill);
+        await adjustGlobalPublicCountForSkillChange(ctx, null, insertedSkill, args.now);
+      }
+      await scheduleGitHubSkillVerification(ctx, {
+        skillId,
+        contentHash: discovered.contentHash,
+        scanStatus: "pending",
+        now: args.now,
+      });
+      matchedSkillIds.add(skillId);
+      stats.inserted += 1;
+      continue;
+    }
+
+    if (
+      skill.ownerPublisherId !== args.ownerPublisherId ||
+      (skill.installKind === "github" &&
+        skill.githubSourceId &&
+        skill.githubSourceId !== sourceId &&
+        !skill.softDeletedAt)
+    ) {
+      issues.push(
+        githubSkillSyncConflictIssue(
+          discovered,
+          "Destination is controlled by another GitHub source.",
+          publisher.handle,
+        ),
+      );
+      stats.conflicts += 1;
+      continue;
+    }
+
+    matchedSkillIds.add(skill._id);
+    const hasAllowedGitHubSource =
+      skill.installKind === "github" &&
+      skill.githubCurrentStatus === "present" &&
+      (skill.githubScanStatus === "clean" || skill.githubScanStatus === "suspicious") &&
+      !skill.softDeletedAt;
+    const hasAllowedHostedSource = skill.installKind !== "github" && Boolean(skill.latestVersionId);
+    const sameCurrentContent =
+      skill.installKind === "github" &&
+      skill.githubSourceId === sourceId &&
+      skill.githubCurrentStatus === "present" &&
+      skill.githubCurrentContentHash === discovered.contentHash;
+
+    if (skill.softDeletedAt && !canAutoReviveGitHubSkill(skill)) {
+      stats.unchanged += 1;
+      continue;
+    }
+
+    if (sameCurrentContent) {
+      const previousSkill = { ...skill };
+      const patch = {
+        displayName: discovered.displayName,
+        summary: discovered.summary,
+        ownerUserId: args.ownerUserId,
+        ownerPublisherId: args.ownerPublisherId,
+        githubPath: discovered.path,
+        githubHasSkillCard: Boolean(discovered.skillCardMarkdownPath),
+        githubCurrentCommit: args.snapshot.commit,
+        githubCurrentCheckedAt: args.now,
+        githubRemovedAt: undefined,
+        updatedAt: args.now,
+      };
+      await ctx.db.patch(skill._id, patch);
+      const nextSkill = { ...previousSkill, ...patch };
+      await syncSkillSearchDigestForSkill(ctx, nextSkill);
+      await adjustGlobalPublicCountForSkillChange(ctx, previousSkill, nextSkill, args.now);
+      stats.unchanged += 1;
+      continue;
+    }
+
+    if (hasAllowedGitHubSource || hasAllowedHostedSource) {
+      const candidateId = await upsertGitHubSkillCandidate(ctx, {
+        skill,
+        sourceId,
+        discovered,
+        commit: args.snapshot.commit,
+        now: args.now,
+      });
+      matchedCandidateIds.add(candidateId);
+      stats.changed += 1;
+      continue;
+    }
+
+    const previousSkill = { ...skill };
+    if (skill.githubPendingCandidateId) {
+      await ctx.db.delete(skill.githubPendingCandidateId);
+    }
+    const moderation = githubBackedSkillModeration("pending");
+    const patch = {
+      displayName: discovered.displayName,
+      summary: discovered.summary,
+      ownerUserId: args.ownerUserId,
+      ownerPublisherId: args.ownerPublisherId,
+      installKind: "github" as const,
+      githubSourceId: sourceId,
+      githubPath: discovered.path,
+      githubHasSkillCard: Boolean(discovered.skillCardMarkdownPath),
+      githubCurrentCommit: args.snapshot.commit,
+      githubCurrentContentHash: discovered.contentHash,
+      githubCurrentStatus: "present" as const,
+      githubCurrentCheckedAt: args.now,
+      githubScanStatus: "pending" as const,
+      githubRemovedAt: undefined,
+      githubPendingCandidateId: undefined,
+      latestVersionId: undefined,
+      latestVersionSummary: latestGitHubVersionSummary(discovered.upstreamVersion, args.now),
+      softDeletedAt: undefined,
+      updatedAt: args.now,
+      ...moderation,
+    };
+    await ctx.db.patch(skill._id, patch);
+    const nextSkill = { ...previousSkill, ...patch };
+    await syncSkillSearchDigestForSkill(ctx, nextSkill);
+    await adjustGlobalPublicCountForSkillChange(ctx, previousSkill, nextSkill, args.now);
+    await scheduleGitHubSkillVerification(ctx, {
+      skillId: skill._id,
+      contentHash: discovered.contentHash,
+      scanStatus: "pending",
+      now: args.now,
+    });
+    if (skill.softDeletedAt) stats.revived += 1;
+    else stats.changed += 1;
+  }
+
+  for (const skill of sourceSkills) {
+    if (matchedSkillIds.has(skill._id)) continue;
+    const previousSkill = { ...skill };
+    if (skill.githubPendingCandidateId) await ctx.db.delete(skill.githubPendingCandidateId);
+    const removedAt = skill.githubRemovedAt ?? args.now;
+    const patch = {
+      githubCurrentStatus: "missing" as const,
+      githubCurrentCheckedAt: args.now,
+      githubRemovedAt: removedAt,
+      githubPendingCandidateId: undefined,
+      softDeletedAt: skill.softDeletedAt ?? removedAt,
+      moderationStatus: "hidden" as const,
+      moderationReason: "github.upstream.removed",
+      moderationVerdict: undefined,
+      moderationFlags: [],
+      isSuspicious: false,
+      updatedAt: args.now,
+    };
+    await ctx.db.patch(skill._id, patch);
+    const nextSkill = { ...previousSkill, ...patch };
+    await syncSkillSearchDigestForSkill(ctx, nextSkill);
+    await adjustGlobalPublicCountForSkillChange(ctx, previousSkill, nextSkill, args.now);
+    stats.removed += 1;
+  }
+
+  for (const candidate of sourceCandidates) {
+    if (matchedCandidateIds.has(candidate._id)) continue;
+    const skill = await ctx.db.get(candidate.skillId);
+    if (skill?.githubPendingCandidateId === candidate._id) {
+      await ctx.db.patch(skill._id, {
+        githubPendingCandidateId: undefined,
+        updatedAt: args.now,
+      });
+    }
+    await ctx.db.delete(candidate._id);
+  }
+
+  await ctx.db.patch(sourceId, {
+    lastSyncIssues: issues,
+    lastSyncInvalidSkills: invalidSkills,
+    updatedAt: args.now,
+  });
+  return {
+    ok: true,
+    repo: args.repo,
+    sourceId,
+    commit: args.snapshot.commit,
+    manifestStatus: args.snapshot.manifestStatus,
+    issues,
+    invalidSkills,
+    stats,
+  };
+}
+
+async function upsertGitHubSkillCandidate(
+  ctx: MutationCtx,
+  args: {
+    skill: Doc<"skills">;
+    sourceId: Id<"githubSkillSources">;
+    discovered: GitHubSkillSourceMetadataSnapshot["skills"][number];
+    commit: string;
+    now: number;
+  },
+) {
+  const existing = args.skill.githubPendingCandidateId
+    ? await ctx.db.get(args.skill.githubPendingCandidateId)
+    : await ctx.db
+        .query("githubSkillCandidates")
+        .withIndex("by_skill", (q) => q.eq("skillId", args.skill._id))
+        .unique();
+  const reusableScan = await ctx.db
+    .query("githubSkillScans")
+    .withIndex("by_skill_and_content_hash", (q) =>
+      q.eq("skillId", args.skill._id).eq("contentHash", args.discovered.contentHash),
+    )
+    .unique();
+  const scanStatus = reusableScan?.status ?? "pending";
+  const doc = {
+    skillId: args.skill._id,
+    githubSourceId: args.sourceId,
+    githubPath: args.discovered.path,
+    githubHasSkillCard: Boolean(args.discovered.skillCardMarkdownPath),
+    githubCommit: args.commit,
+    githubContentHash: args.discovered.contentHash,
+    displayName: args.discovered.displayName,
+    summary: args.discovered.summary,
+    upstreamVersion: args.discovered.upstreamVersion,
+    skillMarkdownPath: undefined,
+    skillMarkdown: undefined,
+    skillCardMarkdownPath: undefined,
+    skillCardMarkdown: undefined,
+    scanStatus,
+    updatedAt: args.now,
+  };
+  let candidateId: Id<"githubSkillCandidates">;
+  if (existing) {
+    candidateId = existing._id;
+    await ctx.db.patch(existing._id, doc);
+  } else {
+    candidateId = await ctx.db.insert("githubSkillCandidates", {
+      ...stripUndefined(doc),
+      createdAt: args.now,
+    } as Omit<Doc<"githubSkillCandidates">, "_id" | "_creationTime">);
+  }
+  await ctx.db.patch(args.skill._id, {
+    githubPendingCandidateId: candidateId,
+    updatedAt: args.now,
+  });
+  if (scanStatus === "pending" || scanStatus === "clean" || scanStatus === "suspicious") {
+    await scheduleGitHubSkillVerification(ctx, {
+      skillId: args.skill._id,
+      contentHash: args.discovered.contentHash,
+      scanStatus,
+      now: args.now,
+      candidateId,
+    });
+  }
+  return candidateId;
+}
+
+function githubSkillSyncConflictIssue(
+  discovered: GitHubSkillSourceMetadataSnapshot["skills"][number],
+  message: string,
+  existingOwnerHandle: string,
+): GitHubSkillSourceSyncIssue {
+  return {
+    slug: discovered.slug,
+    path: discovered.path,
+    displayName: discovered.displayName,
+    kind: "slug_conflict",
+    severity: "error",
+    message,
+    existingOwnerHandle,
+  };
+}
+
+function latestGitHubVersionSummary(version: string | undefined, now: number) {
+  if (!version) return undefined;
+  return {
+    version,
+    createdAt: now,
+    changelog: "Synced from GitHub source.",
+    changelogSource: "auto" as const,
+  };
+}
+
 async function findGitHubSkillRevivalCandidate(
   ctx: MutationCtx,
   args: {
@@ -705,6 +1320,15 @@ async function findGitHubSkillRevivalCandidate(
 
 function canReviveGitHubSkillForSource(skill: Doc<"skills">) {
   return skill.installKind === "github" && typeof skill.softDeletedAt === "number";
+}
+
+function canAutoReviveGitHubSkill(skill: Doc<"skills">) {
+  return (
+    skill.installKind === "github" &&
+    skill.githubCurrentStatus === "missing" &&
+    typeof skill.githubRemovedAt === "number" &&
+    skill.softDeletedAt === skill.githubRemovedAt
+  );
 }
 
 function hasGitHubSkillContent(
@@ -791,6 +1415,56 @@ export const upsertGitHubSkillContentInternal = internalMutation({
   handler: upsertGitHubSkillContentHandler,
 });
 
+export async function upsertGitHubSkillCandidateContentHandler(
+  ctx: MutationCtx,
+  args: {
+    candidateId: Id<"githubSkillCandidates">;
+    discovered: DiscoveredGitHubSkill;
+    commit: string;
+    now?: number;
+  },
+) {
+  const candidate = await ctx.db.get(args.candidateId);
+  const skill = candidate ? await ctx.db.get(candidate.skillId) : null;
+  if (
+    !candidate ||
+    !skill ||
+    skill.githubPendingCandidateId !== candidate._id ||
+    candidate.githubPath !== args.discovered.path ||
+    candidate.githubCommit !== args.commit ||
+    candidate.githubContentHash !== args.discovered.contentHash
+  ) {
+    return { ok: true as const, skipped: "stale-candidate" as const };
+  }
+  const now = args.now ?? Date.now();
+  await ctx.db.patch(candidate._id, {
+    skillMarkdownPath: args.discovered.skillMarkdownPath,
+    skillMarkdown: args.discovered.skillMarkdown,
+    skillCardMarkdownPath: args.discovered.skillCardMarkdownPath,
+    skillCardMarkdown: args.discovered.skillCardMarkdown,
+    updatedAt: now,
+  });
+  if (candidate.scanStatus === "clean" || candidate.scanStatus === "suspicious") {
+    return await applyGitHubSkillVerificationResultHandler(ctx, {
+      skillId: candidate.skillId,
+      contentHash: candidate.githubContentHash,
+      scanStatus: candidate.scanStatus,
+      now,
+    });
+  }
+  return { ok: true as const };
+}
+
+export const upsertGitHubSkillCandidateContentInternal = internalMutation({
+  args: {
+    candidateId: v.id("githubSkillCandidates"),
+    discovered: discoveredSkillContentValidator,
+    commit: v.string(),
+    now: v.optional(v.number()),
+  },
+  handler: upsertGitHubSkillCandidateContentHandler,
+});
+
 async function scheduleGitHubSkillVerification(
   ctx: MutationCtx,
   args: {
@@ -798,6 +1472,7 @@ async function scheduleGitHubSkillVerification(
     contentHash: string;
     scanStatus: unknown;
     now: number;
+    candidateId?: Id<"githubSkillCandidates">;
   },
 ) {
   const scan = await ctx.db
@@ -830,21 +1505,34 @@ async function scheduleGitHubSkillVerification(
     return;
   }
   const skill = await ctx.db.get(args.skillId);
-  if (
-    !skill ||
-    skill.installKind !== "github" ||
-    !skill.githubSourceId ||
-    !skill.githubPath ||
-    skill.githubCurrentStatus !== "present" ||
-    !skill.githubCurrentCommit ||
-    skill.githubCurrentContentHash !== args.contentHash
-  ) {
-    return;
-  }
+  if (!skill) return;
+  const candidate = args.candidateId ? await ctx.db.get(args.candidateId) : null;
+  const target =
+    candidate &&
+    skill.githubPendingCandidateId === candidate._id &&
+    candidate.githubContentHash === args.contentHash
+      ? {
+          sourceId: candidate.githubSourceId,
+          path: candidate.githubPath,
+          commit: candidate.githubCommit,
+        }
+      : skill.installKind === "github" &&
+          skill.githubSourceId &&
+          skill.githubPath &&
+          skill.githubCurrentStatus === "present" &&
+          skill.githubCurrentCommit &&
+          skill.githubCurrentContentHash === args.contentHash
+        ? {
+            sourceId: skill.githubSourceId,
+            path: skill.githubPath,
+            commit: skill.githubCurrentCommit,
+          }
+        : null;
+  if (!target) return;
   const pendingScanInsert = {
-    githubSourceId: skill.githubSourceId,
-    commit: skill.githubCurrentCommit,
-    path: skill.githubPath,
+    githubSourceId: target.sourceId,
+    commit: target.commit,
+    path: target.path,
     status: "pending" as const,
     updatedAt: args.now,
   };
@@ -873,6 +1561,8 @@ export const applyGitHubSkillSourceSyncInternal = internalMutation({
     repo: v.string(),
     ownerUserId: v.id("users"),
     ownerPublisherId: v.optional(v.id("publishers")),
+    githubRepositoryId: v.optional(v.string()),
+    githubOwnerId: v.optional(v.string()),
     snapshot: sourceSnapshotValidator,
     now: v.optional(v.number()),
   },
@@ -891,7 +1581,79 @@ export async function applyGitHubSkillVerificationResultHandler(
   args: ApplyGitHubSkillVerificationResultArgs,
 ) {
   const skill = await ctx.db.get(args.skillId);
-  if (!skill || skill.installKind !== "github") {
+  if (!skill) {
+    return { ok: true as const, skipped: "missing-github-skill" as const };
+  }
+  const candidate = skill.githubPendingCandidateId
+    ? await ctx.db.get(skill.githubPendingCandidateId)
+    : null;
+  if (candidate?.githubContentHash === args.contentHash) {
+    const now = args.now ?? Date.now();
+    await ctx.db.patch(candidate._id, {
+      scanStatus: args.scanStatus,
+      updatedAt: now,
+    });
+    if (args.scanStatus !== "clean" && args.scanStatus !== "suspicious") {
+      return { ok: true as const, promoted: false };
+    }
+    if (!candidate.skillMarkdown || !candidate.skillMarkdownPath) {
+      return { ok: true as const, skipped: "candidate-content-not-cached" as const };
+    }
+    if (
+      skill.softDeletedAt ||
+      skill.moderationStatus === "hidden" ||
+      skill.moderationStatus === "removed"
+    ) {
+      return { ok: true as const, skipped: "skill-no-longer-eligible" as const };
+    }
+    const previousSkill = { ...skill };
+    const moderation = githubBackedSkillModeration(args.scanStatus);
+    const patch = {
+      displayName: candidate.displayName,
+      summary: candidate.summary,
+      installKind: "github" as const,
+      githubSourceId: candidate.githubSourceId,
+      githubPath: candidate.githubPath,
+      githubHasSkillCard: candidate.githubHasSkillCard,
+      githubCurrentCommit: candidate.githubCommit,
+      githubCurrentContentHash: candidate.githubContentHash,
+      githubCurrentStatus: "present" as const,
+      githubCurrentCheckedAt: now,
+      githubScanStatus: args.scanStatus,
+      githubRemovedAt: undefined,
+      githubPendingCandidateId: undefined,
+      latestVersionId: undefined,
+      latestVersionSummary: latestGitHubVersionSummary(candidate.upstreamVersion, now),
+      softDeletedAt: undefined,
+      updatedAt: now,
+      ...moderation,
+    };
+    await upsertGitHubSkillContent(ctx, {
+      skillId: skill._id,
+      sourceId: candidate.githubSourceId,
+      discovered: {
+        slug: skill.slug,
+        displayName: candidate.displayName,
+        summary: candidate.summary,
+        upstreamVersion: candidate.upstreamVersion,
+        path: candidate.githubPath,
+        skillMarkdownPath: candidate.skillMarkdownPath,
+        skillMarkdown: candidate.skillMarkdown,
+        skillCardMarkdownPath: candidate.skillCardMarkdownPath,
+        skillCardMarkdown: candidate.skillCardMarkdown,
+        contentHash: candidate.githubContentHash,
+      },
+      commit: candidate.githubCommit,
+      now,
+    });
+    await ctx.db.patch(skill._id, patch);
+    const nextSkill = { ...previousSkill, ...patch };
+    await syncSkillSearchDigestForSkill(ctx, nextSkill);
+    await adjustGlobalPublicCountForSkillChange(ctx, previousSkill, nextSkill, now);
+    await ctx.db.delete(candidate._id);
+    return { ok: true as const, promoted: true };
+  }
+  if (skill.installKind !== "github") {
     return { ok: true as const, skipped: "missing-github-skill" as const };
   }
   if (
@@ -966,6 +1728,13 @@ export async function verifyGitHubSkillHandler(
       currentContentHash: discovered?.contentHash,
     };
   }
+  if (target.candidateId) {
+    await ctx.runMutation(internal.githubSkillSync.upsertGitHubSkillCandidateContentInternal, {
+      candidateId: target.candidateId,
+      discovered,
+      commit: target.skill.githubCurrentCommit,
+    });
+  }
 
   const staticScan = runStaticModerationScan({
     slug: target.skill.slug,
@@ -1023,17 +1792,19 @@ export async function configurePublicGitHubSkillSourceHandler(
   assertGitHubSkillSyncRuntimeEnabled();
   const actor = authOverride ?? (await requireUserFromAction(ctx));
   const metadata = await fetchPublicGitHubRepoMetadata(args.repo, fetcher);
+  if (!metadata.repositoryId || !metadata.ownerId) {
+    throw new ConvexError("GitHub repo identity lookup failed.");
+  }
   const setup = (await ctx.runQuery(
     internal.githubSkillSync.getPublicGitHubSkillSourceSetupContextInternal,
     {
       ownerPublisherId: args.ownerPublisherId,
       actorUserId: actor.userId,
       repo: metadata.repo,
+      githubRepositoryId: metadata.repositoryId,
+      githubOwnerId: metadata.ownerId,
     },
   )) as GitHubSkillSourceSetupContext;
-  if (!setup.official) {
-    throw new ConvexError("GitHub source sync is only available for official publishers.");
-  }
   const snapshot = await fetchGitHubSkillSourceSnapshot(
     {
       repo: metadata.repo,
@@ -1041,14 +1812,17 @@ export async function configurePublicGitHubSkillSourceHandler(
     },
     fetcher,
   );
+  const revalidatedMetadata = await revalidateGitHubRepoMetadata(metadata, fetcher);
   if (snapshot.skills.length === 0) {
     throw new ConvexError("No skills were found in that public GitHub repo.");
   }
   return await applyFetchedGitHubSkillSourceSnapshot(ctx, {
     sourceId: setup.existingSource?._id,
-    repo: metadata.repo,
+    repo: revalidatedMetadata.repo,
     ownerUserId: setup.ownerUserId,
     ownerPublisherId: args.ownerPublisherId,
+    githubRepositoryId: revalidatedMetadata.repositoryId,
+    githubOwnerId: revalidatedMetadata.ownerId,
     snapshot,
   });
 }
@@ -1069,6 +1843,8 @@ async function applyFetchedGitHubSkillSourceSnapshot(
     repo: string;
     ownerUserId: Id<"users">;
     ownerPublisherId?: Id<"publishers">;
+    githubRepositoryId?: string;
+    githubOwnerId?: string;
     snapshot: GitHubSkillSourceSnapshot;
   },
 ) {
@@ -1079,6 +1855,8 @@ async function applyFetchedGitHubSkillSourceSnapshot(
       repo: args.repo,
       ownerUserId: args.ownerUserId,
       ownerPublisherId: args.ownerPublisherId,
+      githubRepositoryId: args.githubRepositoryId,
+      githubOwnerId: args.githubOwnerId,
       snapshot: toGitHubSkillSourceMetadataSnapshot(args.snapshot),
     },
   )) as SyncOneResult;
@@ -1111,6 +1889,14 @@ async function persistGitHubSkillContentsForSnapshot(
   for (const discovered of snapshot.skills) {
     const target = targetByPath.get(discovered.path);
     if (!target || target.githubCurrentContentHash !== discovered.contentHash) continue;
+    if (target.candidateId) {
+      await ctx.runMutation(internal.githubSkillSync.upsertGitHubSkillCandidateContentInternal, {
+        candidateId: target.candidateId,
+        discovered,
+        commit: snapshot.commit,
+      });
+      continue;
+    }
     await ctx.runMutation(internal.githubSkillSync.upsertGitHubSkillContentInternal, {
       skillId: target.skillId,
       sourceId: result.sourceId,
@@ -1147,12 +1933,15 @@ export const syncGitHubSkillSource: ReturnType<typeof action> = action({
       repo,
       defaultBranch: args.defaultBranch ?? source?.defaultBranch ?? metadata.defaultBranch,
     });
+    const revalidatedMetadata = isLegacyNvidiaSkillSource(repo)
+      ? metadata
+      : await revalidateGitHubRepoMetadata(metadata, fetch);
 
     if (args.dryRun) {
       return {
         ok: true as const,
         dryRun: true as const,
-        repo,
+        repo: revalidatedMetadata.repo,
         sourceId: source?._id,
         commit: snapshot.commit,
         manifestStatus: snapshot.manifestStatus,
@@ -1162,9 +1951,11 @@ export const syncGitHubSkillSource: ReturnType<typeof action> = action({
 
     return await applyFetchedGitHubSkillSourceSnapshot(ctx, {
       sourceId: source?._id,
-      repo,
+      repo: revalidatedMetadata.repo,
       ownerUserId,
       ownerPublisherId,
+      githubRepositoryId: revalidatedMetadata.repositoryId,
+      githubOwnerId: revalidatedMetadata.ownerId,
       snapshot,
     });
   },
@@ -1211,18 +2002,32 @@ export async function syncGitHubSkillSourcesHandler(
         { publisherId: source.ownerPublisherId },
       )) as Id<"users">;
       const metadata = await fetchPublicGitHubRepoMetadata(source.repo, fetcher);
+      if (
+        !isLegacyNvidiaSkillSource(source.repo) &&
+        (!source.githubRepositoryId ||
+          !source.githubOwnerId ||
+          metadata.repositoryId !== source.githubRepositoryId ||
+          metadata.ownerId !== source.githubOwnerId)
+      ) {
+        throw new ConvexError("GitHub repository authorization no longer matches.");
+      }
       const snapshot = await fetchGitHubSkillSourceSnapshot(
         {
-          repo: source.repo,
+          repo: metadata.repo,
           defaultBranch: source.defaultBranch ?? metadata.defaultBranch,
         },
         fetcher,
       );
+      const revalidatedMetadata = isLegacyNvidiaSkillSource(source.repo)
+        ? metadata
+        : await revalidateGitHubRepoMetadata(metadata, fetcher);
       const result = await applyFetchedGitHubSkillSourceSnapshot(ctx, {
         sourceId: source._id,
-        repo: source.repo,
+        repo: revalidatedMetadata.repo,
         ownerUserId,
         ownerPublisherId: source.ownerPublisherId,
+        githubRepositoryId: revalidatedMetadata.repositoryId,
+        githubOwnerId: revalidatedMetadata.ownerId,
         snapshot,
       });
       results.push(result);
@@ -1231,11 +2036,21 @@ export async function syncGitHubSkillSourcesHandler(
       skillsRemoved += result.stats.removed;
     } catch (error) {
       const message = getErrorMessage(error);
-      await ctx.runMutation(internal.githubSkillSync.recordGitHubSkillSourceSyncAttemptInternal, {
-        sourceId: source._id,
-        status: "failed",
-        error: message,
-      });
+      if (!isLegacyNvidiaSkillSource(source.repo) && isGitHubSourceAuthorizationFailure(message)) {
+        await ctx.runMutation(
+          internal.githubSkillSync.revokeGitHubSkillSourceAuthorizationInternal,
+          {
+            sourceId: source._id,
+            error: message,
+          },
+        );
+      } else {
+        await ctx.runMutation(internal.githubSkillSync.recordGitHubSkillSourceSyncAttemptInternal, {
+          sourceId: source._id,
+          status: "failed",
+          error: message,
+        });
+      }
       logErrorEvent(Events.GitHubSkillSourceSyncSourceFailed, {
         repo: source.repo,
         sourceId: source._id,
@@ -1470,20 +2285,58 @@ async function fetchPublicGitHubRepoMetadata(
     throw new ConvexError("GitHub repo lookup failed.");
   }
   const body = (await response.json()) as Record<string, unknown>;
+  const ownerData =
+    body.owner && typeof body.owner === "object" ? (body.owner as Record<string, unknown>) : null;
+  const repositoryId = normalizeGitHubNumericId(body.id);
+  const ownerId = normalizeGitHubNumericId(ownerData?.id);
   const fullName = typeof body.full_name === "string" ? body.full_name.trim() : "";
   const visibility = typeof body.visibility === "string" ? body.visibility : "";
   if (body.private !== false || (visibility && visibility !== "public")) {
     throw new ConvexError(PUBLIC_REPO_ONLY_ERROR);
   }
   if (body.disabled === true) throw new ConvexError("GitHub repo is disabled.");
+  if ((!repositoryId || !ownerId) && !isLegacyNvidiaSkillSource(normalizedRepo)) {
+    throw new ConvexError("GitHub repo identity lookup failed.");
+  }
   const defaultBranch =
     typeof body.default_branch === "string" && body.default_branch.trim()
       ? body.default_branch.trim()
       : DEFAULT_BRANCH;
   return {
+    ...(repositoryId ? { repositoryId } : {}),
+    ...(ownerId ? { ownerId } : {}),
     repo: normalizeRepo(fullName || normalizedRepo),
     defaultBranch,
   };
+}
+
+function normalizeGitHubNumericId(value: unknown) {
+  if (typeof value === "number" && Number.isSafeInteger(value) && value > 0) {
+    return String(value);
+  }
+  if (typeof value === "string" && /^[1-9]\d*$/.test(value.trim())) {
+    return value.trim();
+  }
+  return null;
+}
+
+function isGitHubSourceAuthorizationFailure(message: string) {
+  return (
+    message.includes("GitHub repository authorization no longer matches") ||
+    message.includes(PUBLIC_REPO_ONLY_ERROR) ||
+    message.includes("GitHub repo is disabled")
+  );
+}
+
+async function revalidateGitHubRepoMetadata(expected: GitHubRepoMetadata, fetcher: typeof fetch) {
+  if (!expected.repositoryId || !expected.ownerId) {
+    throw new ConvexError("GitHub repository authorization no longer matches.");
+  }
+  const current = await fetchPublicGitHubRepoMetadata(expected.repo, fetcher);
+  if (current.repositoryId !== expected.repositoryId || current.ownerId !== expected.ownerId) {
+    throw new ConvexError("GitHub repository authorization no longer matches.");
+  }
+  return current;
 }
 
 async function buildGitHubSkillSourceHeaders(fetcher: typeof fetch) {

--- a/convex/lib/retentionPolicy.ts
+++ b/convex/lib/retentionPolicy.ts
@@ -108,6 +108,7 @@ export const RETENTION_POLICIES = {
   officialPublishers: permanent("Manual official publisher assignments."),
   githubSkillSources: permanent("Tracked GitHub source configuration."),
   githubSkillContents: derived("Cached GitHub source content snapshots.", "githubSkillSources"),
+  githubSkillCandidates: derived("Pending exact GitHub source candidates.", "githubSkillSources"),
   githubSkillScans: derived("Cached GitHub source scan state.", "githubSkillSources"),
   skills: permanent("Canonical skill records."),
   skillSlugAliases: permanent("Historical slug routing aliases."),

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -379,6 +379,11 @@ const githubSkillSourceIssueValidator = v.object({
 const githubSkillSources = defineTable({
   repo: v.string(),
   ownerPublisherId: v.optional(v.id("publishers")),
+  githubRepositoryId: v.optional(v.string()),
+  githubOwnerId: v.optional(v.string()),
+  authorizationStatus: v.optional(v.union(v.literal("active"), v.literal("revoked"))),
+  authorizationCheckedAt: v.optional(v.number()),
+  authorizationError: v.optional(v.string()),
   defaultBranch: v.optional(v.string()),
   lastSyncStatus: v.optional(v.union(v.literal("ok"), v.literal("failed"), v.literal("skipped"))),
   lastSyncError: v.optional(v.string()),
@@ -396,6 +401,7 @@ const githubSkillSources = defineTable({
   updatedAt: v.number(),
 })
   .index("by_repo", ["repo"])
+  .index("by_github_repository_id", ["githubRepositoryId"])
   .index("by_owner_publisher", ["ownerPublisherId"])
   .index("by_owner_publisher_and_repo", ["ownerPublisherId", "repo"])
   .index("by_created", ["createdAt"])
@@ -488,6 +494,28 @@ const githubSkillCurrentStatusValidator = v.union(
   v.literal("missing"),
   v.literal("unknown"),
 );
+
+const githubSkillCandidates = defineTable({
+  skillId: v.id("skills"),
+  githubSourceId: v.id("githubSkillSources"),
+  githubPath: v.string(),
+  githubHasSkillCard: v.boolean(),
+  githubCommit: v.string(),
+  githubContentHash: v.string(),
+  displayName: v.string(),
+  summary: v.optional(v.string()),
+  upstreamVersion: v.optional(v.string()),
+  skillMarkdownPath: v.optional(v.string()),
+  skillMarkdown: v.optional(v.string()),
+  skillCardMarkdownPath: v.optional(v.string()),
+  skillCardMarkdown: v.optional(v.string()),
+  scanStatus: githubSkillScanStatusValidator,
+  createdAt: v.number(),
+  updatedAt: v.number(),
+})
+  .index("by_skill", ["skillId"])
+  .index("by_skill_and_content_hash", ["skillId", "githubContentHash"])
+  .index("by_github_source", ["githubSourceId"]);
 
 const githubSkillScans = defineTable({
   skillId: v.id("skills"),
@@ -804,6 +832,7 @@ const skills = defineTable({
   githubCurrentCheckedAt: v.optional(v.number()),
   githubScanStatus: v.optional(githubSkillScanStatusValidator),
   githubRemovedAt: v.optional(v.number()),
+  githubPendingCandidateId: v.optional(v.id("githubSkillCandidates")),
   latestVersionId: v.optional(v.id("skillVersions")),
   latestVersionSummary: v.optional(
     v.object({
@@ -3606,6 +3635,7 @@ export default defineSchema({
   officialPublishers,
   githubSkillSources,
   githubSkillContents,
+  githubSkillCandidates,
   githubSkillScans,
   skills,
   skillSlugAliases,

--- a/convex/securityScan.test.ts
+++ b/convex/securityScan.test.ts
@@ -5408,6 +5408,141 @@ describe("securityScan", () => {
     },
   );
 
+  it("prepares and finalizes only the skill's exact pending GitHub candidate", async () => {
+    const candidateCommit = "b".repeat(40);
+    const docs = new Map<string, Record<string, unknown>>([
+      [
+        "skills:1",
+        {
+          _id: "skills:1",
+          installKind: "hosted",
+          latestVersionId: "skillVersions:1",
+          githubPendingCandidateId: "githubSkillCandidates:1",
+          ownerUserId: "users:1",
+          slug: "demo",
+          displayName: "Demo",
+        },
+      ],
+      [
+        "githubSkillCandidates:1",
+        {
+          _id: "githubSkillCandidates:1",
+          skillId: "skills:1",
+          githubSourceId: "githubSkillSources:generic",
+          githubPath: "skills/demo",
+          githubCommit: candidateCommit,
+          githubContentHash: "candidate-hash",
+        },
+      ],
+    ]);
+    const inserts: Array<{ table: string; doc: Record<string, unknown> }> = [];
+    const insert = vi.fn(async (table: string, doc: Record<string, unknown>) => {
+      const id = `${table}:new-${inserts.length + 1}`;
+      docs.set(id, { _id: id, ...doc });
+      inserts.push({ table, doc });
+      return id;
+    });
+    const patch = vi.fn(async (id: string, next: Record<string, unknown>) => {
+      const doc = docs.get(id);
+      if (!doc) return;
+      for (const [key, value] of Object.entries(next)) {
+        if (value === undefined) delete doc[key];
+        else doc[key] = value;
+      }
+    });
+    const query = vi.fn((table: string) => ({
+      withIndex: vi.fn(() => ({
+        unique: vi.fn(async () =>
+          table === "githubSkillScans"
+            ? (Array.from(docs.values()).find((doc) =>
+                String(doc._id).startsWith("githubSkillScans:"),
+              ) ?? null)
+            : null,
+        ),
+        take: vi.fn(async () =>
+          table === "skillScanRequestFileChunks"
+            ? Array.from(docs.values())
+                .filter((doc) => String(doc._id).startsWith("skillScanRequestFileChunks:"))
+                .slice(0, 1)
+            : [],
+        ),
+      })),
+    }));
+    const ctx = {
+      db: {
+        get: vi.fn(async (id: string) => docs.get(id) ?? null),
+        query,
+        insert,
+        patch,
+        replace: vi.fn(),
+        delete: vi.fn(),
+        normalizeId: vi.fn(() => null),
+        system: {},
+      },
+    };
+    const args = {
+      skillId: "skills:1",
+      contentHash: "candidate-hash",
+      commit: candidateCommit,
+      parsed: { frontmatter: {} },
+      staticScan: {
+        status: "clean" as const,
+        reasonCodes: [],
+        findings: [] as [],
+        summary: "No static findings.",
+        engineVersion: "test",
+        checkedAt: 2,
+      },
+    };
+
+    const prepared = await prepareGitHubSkillScanRequestInternalHandler(ctx as never, args);
+
+    expect(prepared).toMatchObject({
+      ok: true,
+      prepared: true,
+      scanId: expect.stringMatching(/^githubSkillScans:/),
+      requestId: expect.stringMatching(/^skillScanRequests:/),
+    });
+    const scan = Array.from(docs.values()).find((doc) =>
+      String(doc._id).startsWith("githubSkillScans:"),
+    );
+    expect(scan).toMatchObject({
+      githubSourceId: "githubSkillSources:generic",
+      commit: candidateCommit,
+      path: "skills/demo",
+      contentHash: "candidate-hash",
+    });
+    if (!prepared.requestId) throw new Error("missing prepared request");
+    await appendGitHubSkillScanRequestFilesInternalHandler(ctx as never, {
+      requestId: prepared.requestId,
+      chunkIndex: 0,
+      files: [{ path: "SKILL.md", size: 10, storageId: "storage:1", sha256: "sha256" }],
+    });
+
+    await expect(
+      finalizeGitHubSkillScanRequestInternalHandler(ctx as never, {
+        requestId: prepared.requestId,
+      }),
+    ).resolves.toMatchObject({
+      ok: true,
+      queued: true,
+      scanId: scan?._id,
+    });
+    expect(inserts.map((entry) => entry.table)).toEqual([
+      "githubSkillScans",
+      "skillScanRequests",
+      "skillScanRequestFileChunks",
+      "securityScanJobs",
+    ]);
+
+    await expect(
+      prepareGitHubSkillScanRequestInternalHandler(ctx as never, {
+        ...args,
+        contentHash: "stale-hash",
+      }),
+    ).resolves.toEqual({ ok: true, skipped: "stale-or-missing" });
+  });
+
   it("does not prepare generic GitHub scan state when rollout is off", async () => {
     vi.stubEnv("CLAWHUB_GITHUB_SKILL_SYNC_ROLLOUT_MODE", "off");
     const insert = vi.fn();

--- a/convex/securityScan.ts
+++ b/convex/securityScan.ts
@@ -1352,6 +1352,40 @@ export async function enqueueSkillsShCatalogScanRequest(
   return { requestId, jobId };
 }
 
+async function resolveGitHubSkillScanTarget(
+  ctx: Pick<MutationCtx, "db">,
+  skill: Doc<"skills">,
+  args: { commit: string; contentHash: string },
+) {
+  if (
+    skill.installKind === "github" &&
+    skill.githubSourceId &&
+    skill.githubPath &&
+    skill.githubCurrentStatus === "present" &&
+    skill.githubCurrentCommit === args.commit &&
+    skill.githubCurrentContentHash === args.contentHash
+  ) {
+    return {
+      githubSourceId: skill.githubSourceId,
+      githubPath: skill.githubPath,
+    };
+  }
+  if (!skill.githubPendingCandidateId) return null;
+  const candidate = await ctx.db.get(skill.githubPendingCandidateId);
+  if (
+    !candidate ||
+    candidate.skillId !== skill._id ||
+    candidate.githubCommit !== args.commit ||
+    candidate.githubContentHash !== args.contentHash
+  ) {
+    return null;
+  }
+  return {
+    githubSourceId: candidate.githubSourceId,
+    githubPath: candidate.githubPath,
+  };
+}
+
 export const prepareGitHubSkillScanRequestInternal = internalMutation({
   args: {
     skillId: v.id("skills"),
@@ -1365,18 +1399,16 @@ export const prepareGitHubSkillScanRequestInternal = internalMutation({
   },
   handler: async (ctx, args) => {
     const skill = await ctx.db.get(args.skillId);
-    if (
-      !skill ||
-      skill.installKind !== "github" ||
-      !skill.githubSourceId ||
-      !skill.githubPath ||
-      skill.githubCurrentStatus !== "present" ||
-      skill.githubCurrentCommit !== args.commit ||
-      skill.githubCurrentContentHash !== args.contentHash
-    ) {
+    const target = skill
+      ? await resolveGitHubSkillScanTarget(ctx, skill, {
+          commit: args.commit,
+          contentHash: args.contentHash,
+        })
+      : null;
+    if (!skill || !target) {
       return { ok: true as const, skipped: "stale-or-missing" as const };
     }
-    if (!(await isGitHubSkillScanAllowed(ctx, skill.githubSourceId))) {
+    if (!(await isGitHubSkillScanAllowed(ctx, target.githubSourceId))) {
       return { ok: true as const, skipped: "rollout-disabled" as const };
     }
     const existing = await ctx.db
@@ -1387,9 +1419,9 @@ export const prepareGitHubSkillScanRequestInternal = internalMutation({
       .unique();
     if (existing && !args.force && existing.status !== "pending" && existing.status !== "failed") {
       await ctx.db.patch(existing._id, {
-        githubSourceId: skill.githubSourceId,
+        githubSourceId: target.githubSourceId,
         commit: args.commit,
-        path: skill.githubPath,
+        path: target.githubPath,
         staticScan: args.staticScan,
         updatedAt: Date.now(),
       });
@@ -1431,10 +1463,10 @@ export const prepareGitHubSkillScanRequestInternal = internalMutation({
       existing?._id ??
       (await ctx.db.insert("githubSkillScans", {
         skillId: skill._id,
-        githubSourceId: skill.githubSourceId,
+        githubSourceId: target.githubSourceId,
         contentHash: args.contentHash,
         commit: args.commit,
-        path: skill.githubPath,
+        path: target.githubPath,
         status: "pending",
         staticScan: args.staticScan,
         createdAt: now,
@@ -1442,9 +1474,9 @@ export const prepareGitHubSkillScanRequestInternal = internalMutation({
       }));
     if (existing) {
       await ctx.db.patch(existing._id, {
-        githubSourceId: skill.githubSourceId,
+        githubSourceId: target.githubSourceId,
         commit: args.commit,
-        path: skill.githubPath,
+        path: target.githubPath,
         status: "pending",
         staticScan: args.staticScan,
         skillSpectorAnalysis: undefined,
@@ -1578,17 +1610,20 @@ export const finalizeGitHubSkillScanRequestInternal = internalMutation({
       throw new ConvexError("GitHub scan request was already finalized");
     }
     const skill = scan ? await ctx.db.get(scan.skillId) : null;
+    const target = skill
+      ? await resolveGitHubSkillScanTarget(ctx, skill, {
+          commit: scan.commit,
+          contentHash: scan.contentHash,
+        })
+      : null;
     if (
       !scan ||
       scan.status !== "pending" ||
       scan.skillScanRequestId !== request._id ||
       !skill ||
-      skill.installKind !== "github" ||
-      skill.githubCurrentStatus !== "present" ||
-      skill.githubSourceId !== scan.githubSourceId ||
-      skill.githubPath !== scan.path ||
-      skill.githubCurrentCommit !== scan.commit ||
-      skill.githubCurrentContentHash !== scan.contentHash
+      !target ||
+      target.githubSourceId !== scan.githubSourceId ||
+      target.githubPath !== scan.path
     ) {
       throw new ConvexError("GitHub scan request is no longer current");
     }

--- a/specs/github-backed-skills.md
+++ b/specs/github-backed-skills.md
@@ -50,6 +50,19 @@ skills:
 This table is not an install artifact store. OpenClaw must not install from
 `githubSkillContents`.
 
+`githubSkillCandidates` stores an exact pending replacement for a canonical
+skill while its currently allowed source remains active:
+
+- canonical `skillId`
+- immutable source repository, path, commit, and folder content hash
+- bounded display Markdown fetched from that exact commit
+- the ClawHub scan state for that exact content
+
+Candidates do not create `skillVersions`. A clean or suspicious exact verdict
+promotes the candidate onto the existing skill row and then deletes the
+candidate. Failed, malicious, stale, removed, or disconnected candidates never
+replace the active source.
+
 ## Dark skills.sh discovery metadata
 
 The skills.sh discovery pipeline has a separate hidden metadata table and does
@@ -87,15 +100,21 @@ not create or mutate `skills` rows during its planning gates.
 
 ## Publisher Gate
 
-GitHub-backed source sync is official-publisher-only for now.
+The legacy `NVIDIA/skills` source keeps its existing production behavior.
+Generic GitHub Skill Sync remains dark unless the GitHub Skill Sync rollout
+capability is enabled.
 
-Official means an exact row exists in `officialPublishers` for the publisher.
-It is not inherited from org membership, GitHub identity, OIDC, or
-`trustedPublisher`.
+When enabled, repository enrollment requires:
 
-Default official publishers are not seeded from deploy. Maintainers should mark
-official publishers explicitly using the moderation/admin CLI before enabling
-their source sync.
+- publisher-admin access
+- a public GitHub repository
+- immutable GitHub repository and owner IDs
+- the publisher's matching immutable GitHub user ID, or a verified GitHub
+  organization ID plus fresh organization-admin membership
+
+Repository names, redirects, display handles, and skills.sh owner strings do not
+authorize enrollment. The repository identity is checked again after snapshot
+fetch so a transfer cannot race source activation.
 
 ## Sync
 
@@ -152,8 +171,7 @@ uploads:
 > A normal install/update may only install content whose exact current content
 > hash has a completed, non-blocked ClawHub scan result.
 
-When a new source-backed skill appears or an existing skill's content hash
-changes:
+When a new source-backed skill appears:
 
 - set `githubScanStatus: "pending"`
 - keep the catalog entry visible with `moderationReason: "pending.scan"`, while
@@ -171,6 +189,14 @@ changes:
 - do not schedule another heavy verification action while that content hash
   already has an active queued/running scan job or a recently prepared request
 - enqueue explicit owner/moderator rescans in the high-priority manual queue
+
+When an already allowed GitHub-backed skill changes, or a Hosted Skill owned by
+the same publisher occupies the destination, ClawHub creates an exact pending
+candidate instead of overwriting the active source. The prior verified GitHub
+commit or hosted version remains active until the candidate's own exact scan is
+allowed. Promotion patches the existing canonical skill row in place, preserving
+its slug, routes, ClawHub metrics, bookmarks, prior hosted versions, and audit
+relationships.
 
 When verification succeeds cleanly:
 
@@ -221,6 +247,13 @@ If the upstream path disappears:
 
 The row may remain for audit/history, but users must not silently install an old
 ClawHub-cached revision after upstream removed or changed it.
+
+Removing a selected repository also removes its pending candidates before
+deleting the source, so an in-flight callback cannot promote disconnected
+content. Active source-backed skills become missing and hidden. Re-enrollment or
+upstream reappearance may revive the same canonical skill row, but the
+reappeared exact content returns to pending and must pass scanning before
+installation.
 
 ## Install Resolver
 
@@ -326,15 +359,18 @@ resolver and current scan/upstream state, not by stale cached UI metadata.
 
 Keep coverage for:
 
-- configuring only official publishers
+- immutable publisher/repository authorization and transfer-race rejection
 - parsing `skills.sh.json`
 - 15-minute cron registration
 - new skill -> pending scan -> blocked install
-- changed content hash -> pending scan -> no stale commit served
+- changed content hash -> pending candidate -> prior verified commit remains served
+- Hosted Skill -> pending candidate -> in-place GitHub promotion with history preserved
+- reusable exact verdict -> promotion only after exact display content is cached
 - clean verification -> pinned GitHub install descriptor
 - suspicious verification -> pinned GitHub install descriptor with suspicious review metadata
 - failed/malicious scan -> blocked install
-- removed upstream path -> hidden/blocked install
+- removed upstream path -> hidden/blocked install -> scan-gated reappearance
+- repository removal -> pending candidates canceled and active source blocked
 - cached `SKILL.md` and `skill-card.md` display content
 - no `skillVersions` for GitHub-backed skills
 - OpenClaw installing the pinned GitHub commit/path rather than ClawHub bytes


### PR DESCRIPTION
## Summary

- generalize the NVIDIA GitHub-backed engine to verified-publisher selected public repositories behind the existing GitHub Skill Sync rollout gate
- authorize repositories by immutable GitHub repository/owner identity with transfer-race revalidation and fail-closed revocation
- add exact pending candidates so changed GitHub content and Hosted Skill replacements preserve the canonical skill, metrics, bookmarks, versions, and audit history until scan-gated promotion
- cancel candidates on repository removal, preserve intentional moderation/deletion, and support scan-gated upstream reappearance
- keep NVIDIA behavior and production activation unchanged; no hosted `skillVersions` are created for synced GitHub content

## Validation

- `bunx vitest run convex/githubSkillSync.test.ts convex/githubSkillSources.test.ts convex/securityScan.test.ts` (153 passed)
- `bun run ci:unit` (5,093 passed, 1 skipped)
- `bun run ci:static`
- `bun run ci:types-build`
- `bunx tsc -p convex/tsconfig.json --noEmit --pretty false`
- autoreview findings addressed for intentional deletion/moderation, source revocation, candidate completion, and exact reusable verdicts; repeated 404 finding rejected with a passing scheduled-sync revocation regression

## Rollout boundary

CLAW-586 remains the controlling dark rollout gate. This PR does not deploy or activate production, enable schedules, mutate production catalog state, create claims, or release a CLI.
