### PR TITLE
fix: restore rollout automation runtime identity

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -133,6 +133,12 @@ jobs:
             esac
           done
 
+      - name: Stamp Convex runtime environment
+        if: needs.validate-deploy-request.outputs.deploy_backend == 'true'
+        env:
+          CONVEX_DEPLOY_KEY: ${{ secrets.CONVEX_DEPLOY_KEY }}
+        run: bunx convex env set CLAWHUB_ENV production --prod
+
       - name: Stamp Convex build SHA
         if: needs.validate-deploy-request.outputs.deploy_backend == 'true'
         env:

--- a/.github/workflows/scheduled-live-checks.yml
+++ b/.github/workflows/scheduled-live-checks.yml
@@ -36,6 +36,8 @@ jobs:
 
       - name: Run GitHub-backed skills live canary
         env:
+          CLAWHUB_ENV: test
+          CLAWHUB_GITHUB_SKILL_SYNC_ROLLOUT_MODE: test
           CLAWHUB_LIVE_GITHUB_CANARY: "1"
           CLAWHUB_LIVE_GITHUB_REPO: ${{ inputs.github-repo || 'openclaw/agent-skills' }}
           CLAWHUB_LIVE_GITHUB_SKILL: ${{ inputs.github-skill || 'handoff' }}

