### PR TITLE
fix(deps): upgrade PostCSS past path traversal advisory

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -171,7 +171,7 @@
     "fast-uri": "3.1.4",
     "js-yaml": "4.3.0",
     "next": "16.2.11",
-    "postcss": "8.5.12",
+    "postcss": "8.5.18",
     "sharp": "0.35.3",
     "shell-quote": "1.10.0",
     "undici": "7.28.0",
@@ -1700,7 +1700,7 @@
 
     "postal-mime": ["postal-mime@2.7.4", "", {}, "sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g=="],
 
-    "postcss": ["postcss@8.5.12", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA=="],
+    "postcss": ["postcss@8.5.18", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ=="],
 
     "preact": ["preact@10.24.3", "", {}, "sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA=="],
 

--- a/package.json
+++ b/package.json
@@ -189,7 +189,7 @@
     "fast-uri": "3.1.4",
     "js-yaml": "4.3.0",
     "next": "16.2.11",
-    "postcss": "8.5.12",
+    "postcss": "8.5.18",
     "sharp": "0.35.3",
     "shell-quote": "1.10.0",
     "undici": "7.28.0",


### PR DESCRIPTION
## Summary
- upgrade the central PostCSS override from 8.5.12 to 8.5.18
- refresh only the matching Bun lockfile entry
- restore the required audit gate without suppressing the advisory

## Validation
- `bun audit`
- `bun install --frozen-lockfile`
- `bun run ci:static`
- `bun run ci:types-build`
- autoreview: clean