--- a/convex/githubSkillSync.live.test.ts
+++ b/convex/githubSkillSync.live.test.ts
@@ -123,7 +123,18 @@ describe("GitHub-backed skills live canary", () => {
     async () => {
       const repo = process.env.CLAWHUB_LIVE_GITHUB_REPO?.trim() || "openclaw/agent-skills";
       const skillSlug = process.env.CLAWHUB_LIVE_GITHUB_SKILL?.trim() || "handoff";
+      const publisherHandle = repo.split("/", 1)[0]?.trim().toLowerCase() || "live";
       const { db, tables } = createDb({
+        publishers: [
+          {
+            _id: "publishers:live",
+            kind: "org",
+            handle: publisherHandle,
+            displayName: publisherHandle,
+            createdAt: 1,
+            updatedAt: 1,
+          },
+        ],
         globalStats: [
           {
             _id: "globalStats:default",

--- a/specs/github-backed-skills.md
+++ b/specs/github-backed-skills.md
@@ -104,6 +104,12 @@ The legacy `NVIDIA/skills` source keeps its existing production behavior.
 Generic GitHub Skill Sync remains dark unless the GitHub Skill Sync rollout
 capability is enabled.
 
+Automation must identify its runtime explicitly. The scheduled live canary runs
+the generic sync path against an in-memory database with `CLAWHUB_ENV=test` and
+the GitHub Skill Sync rollout in `test` mode. Production deploys stamp
+`CLAWHUB_ENV=production` before deploying Convex, while ordinary production
+deploys still require both external-skill rollout modes to remain `off`.
+
 When enabled, repository enrollment requires:
 
 - publisher-admin access

--- a/src/__tests__/deploy-workflow.test.ts
+++ b/src/__tests__/deploy-workflow.test.ts
@@ -52,6 +52,7 @@ describe("production deploy workflow", () => {
     expect(convexSecretSteps).toEqual([
       "Check deploy configuration",
       "Require dark rollout modes",
+      "Stamp Convex runtime environment",
       "Stamp Convex build SHA",
       "Stamp Convex deploy time",
       "Deploy Convex",
@@ -79,6 +80,20 @@ describe("production deploy workflow", () => {
     expect(verifyDark?.run).toContain('.environment == "production"');
     expect(verifyDark?.run).toContain(".skillsSh.runtimeEnabled == false");
     expect(verifyDark?.run).toContain(".githubSkillSync.selfServiceEnabled == false");
+  });
+
+  it("stamps the production runtime identity before deploying Convex", async () => {
+    const workflow = parseYaml(await readFile(".github/workflows/deploy.yml", "utf8")) as {
+      jobs?: Record<string, WorkflowJob>;
+    };
+    const steps = workflow.jobs?.["deploy-production"]?.steps ?? [];
+    const stampIndex = steps.findIndex((step) => step.name === "Stamp Convex runtime environment");
+    const deployIndex = steps.findIndex((step) => step.name === "Deploy Convex");
+    const stamp = steps[stampIndex];
+
+    expect(stampIndex).toBeGreaterThanOrEqual(0);
+    expect(stampIndex).toBeLessThan(deployIndex);
+    expect(stamp?.run).toBe("bunx convex env set CLAWHUB_ENV production --prod");
   });
 
   it("publishes the initial promotions snapshot after backend deploy", async () => {

--- a/src/__tests__/scheduled-live-checks-workflow.test.ts
+++ b/src/__tests__/scheduled-live-checks-workflow.test.ts
@@ -2,25 +2,44 @@ import { readFile } from "node:fs/promises";
 import { describe, expect, it } from "vitest";
 import { parse as parseYaml } from "yaml";
 
+type WorkflowStep = {
+  env?: Record<string, string>;
+  name?: string;
+};
+
+type WorkflowJob = {
+  concurrency?: {
+    group?: string;
+    "cancel-in-progress"?: boolean;
+  };
+  steps?: WorkflowStep[];
+};
+
+async function readWorkflow() {
+  return parseYaml(await readFile(".github/workflows/scheduled-live-checks.yml", "utf8")) as {
+    jobs?: Record<string, WorkflowJob>;
+  };
+}
+
 describe("scheduled live checks workflow", () => {
   it("serializes failure issue updates across refs", async () => {
-    const workflow = parseYaml(
-      await readFile(".github/workflows/scheduled-live-checks.yml", "utf8"),
-    ) as {
-      jobs?: Record<
-        string,
-        {
-          concurrency?: {
-            group?: string;
-            "cancel-in-progress"?: boolean;
-          };
-        }
-      >;
-    };
+    const workflow = await readWorkflow();
 
     expect(workflow.jobs?.["open-failure-issue"]?.concurrency).toEqual({
       group: "clawhub-scheduled-live-checks-failure-issue",
       "cancel-in-progress": false,
+    });
+  });
+
+  it("runs the GitHub-backed canary with Test-only rollout capabilities", async () => {
+    const workflow = await readWorkflow();
+    const canary = workflow.jobs?.["github-backed-skills"]?.steps?.find(
+      (step) => step.name === "Run GitHub-backed skills live canary",
+    );
+
+    expect(canary?.env).toMatchObject({
+      CLAWHUB_ENV: "test",
+      CLAWHUB_GITHUB_SKILL_SYNC_ROLLOUT_MODE: "test",
     });
   });
 });


### PR DESCRIPTION
## Summary

- run the scheduled GitHub-backed skills canary with explicit Test runtime identity and the GitHub Skill Sync `test` capability
- update the live in-memory fixture for the publisher invariant introduced by the generalized sync engine
- stamp `CLAWHUB_ENV=production` before production Convex deploys so dark-capability readback identifies the runtime without relaxing any rollout gate
- lock both automation contracts into focused workflow tests and document the boundary

Fixes #3250.

## Root cause

PR #3236 made external-skill rollout capabilities fail closed when runtime mode or environment identity is missing. The scheduled live canary provided neither, so it stopped at `GitHub Skill Sync rollout is disabled`. Once Test mode is supplied, PR #3249's generalized sync path also requires the owner publisher row that the old in-memory fixture omitted.

The same missing runtime identity caused production deploy runs https://github.com/openclaw/clawhub/actions/runs/30046954088 and https://github.com/openclaw/clawhub/actions/runs/30048392303 to deploy Convex successfully, then fail dark-capability verification with `environment: unknown`. Rollout modes were and remain `off`; this change preserves that fail-closed production behavior.

## Validation

- live canary against `openclaw/agent-skills` + `handoff`: passed
- `bunx vitest run src/__tests__/deploy-workflow.test.ts src/__tests__/scheduled-live-checks-workflow.test.ts packages/schema/src/rolloutCapabilities.test.ts convex/rolloutCapabilities.test.ts`
- `bun run ci:static`
- `bun run ci:unit` (5,096 passed, 1 skipped)
- autoreview: clean

No production deploy or production data/config mutation was performed.
