### PR TITLE
feat: add permanent Test ranking metrics import

### DIFF
--- a/.github/workflows/reserve-test.yml
+++ b/.github/workflows/reserve-test.yml
@@ -30,6 +30,7 @@ jobs:
     steps:
       - name: Verify exact current main
         env:
+          DATASET_VERSION: ${{ inputs.dataset_version }}
           EXPECTED_SHA: ${{ inputs.expected_sha }}
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -39,7 +40,7 @@ jobs:
             echo "::error::Test reservation must match exact current main"
             exit 1
           fi
-          if [[ ! "${{ inputs.dataset_version }}" =~ ^ranking-metrics-[0-9]{4}-[0-9]{2}-[0-9]{2}-v[0-9]+$ ]]; then
+          if [[ ! "$DATASET_VERSION" =~ ^ranking-metrics-[0-9]{4}-[0-9]{2}-[0-9]{2}-v[0-9]+$ ]]; then
             echo "::error::Invalid ranking dataset version"
             exit 1
           fi

--- a/.github/workflows/reserve-test.yml
+++ b/.github/workflows/reserve-test.yml
@@ -1,0 +1,48 @@
+name: Reserve Test
+run-name: Reserve Test for ${{ inputs.dataset_version }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      dataset_version:
+        description: Ranking dataset version that will use the exclusive Test lane
+        required: true
+        type: string
+      expected_sha:
+        description: Exact current main SHA permitted to reserve Test
+        required: true
+        type: string
+
+concurrency:
+  group: deploy-test
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  reserve-test:
+    if: github.ref == 'refs/heads/main' && inputs.expected_sha == github.sha
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    environment:
+      name: Test
+    steps:
+      - name: Verify exact current main
+        env:
+          EXPECTED_SHA: ${{ inputs.expected_sha }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          main_sha="$(gh api "repos/$GITHUB_REPOSITORY/commits/main" --jq .sha)"
+          if [[ "$EXPECTED_SHA" != "$GITHUB_SHA" || "$GITHUB_SHA" != "$main_sha" ]]; then
+            echo "::error::Test reservation must match exact current main"
+            exit 1
+          fi
+          if [[ ! "${{ inputs.dataset_version }}" =~ ^ranking-metrics-[0-9]{4}-[0-9]{2}-[0-9]{2}-v[0-9]+$ ]]; then
+            echo "::error::Invalid ranking dataset version"
+            exit 1
+          fi
+
+      - name: Hold exclusive Test lane until canceled
+        run: sleep 20700

--- a/convex/functions.ts
+++ b/convex/functions.ts
@@ -414,6 +414,7 @@ export async function repointPackageLatestRelease(
 }
 
 triggers.register("skills", async (ctx, change) => {
+  assertRankingMetricWritesAllowed();
   await adjustPublisherStatsForSkillChange(
     ctx,
     change.operation === "insert" ? null : change.oldDoc,
@@ -443,6 +444,7 @@ triggers.register("skillVersions", async (ctx, change) => {
 });
 
 triggers.register("packages", async (ctx, change) => {
+  assertRankingMetricWritesAllowed();
   await adjustPublisherStatsForPackageChange(
     ctx,
     change.operation === "insert" ? null : change.oldDoc,
@@ -475,12 +477,14 @@ triggers.register("packageReleases", async (ctx, change) => {
 });
 
 triggers.register("users", async (ctx, change) => {
+  assertRankingMetricWritesAllowed();
   if (!shouldScheduleOwnerUserPackageDigestSyncForUserChange(change)) return;
   const ownerUserId = change.operation === "delete" ? change.id : change.newDoc._id;
   await scheduleOwnerUserPackageDigestSync(ctx, ownerUserId);
 });
 
 triggers.register("publishers", async (ctx, change) => {
+  assertRankingMetricWritesAllowed();
   if (!shouldScheduleOwnerPublisherDigestSyncForPublisherChange(change)) return;
   const ownerPublisherId = change.operation === "delete" ? change.id : change.newDoc._id;
   await scheduleOwnerPublisherDigestSync(ctx, ownerPublisherId);

--- a/convex/functions.ts
+++ b/convex/functions.ts
@@ -24,6 +24,7 @@ import {
   adjustPublisherStatsForPackageChange,
   adjustPublisherStatsForSkillChange,
 } from "./lib/publisherStats";
+import { assertRankingMetricWritesAllowed } from "./lib/rankingMetricsImportLock";
 import {
   deleteSkillSearchDigests,
   extractValidatedDigestFields,
@@ -483,6 +484,14 @@ triggers.register("publishers", async (ctx, change) => {
   if (!shouldScheduleOwnerPublisherDigestSyncForPublisherChange(change)) return;
   const ownerPublisherId = change.operation === "delete" ? change.id : change.newDoc._id;
   await scheduleOwnerPublisherDigestSync(ctx, ownerPublisherId);
+});
+
+triggers.register("skillDailyStats", async () => {
+  assertRankingMetricWritesAllowed();
+});
+
+triggers.register("packageDailyStats", async () => {
+  assertRankingMetricWritesAllowed();
 });
 
 export const mutation = customMutation(rawMutation, customCtx(triggers.wrapDB));

--- a/convex/lib/rankingMetricsImportLock.test.ts
+++ b/convex/lib/rankingMetricsImportLock.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  assertRankingMetricWritesAllowed,
+  RANKING_METRICS_IMPORT_LOCK_ENV,
+} from "./rankingMetricsImportLock";
+
+const original = process.env[RANKING_METRICS_IMPORT_LOCK_ENV];
+
+afterEach(() => {
+  if (original === undefined) delete process.env[RANKING_METRICS_IMPORT_LOCK_ENV];
+  else process.env[RANKING_METRICS_IMPORT_LOCK_ENV] = original;
+});
+
+describe("ranking metric import write lock", () => {
+  it("blocks aggregate writes while an import lock is active", () => {
+    process.env[RANKING_METRICS_IMPORT_LOCK_ENV] =
+      "ranking-metrics-2026-07-23-v1:12345:1784930400000";
+    expect(() => assertRankingMetricWritesAllowed(1_784_930_000_000)).toThrow("temporarily paused");
+  });
+
+  it("fails closed for malformed locks and allows expired locks", () => {
+    process.env[RANKING_METRICS_IMPORT_LOCK_ENV] = "malformed";
+    expect(() => assertRankingMetricWritesAllowed(1_784_930_000_000)).toThrow("temporarily paused");
+
+    process.env[RANKING_METRICS_IMPORT_LOCK_ENV] =
+      "ranking-metrics-2026-07-23-v1:12345:1784920000000";
+    expect(() => assertRankingMetricWritesAllowed(1_784_930_000_000)).not.toThrow();
+  });
+});

--- a/convex/lib/rankingMetricsImportLock.ts
+++ b/convex/lib/rankingMetricsImportLock.ts
@@ -1,0 +1,9 @@
+export const RANKING_METRICS_IMPORT_LOCK_ENV = "CLAWHUB_RANKING_METRICS_IMPORT_LOCK";
+
+export function assertRankingMetricWritesAllowed(now = Date.now()) {
+  const lock = process.env[RANKING_METRICS_IMPORT_LOCK_ENV];
+  if (!lock) return;
+  const expiresAt = Number(lock.split(":").at(-1));
+  if (Number.isSafeInteger(expiresAt) && expiresAt <= now) return;
+  throw new Error("Ranking metric writes are temporarily paused for a Test dataset import");
+}

--- a/convex/lib/rankingMetricsImportLock.ts
+++ b/convex/lib/rankingMetricsImportLock.ts
@@ -5,5 +5,5 @@ export function assertRankingMetricWritesAllowed(now = Date.now()) {
   if (!lock) return;
   const expiresAt = Number(lock.split(":").at(-1));
   if (Number.isSafeInteger(expiresAt) && expiresAt <= now) return;
-  throw new Error("Ranking metric writes are temporarily paused for a Test dataset import");
+  throw new Error("Ranking import source writes are temporarily paused for a Test dataset import");
 }

--- a/convex/lib/retentionPolicy.ts
+++ b/convex/lib/retentionPolicy.ts
@@ -190,6 +190,9 @@ export const RETENTION_POLICIES = {
   skillLeaderboards: derived("Leaderboard snapshots can be rebuilt from stats.", "skillDailyStats"),
   skillStatBackfillState: permanent("Backfill cursor state."),
   globalStats: derived("Global stats aggregate can be recalculated.", "skills/packages"),
+  rankingMetricImports: permanent(
+    "Versioned Test ranking import provenance is retained until explicit cleanup.",
+  ),
   skillStatEvents: ephemeral(
     "Skill stat event log is retained only after both consumers pass it.",
     {

--- a/convex/lib/skillStats.ts
+++ b/convex/lib/skillStats.ts
@@ -1,6 +1,7 @@
 import type { Doc, Id } from "../_generated/dataModel";
 import type { MutationCtx } from "../_generated/server";
 import { toDayKey } from "./leaderboards";
+import { assertRankingMetricWritesAllowed } from "./rankingMetricsImportLock";
 
 type SkillStatDeltas = {
   downloads?: number;
@@ -118,6 +119,7 @@ export async function bumpDailySkillStats(
   const downloads = params.downloads ?? 0;
   const installs = params.installs ?? 0;
   if (downloads === 0 && installs === 0) return;
+  assertRankingMetricWritesAllowed();
 
   const day = toDayKey(params.now);
   const existing = await ctx.db

--- a/convex/packages.ts
+++ b/convex/packages.ts
@@ -108,6 +108,7 @@ import {
   getPublishTotalSizeError,
   MAX_PUBLISH_TOTAL_BYTES,
 } from "./lib/publishLimits";
+import { assertRankingMetricWritesAllowed } from "./lib/rankingMetricsImportLock";
 import {
   computeRecommendationScore,
   RECOMMENDATION_SCORE_VERSION,
@@ -4557,6 +4558,7 @@ async function bumpDailyPackageStats(
   },
 ) {
   if (params.downloads === 0 && params.installs === 0) return;
+  assertRankingMetricWritesAllowed();
 
   const existing = await ctx.db
     .query("packageDailyStats")

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -2027,6 +2027,9 @@ const packageDailyStats = defineTable({
   day: v.number(),
   downloads: v.number(),
   installs: v.number(),
+  bookmarks: v.optional(v.number()),
+  rankingDatasetVersion: v.optional(v.string()),
+  rankingImportedAt: v.optional(v.number()),
   updatedAt: v.number(),
 })
   .index("by_package_day", ["packageId", "day"])
@@ -2482,6 +2485,9 @@ const skillDailyStats = defineTable({
   day: v.number(),
   downloads: v.number(),
   installs: v.number(),
+  bookmarks: v.optional(v.number()),
+  rankingDatasetVersion: v.optional(v.string()),
+  rankingImportedAt: v.optional(v.number()),
   updatedAt: v.number(),
 })
   .index("by_skill_day", ["skillId", "day"])
@@ -2515,6 +2521,25 @@ const globalStats = defineTable({
   activePluginsCount: v.optional(v.number()),
   updatedAt: v.number(),
 }).index("by_key", ["key"]);
+
+const rankingMetricImports = defineTable({
+  datasetVersion: v.string(),
+  checksum: v.string(),
+  generatedAt: v.string(),
+  importedAt: v.number(),
+  startDay: v.number(),
+  endDay: v.number(),
+  targetCount: v.number(),
+  skillTargetCount: v.number(),
+  packageTargetCount: v.number(),
+  dailyRowCount: v.number(),
+  importedSkillRows: v.number(),
+  importedPackageRows: v.number(),
+  unresolvedTargets: v.number(),
+  skippedOverlayRows: v.number(),
+})
+  .index("by_dataset_version", ["datasetVersion"])
+  .index("by_imported_at", ["importedAt"]);
 
 const skillStatEvents = defineTable({
   skillId: v.id("skills"),
@@ -3926,6 +3951,7 @@ export default defineSchema({
   skillLeaderboards,
   skillStatBackfillState,
   globalStats,
+  rankingMetricImports,
   skillStatEvents,
   skillStatUpdateCursors,
   skillStatDocSyncLeases,

--- a/package.json
+++ b/package.json
@@ -66,6 +66,8 @@
     "seed:public-corpus": "bun run setup:worktree -- --quiet && bunx convex dev --once --typecheck=disable && bun scripts/public-corpus/seed-public-corpus.ts",
     "seed:test": "bun scripts/seed-test.ts",
     "seed:test:import-snapshot": "bun scripts/staging-seed/import-test-snapshot.ts",
+    "seed:test:ranking-export": "bun scripts/ranking-metrics/export-prod-ranking-metrics.ts",
+    "seed:test:ranking-import": "bun scripts/ranking-metrics/import-test-ranking-metrics.ts",
     "seed:test:sanitize-snapshot": "bun scripts/staging-seed/sanitize-prod-snapshot.ts",
     "seed:test:validate-snapshot": "bun scripts/staging-seed/validate-sanitized-snapshot.ts",
     "setup:worktree": "bun scripts/setup-worktree.ts",

--- a/scripts/ranking-metrics/export-prod-ranking-metrics.ts
+++ b/scripts/ranking-metrics/export-prod-ranking-metrics.ts
@@ -1,0 +1,273 @@
+#!/usr/bin/env bun
+import { writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { readSnapshotTable } from "../staging-seed/snapshotIo";
+import {
+  dummyIdentity,
+  isPublicPackageSnapshot,
+  isPublicSkillSnapshot,
+  type SnapshotDocument,
+} from "../staging-seed/snapshotPolicy";
+import {
+  buildRankingDataset,
+  type RankingMetricDay,
+  type RankingMetricPackageTarget,
+  type RankingMetricSkillTarget,
+  type RankingMetricTarget,
+} from "./rankingDataset";
+
+type TargetBuilder =
+  | Omit<RankingMetricSkillTarget, "days">
+  | Omit<RankingMetricPackageTarget, "days">;
+
+const SOURCE_TABLES = [
+  "skills",
+  "packages",
+  "skillDailyStats",
+  "packageDailyStats",
+  "stars",
+] as const;
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const targetBySourceId = new Map<string, TargetBuilder>();
+  const dayRows = new Map<string, Map<number, RankingMetricDay>>();
+
+  for await (const row of readSnapshotTable(options.snapshot, "skills")) {
+    if (!isSnapshotDocument(row) || !isPublicSkillSnapshot(row)) continue;
+    const slug = stringField(row, "slug");
+    const ownerPublisherId = optionalStringField(row, "ownerPublisherId");
+    const ownerUserId = optionalStringField(row, "ownerUserId");
+    const sourceOwnerId = ownerPublisherId ?? ownerUserId;
+    if (!slug || !sourceOwnerId) continue;
+    targetBySourceId.set(row._id, {
+      kind: "skill",
+      ownerHandle: dummyIdentity(sourceOwnerId, ownerPublisherId ? "publisher" : "user").handle,
+      slug,
+      createdAt: timestampField(row, "createdAt", row._creationTime),
+    });
+  }
+
+  for await (const row of readSnapshotTable(options.snapshot, "packages")) {
+    if (!isSnapshotDocument(row) || !isPublicPackageSnapshot(row)) continue;
+    const normalizedName = stringField(row, "normalizedName");
+    const family = row.family;
+    const channel = stringField(row, "channel");
+    if (!normalizedName || (family !== "code-plugin" && family !== "bundle-plugin") || !channel) {
+      continue;
+    }
+    targetBySourceId.set(row._id, {
+      kind: "package",
+      normalizedName,
+      family,
+      channel,
+      createdAt: timestampField(row, "createdAt", row._creationTime),
+    });
+  }
+
+  await aggregateDailyTable(
+    "skillDailyStats",
+    "skillId",
+    targetBySourceId,
+    dayRows,
+    options.snapshot,
+    options.startDay,
+    options.endDay,
+  );
+  await aggregateDailyTable(
+    "packageDailyStats",
+    "packageId",
+    targetBySourceId,
+    dayRows,
+    options.snapshot,
+    options.startDay,
+    options.endDay,
+  );
+  await aggregateBookmarks(
+    targetBySourceId,
+    dayRows,
+    options.snapshot,
+    options.startDay,
+    options.endDay,
+  );
+
+  const targets: RankingMetricTarget[] = [];
+  for (const [sourceId, metadata] of targetBySourceId) {
+    const days = [...(dayRows.get(sourceId)?.values() ?? [])]
+      .filter((row) => row.downloads !== 0 || row.installs !== 0 || row.bookmarks !== 0)
+      .sort((left, right) => left.day - right.day);
+    if (days.length === 0) continue;
+    targets.push({ ...metadata, days } as RankingMetricTarget);
+  }
+  targets.sort(compareTargets);
+
+  const dataset = buildRankingDataset({
+    datasetVersion: options.datasetVersion,
+    generatedAt: new Date().toISOString(),
+    startDay: options.startDay,
+    endDay: options.endDay,
+    targets,
+  });
+  await writeFile(options.output, `${JSON.stringify(dataset)}\n`, { flag: "wx" });
+  console.log(
+    JSON.stringify(
+      {
+        ok: true,
+        output: options.output,
+        sourceTables: SOURCE_TABLES,
+        ...dataset.counts,
+        datasetVersion: dataset.datasetVersion,
+        checksum: dataset.checksum,
+        startDay: dataset.startDay,
+        endDay: dataset.endDay,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+async function aggregateDailyTable(
+  table: "skillDailyStats" | "packageDailyStats",
+  idField: "skillId" | "packageId",
+  targets: ReadonlyMap<string, TargetBuilder>,
+  dayRows: Map<string, Map<number, RankingMetricDay>>,
+  snapshot: string,
+  startDay: number,
+  endDay: number,
+) {
+  for await (const row of readSnapshotTable(snapshot, table)) {
+    const sourceId = optionalStringField(row, idField);
+    const day = integerField(row, "day");
+    if (!sourceId || !targets.has(sourceId) || day === null || day < startDay || day > endDay) {
+      continue;
+    }
+    const aggregate = ensureDay(dayRows, sourceId, day);
+    aggregate.downloads += nonNegativeIntegerField(row, "downloads");
+    aggregate.installs += nonNegativeIntegerField(row, "installs");
+  }
+}
+
+async function aggregateBookmarks(
+  targets: ReadonlyMap<string, TargetBuilder>,
+  dayRows: Map<string, Map<number, RankingMetricDay>>,
+  snapshot: string,
+  startDay: number,
+  endDay: number,
+) {
+  for await (const row of readSnapshotTable(snapshot, "stars")) {
+    const sourceId = optionalStringField(row, "skillId");
+    if (!sourceId || !targets.has(sourceId)) continue;
+    const createdAt = numberField(row, "createdAt");
+    if (createdAt === null) continue;
+    const day = Math.floor(createdAt / 86_400_000);
+    if (day < startDay || day > endDay) continue;
+    ensureDay(dayRows, sourceId, day).bookmarks += 1;
+  }
+}
+
+function ensureDay(
+  rows: Map<string, Map<number, RankingMetricDay>>,
+  sourceId: string,
+  day: number,
+) {
+  let targetRows = rows.get(sourceId);
+  if (!targetRows) {
+    targetRows = new Map();
+    rows.set(sourceId, targetRows);
+  }
+  let row = targetRows.get(day);
+  if (!row) {
+    row = { day, downloads: 0, installs: 0, bookmarks: 0 };
+    targetRows.set(day, row);
+  }
+  return row;
+}
+
+export function parseArgs(args: string[]) {
+  let output = "";
+  let snapshot = "";
+  let datasetVersion = "";
+  let endDay = Math.floor(Date.now() / 86_400_000);
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--output") output = args[++index] ?? "";
+    else if (arg.startsWith("--output=")) output = arg.slice("--output=".length);
+    else if (arg === "--snapshot") snapshot = args[++index] ?? "";
+    else if (arg.startsWith("--snapshot=")) snapshot = arg.slice("--snapshot=".length);
+    else if (arg === "--dataset-version") datasetVersion = args[++index] ?? "";
+    else if (arg.startsWith("--dataset-version=")) {
+      datasetVersion = arg.slice("--dataset-version=".length);
+    } else if (arg === "--end-day") {
+      endDay = Number(args[++index]);
+    } else if (arg.startsWith("--end-day=")) {
+      endDay = Number(arg.slice("--end-day=".length));
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  if (!output) throw new Error("--output is required");
+  if (!snapshot) throw new Error("--snapshot is required");
+  if (!datasetVersion) throw new Error("--dataset-version is required");
+  if (!Number.isSafeInteger(endDay)) throw new Error("--end-day must be an integer day key");
+  return {
+    output: resolve(output),
+    snapshot: resolve(snapshot),
+    datasetVersion,
+    startDay: endDay - 59,
+    endDay,
+  };
+}
+
+function compareTargets(left: RankingMetricTarget, right: RankingMetricTarget) {
+  const leftKey =
+    left.kind === "skill"
+      ? `skill:${left.ownerHandle}/${left.slug}`
+      : `package:${left.normalizedName}`;
+  const rightKey =
+    right.kind === "skill"
+      ? `skill:${right.ownerHandle}/${right.slug}`
+      : `package:${right.normalizedName}`;
+  return leftKey.localeCompare(rightKey);
+}
+
+function isSnapshotDocument(value: Record<string, unknown>): value is SnapshotDocument {
+  return typeof value._id === "string" && typeof value._creationTime === "number";
+}
+
+function stringField(row: Record<string, unknown>, field: string) {
+  const value = row[field];
+  return typeof value === "string" && value ? value : null;
+}
+
+function optionalStringField(row: Record<string, unknown>, field: string) {
+  return stringField(row, field);
+}
+
+function numberField(row: Record<string, unknown>, field: string) {
+  const value = row[field];
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function integerField(row: Record<string, unknown>, field: string) {
+  const value = numberField(row, field);
+  return value !== null && Number.isSafeInteger(value) ? value : null;
+}
+
+function nonNegativeIntegerField(row: Record<string, unknown>, field: string) {
+  const value = integerField(row, field);
+  if (value === null || value < 0) throw new Error(`${field} must be a non-negative integer`);
+  return value;
+}
+
+function timestampField(row: Record<string, unknown>, field: string, fallback: number) {
+  const value = integerField(row, field);
+  return value !== null && value >= 0 ? value : Math.floor(fallback);
+}
+
+if (import.meta.main) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exit(1);
+  });
+}

--- a/scripts/ranking-metrics/export-prod-ranking-metrics.ts
+++ b/scripts/ranking-metrics/export-prod-ranking-metrics.ts
@@ -10,6 +10,7 @@ import {
 } from "../staging-seed/snapshotPolicy";
 import {
   buildRankingDataset,
+  packageTargetIdentity,
   type RankingMetricDay,
   type RankingMetricPackageTarget,
   type RankingMetricSkillTarget,
@@ -223,11 +224,11 @@ function compareTargets(left: RankingMetricTarget, right: RankingMetricTarget) {
   const leftKey =
     left.kind === "skill"
       ? `skill:${left.ownerHandle}/${left.slug}`
-      : `package:${left.normalizedName}`;
+      : packageTargetIdentity(left.normalizedName, left.family, left.channel);
   const rightKey =
     right.kind === "skill"
       ? `skill:${right.ownerHandle}/${right.slug}`
-      : `package:${right.normalizedName}`;
+      : packageTargetIdentity(right.normalizedName, right.family, right.channel);
   return leftKey.localeCompare(rightKey);
 }
 

--- a/scripts/ranking-metrics/import-test-ranking-metrics.test.ts
+++ b/scripts/ranking-metrics/import-test-ranking-metrics.test.ts
@@ -7,9 +7,13 @@ import { CLAWHUB_TEST_DEPLOYMENT } from "../seed-test";
 import {
   assertRankingTablesUnchanged,
   assertTestDeployment,
+  buildConvexImportArchiveCommand,
   copySnapshotTable,
   mergeDailyTable,
+  mergeRankingMetricImportRows,
   parseArgs,
+  readCurrentTestMetadata,
+  resolveTargets,
   type ResolvedRankingMetricTarget,
 } from "./import-test-ranking-metrics";
 
@@ -36,6 +40,108 @@ describe("Test ranking metric command guard", () => {
         deployment: CLAWHUB_TEST_DEPLOYMENT,
       }),
     );
+  });
+
+  it("replaces all three ranking tables in one atomic ZIP import", () => {
+    expect(
+      buildConvexImportArchiveCommand("/tmp/ranking-tables.zip", CLAWHUB_TEST_DEPLOYMENT),
+    ).toEqual({
+      command: "bunx",
+      args: [
+        "convex",
+        "import",
+        "--deployment",
+        CLAWHUB_TEST_DEPLOYMENT,
+        "--replace",
+        "--yes",
+        "/tmp/ranking-tables.zip",
+      ],
+    });
+  });
+
+  it("replaces only matching import provenance and preserves system identities", () => {
+    const prior = {
+      _id: "prior",
+      _creationTime: 1,
+      datasetVersion: "ranking-metrics-2026-07-01-v1",
+      checksum: "prior-checksum",
+    };
+    const replaced = {
+      _id: "same-version",
+      _creationTime: 2,
+      datasetVersion: "ranking-metrics-2026-07-23-v1",
+      checksum: "old-checksum",
+    };
+    const next = {
+      datasetVersion: "ranking-metrics-2026-07-23-v1",
+      checksum: "new-checksum",
+    };
+
+    expect(mergeRankingMetricImportRows([prior, replaced], next)).toEqual([
+      prior,
+      { ...next, _id: "same-version", _creationTime: 2 },
+    ]);
+  });
+
+  it("resolves package targets by normalized name, family, and channel", async () => {
+    const workDir = join(tmpdir(), `ranking-packages-${crypto.randomUUID()}`);
+    cleanupPaths.push(workDir);
+    await mkdir(workDir);
+    const snapshot = join(workDir, "packages.zip");
+    await writeFile(
+      snapshot,
+      zipSync({
+        "users/documents.jsonl": encodeRows([
+          {
+            _id: "snapshot-owner",
+            _creationTime: 1,
+            handle: "test-snapshot-user-0123456789ab",
+          },
+        ]),
+        "publishers/documents.jsonl": encodeRows([]),
+        "skills/documents.jsonl": encodeRows([]),
+        "packages/documents.jsonl": encodeRows([
+          {
+            _id: "code-stable",
+            _creationTime: 1,
+            ownerUserId: "snapshot-owner",
+            normalizedName: "@openclaw/calendar",
+            family: "code-plugin",
+            channel: "stable",
+          },
+          {
+            _id: "bundle-stable",
+            _creationTime: 1,
+            ownerUserId: "snapshot-owner",
+            normalizedName: "@openclaw/calendar",
+            family: "bundle-plugin",
+            channel: "stable",
+          },
+        ]),
+        "rankingMetricImports/documents.jsonl": encodeRows([]),
+      }),
+    );
+
+    const current = await readCurrentTestMetadata(snapshot);
+    const target = {
+      kind: "package" as const,
+      normalizedName: "@openclaw/calendar",
+      family: "code-plugin" as const,
+      channel: "stable",
+      createdAt: 1,
+      days: [{ day: 20_656, downloads: 1, installs: 0, bookmarks: 0 }],
+    };
+    expect(resolveTargets([target], current).targets).toEqual([
+      expect.objectContaining({ kind: "package", targetId: "code-stable" }),
+    ]);
+    expect(() => resolveTargets([{ ...target, channel: "beta" }], current)).toThrow(
+      "package identity mismatch",
+    );
+    const exactMatches = [...current.packagesByIdentity.values()].find(
+      (matches) => matches[0]?.targetId === "code-stable",
+    );
+    exactMatches?.push({ targetId: "duplicate-code-stable", legacySnapshotTarget: true });
+    expect(() => resolveTargets([target], current)).toThrow("ambiguous package identity");
   });
 
   it("streams an idempotent replacement while preserving feature-owned rows", async () => {

--- a/scripts/ranking-metrics/import-test-ranking-metrics.test.ts
+++ b/scripts/ranking-metrics/import-test-ranking-metrics.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { zipSync } from "fflate";
 import { afterEach, describe, expect, it } from "vitest";
+import { parse as parseYaml } from "yaml";
 import { CLAWHUB_TEST_DEPLOYMENT } from "../seed-test";
 import {
   assertRankingTablesUnchanged,
@@ -15,6 +16,7 @@ import {
   readCurrentTestMetadata,
   resolveTargets,
   type ResolvedRankingMetricTarget,
+  validateExclusiveTestLane,
 } from "./import-test-ranking-metrics";
 
 const cleanupPaths: string[] = [];
@@ -34,12 +36,80 @@ describe("Test ranking metric command guard", () => {
 
   it("requires an explicit backup path for every mutating operation", () => {
     expect(() => parseArgs(["--dataset", "dataset.json"])).toThrow("--backup-dir");
-    expect(parseArgs(["--dataset", "dataset.json", "--backup-dir", "proof/backup"])).toEqual(
+    expect(() => parseArgs(["--dataset", "dataset.json", "--backup-dir", "proof/backup"])).toThrow(
+      "--lane-run-id",
+    );
+    expect(
+      parseArgs([
+        "--dataset",
+        "dataset.json",
+        "--backup-dir",
+        "proof/backup",
+        "--lane-run-id",
+        "12345",
+      ]),
+    ).toEqual(
       expect.objectContaining({
         mode: "import",
         deployment: CLAWHUB_TEST_DEPLOYMENT,
+        laneRunId: 12345,
       }),
     );
+  });
+
+  it("accepts only an active exact-main Test lane reservation", () => {
+    const reservation = {
+      id: 12_345,
+      status: "in_progress",
+      event: "workflow_dispatch",
+      head_branch: "main",
+      head_sha: "abc123",
+      path: ".github/workflows/reserve-test.yml",
+      display_title: "Reserve Test for ranking-metrics-2026-07-23-v1",
+      run_started_at: "2026-07-24T19:00:00.000Z",
+    };
+    expect(() =>
+      validateExclusiveTestLane({
+        reservation,
+        runId: 12_345,
+        datasetVersion: "ranking-metrics-2026-07-23-v1",
+        localSha: "abc123",
+        mainSha: "abc123",
+        now: Date.parse("2026-07-24T20:00:00.000Z"),
+      }),
+    ).not.toThrow();
+    expect(() =>
+      validateExclusiveTestLane({
+        reservation: { ...reservation, status: "completed" },
+        runId: 12_345,
+        datasetVersion: "ranking-metrics-2026-07-23-v1",
+        localSha: "abc123",
+        mainSha: "abc123",
+        now: Date.parse("2026-07-24T20:00:00.000Z"),
+      }),
+    ).toThrow("not actively holding");
+    expect(() =>
+      validateExclusiveTestLane({
+        reservation,
+        runId: 12_345,
+        datasetVersion: "ranking-metrics-2026-07-23-v1",
+        localSha: "different",
+        mainSha: "abc123",
+        now: Date.parse("2026-07-24T20:00:00.000Z"),
+      }),
+    ).toThrow("exact current main");
+  });
+
+  it("reserves the same non-canceling concurrency lane as Test deploys", async () => {
+    const workflow = parseYaml(await readFile(".github/workflows/reserve-test.yml", "utf8")) as {
+      concurrency?: { group?: string; "cancel-in-progress"?: boolean };
+      jobs?: Record<string, { environment?: { name?: string }; "timeout-minutes"?: number }>;
+    };
+    expect(workflow.concurrency).toEqual({ group: "deploy-test", "cancel-in-progress": false });
+    expect(workflow.jobs?.["reserve-test"]).toMatchObject({
+      environment: { name: "Test" },
+      "timeout-minutes": 360,
+    });
   });
 
   it("replaces all three ranking tables in one atomic ZIP import", () => {

--- a/scripts/ranking-metrics/import-test-ranking-metrics.test.ts
+++ b/scripts/ranking-metrics/import-test-ranking-metrics.test.ts
@@ -7,6 +7,7 @@ import { parse as parseYaml } from "yaml";
 import { CLAWHUB_TEST_DEPLOYMENT } from "../seed-test";
 import {
   assertRankingTablesUnchanged,
+  assertRankingTablesMatchDigests,
   assertTestDeployment,
   buildConvexImportArchiveCommand,
   copySnapshotTable,
@@ -14,6 +15,7 @@ import {
   mergeRankingMetricImportRows,
   parseArgs,
   readCurrentTestMetadata,
+  rankingTableDigests,
   resolveTargets,
   type ResolvedRankingMetricTarget,
   validateExclusiveTestLane,
@@ -381,6 +383,14 @@ describe("Test ranking metric command guard", () => {
     await expect(assertRankingTablesUnchanged(baseline, unchanged)).resolves.toBeUndefined();
     await expect(assertRankingTablesUnchanged(baseline, changed)).rejects.toThrow(
       "skillDailyStats changed after the backup snapshot",
+    );
+
+    const rollbackDigests = await rankingTableDigests(baseline);
+    await expect(
+      assertRankingTablesMatchDigests(unchanged, rollbackDigests),
+    ).resolves.toBeUndefined();
+    await expect(assertRankingTablesMatchDigests(changed, rollbackDigests)).rejects.toThrow(
+      "skillDailyStats no longer matches the rollback source state",
     );
   });
 });

--- a/scripts/ranking-metrics/import-test-ranking-metrics.test.ts
+++ b/scripts/ranking-metrics/import-test-ranking-metrics.test.ts
@@ -8,6 +8,7 @@ import { CLAWHUB_TEST_DEPLOYMENT } from "../seed-test";
 import {
   assertRankingTablesUnchanged,
   assertRankingTablesMatchDigests,
+  assertRankingTablesMatchLogicalDigests,
   assertTestDeployment,
   buildConvexImportArchiveCommand,
   copySnapshotTable,
@@ -16,6 +17,7 @@ import {
   parseArgs,
   readCurrentTestMetadata,
   rankingTableDigests,
+  rankingTableLogicalDigests,
   resolveTargets,
   type ResolvedRankingMetricTarget,
   validateExclusiveTestLane,
@@ -360,6 +362,7 @@ describe("Test ranking metric command guard", () => {
     await mkdir(workDir);
     const baseline = join(workDir, "baseline.zip");
     const unchanged = join(workDir, "unchanged.zip");
+    const rekeyed = join(workDir, "rekeyed.zip");
     const changed = join(workDir, "changed.zip");
     const tables = {
       "skillDailyStats/documents.jsonl": encodeRows([
@@ -370,6 +373,15 @@ describe("Test ranking metric command guard", () => {
     };
     await writeFile(baseline, zipSync(tables));
     await writeFile(unchanged, zipSync(tables));
+    await writeFile(
+      rekeyed,
+      zipSync({
+        ...tables,
+        "skillDailyStats/documents.jsonl": encodeRows([
+          dailyRow("replacement-system-id", "snapshot-skill", 20_655, 10),
+        ]),
+      }),
+    );
     await writeFile(
       changed,
       zipSync({
@@ -390,6 +402,14 @@ describe("Test ranking metric command guard", () => {
       assertRankingTablesMatchDigests(unchanged, rollbackDigests),
     ).resolves.toBeUndefined();
     await expect(assertRankingTablesMatchDigests(changed, rollbackDigests)).rejects.toThrow(
+      "skillDailyStats no longer matches the rollback source state",
+    );
+
+    const logicalDigests = await rankingTableLogicalDigests(baseline);
+    await expect(
+      assertRankingTablesMatchLogicalDigests(rekeyed, logicalDigests),
+    ).resolves.toBeUndefined();
+    await expect(assertRankingTablesMatchLogicalDigests(changed, logicalDigests)).rejects.toThrow(
       "skillDailyStats no longer matches the rollback source state",
     );
   });

--- a/scripts/ranking-metrics/import-test-ranking-metrics.test.ts
+++ b/scripts/ranking-metrics/import-test-ranking-metrics.test.ts
@@ -1,0 +1,242 @@
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { zipSync } from "fflate";
+import { afterEach, describe, expect, it } from "vitest";
+import { CLAWHUB_TEST_DEPLOYMENT } from "../seed-test";
+import {
+  assertRankingTablesUnchanged,
+  assertTestDeployment,
+  copySnapshotTable,
+  mergeDailyTable,
+  parseArgs,
+  type ResolvedRankingMetricTarget,
+} from "./import-test-ranking-metrics";
+
+const cleanupPaths: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    cleanupPaths.splice(0).map((path) => rm(path, { recursive: true, force: true })),
+  );
+});
+
+describe("Test ranking metric command guard", () => {
+  it("accepts only the exact permanent Test deployment", () => {
+    expect(() => assertTestDeployment(CLAWHUB_TEST_DEPLOYMENT)).not.toThrow();
+    expect(() => assertTestDeployment("wry-manatee-359")).toThrow("may only target");
+    expect(() => assertTestDeployment("unknown")).toThrow("may only target");
+  });
+
+  it("requires an explicit backup path for every mutating operation", () => {
+    expect(() => parseArgs(["--dataset", "dataset.json"])).toThrow("--backup-dir");
+    expect(parseArgs(["--dataset", "dataset.json", "--backup-dir", "proof/backup"])).toEqual(
+      expect.objectContaining({
+        mode: "import",
+        deployment: CLAWHUB_TEST_DEPLOYMENT,
+      }),
+    );
+  });
+
+  it("streams an idempotent replacement while preserving feature-owned rows", async () => {
+    const workDir = join(tmpdir(), `ranking-import-${crypto.randomUUID()}`);
+    cleanupPaths.push(workDir);
+    const firstSnapshot = join(workDir, "first.zip");
+    const firstOutput = join(workDir, "first.jsonl");
+    const secondSnapshot = join(workDir, "second.zip");
+    const secondOutput = join(workDir, "second.jsonl");
+    await mkdir(workDir);
+    await writeFile(
+      firstSnapshot,
+      zipSync({
+        "skillDailyStats/documents.jsonl": encodeRows([
+          dailyRow("legacy", "snapshot-skill", 20_655, 1),
+          dailyRow("feature", "feature-skill", 20_655, 99),
+          dailyRow("sparse-stale", "snapshot-skill", 20_654, 8),
+          dailyRow("absent-stale", "snapshot-absent", 20_655, 6),
+          dailyRow("outside-window", "snapshot-absent", 20_596, 5),
+          {
+            ...dailyRow("prior-import", "snapshot-skill", 20_653, 7),
+            rankingDatasetVersion: "ranking-metrics-2026-07-09-v1",
+            rankingImportedAt: 2,
+          },
+        ]),
+      }),
+    );
+
+    const targets: ResolvedRankingMetricTarget[] = [
+      {
+        kind: "skill",
+        targetId: "snapshot-skill",
+        legacySnapshotTarget: true,
+        days: [
+          { day: 20_655, downloads: 10, installs: 4, bookmarks: 2 },
+          { day: 20_656, downloads: 12, installs: 5, bookmarks: 3 },
+        ],
+      },
+    ];
+    const input = {
+      table: "skillDailyStats" as const,
+      idField: "skillId" as const,
+      datasetVersion: "ranking-metrics-2026-07-23-v1",
+      importedAt: 3,
+      startDay: 20_597,
+      endDay: 20_656,
+      legacyTargetIds: new Set(["snapshot-skill", "snapshot-absent"]),
+      targets,
+    };
+
+    expect(
+      await mergeDailyTable({
+        ...input,
+        snapshot: firstSnapshot,
+        output: firstOutput,
+      }),
+    ).toEqual({ importedRows: 2 });
+    const firstRows = await readJsonLines(firstOutput);
+    expect(firstRows).toContainEqual(
+      expect.objectContaining({
+        _id: "feature",
+        _creationTime: 1,
+        skillId: "feature-skill",
+        day: 20_655,
+        downloads: 99,
+      }),
+    );
+    expect(firstRows).toContainEqual(
+      expect.objectContaining({
+        _id: "legacy",
+        _creationTime: 1,
+        skillId: "snapshot-skill",
+        day: 20_655,
+        rankingDatasetVersion: "ranking-metrics-2026-07-23-v1",
+      }),
+    );
+    expect(firstRows.find((row) => row.skillId === "feature-skill")).not.toHaveProperty(
+      "rankingDatasetVersion",
+    );
+    expect(firstRows).not.toContainEqual(expect.objectContaining({ _id: "prior-import" }));
+    expect(firstRows).not.toContainEqual(
+      expect.objectContaining({ skillId: "snapshot-skill", day: 20_654 }),
+    );
+    expect(firstRows).not.toContainEqual(
+      expect.objectContaining({ skillId: "snapshot-absent", day: 20_655 }),
+    );
+    expect(firstRows).toContainEqual(
+      expect.objectContaining({ skillId: "snapshot-absent", day: 20_596 }),
+    );
+
+    const persistedFirstRows = firstRows.map((row, index) => ({
+      ...row,
+      _id: row._id ?? `first-import-${index}`,
+      _creationTime: row._creationTime ?? 4,
+    }));
+    await writeFile(
+      secondSnapshot,
+      zipSync({
+        "skillDailyStats/documents.jsonl": encodeRows(persistedFirstRows),
+      }),
+    );
+    expect(
+      await mergeDailyTable({
+        ...input,
+        snapshot: secondSnapshot,
+        output: secondOutput,
+      }),
+    ).toEqual({ importedRows: 2 });
+
+    expect(sortRows(await readJsonLines(secondOutput))).toEqual(sortRows(persistedFirstRows));
+  });
+
+  it("can regenerate rollback table artifacts after a partial restore", async () => {
+    const workDir = join(tmpdir(), `ranking-rollback-${crypto.randomUUID()}`);
+    cleanupPaths.push(workDir);
+    await mkdir(workDir);
+    const snapshot = join(workDir, "backup.zip");
+    const output = join(workDir, "skillDailyStats.restore.jsonl");
+    await writeFile(
+      snapshot,
+      zipSync({
+        "skillDailyStats/documents.jsonl": encodeRows([
+          dailyRow("restore", "snapshot-skill", 20_655, 10),
+        ]),
+      }),
+    );
+
+    await copySnapshotTable(snapshot, "skillDailyStats", output);
+    await copySnapshotTable(snapshot, "skillDailyStats", output);
+
+    expect(await readJsonLines(output)).toEqual([
+      expect.objectContaining({
+        _id: "restore",
+        _creationTime: 1,
+        skillId: "snapshot-skill",
+        downloads: 10,
+      }),
+    ]);
+  });
+
+  it("fails closed when a target table changes after the backup snapshot", async () => {
+    const workDir = join(tmpdir(), `ranking-preflight-${crypto.randomUUID()}`);
+    cleanupPaths.push(workDir);
+    await mkdir(workDir);
+    const baseline = join(workDir, "baseline.zip");
+    const unchanged = join(workDir, "unchanged.zip");
+    const changed = join(workDir, "changed.zip");
+    const tables = {
+      "skillDailyStats/documents.jsonl": encodeRows([
+        dailyRow("skill-row", "snapshot-skill", 20_655, 10),
+      ]),
+      "packageDailyStats/documents.jsonl": encodeRows([]),
+      "rankingMetricImports/documents.jsonl": encodeRows([]),
+    };
+    await writeFile(baseline, zipSync(tables));
+    await writeFile(unchanged, zipSync(tables));
+    await writeFile(
+      changed,
+      zipSync({
+        ...tables,
+        "skillDailyStats/documents.jsonl": encodeRows([
+          dailyRow("skill-row", "snapshot-skill", 20_655, 11),
+        ]),
+      }),
+    );
+
+    await expect(assertRankingTablesUnchanged(baseline, unchanged)).resolves.toBeUndefined();
+    await expect(assertRankingTablesUnchanged(baseline, changed)).rejects.toThrow(
+      "skillDailyStats changed after the backup snapshot",
+    );
+  });
+});
+
+function dailyRow(id: string, skillId: string, day: number, downloads: number) {
+  return {
+    _id: id,
+    _creationTime: 1,
+    skillId,
+    day,
+    downloads,
+    installs: 0,
+    updatedAt: 1,
+  };
+}
+
+function encodeRows(rows: Record<string, unknown>[]) {
+  return new TextEncoder().encode(`${rows.map((row) => JSON.stringify(row)).join("\n")}\n`);
+}
+
+async function readJsonLines(path: string) {
+  return (await readFile(path, "utf8"))
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as Record<string, unknown>);
+}
+
+function sortRows(rows: Record<string, unknown>[]) {
+  return [...rows].sort(
+    (left, right) =>
+      String(left.skillId).localeCompare(String(right.skillId)) ||
+      Number(left.day) - Number(right.day),
+  );
+}

--- a/scripts/ranking-metrics/import-test-ranking-metrics.test.ts
+++ b/scripts/ranking-metrics/import-test-ranking-metrics.test.ts
@@ -173,7 +173,14 @@ describe("Test ranking metric command guard", () => {
           },
         ]),
         "publishers/documents.jsonl": encodeRows([]),
-        "skills/documents.jsonl": encodeRows([]),
+        "skills/documents.jsonl": encodeRows([
+          {
+            _id: "snapshot-skill",
+            _creationTime: 1,
+            ownerUserId: "snapshot-owner",
+            slug: "calendar-skill",
+          },
+        ]),
         "packages/documents.jsonl": encodeRows([
           {
             _id: "code-stable",
@@ -208,13 +215,33 @@ describe("Test ranking metric command guard", () => {
     expect(resolveTargets([target], current).targets).toEqual([
       expect.objectContaining({ kind: "package", targetId: "code-stable" }),
     ]);
+    expect(() => resolveTargets([{ ...target, createdAt: 2 }], current)).toThrow(
+      "package creation timestamp mismatch",
+    );
+    const skillTarget = {
+      kind: "skill" as const,
+      ownerHandle: "test-snapshot-user-0123456789ab",
+      slug: "calendar-skill",
+      createdAt: 1,
+      days: target.days,
+    };
+    expect(resolveTargets([skillTarget], current).targets).toEqual([
+      expect.objectContaining({ kind: "skill", targetId: "snapshot-skill" }),
+    ]);
+    expect(() => resolveTargets([{ ...skillTarget, createdAt: 2 }], current)).toThrow(
+      "skill creation timestamp mismatch",
+    );
     expect(() => resolveTargets([{ ...target, channel: "beta" }], current)).toThrow(
       "package identity mismatch",
     );
     const exactMatches = [...current.packagesByIdentity.values()].find(
       (matches) => matches[0]?.targetId === "code-stable",
     );
-    exactMatches?.push({ targetId: "duplicate-code-stable", legacySnapshotTarget: true });
+    exactMatches?.push({
+      targetId: "duplicate-code-stable",
+      legacySnapshotTarget: true,
+      createdAt: 1,
+    });
     expect(() => resolveTargets([target], current)).toThrow("ambiguous package identity");
   });
 
@@ -365,6 +392,10 @@ describe("Test ranking metric command guard", () => {
     const rekeyed = join(workDir, "rekeyed.zip");
     const changed = join(workDir, "changed.zip");
     const tables = {
+      "users/documents.jsonl": encodeRows([]),
+      "publishers/documents.jsonl": encodeRows([]),
+      "skills/documents.jsonl": encodeRows([]),
+      "packages/documents.jsonl": encodeRows([]),
       "skillDailyStats/documents.jsonl": encodeRows([
         dailyRow("skill-row", "snapshot-skill", 20_655, 10),
       ]),
@@ -391,10 +422,23 @@ describe("Test ranking metric command guard", () => {
         ]),
       }),
     );
+    const changedIdentity = join(workDir, "changed-identity.zip");
+    await writeFile(
+      changedIdentity,
+      zipSync({
+        ...tables,
+        "skills/documents.jsonl": encodeRows([
+          { _id: "replacement-skill", _creationTime: 2, slug: "renamed" },
+        ]),
+      }),
+    );
 
     await expect(assertRankingTablesUnchanged(baseline, unchanged)).resolves.toBeUndefined();
     await expect(assertRankingTablesUnchanged(baseline, changed)).rejects.toThrow(
       "skillDailyStats changed after the backup snapshot",
+    );
+    await expect(assertRankingTablesUnchanged(baseline, changedIdentity)).rejects.toThrow(
+      "skills changed after the backup snapshot",
     );
 
     const rollbackDigests = await rankingTableDigests(baseline);

--- a/scripts/ranking-metrics/import-test-ranking-metrics.ts
+++ b/scripts/ranking-metrics/import-test-ranking-metrics.ts
@@ -23,6 +23,13 @@ type DailyTable = "skillDailyStats" | "packageDailyStats";
 type DailyIdField = "skillId" | "packageId";
 const RANKING_TABLES = ["skillDailyStats", "packageDailyStats", "rankingMetricImports"] as const;
 type RankingTable = (typeof RANKING_TABLES)[number];
+const IMPORT_SOURCE_TABLES = [
+  "users",
+  "publishers",
+  "skills",
+  "packages",
+  ...RANKING_TABLES,
+] as const;
 const TEST_LANE_WORKFLOW_PATH = ".github/workflows/reserve-test.yml";
 const TEST_LANE_MAX_AGE_MS = 5 * 60 * 60 * 1_000;
 export type ResolvedRankingMetricTarget = {
@@ -31,7 +38,7 @@ export type ResolvedRankingMetricTarget = {
   legacySnapshotTarget: boolean;
   days: RankingMetricDay[];
 };
-type TargetMatch = { targetId: string; legacySnapshotTarget: boolean };
+type TargetMatch = { targetId: string; legacySnapshotTarget: boolean; createdAt: number | null };
 type PlannedTablePaths = {
   root: string;
   skillDailyStats: string;
@@ -224,7 +231,7 @@ export async function readCurrentTestMetadata(snapshot: string) {
   const publisherHandles = new Map(
     publishers.map((row) => [String(row._id), String(row.handle ?? "")]),
   );
-  const skillsByIdentity = new Map<string, { targetId: string; legacySnapshotTarget: boolean }>();
+  const skillsByIdentity = new Map<string, TargetMatch>();
   const legacySkillTargetIds = new Set<string>();
   for (const row of skills) {
     const ownerHandle =
@@ -233,7 +240,11 @@ export async function readCurrentTestMetadata(snapshot: string) {
     if (!ownerHandle || typeof row.slug !== "string") continue;
     const targetId = String(row._id);
     const legacySnapshotTarget = ownerHandle.startsWith("test-snapshot-");
-    skillsByIdentity.set(`${ownerHandle}/${row.slug}`, { targetId, legacySnapshotTarget });
+    skillsByIdentity.set(`${ownerHandle}/${row.slug}`, {
+      targetId,
+      legacySnapshotTarget,
+      createdAt: snapshotCreatedAt(row),
+    });
     if (legacySnapshotTarget) legacySkillTargetIds.add(targetId);
   }
   const packagesByIdentity = new Map<string, TargetMatch[]>();
@@ -246,7 +257,7 @@ export async function readCurrentTestMetadata(snapshot: string) {
     if (typeof row.normalizedName !== "string") continue;
     const targetId = String(row._id);
     const legacySnapshotTarget = ownerHandle?.startsWith("test-snapshot-") ?? false;
-    const match = { targetId, legacySnapshotTarget };
+    const match = { targetId, legacySnapshotTarget, createdAt: snapshotCreatedAt(row) };
     appendMapValue(packageCandidatesByName, row.normalizedName, match);
     if (
       (row.family === "code-plugin" || row.family === "bundle-plugin") &&
@@ -307,6 +318,13 @@ export function resolveTargets(
       unresolvedTargets += 1;
       continue;
     }
+    if (match.createdAt !== target.createdAt) {
+      const identity =
+        target.kind === "skill"
+          ? `skill creation timestamp mismatch: ${target.ownerHandle}/${target.slug}`
+          : `package creation timestamp mismatch: ${target.normalizedName}`;
+      throw new Error(identity);
+    }
     resolved.push({
       kind: target.kind,
       targetId: match.targetId,
@@ -315,6 +333,17 @@ export function resolveTargets(
     });
   }
   return { targets: resolved, unresolvedTargets };
+}
+
+function snapshotCreatedAt(row: Record<string, unknown>) {
+  const createdAt = row.createdAt;
+  if (typeof createdAt === "number" && Number.isSafeInteger(createdAt) && createdAt >= 0) {
+    return createdAt;
+  }
+  const creationTime = row._creationTime;
+  return typeof creationTime === "number" && Number.isFinite(creationTime) && creationTime >= 0
+    ? Math.floor(creationTime)
+    : null;
 }
 
 function packageIdentity(normalizedName: string, family: string, channel: string) {
@@ -591,7 +620,7 @@ async function importPlannedTables(
 }
 
 export async function assertRankingTablesUnchanged(baseline: string, current: string) {
-  for (const table of RANKING_TABLES) {
+  for (const table of IMPORT_SOURCE_TABLES) {
     const [baselineDigest, currentDigest] = await Promise.all([
       digestSnapshotTable(baseline, table),
       digestSnapshotTable(current, table),

--- a/scripts/ranking-metrics/import-test-ranking-metrics.ts
+++ b/scripts/ranking-metrics/import-test-ranking-metrics.ts
@@ -552,10 +552,12 @@ async function importPlannedTables(
   const archive = join(workDir, "ranking-tables.next.zip");
   createTableArchive(plannedRoot, archive);
   assertExclusiveTestLane(laneRunId, datasetVersion);
+  const expectedLogicalDigests = await rankingTableLogicalDigests(archive);
+  await recordRollbackSourceState(workDir, expectedLogicalDigests);
   importArchive(deployment, archive);
   const importedSnapshot = join(workDir, "test-after.zip");
   exportDeploymentSnapshot(deployment, importedSnapshot);
-  await recordRollbackSourceState(workDir, importedSnapshot);
+  await assertRankingTablesMatchLogicalDigests(importedSnapshot, expectedLogicalDigests);
   return importedSnapshot;
 }
 
@@ -594,10 +596,65 @@ export async function assertRankingTablesMatchDigests(
   }
 }
 
-async function recordRollbackSourceState(backupDir: string, snapshot: string) {
+export async function rankingTableLogicalDigests(snapshot: string) {
+  const entries = await Promise.all(
+    RANKING_TABLES.map(
+      async (table) => [table, await logicalDigestSnapshotTable(snapshot, table)] as const,
+    ),
+  );
+  return Object.fromEntries(entries) as Record<RankingTable, string>;
+}
+
+export async function assertRankingTablesMatchLogicalDigests(
+  snapshot: string,
+  expected: Partial<Record<RankingTable, unknown>>,
+) {
+  for (const table of RANKING_TABLES) {
+    if (typeof expected[table] !== "string") {
+      throw new Error(`Backup manifest is missing the ${table} rollback source digest`);
+    }
+    if ((await logicalDigestSnapshotTable(snapshot, table)) !== expected[table]) {
+      throw new Error(`${table} no longer matches the rollback source state`);
+    }
+  }
+}
+
+async function logicalDigestSnapshotTable(snapshot: string, table: RankingTable) {
+  // Convex assigns system IDs on import, so bind rollback to an order-independent logical multiset.
+  const mask = (1n << 256n) - 1n;
+  let count = 0;
+  let xor = 0n;
+  let sum = 0n;
+  for await (const row of readSnapshotTable(snapshot, table)) {
+    const { _id: _id, _creationTime: _creationTime, ...logicalRow } = row;
+    const rowHash = BigInt(
+      `0x${createHash("sha256").update(stableStringify(logicalRow)).digest("hex")}`,
+    );
+    count += 1;
+    xor ^= rowHash;
+    sum = (sum + rowHash) & mask;
+  }
+  return `${count}:${xor.toString(16).padStart(64, "0")}:${sum.toString(16).padStart(64, "0")}`;
+}
+
+function stableStringify(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(",")}]`;
+  if (isRecord(value)) {
+    return `{${Object.keys(value)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+async function recordRollbackSourceState(
+  backupDir: string,
+  expectedCurrentLogicalDigests: Record<RankingTable, string>,
+) {
   const manifestPath = join(backupDir, "backup-manifest.json");
   const manifest = JSON.parse(await readFile(manifestPath, "utf8")) as Record<string, unknown>;
-  manifest.expectedCurrentDigests = await rankingTableDigests(snapshot);
+  manifest.expectedCurrentLogicalDigests = expectedCurrentLogicalDigests;
   await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
 }
 
@@ -614,13 +671,13 @@ async function restoreBackup(backupDir: string, deployment: string, laneRunId: n
   const manifest = JSON.parse(await readFile(`${backupDir}/backup-manifest.json`, "utf8")) as {
     deployment?: unknown;
     datasetVersion?: unknown;
-    expectedCurrentDigests?: Partial<Record<RankingTable, unknown>>;
+    expectedCurrentLogicalDigests?: Partial<Record<RankingTable, unknown>>;
     snapshot?: unknown;
   };
   if (
     manifest.deployment !== CLAWHUB_TEST_DEPLOYMENT ||
     typeof manifest.datasetVersion !== "string" ||
-    !manifest.expectedCurrentDigests ||
+    !manifest.expectedCurrentLogicalDigests ||
     manifest.snapshot !== "test-before.zip"
   ) {
     throw new Error("Backup manifest is not for the permanent Test deployment");
@@ -637,7 +694,10 @@ async function restoreBackup(backupDir: string, deployment: string, laneRunId: n
     ]);
     const currentSnapshot = join(workDir, "test-current.zip");
     exportDeploymentSnapshot(deployment, currentSnapshot);
-    await assertRankingTablesMatchDigests(currentSnapshot, manifest.expectedCurrentDigests);
+    await assertRankingTablesMatchLogicalDigests(
+      currentSnapshot,
+      manifest.expectedCurrentLogicalDigests,
+    );
     const archive = join(workDir, "ranking-tables.rollback.zip");
     createTableArchive(planned.root, archive);
     assertExclusiveTestLane(laneRunId, manifest.datasetVersion);

--- a/scripts/ranking-metrics/import-test-ranking-metrics.ts
+++ b/scripts/ranking-metrics/import-test-ranking-metrics.ts
@@ -19,6 +19,8 @@ import {
 type Mode = "import" | "readback" | "cleanup" | "rollback";
 type DailyTable = "skillDailyStats" | "packageDailyStats";
 type DailyIdField = "skillId" | "packageId";
+const TEST_LANE_WORKFLOW_PATH = ".github/workflows/reserve-test.yml";
+const TEST_LANE_MAX_AGE_MS = 5 * 60 * 60 * 1_000;
 export type ResolvedRankingMetricTarget = {
   kind: "skill" | "package";
   targetId: string;
@@ -38,7 +40,7 @@ async function main() {
   assertTestDeployment(options.deployment);
 
   if (options.mode === "rollback") {
-    await restoreBackup(options.backupDir, options.deployment);
+    await restoreBackup(options.backupDir, options.deployment, options.laneRunId);
     return;
   }
   if (options.mode === "readback") {
@@ -50,17 +52,22 @@ async function main() {
   }
 
   const dataset = parseRankingDataset(await readFile(options.dataset, "utf8"));
+  assertExclusiveTestLane(options.laneRunId, dataset.datasetVersion);
   await assertEmptyDirectory(options.backupDir);
   await mkdir(options.backupDir, { recursive: true });
   const snapshot = `${options.backupDir}/test-before.zip`;
   exportDeploymentSnapshot(options.deployment, snapshot);
   const current = await readCurrentTestMetadata(snapshot);
-  await writeBackupManifest(options.backupDir, current.rankingMetricImports.length);
+  await writeBackupManifest(
+    options.backupDir,
+    current.rankingMetricImports.length,
+    dataset.datasetVersion,
+  );
 
   if (options.mode === "cleanup") {
-    await applyCleanup(current, dataset, options.deployment, options.backupDir);
+    await applyCleanup(current, dataset, options.deployment, options.backupDir, options.laneRunId);
   } else {
-    await applyImport(current, dataset, options.deployment, options.backupDir);
+    await applyImport(current, dataset, options.deployment, options.backupDir, options.laneRunId);
   }
 }
 
@@ -69,6 +76,7 @@ async function applyImport(
   dataset: RankingDataset,
   deployment: string,
   workDir: string,
+  laneRunId: number,
 ) {
   const resolved = resolveTargets(dataset.targets, current);
   const importedAt = Date.now();
@@ -116,7 +124,7 @@ async function applyImport(
   });
   await writeJsonLines(planned.rankingMetricImports, metadata);
 
-  await importPlannedTables(workDir, planned.root, deployment);
+  await importPlannedTables(workDir, planned.root, deployment, laneRunId, dataset.datasetVersion);
   const proof = await readback(deployment, dataset.datasetVersion);
   console.log(JSON.stringify({ ok: true, mode: "import", ...proof }, null, 2));
 }
@@ -126,6 +134,7 @@ async function applyCleanup(
   dataset: RankingDataset,
   deployment: string,
   workDir: string,
+  laneRunId: number,
 ) {
   const snapshot = `${workDir}/test-before.zip`;
   const planned = await createPlannedTablePaths(workDir);
@@ -142,7 +151,7 @@ async function applyCleanup(
     planned.rankingMetricImports,
     current.rankingMetricImports.filter((row) => row.datasetVersion !== dataset.datasetVersion),
   );
-  await importPlannedTables(workDir, planned.root, deployment);
+  await importPlannedTables(workDir, planned.root, deployment, laneRunId, dataset.datasetVersion);
   console.log(
     JSON.stringify(
       {
@@ -465,12 +474,17 @@ async function summarizeSnapshotTable(
   };
 }
 
-async function writeBackupManifest(backupDir: string, metadataRows: number) {
+async function writeBackupManifest(
+  backupDir: string,
+  metadataRows: number,
+  datasetVersion: string,
+) {
   await writeFile(
     `${backupDir}/backup-manifest.json`,
     `${JSON.stringify(
       {
         deployment: CLAWHUB_TEST_DEPLOYMENT,
+        datasetVersion,
         createdAt: new Date().toISOString(),
         snapshot: "test-before.zip",
         tables: {
@@ -501,13 +515,20 @@ async function createPlannedTablePaths(workDir: string): Promise<PlannedTablePat
   return paths;
 }
 
-async function importPlannedTables(workDir: string, plannedRoot: string, deployment: string) {
+async function importPlannedTables(
+  workDir: string,
+  plannedRoot: string,
+  deployment: string,
+  laneRunId: number,
+  datasetVersion: string,
+) {
   const baseline = `${workDir}/test-before.zip`;
   const preflight = `${workDir}/test-preflight.zip`;
   exportDeploymentSnapshot(deployment, preflight);
   await assertRankingTablesUnchanged(baseline, preflight);
   const archive = join(workDir, "ranking-tables.next.zip");
   createTableArchive(plannedRoot, archive);
+  assertExclusiveTestLane(laneRunId, datasetVersion);
   importArchive(deployment, archive);
 }
 
@@ -532,14 +553,20 @@ async function digestSnapshotTable(snapshot: string, table: string) {
   return digest.digest("hex");
 }
 
-async function restoreBackup(backupDir: string, deployment: string) {
+async function restoreBackup(backupDir: string, deployment: string, laneRunId: number) {
   const manifest = JSON.parse(await readFile(`${backupDir}/backup-manifest.json`, "utf8")) as {
     deployment?: unknown;
+    datasetVersion?: unknown;
     snapshot?: unknown;
   };
-  if (manifest.deployment !== CLAWHUB_TEST_DEPLOYMENT || manifest.snapshot !== "test-before.zip") {
+  if (
+    manifest.deployment !== CLAWHUB_TEST_DEPLOYMENT ||
+    typeof manifest.datasetVersion !== "string" ||
+    manifest.snapshot !== "test-before.zip"
+  ) {
     throw new Error("Backup manifest is not for the permanent Test deployment");
   }
+  assertExclusiveTestLane(laneRunId, manifest.datasetVersion);
   const snapshot = `${backupDir}/test-before.zip`;
   const workDir = await mkdtemp(`${tmpdir()}/clawhub-ranking-rollback-`);
   try {
@@ -551,6 +578,7 @@ async function restoreBackup(backupDir: string, deployment: string) {
     ]);
     const archive = join(workDir, "ranking-tables.rollback.zip");
     createTableArchive(planned.root, archive);
+    assertExclusiveTestLane(laneRunId, manifest.datasetVersion);
     importArchive(deployment, archive);
     console.log(JSON.stringify({ ok: true, mode: "rollback", deployment, backupDir }, null, 2));
   } finally {
@@ -573,6 +601,71 @@ export function buildConvexImportArchiveCommand(archive: string, deployment: str
     command: "bunx",
     args: ["convex", "import", "--deployment", deployment, "--replace", "--yes", archive],
   };
+}
+
+function assertExclusiveTestLane(runId: number, datasetVersion: string) {
+  const reservation = JSON.parse(
+    commandOutput("gh", ["api", `repos/openclaw/clawhub/actions/runs/${runId}`]),
+  ) as unknown;
+  const localSha = commandOutput("git", ["rev-parse", "HEAD"]);
+  const mainSha = commandOutput("gh", [
+    "api",
+    "repos/openclaw/clawhub/commits/main",
+    "--jq",
+    ".sha",
+  ]);
+  validateExclusiveTestLane({
+    reservation,
+    runId,
+    datasetVersion,
+    localSha,
+    mainSha,
+    now: Date.now(),
+  });
+}
+
+export function validateExclusiveTestLane(input: {
+  reservation: unknown;
+  runId: number;
+  datasetVersion: string;
+  localSha: string;
+  mainSha: string;
+  now: number;
+}) {
+  if (!isRecord(input.reservation)) {
+    throw new Error("Test lane reservation response is invalid");
+  }
+  const run = input.reservation;
+  if (
+    run.id !== input.runId ||
+    run.status !== "in_progress" ||
+    run.event !== "workflow_dispatch" ||
+    run.head_branch !== "main" ||
+    run.path !== TEST_LANE_WORKFLOW_PATH ||
+    run.display_title !== `Reserve Test for ${input.datasetVersion}`
+  ) {
+    throw new Error(`GitHub Actions run ${input.runId} is not actively holding the Test lane`);
+  }
+  if (run.head_sha !== input.localSha || run.head_sha !== input.mainSha) {
+    throw new Error("Test lane reservation, local checkout, and exact current main must match");
+  }
+  const startedAt = typeof run.run_started_at === "string" ? Date.parse(run.run_started_at) : NaN;
+  const ageMs = input.now - startedAt;
+  if (!Number.isFinite(startedAt) || ageMs < 0 || ageMs >= TEST_LANE_MAX_AGE_MS) {
+    throw new Error(`GitHub Actions run ${input.runId} is not actively holding a fresh Test lane`);
+  }
+}
+
+function commandOutput(command: string, args: string[]) {
+  const result = spawnSync(command, args, {
+    cwd: process.cwd(),
+    encoding: "utf8",
+    env: process.env,
+  });
+  if (result.status !== 0 || !result.stdout.trim()) {
+    throw new Error(`Failed to verify Test lane with ${command} ${args[0] ?? ""}`);
+  }
+  return result.stdout.trim();
 }
 
 function importArchive(deployment: string, archive: string) {
@@ -692,12 +785,17 @@ export function assertTestDeployment(deployment: string) {
   }
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 export function parseArgs(args: string[]) {
   let mode: Mode = "import";
   let deployment = CLAWHUB_TEST_DEPLOYMENT;
   let dataset = "";
   let datasetVersion = "";
   let backupDir = "";
+  let laneRunId = 0;
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index];
     if (arg === "--readback") mode = "readback";
@@ -712,10 +810,16 @@ export function parseArgs(args: string[]) {
       datasetVersion = arg.slice("--dataset-version=".length);
     } else if (arg === "--backup-dir") backupDir = args[++index] ?? "";
     else if (arg.startsWith("--backup-dir=")) backupDir = arg.slice("--backup-dir=".length);
-    else throw new Error(`Unknown argument: ${arg}`);
+    else if (arg === "--lane-run-id") laneRunId = Number(args[++index]);
+    else if (arg.startsWith("--lane-run-id=")) {
+      laneRunId = Number(arg.slice("--lane-run-id=".length));
+    } else throw new Error(`Unknown argument: ${arg}`);
   }
   assertTestDeployment(deployment);
   if (mode !== "readback" && !backupDir) throw new Error("--backup-dir is required");
+  if (mode !== "readback" && (!Number.isSafeInteger(laneRunId) || laneRunId <= 0)) {
+    throw new Error("--lane-run-id is required for mutating operations");
+  }
   if ((mode === "import" || mode === "cleanup") && !dataset)
     throw new Error("--dataset is required");
   if (mode === "rollback" && dataset) throw new Error("--dataset is not valid with --rollback");
@@ -725,6 +829,7 @@ export function parseArgs(args: string[]) {
     dataset: dataset ? resolve(dataset) : "",
     datasetVersion,
     backupDir: backupDir ? resolve(backupDir) : "",
+    laneRunId,
   };
 }
 

--- a/scripts/ranking-metrics/import-test-ranking-metrics.ts
+++ b/scripts/ranking-metrics/import-test-ranking-metrics.ts
@@ -5,10 +5,11 @@ import { once } from "node:events";
 import { createWriteStream, type WriteStream } from "node:fs";
 import { mkdir, mkdtemp, readFile, readdir, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { resolve } from "node:path";
+import { join, resolve } from "node:path";
 import { CLAWHUB_TEST_DEPLOYMENT } from "../seed-test";
 import { readSnapshotTable } from "../staging-seed/snapshotIo";
 import {
+  packageTargetIdentity,
   parseRankingDataset,
   type RankingDataset,
   type RankingMetricDay,
@@ -23,6 +24,13 @@ export type ResolvedRankingMetricTarget = {
   targetId: string;
   legacySnapshotTarget: boolean;
   days: RankingMetricDay[];
+};
+type TargetMatch = { targetId: string; legacySnapshotTarget: boolean };
+type PlannedTablePaths = {
+  root: string;
+  skillDailyStats: string;
+  packageDailyStats: string;
+  rankingMetricImports: string;
 };
 
 async function main() {
@@ -65,11 +73,12 @@ async function applyImport(
   const resolved = resolveTargets(dataset.targets, current);
   const importedAt = Date.now();
   const snapshot = `${workDir}/test-before.zip`;
+  const planned = await createPlannedTablePaths(workDir);
   const skillPlan = await mergeDailyTable({
     snapshot,
     table: "skillDailyStats",
     idField: "skillId",
-    output: `${workDir}/skillDailyStats.next.jsonl`,
+    output: planned.skillDailyStats,
     datasetVersion: dataset.datasetVersion,
     importedAt,
     startDay: dataset.startDay,
@@ -81,7 +90,7 @@ async function applyImport(
     snapshot,
     table: "packageDailyStats",
     idField: "packageId",
-    output: `${workDir}/packageDailyStats.next.jsonl`,
+    output: planned.packageDailyStats,
     datasetVersion: dataset.datasetVersion,
     importedAt,
     startDay: dataset.startDay,
@@ -89,27 +98,25 @@ async function applyImport(
     legacyTargetIds: current.legacyPackageTargetIds,
     targets: resolved.targets.filter((target) => target.kind === "package"),
   });
-  const metadata = [
-    {
-      datasetVersion: dataset.datasetVersion,
-      checksum: dataset.checksum,
-      generatedAt: dataset.generatedAt,
-      importedAt,
-      startDay: dataset.startDay,
-      endDay: dataset.endDay,
-      targetCount: dataset.counts.targets,
-      skillTargetCount: dataset.counts.skillTargets,
-      packageTargetCount: dataset.counts.packageTargets,
-      dailyRowCount: dataset.counts.dailyRows,
-      importedSkillRows: skillPlan.importedRows,
-      importedPackageRows: packagePlan.importedRows,
-      unresolvedTargets: resolved.unresolvedTargets,
-      skippedOverlayRows: 0,
-    },
-  ];
-  await writeJsonLines(`${workDir}/rankingMetricImports.next.jsonl`, metadata);
+  const metadata = mergeRankingMetricImportRows(current.rankingMetricImports, {
+    datasetVersion: dataset.datasetVersion,
+    checksum: dataset.checksum,
+    generatedAt: dataset.generatedAt,
+    importedAt,
+    startDay: dataset.startDay,
+    endDay: dataset.endDay,
+    targetCount: dataset.counts.targets,
+    skillTargetCount: dataset.counts.skillTargets,
+    packageTargetCount: dataset.counts.packageTargets,
+    dailyRowCount: dataset.counts.dailyRows,
+    importedSkillRows: skillPlan.importedRows,
+    importedPackageRows: packagePlan.importedRows,
+    unresolvedTargets: resolved.unresolvedTargets,
+    skippedOverlayRows: 0,
+  });
+  await writeJsonLines(planned.rankingMetricImports, metadata);
 
-  await importPlannedTables(workDir, deployment);
+  await importPlannedTables(workDir, planned.root, deployment);
   const proof = await readback(deployment, dataset.datasetVersion);
   console.log(JSON.stringify({ ok: true, mode: "import", ...proof }, null, 2));
 }
@@ -121,25 +128,21 @@ async function applyCleanup(
   workDir: string,
 ) {
   const snapshot = `${workDir}/test-before.zip`;
+  const planned = await createPlannedTablePaths(workDir);
   const [skill, packageRows] = await Promise.all([
-    filterDailyTable(
-      snapshot,
-      "skillDailyStats",
-      `${workDir}/skillDailyStats.next.jsonl`,
-      dataset.datasetVersion,
-    ),
+    filterDailyTable(snapshot, "skillDailyStats", planned.skillDailyStats, dataset.datasetVersion),
     filterDailyTable(
       snapshot,
       "packageDailyStats",
-      `${workDir}/packageDailyStats.next.jsonl`,
+      planned.packageDailyStats,
       dataset.datasetVersion,
     ),
   ]);
   await writeJsonLines(
-    `${workDir}/rankingMetricImports.next.jsonl`,
+    planned.rankingMetricImports,
     current.rankingMetricImports.filter((row) => row.datasetVersion !== dataset.datasetVersion),
   );
-  await importPlannedTables(workDir, deployment);
+  await importPlannedTables(workDir, planned.root, deployment);
   console.log(
     JSON.stringify(
       {
@@ -155,7 +158,7 @@ async function applyCleanup(
   );
 }
 
-async function readCurrentTestMetadata(snapshot: string) {
+export async function readCurrentTestMetadata(snapshot: string) {
   const [users, publishers, skills, packages, imports] = await Promise.all([
     collectSnapshotTable(snapshot, "users"),
     collectSnapshotTable(snapshot, "publishers"),
@@ -179,38 +182,73 @@ async function readCurrentTestMetadata(snapshot: string) {
     skillsByIdentity.set(`${ownerHandle}/${row.slug}`, { targetId, legacySnapshotTarget });
     if (legacySnapshotTarget) legacySkillTargetIds.add(targetId);
   }
-  const packagesByIdentity = new Map<string, { targetId: string; legacySnapshotTarget: boolean }>();
+  const packagesByIdentity = new Map<string, TargetMatch[]>();
+  const packageCandidatesByName = new Map<string, TargetMatch[]>();
   const legacyPackageTargetIds = new Set<string>();
   for (const row of packages) {
     const ownerHandle =
       publisherHandles.get(String(row.ownerPublisherId ?? "")) ??
       userHandles.get(String(row.ownerUserId ?? ""));
-    if (!ownerHandle || typeof row.normalizedName !== "string") continue;
+    if (typeof row.normalizedName !== "string") continue;
     const targetId = String(row._id);
-    const legacySnapshotTarget = ownerHandle.startsWith("test-snapshot-");
-    packagesByIdentity.set(row.normalizedName, { targetId, legacySnapshotTarget });
+    const legacySnapshotTarget = ownerHandle?.startsWith("test-snapshot-") ?? false;
+    const match = { targetId, legacySnapshotTarget };
+    appendMapValue(packageCandidatesByName, row.normalizedName, match);
+    if (
+      (row.family === "code-plugin" || row.family === "bundle-plugin") &&
+      typeof row.channel === "string"
+    ) {
+      appendMapValue(
+        packagesByIdentity,
+        packageIdentity(row.normalizedName, row.family, row.channel),
+        match,
+      );
+    }
     if (legacySnapshotTarget) legacyPackageTargetIds.add(targetId);
   }
   return {
     skillsByIdentity,
     packagesByIdentity,
+    packageCandidatesByName,
     legacySkillTargetIds,
     legacyPackageTargetIds,
     rankingMetricImports: imports,
   };
 }
 
-function resolveTargets(
+export function resolveTargets(
   targets: RankingMetricTarget[],
   current: Awaited<ReturnType<typeof readCurrentTestMetadata>>,
 ) {
   const resolved: ResolvedRankingMetricTarget[] = [];
   let unresolvedTargets = 0;
   for (const target of targets) {
-    const match =
-      target.kind === "skill"
-        ? current.skillsByIdentity.get(`${target.ownerHandle}/${target.slug}`)
-        : current.packagesByIdentity.get(target.normalizedName);
+    const match = (() => {
+      if (target.kind === "skill") {
+        return current.skillsByIdentity.get(`${target.ownerHandle}/${target.slug}`);
+      }
+      const matches =
+        current.packagesByIdentity.get(
+          packageIdentity(target.normalizedName, target.family, target.channel),
+        ) ?? [];
+      if (matches.length > 1) {
+        throw new Error(
+          `ambiguous package identity: ${target.normalizedName} (${target.family}/${target.channel})`,
+        );
+      }
+      if (matches.length === 0 && current.packageCandidatesByName.has(target.normalizedName)) {
+        throw new Error(
+          `package identity mismatch: ${target.normalizedName} (${target.family}/${target.channel})`,
+        );
+      }
+      const exact = matches[0];
+      if (exact && !exact.legacySnapshotTarget) {
+        throw new Error(
+          `package identity mismatch: ${target.normalizedName} is not a Test snapshot target`,
+        );
+      }
+      return exact;
+    })();
     if (!match?.legacySnapshotTarget) {
       unresolvedTargets += 1;
       continue;
@@ -223,6 +261,16 @@ function resolveTargets(
     });
   }
   return { targets: resolved, unresolvedTargets };
+}
+
+function packageIdentity(normalizedName: string, family: string, channel: string) {
+  return packageTargetIdentity(normalizedName, family, channel);
+}
+
+function appendMapValue<Key, Value>(map: Map<Key, Value[]>, key: Key, value: Value) {
+  const values = map.get(key);
+  if (values) values.push(value);
+  else map.set(key, [value]);
 }
 
 export async function mergeDailyTable(input: {
@@ -437,19 +485,30 @@ async function writeBackupManifest(backupDir: string, metadataRows: number) {
   );
 }
 
-async function importPlannedTables(workDir: string, deployment: string) {
+async function createPlannedTablePaths(workDir: string): Promise<PlannedTablePaths> {
+  const root = join(workDir, "planned-ranking-tables");
+  const paths = {
+    root,
+    skillDailyStats: join(root, "skillDailyStats", "documents.jsonl"),
+    packageDailyStats: join(root, "packageDailyStats", "documents.jsonl"),
+    rankingMetricImports: join(root, "rankingMetricImports", "documents.jsonl"),
+  };
+  await Promise.all([
+    mkdir(join(root, "skillDailyStats"), { recursive: true }),
+    mkdir(join(root, "packageDailyStats"), { recursive: true }),
+    mkdir(join(root, "rankingMetricImports"), { recursive: true }),
+  ]);
+  return paths;
+}
+
+async function importPlannedTables(workDir: string, plannedRoot: string, deployment: string) {
   const baseline = `${workDir}/test-before.zip`;
   const preflight = `${workDir}/test-preflight.zip`;
   exportDeploymentSnapshot(deployment, preflight);
   await assertRankingTablesUnchanged(baseline, preflight);
-  try {
-    importTable(deployment, "skillDailyStats", `${workDir}/skillDailyStats.next.jsonl`);
-    importTable(deployment, "packageDailyStats", `${workDir}/packageDailyStats.next.jsonl`);
-    importTable(deployment, "rankingMetricImports", `${workDir}/rankingMetricImports.next.jsonl`);
-  } catch (error) {
-    await restoreBackup(workDir, deployment);
-    throw error;
-  }
+  const archive = join(workDir, "ranking-tables.next.zip");
+  createTableArchive(plannedRoot, archive);
+  importArchive(deployment, archive);
 }
 
 export async function assertRankingTablesUnchanged(baseline: string, current: string) {
@@ -482,49 +541,48 @@ async function restoreBackup(backupDir: string, deployment: string) {
     throw new Error("Backup manifest is not for the permanent Test deployment");
   }
   const snapshot = `${backupDir}/test-before.zip`;
-  await Promise.all([
-    copySnapshotTable(snapshot, "skillDailyStats", `${backupDir}/skillDailyStats.restore.jsonl`),
-    copySnapshotTable(
-      snapshot,
-      "packageDailyStats",
-      `${backupDir}/packageDailyStats.restore.jsonl`,
-    ),
-    copySnapshotTable(
-      snapshot,
-      "rankingMetricImports",
-      `${backupDir}/rankingMetricImports.restore.jsonl`,
-    ),
-  ]);
-  importTable(deployment, "skillDailyStats", `${backupDir}/skillDailyStats.restore.jsonl`);
-  importTable(deployment, "packageDailyStats", `${backupDir}/packageDailyStats.restore.jsonl`);
-  importTable(
-    deployment,
-    "rankingMetricImports",
-    `${backupDir}/rankingMetricImports.restore.jsonl`,
-  );
-  console.log(JSON.stringify({ ok: true, mode: "rollback", deployment, backupDir }, null, 2));
+  const workDir = await mkdtemp(`${tmpdir()}/clawhub-ranking-rollback-`);
+  try {
+    const planned = await createPlannedTablePaths(workDir);
+    await Promise.all([
+      copySnapshotTable(snapshot, "skillDailyStats", planned.skillDailyStats),
+      copySnapshotTable(snapshot, "packageDailyStats", planned.packageDailyStats),
+      copySnapshotTable(snapshot, "rankingMetricImports", planned.rankingMetricImports),
+    ]);
+    const archive = join(workDir, "ranking-tables.rollback.zip");
+    createTableArchive(planned.root, archive);
+    importArchive(deployment, archive);
+    console.log(JSON.stringify({ ok: true, mode: "rollback", deployment, backupDir }, null, 2));
+  } finally {
+    await rm(workDir, { recursive: true, force: true });
+  }
 }
 
-function importTable(deployment: string, table: string, file: string) {
+function createTableArchive(root: string, archive: string) {
+  const result = spawnSync("zip", ["-q", "-r", archive, "."], {
+    cwd: root,
+    env: process.env,
+    stdio: "inherit",
+  });
+  if (result.status !== 0) throw new Error("Failed to create ranking table import archive");
+}
+
+export function buildConvexImportArchiveCommand(archive: string, deployment: string) {
   assertTestDeployment(deployment);
-  const result = spawnSync(
-    "bunx",
-    [
-      "convex",
-      "import",
-      "--deployment",
-      deployment,
-      "--table",
-      table,
-      "--replace",
-      "--yes",
-      "--format",
-      "jsonLines",
-      file,
-    ],
-    { cwd: process.cwd(), env: process.env, stdio: "inherit" },
-  );
-  if (result.status !== 0) throw new Error(`Failed to import Test table ${table}`);
+  return {
+    command: "bunx",
+    args: ["convex", "import", "--deployment", deployment, "--replace", "--yes", archive],
+  };
+}
+
+function importArchive(deployment: string, archive: string) {
+  const step = buildConvexImportArchiveCommand(archive, deployment);
+  const result = spawnSync(step.command, step.args, {
+    cwd: process.cwd(),
+    env: process.env,
+    stdio: "inherit",
+  });
+  if (result.status !== 0) throw new Error("Failed to atomically import Test ranking tables");
 }
 
 function exportDeploymentSnapshot(deployment: string, path: string) {
@@ -581,6 +639,24 @@ function systemFields(row: Record<string, unknown>) {
     ...(typeof row._id === "string" ? { _id: row._id } : {}),
     ...(typeof row._creationTime === "number" ? { _creationTime: row._creationTime } : {}),
   };
+}
+
+export function mergeRankingMetricImportRows(
+  current: Record<string, unknown>[],
+  next: Record<string, unknown>,
+) {
+  const datasetVersion = next.datasetVersion;
+  let replaced = false;
+  const rows = current.map((row) => {
+    if (row.datasetVersion !== datasetVersion) return row;
+    if (replaced) {
+      throw new Error(`duplicate ranking import provenance for ${String(datasetVersion)}`);
+    }
+    replaced = true;
+    return { ...next, ...systemFields(row) };
+  });
+  if (!replaced) rows.push(next);
+  return rows;
 }
 
 async function writeJsonLines(path: string, rows: Record<string, unknown>[]) {

--- a/scripts/ranking-metrics/import-test-ranking-metrics.ts
+++ b/scripts/ranking-metrics/import-test-ranking-metrics.ts
@@ -6,6 +6,8 @@ import { createWriteStream, type WriteStream } from "node:fs";
 import { mkdir, mkdtemp, readFile, readdir, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+import { RANKING_METRICS_IMPORT_LOCK_ENV } from "../../convex/lib/rankingMetricsImportLock";
 import { CLAWHUB_TEST_DEPLOYMENT } from "../seed-test";
 import { readSnapshotTable } from "../staging-seed/snapshotIo";
 import {
@@ -54,23 +56,43 @@ async function main() {
   }
 
   const dataset = parseRankingDataset(await readFile(options.dataset, "utf8"));
-  assertExclusiveTestLane(options.laneRunId, dataset.datasetVersion);
-  await assertEmptyDirectory(options.backupDir);
-  await mkdir(options.backupDir, { recursive: true });
-  const snapshot = `${options.backupDir}/test-before.zip`;
-  exportDeploymentSnapshot(options.deployment, snapshot);
-  const current = await readCurrentTestMetadata(snapshot);
-  await writeBackupManifest(
-    options.backupDir,
-    current.rankingMetricImports.length,
+  await withRankingMetricsWriteLock(
+    options.deployment,
+    options.laneRunId,
     dataset.datasetVersion,
-  );
+    async (lockValue) => {
+      await assertEmptyDirectory(options.backupDir);
+      await mkdir(options.backupDir, { recursive: true });
+      const snapshot = `${options.backupDir}/test-before.zip`;
+      exportDeploymentSnapshot(options.deployment, snapshot);
+      const current = await readCurrentTestMetadata(snapshot);
+      await writeBackupManifest(
+        options.backupDir,
+        current.rankingMetricImports.length,
+        dataset.datasetVersion,
+      );
 
-  if (options.mode === "cleanup") {
-    await applyCleanup(current, dataset, options.deployment, options.backupDir, options.laneRunId);
-  } else {
-    await applyImport(current, dataset, options.deployment, options.backupDir, options.laneRunId);
-  }
+      if (options.mode === "cleanup") {
+        await applyCleanup(
+          current,
+          dataset,
+          options.deployment,
+          options.backupDir,
+          options.laneRunId,
+          lockValue,
+        );
+      } else {
+        await applyImport(
+          current,
+          dataset,
+          options.deployment,
+          options.backupDir,
+          options.laneRunId,
+          lockValue,
+        );
+      }
+    },
+  );
 }
 
 async function applyImport(
@@ -79,6 +101,7 @@ async function applyImport(
   deployment: string,
   workDir: string,
   laneRunId: number,
+  lockValue: string,
 ) {
   const resolved = resolveTargets(dataset.targets, current);
   const importedAt = Date.now();
@@ -132,6 +155,7 @@ async function applyImport(
     deployment,
     laneRunId,
     dataset.datasetVersion,
+    lockValue,
   );
   const proof = await readbackSnapshot(
     deployment,
@@ -147,6 +171,7 @@ async function applyCleanup(
   deployment: string,
   workDir: string,
   laneRunId: number,
+  lockValue: string,
 ) {
   const snapshot = `${workDir}/test-before.zip`;
   const planned = await createPlannedTablePaths(workDir);
@@ -169,6 +194,7 @@ async function applyCleanup(
     deployment,
     laneRunId,
     dataset.datasetVersion,
+    lockValue,
   );
   await rm(cleanedSnapshot, { force: true });
   console.log(
@@ -544,7 +570,9 @@ async function importPlannedTables(
   deployment: string,
   laneRunId: number,
   datasetVersion: string,
+  lockValue: string,
 ) {
+  assertTestRankingWriteLock(deployment, lockValue);
   const baseline = `${workDir}/test-before.zip`;
   const preflight = `${workDir}/test-preflight.zip`;
   exportDeploymentSnapshot(deployment, preflight);
@@ -552,6 +580,7 @@ async function importPlannedTables(
   const archive = join(workDir, "ranking-tables.next.zip");
   createTableArchive(plannedRoot, archive);
   assertExclusiveTestLane(laneRunId, datasetVersion);
+  assertTestRankingWriteLock(deployment, lockValue);
   const expectedLogicalDigests = await rankingTableLogicalDigests(archive);
   await recordRollbackSourceState(workDir, expectedLogicalDigests);
   importArchive(deployment, archive);
@@ -682,30 +711,32 @@ async function restoreBackup(backupDir: string, deployment: string, laneRunId: n
   ) {
     throw new Error("Backup manifest is not for the permanent Test deployment");
   }
-  assertExclusiveTestLane(laneRunId, manifest.datasetVersion);
-  const snapshot = `${backupDir}/test-before.zip`;
-  const workDir = await mkdtemp(`${tmpdir()}/clawhub-ranking-rollback-`);
-  try {
-    const planned = await createPlannedTablePaths(workDir);
-    await Promise.all([
-      copySnapshotTable(snapshot, "skillDailyStats", planned.skillDailyStats),
-      copySnapshotTable(snapshot, "packageDailyStats", planned.packageDailyStats),
-      copySnapshotTable(snapshot, "rankingMetricImports", planned.rankingMetricImports),
-    ]);
-    const currentSnapshot = join(workDir, "test-current.zip");
-    exportDeploymentSnapshot(deployment, currentSnapshot);
-    await assertRankingTablesMatchLogicalDigests(
-      currentSnapshot,
-      manifest.expectedCurrentLogicalDigests,
-    );
-    const archive = join(workDir, "ranking-tables.rollback.zip");
-    createTableArchive(planned.root, archive);
-    assertExclusiveTestLane(laneRunId, manifest.datasetVersion);
-    importArchive(deployment, archive);
-    console.log(JSON.stringify({ ok: true, mode: "rollback", deployment, backupDir }, null, 2));
-  } finally {
-    await rm(workDir, { recursive: true, force: true });
-  }
+  const datasetVersion = manifest.datasetVersion;
+  const expectedCurrentLogicalDigests = manifest.expectedCurrentLogicalDigests;
+  await withRankingMetricsWriteLock(deployment, laneRunId, datasetVersion, async (lockValue) => {
+    const snapshot = `${backupDir}/test-before.zip`;
+    const workDir = await mkdtemp(`${tmpdir()}/clawhub-ranking-rollback-`);
+    try {
+      const planned = await createPlannedTablePaths(workDir);
+      await Promise.all([
+        copySnapshotTable(snapshot, "skillDailyStats", planned.skillDailyStats),
+        copySnapshotTable(snapshot, "packageDailyStats", planned.packageDailyStats),
+        copySnapshotTable(snapshot, "rankingMetricImports", planned.rankingMetricImports),
+      ]);
+      assertTestRankingWriteLock(deployment, lockValue);
+      const currentSnapshot = join(workDir, "test-current.zip");
+      exportDeploymentSnapshot(deployment, currentSnapshot);
+      await assertRankingTablesMatchLogicalDigests(currentSnapshot, expectedCurrentLogicalDigests);
+      const archive = join(workDir, "ranking-tables.rollback.zip");
+      createTableArchive(planned.root, archive);
+      assertExclusiveTestLane(laneRunId, datasetVersion);
+      assertTestRankingWriteLock(deployment, lockValue);
+      importArchive(deployment, archive);
+      console.log(JSON.stringify({ ok: true, mode: "rollback", deployment, backupDir }, null, 2));
+    } finally {
+      await rm(workDir, { recursive: true, force: true });
+    }
+  });
 }
 
 function createTableArchive(root: string, archive: string) {
@@ -744,6 +775,79 @@ function assertExclusiveTestLane(runId: number, datasetVersion: string) {
     mainSha,
     now: Date.now(),
   });
+}
+
+async function withRankingMetricsWriteLock<Result>(
+  deployment: string,
+  laneRunId: number,
+  datasetVersion: string,
+  operation: (lockValue: string) => Promise<Result>,
+) {
+  assertTestDeployment(deployment);
+  assertExclusiveTestLane(laneRunId, datasetVersion);
+  const existing = readTestRankingWriteLock(deployment);
+  if (existing && !isExpiredRankingWriteLock(existing)) {
+    throw new Error("The permanent Test ranking metric write lock is already active");
+  }
+  const lockValue = `${datasetVersion}:${laneRunId}:${Date.now() + 6 * 60 * 60 * 1_000}`;
+  runConvexEnvCommand(deployment, ["set", RANKING_METRICS_IMPORT_LOCK_ENV, lockValue]);
+  try {
+    await delay(5_000);
+    assertExclusiveTestLane(laneRunId, datasetVersion);
+    assertTestRankingWriteLock(deployment, lockValue);
+    return await operation(lockValue);
+  } finally {
+    const current = readTestRankingWriteLock(deployment);
+    if (current !== lockValue) {
+      throw new Error("Refusing to clear a Test ranking metric write lock owned by another run");
+    }
+    runConvexEnvCommand(deployment, ["remove", RANKING_METRICS_IMPORT_LOCK_ENV]);
+  }
+}
+
+function assertTestRankingWriteLock(deployment: string, expected: string) {
+  const current = readTestRankingWriteLock(deployment);
+  const expiresAt = Number(expected.split(":").at(-1));
+  if (
+    current !== expected ||
+    !Number.isSafeInteger(expiresAt) ||
+    expiresAt - Date.now() < 30 * 60_000
+  ) {
+    throw new Error("The permanent Test ranking metric write lock is not safely active");
+  }
+}
+
+function isExpiredRankingWriteLock(value: string) {
+  const expiresAt = Number(value.split(":").at(-1));
+  return Number.isSafeInteger(expiresAt) && expiresAt <= Date.now();
+}
+
+function readTestRankingWriteLock(deployment: string) {
+  const result = spawnSync(
+    "bunx",
+    ["convex", "env", "get", RANKING_METRICS_IMPORT_LOCK_ENV, "--deployment", deployment],
+    { cwd: process.cwd(), encoding: "utf8", env: process.env },
+  );
+  const output = `${result.stdout ?? ""}\n${result.stderr ?? ""}`.trim();
+  if (output.includes(`Environment variable "${RANKING_METRICS_IMPORT_LOCK_ENV}" not found`)) {
+    return "";
+  }
+  if (result.status !== 0 || !result.stdout.trim()) {
+    throw new Error("Failed to read the permanent Test ranking metric write lock");
+  }
+  return result.stdout.trim();
+}
+
+function runConvexEnvCommand(deployment: string, args: string[]) {
+  assertTestDeployment(deployment);
+  const result = spawnSync("bunx", ["convex", "env", ...args, "--deployment", deployment], {
+    cwd: process.cwd(),
+    env: process.env,
+    stdio: "ignore",
+  });
+  if (result.status !== 0) {
+    throw new Error("Failed to update the permanent Test ranking metric write lock");
+  }
 }
 
 export function validateExclusiveTestLane(input: {

--- a/scripts/ranking-metrics/import-test-ranking-metrics.ts
+++ b/scripts/ranking-metrics/import-test-ranking-metrics.ts
@@ -19,6 +19,8 @@ import {
 type Mode = "import" | "readback" | "cleanup" | "rollback";
 type DailyTable = "skillDailyStats" | "packageDailyStats";
 type DailyIdField = "skillId" | "packageId";
+const RANKING_TABLES = ["skillDailyStats", "packageDailyStats", "rankingMetricImports"] as const;
+type RankingTable = (typeof RANKING_TABLES)[number];
 const TEST_LANE_WORKFLOW_PATH = ".github/workflows/reserve-test.yml";
 const TEST_LANE_MAX_AGE_MS = 5 * 60 * 60 * 1_000;
 export type ResolvedRankingMetricTarget = {
@@ -124,8 +126,18 @@ async function applyImport(
   });
   await writeJsonLines(planned.rankingMetricImports, metadata);
 
-  await importPlannedTables(workDir, planned.root, deployment, laneRunId, dataset.datasetVersion);
-  const proof = await readback(deployment, dataset.datasetVersion);
+  const importedSnapshot = await importPlannedTables(
+    workDir,
+    planned.root,
+    deployment,
+    laneRunId,
+    dataset.datasetVersion,
+  );
+  const proof = await readbackSnapshot(
+    deployment,
+    importedSnapshot,
+    dataset.datasetVersion,
+  ).finally(() => rm(importedSnapshot, { force: true }));
   console.log(JSON.stringify({ ok: true, mode: "import", ...proof }, null, 2));
 }
 
@@ -151,7 +163,14 @@ async function applyCleanup(
     planned.rankingMetricImports,
     current.rankingMetricImports.filter((row) => row.datasetVersion !== dataset.datasetVersion),
   );
-  await importPlannedTables(workDir, planned.root, deployment, laneRunId, dataset.datasetVersion);
+  const cleanedSnapshot = await importPlannedTables(
+    workDir,
+    planned.root,
+    deployment,
+    laneRunId,
+    dataset.datasetVersion,
+  );
+  await rm(cleanedSnapshot, { force: true });
   console.log(
     JSON.stringify(
       {
@@ -380,53 +399,57 @@ async function readback(deployment: string, datasetVersion: string) {
   const snapshot = `${workDir}/test-readback.zip`;
   try {
     exportDeploymentSnapshot(deployment, snapshot);
-    const imports = await collectSnapshotTable(snapshot, "rankingMetricImports");
-    const metadata = imports.find((row) => row.datasetVersion === datasetVersion);
-    if (!metadata) throw new Error(`No Test import metadata found for ${datasetVersion}`);
-    const startDay = Number(metadata.startDay);
-    const endDay = Number(metadata.endDay);
-    const [skill, packageRows] = await Promise.all([
-      summarizeSnapshotTable(
-        snapshot,
-        "skillDailyStats",
-        "skillId",
-        datasetVersion,
-        startDay,
-        endDay,
-      ),
-      summarizeSnapshotTable(
-        snapshot,
-        "packageDailyStats",
-        "packageId",
-        datasetVersion,
-        startDay,
-        endDay,
-      ),
-    ]);
-    return {
-      deployment,
-      datasetVersion,
-      checksum: metadata.checksum,
-      generatedAt: metadata.generatedAt,
-      importedAt: metadata.importedAt,
-      declared: {
-        targets: metadata.targetCount,
-        skillTargets: metadata.skillTargetCount,
-        packageTargets: metadata.packageTargetCount,
-        dailyRows: metadata.dailyRowCount,
-        startDay,
-        endDay,
-      },
-      imported: {
-        skill,
-        package: packageRows,
-        unresolvedTargets: metadata.unresolvedTargets,
-        skippedOverlayRows: metadata.skippedOverlayRows,
-      },
-    };
+    return await readbackSnapshot(deployment, snapshot, datasetVersion);
   } finally {
     await rm(workDir, { recursive: true, force: true });
   }
+}
+
+async function readbackSnapshot(deployment: string, snapshot: string, datasetVersion: string) {
+  const imports = await collectSnapshotTable(snapshot, "rankingMetricImports");
+  const metadata = imports.find((row) => row.datasetVersion === datasetVersion);
+  if (!metadata) throw new Error(`No Test import metadata found for ${datasetVersion}`);
+  const startDay = Number(metadata.startDay);
+  const endDay = Number(metadata.endDay);
+  const [skill, packageRows] = await Promise.all([
+    summarizeSnapshotTable(
+      snapshot,
+      "skillDailyStats",
+      "skillId",
+      datasetVersion,
+      startDay,
+      endDay,
+    ),
+    summarizeSnapshotTable(
+      snapshot,
+      "packageDailyStats",
+      "packageId",
+      datasetVersion,
+      startDay,
+      endDay,
+    ),
+  ]);
+  return {
+    deployment,
+    datasetVersion,
+    checksum: metadata.checksum,
+    generatedAt: metadata.generatedAt,
+    importedAt: metadata.importedAt,
+    declared: {
+      targets: metadata.targetCount,
+      skillTargets: metadata.skillTargetCount,
+      packageTargets: metadata.packageTargetCount,
+      dailyRows: metadata.dailyRowCount,
+      startDay,
+      endDay,
+    },
+    imported: {
+      skill,
+      package: packageRows,
+      unresolvedTargets: metadata.unresolvedTargets,
+      skippedOverlayRows: metadata.skippedOverlayRows,
+    },
+  };
 }
 
 async function summarizeSnapshotTable(
@@ -530,10 +553,14 @@ async function importPlannedTables(
   createTableArchive(plannedRoot, archive);
   assertExclusiveTestLane(laneRunId, datasetVersion);
   importArchive(deployment, archive);
+  const importedSnapshot = join(workDir, "test-after.zip");
+  exportDeploymentSnapshot(deployment, importedSnapshot);
+  await recordRollbackSourceState(workDir, importedSnapshot);
+  return importedSnapshot;
 }
 
 export async function assertRankingTablesUnchanged(baseline: string, current: string) {
-  for (const table of ["skillDailyStats", "packageDailyStats", "rankingMetricImports"] as const) {
+  for (const table of RANKING_TABLES) {
     const [baselineDigest, currentDigest] = await Promise.all([
       digestSnapshotTable(baseline, table),
       digestSnapshotTable(current, table),
@@ -542,6 +569,36 @@ export async function assertRankingTablesUnchanged(baseline: string, current: st
       throw new Error(`${table} changed after the backup snapshot; aborting before import`);
     }
   }
+}
+
+export async function rankingTableDigests(snapshot: string) {
+  const entries = await Promise.all(
+    RANKING_TABLES.map(
+      async (table) => [table, await digestSnapshotTable(snapshot, table)] as const,
+    ),
+  );
+  return Object.fromEntries(entries) as Record<RankingTable, string>;
+}
+
+export async function assertRankingTablesMatchDigests(
+  snapshot: string,
+  expected: Partial<Record<RankingTable, unknown>>,
+) {
+  for (const table of RANKING_TABLES) {
+    if (typeof expected[table] !== "string") {
+      throw new Error(`Backup manifest is missing the ${table} rollback source digest`);
+    }
+    if ((await digestSnapshotTable(snapshot, table)) !== expected[table]) {
+      throw new Error(`${table} no longer matches the rollback source state`);
+    }
+  }
+}
+
+async function recordRollbackSourceState(backupDir: string, snapshot: string) {
+  const manifestPath = join(backupDir, "backup-manifest.json");
+  const manifest = JSON.parse(await readFile(manifestPath, "utf8")) as Record<string, unknown>;
+  manifest.expectedCurrentDigests = await rankingTableDigests(snapshot);
+  await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
 }
 
 async function digestSnapshotTable(snapshot: string, table: string) {
@@ -557,11 +614,13 @@ async function restoreBackup(backupDir: string, deployment: string, laneRunId: n
   const manifest = JSON.parse(await readFile(`${backupDir}/backup-manifest.json`, "utf8")) as {
     deployment?: unknown;
     datasetVersion?: unknown;
+    expectedCurrentDigests?: Partial<Record<RankingTable, unknown>>;
     snapshot?: unknown;
   };
   if (
     manifest.deployment !== CLAWHUB_TEST_DEPLOYMENT ||
     typeof manifest.datasetVersion !== "string" ||
+    !manifest.expectedCurrentDigests ||
     manifest.snapshot !== "test-before.zip"
   ) {
     throw new Error("Backup manifest is not for the permanent Test deployment");
@@ -576,6 +635,9 @@ async function restoreBackup(backupDir: string, deployment: string, laneRunId: n
       copySnapshotTable(snapshot, "packageDailyStats", planned.packageDailyStats),
       copySnapshotTable(snapshot, "rankingMetricImports", planned.rankingMetricImports),
     ]);
+    const currentSnapshot = join(workDir, "test-current.zip");
+    exportDeploymentSnapshot(deployment, currentSnapshot);
+    await assertRankingTablesMatchDigests(currentSnapshot, manifest.expectedCurrentDigests);
     const archive = join(workDir, "ranking-tables.rollback.zip");
     createTableArchive(planned.root, archive);
     assertExclusiveTestLane(laneRunId, manifest.datasetVersion);

--- a/scripts/ranking-metrics/import-test-ranking-metrics.ts
+++ b/scripts/ranking-metrics/import-test-ranking-metrics.ts
@@ -1,0 +1,660 @@
+#!/usr/bin/env bun
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { once } from "node:events";
+import { createWriteStream, type WriteStream } from "node:fs";
+import { mkdir, mkdtemp, readFile, readdir, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import { CLAWHUB_TEST_DEPLOYMENT } from "../seed-test";
+import { readSnapshotTable } from "../staging-seed/snapshotIo";
+import {
+  parseRankingDataset,
+  type RankingDataset,
+  type RankingMetricDay,
+  type RankingMetricTarget,
+} from "./rankingDataset";
+
+type Mode = "import" | "readback" | "cleanup" | "rollback";
+type DailyTable = "skillDailyStats" | "packageDailyStats";
+type DailyIdField = "skillId" | "packageId";
+export type ResolvedRankingMetricTarget = {
+  kind: "skill" | "package";
+  targetId: string;
+  legacySnapshotTarget: boolean;
+  days: RankingMetricDay[];
+};
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  assertTestDeployment(options.deployment);
+
+  if (options.mode === "rollback") {
+    await restoreBackup(options.backupDir, options.deployment);
+    return;
+  }
+  if (options.mode === "readback") {
+    if (!options.datasetVersion) throw new Error("--dataset-version is required for readback");
+    console.log(
+      JSON.stringify(await readback(options.deployment, options.datasetVersion), null, 2),
+    );
+    return;
+  }
+
+  const dataset = parseRankingDataset(await readFile(options.dataset, "utf8"));
+  await assertEmptyDirectory(options.backupDir);
+  await mkdir(options.backupDir, { recursive: true });
+  const snapshot = `${options.backupDir}/test-before.zip`;
+  exportDeploymentSnapshot(options.deployment, snapshot);
+  const current = await readCurrentTestMetadata(snapshot);
+  await writeBackupManifest(options.backupDir, current.rankingMetricImports.length);
+
+  if (options.mode === "cleanup") {
+    await applyCleanup(current, dataset, options.deployment, options.backupDir);
+  } else {
+    await applyImport(current, dataset, options.deployment, options.backupDir);
+  }
+}
+
+async function applyImport(
+  current: Awaited<ReturnType<typeof readCurrentTestMetadata>>,
+  dataset: RankingDataset,
+  deployment: string,
+  workDir: string,
+) {
+  const resolved = resolveTargets(dataset.targets, current);
+  const importedAt = Date.now();
+  const snapshot = `${workDir}/test-before.zip`;
+  const skillPlan = await mergeDailyTable({
+    snapshot,
+    table: "skillDailyStats",
+    idField: "skillId",
+    output: `${workDir}/skillDailyStats.next.jsonl`,
+    datasetVersion: dataset.datasetVersion,
+    importedAt,
+    startDay: dataset.startDay,
+    endDay: dataset.endDay,
+    legacyTargetIds: current.legacySkillTargetIds,
+    targets: resolved.targets.filter((target) => target.kind === "skill"),
+  });
+  const packagePlan = await mergeDailyTable({
+    snapshot,
+    table: "packageDailyStats",
+    idField: "packageId",
+    output: `${workDir}/packageDailyStats.next.jsonl`,
+    datasetVersion: dataset.datasetVersion,
+    importedAt,
+    startDay: dataset.startDay,
+    endDay: dataset.endDay,
+    legacyTargetIds: current.legacyPackageTargetIds,
+    targets: resolved.targets.filter((target) => target.kind === "package"),
+  });
+  const metadata = [
+    {
+      datasetVersion: dataset.datasetVersion,
+      checksum: dataset.checksum,
+      generatedAt: dataset.generatedAt,
+      importedAt,
+      startDay: dataset.startDay,
+      endDay: dataset.endDay,
+      targetCount: dataset.counts.targets,
+      skillTargetCount: dataset.counts.skillTargets,
+      packageTargetCount: dataset.counts.packageTargets,
+      dailyRowCount: dataset.counts.dailyRows,
+      importedSkillRows: skillPlan.importedRows,
+      importedPackageRows: packagePlan.importedRows,
+      unresolvedTargets: resolved.unresolvedTargets,
+      skippedOverlayRows: 0,
+    },
+  ];
+  await writeJsonLines(`${workDir}/rankingMetricImports.next.jsonl`, metadata);
+
+  await importPlannedTables(workDir, deployment);
+  const proof = await readback(deployment, dataset.datasetVersion);
+  console.log(JSON.stringify({ ok: true, mode: "import", ...proof }, null, 2));
+}
+
+async function applyCleanup(
+  current: Awaited<ReturnType<typeof readCurrentTestMetadata>>,
+  dataset: RankingDataset,
+  deployment: string,
+  workDir: string,
+) {
+  const snapshot = `${workDir}/test-before.zip`;
+  const [skill, packageRows] = await Promise.all([
+    filterDailyTable(
+      snapshot,
+      "skillDailyStats",
+      `${workDir}/skillDailyStats.next.jsonl`,
+      dataset.datasetVersion,
+    ),
+    filterDailyTable(
+      snapshot,
+      "packageDailyStats",
+      `${workDir}/packageDailyStats.next.jsonl`,
+      dataset.datasetVersion,
+    ),
+  ]);
+  await writeJsonLines(
+    `${workDir}/rankingMetricImports.next.jsonl`,
+    current.rankingMetricImports.filter((row) => row.datasetVersion !== dataset.datasetVersion),
+  );
+  await importPlannedTables(workDir, deployment);
+  console.log(
+    JSON.stringify(
+      {
+        ok: true,
+        mode: "cleanup",
+        datasetVersion: dataset.datasetVersion,
+        removedSkillRows: skill.removed,
+        removedPackageRows: packageRows.removed,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+async function readCurrentTestMetadata(snapshot: string) {
+  const [users, publishers, skills, packages, imports] = await Promise.all([
+    collectSnapshotTable(snapshot, "users"),
+    collectSnapshotTable(snapshot, "publishers"),
+    collectSnapshotTable(snapshot, "skills"),
+    collectSnapshotTable(snapshot, "packages"),
+    collectSnapshotTable(snapshot, "rankingMetricImports"),
+  ]);
+  const userHandles = new Map(users.map((row) => [String(row._id), String(row.handle ?? "")]));
+  const publisherHandles = new Map(
+    publishers.map((row) => [String(row._id), String(row.handle ?? "")]),
+  );
+  const skillsByIdentity = new Map<string, { targetId: string; legacySnapshotTarget: boolean }>();
+  const legacySkillTargetIds = new Set<string>();
+  for (const row of skills) {
+    const ownerHandle =
+      publisherHandles.get(String(row.ownerPublisherId ?? "")) ??
+      userHandles.get(String(row.ownerUserId ?? ""));
+    if (!ownerHandle || typeof row.slug !== "string") continue;
+    const targetId = String(row._id);
+    const legacySnapshotTarget = ownerHandle.startsWith("test-snapshot-");
+    skillsByIdentity.set(`${ownerHandle}/${row.slug}`, { targetId, legacySnapshotTarget });
+    if (legacySnapshotTarget) legacySkillTargetIds.add(targetId);
+  }
+  const packagesByIdentity = new Map<string, { targetId: string; legacySnapshotTarget: boolean }>();
+  const legacyPackageTargetIds = new Set<string>();
+  for (const row of packages) {
+    const ownerHandle =
+      publisherHandles.get(String(row.ownerPublisherId ?? "")) ??
+      userHandles.get(String(row.ownerUserId ?? ""));
+    if (!ownerHandle || typeof row.normalizedName !== "string") continue;
+    const targetId = String(row._id);
+    const legacySnapshotTarget = ownerHandle.startsWith("test-snapshot-");
+    packagesByIdentity.set(row.normalizedName, { targetId, legacySnapshotTarget });
+    if (legacySnapshotTarget) legacyPackageTargetIds.add(targetId);
+  }
+  return {
+    skillsByIdentity,
+    packagesByIdentity,
+    legacySkillTargetIds,
+    legacyPackageTargetIds,
+    rankingMetricImports: imports,
+  };
+}
+
+function resolveTargets(
+  targets: RankingMetricTarget[],
+  current: Awaited<ReturnType<typeof readCurrentTestMetadata>>,
+) {
+  const resolved: ResolvedRankingMetricTarget[] = [];
+  let unresolvedTargets = 0;
+  for (const target of targets) {
+    const match =
+      target.kind === "skill"
+        ? current.skillsByIdentity.get(`${target.ownerHandle}/${target.slug}`)
+        : current.packagesByIdentity.get(target.normalizedName);
+    if (!match?.legacySnapshotTarget) {
+      unresolvedTargets += 1;
+      continue;
+    }
+    resolved.push({
+      kind: target.kind,
+      targetId: match.targetId,
+      legacySnapshotTarget: true,
+      days: target.days,
+    });
+  }
+  return { targets: resolved, unresolvedTargets };
+}
+
+export async function mergeDailyTable(input: {
+  snapshot: string;
+  table: DailyTable;
+  idField: DailyIdField;
+  output: string;
+  datasetVersion: string;
+  importedAt: number;
+  startDay: number;
+  endDay: number;
+  legacyTargetIds: ReadonlySet<string>;
+  targets: ResolvedRankingMetricTarget[];
+}) {
+  const incoming = new Map<
+    string,
+    { rows: Array<RankingMetricDay | undefined>; imported: number }
+  >();
+  for (const target of input.targets) {
+    const rows: Array<RankingMetricDay | undefined> = Array.from({ length: 60 });
+    for (const row of target.days) rows[row.day - input.startDay] = row;
+    incoming.set(target.targetId, { rows, imported: 0 });
+  }
+
+  const stream = createWriteStream(input.output, { flags: "wx" });
+  for await (const raw of readSnapshotTable(input.snapshot, input.table)) {
+    const targetId = String(raw[input.idField]);
+    const state = incoming.get(targetId);
+    const day = Number(raw.day);
+    const offset = day - input.startDay;
+    const replacement = state?.rows[offset];
+    if (replacement) {
+      await writeLine(
+        stream,
+        serializeImportedDailyRow(
+          targetId,
+          input.idField,
+          replacement,
+          input.datasetVersion,
+          input.importedAt,
+          raw,
+        ),
+      );
+      state.rows[offset] = undefined;
+      state.imported += 1;
+      continue;
+    }
+    if (typeof raw.rankingDatasetVersion === "string") continue;
+    if (input.legacyTargetIds.has(targetId) && day >= input.startDay && day <= input.endDay) {
+      continue;
+    }
+    await writeLine(stream, raw);
+  }
+
+  let importedRows = 0;
+  for (const [targetId, state] of incoming) {
+    importedRows += state.imported;
+    for (const row of state.rows) {
+      if (!row) continue;
+      await writeLine(
+        stream,
+        serializeImportedDailyRow(
+          targetId,
+          input.idField,
+          row,
+          input.datasetVersion,
+          input.importedAt,
+        ),
+      );
+      importedRows += 1;
+    }
+  }
+  await closeStream(stream);
+  return { importedRows };
+}
+
+async function filterDailyTable(
+  snapshot: string,
+  table: DailyTable,
+  output: string,
+  datasetVersion: string,
+) {
+  const stream = createWriteStream(output, { flags: "wx" });
+  let removed = 0;
+  for await (const row of readSnapshotTable(snapshot, table)) {
+    if (row.rankingDatasetVersion === datasetVersion) {
+      removed += 1;
+      continue;
+    }
+    await writeLine(stream, row);
+  }
+  await closeStream(stream);
+  return { removed };
+}
+
+async function readback(deployment: string, datasetVersion: string) {
+  const workDir = await mkdtemp(`${tmpdir()}/clawhub-ranking-readback-`);
+  const snapshot = `${workDir}/test-readback.zip`;
+  try {
+    exportDeploymentSnapshot(deployment, snapshot);
+    const imports = await collectSnapshotTable(snapshot, "rankingMetricImports");
+    const metadata = imports.find((row) => row.datasetVersion === datasetVersion);
+    if (!metadata) throw new Error(`No Test import metadata found for ${datasetVersion}`);
+    const startDay = Number(metadata.startDay);
+    const endDay = Number(metadata.endDay);
+    const [skill, packageRows] = await Promise.all([
+      summarizeSnapshotTable(
+        snapshot,
+        "skillDailyStats",
+        "skillId",
+        datasetVersion,
+        startDay,
+        endDay,
+      ),
+      summarizeSnapshotTable(
+        snapshot,
+        "packageDailyStats",
+        "packageId",
+        datasetVersion,
+        startDay,
+        endDay,
+      ),
+    ]);
+    return {
+      deployment,
+      datasetVersion,
+      checksum: metadata.checksum,
+      generatedAt: metadata.generatedAt,
+      importedAt: metadata.importedAt,
+      declared: {
+        targets: metadata.targetCount,
+        skillTargets: metadata.skillTargetCount,
+        packageTargets: metadata.packageTargetCount,
+        dailyRows: metadata.dailyRowCount,
+        startDay,
+        endDay,
+      },
+      imported: {
+        skill,
+        package: packageRows,
+        unresolvedTargets: metadata.unresolvedTargets,
+        skippedOverlayRows: metadata.skippedOverlayRows,
+      },
+    };
+  } finally {
+    await rm(workDir, { recursive: true, force: true });
+  }
+}
+
+async function summarizeSnapshotTable(
+  snapshot: string,
+  table: DailyTable,
+  idField: DailyIdField,
+  datasetVersion: string,
+  startDay: number,
+  endDay: number,
+) {
+  let rows = 0;
+  let minimumDay: number | null = null;
+  let maximumDay: number | null = null;
+  const targets = new Set<string>();
+  const window24h = { downloads: 0, installs: 0, bookmarks: 0 };
+  const window60d = { downloads: 0, installs: 0, bookmarks: 0 };
+  for await (const row of readSnapshotTable(snapshot, table)) {
+    if (row.rankingDatasetVersion !== datasetVersion) continue;
+    const day = Number(row.day);
+    const downloads = Number(row.downloads);
+    const installs = Number(row.installs);
+    const bookmarks = Number(row.bookmarks ?? 0);
+    rows += 1;
+    targets.add(String(row[idField]));
+    minimumDay = minimumDay === null ? day : Math.min(minimumDay, day);
+    maximumDay = maximumDay === null ? day : Math.max(maximumDay, day);
+    if (day >= startDay && day <= endDay) {
+      window60d.downloads += downloads;
+      window60d.installs += installs;
+      window60d.bookmarks += bookmarks;
+    }
+    if (day === endDay) {
+      window24h.downloads += downloads;
+      window24h.installs += installs;
+      window24h.bookmarks += bookmarks;
+    }
+  }
+  return {
+    rows,
+    targets: targets.size,
+    startDay: minimumDay,
+    endDay: maximumDay,
+    window24h,
+    window60d,
+  };
+}
+
+async function writeBackupManifest(backupDir: string, metadataRows: number) {
+  await writeFile(
+    `${backupDir}/backup-manifest.json`,
+    `${JSON.stringify(
+      {
+        deployment: CLAWHUB_TEST_DEPLOYMENT,
+        createdAt: new Date().toISOString(),
+        snapshot: "test-before.zip",
+        tables: {
+          skillDailyStats: "snapshot",
+          packageDailyStats: "snapshot",
+          rankingMetricImports: metadataRows,
+        },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+}
+
+async function importPlannedTables(workDir: string, deployment: string) {
+  const baseline = `${workDir}/test-before.zip`;
+  const preflight = `${workDir}/test-preflight.zip`;
+  exportDeploymentSnapshot(deployment, preflight);
+  await assertRankingTablesUnchanged(baseline, preflight);
+  try {
+    importTable(deployment, "skillDailyStats", `${workDir}/skillDailyStats.next.jsonl`);
+    importTable(deployment, "packageDailyStats", `${workDir}/packageDailyStats.next.jsonl`);
+    importTable(deployment, "rankingMetricImports", `${workDir}/rankingMetricImports.next.jsonl`);
+  } catch (error) {
+    await restoreBackup(workDir, deployment);
+    throw error;
+  }
+}
+
+export async function assertRankingTablesUnchanged(baseline: string, current: string) {
+  for (const table of ["skillDailyStats", "packageDailyStats", "rankingMetricImports"] as const) {
+    const [baselineDigest, currentDigest] = await Promise.all([
+      digestSnapshotTable(baseline, table),
+      digestSnapshotTable(current, table),
+    ]);
+    if (baselineDigest !== currentDigest) {
+      throw new Error(`${table} changed after the backup snapshot; aborting before import`);
+    }
+  }
+}
+
+async function digestSnapshotTable(snapshot: string, table: string) {
+  const digest = createHash("sha256");
+  for await (const row of readSnapshotTable(snapshot, table)) {
+    digest.update(JSON.stringify(row));
+    digest.update("\n");
+  }
+  return digest.digest("hex");
+}
+
+async function restoreBackup(backupDir: string, deployment: string) {
+  const manifest = JSON.parse(await readFile(`${backupDir}/backup-manifest.json`, "utf8")) as {
+    deployment?: unknown;
+    snapshot?: unknown;
+  };
+  if (manifest.deployment !== CLAWHUB_TEST_DEPLOYMENT || manifest.snapshot !== "test-before.zip") {
+    throw new Error("Backup manifest is not for the permanent Test deployment");
+  }
+  const snapshot = `${backupDir}/test-before.zip`;
+  await Promise.all([
+    copySnapshotTable(snapshot, "skillDailyStats", `${backupDir}/skillDailyStats.restore.jsonl`),
+    copySnapshotTable(
+      snapshot,
+      "packageDailyStats",
+      `${backupDir}/packageDailyStats.restore.jsonl`,
+    ),
+    copySnapshotTable(
+      snapshot,
+      "rankingMetricImports",
+      `${backupDir}/rankingMetricImports.restore.jsonl`,
+    ),
+  ]);
+  importTable(deployment, "skillDailyStats", `${backupDir}/skillDailyStats.restore.jsonl`);
+  importTable(deployment, "packageDailyStats", `${backupDir}/packageDailyStats.restore.jsonl`);
+  importTable(
+    deployment,
+    "rankingMetricImports",
+    `${backupDir}/rankingMetricImports.restore.jsonl`,
+  );
+  console.log(JSON.stringify({ ok: true, mode: "rollback", deployment, backupDir }, null, 2));
+}
+
+function importTable(deployment: string, table: string, file: string) {
+  assertTestDeployment(deployment);
+  const result = spawnSync(
+    "bunx",
+    [
+      "convex",
+      "import",
+      "--deployment",
+      deployment,
+      "--table",
+      table,
+      "--replace",
+      "--yes",
+      "--format",
+      "jsonLines",
+      file,
+    ],
+    { cwd: process.cwd(), env: process.env, stdio: "inherit" },
+  );
+  if (result.status !== 0) throw new Error(`Failed to import Test table ${table}`);
+}
+
+function exportDeploymentSnapshot(deployment: string, path: string) {
+  assertTestDeployment(deployment);
+  const result = spawnSync(
+    "bunx",
+    ["convex", "export", "--deployment", deployment, "--path", path],
+    { cwd: process.cwd(), env: process.env, stdio: "inherit" },
+  );
+  if (result.status !== 0) throw new Error("Failed to export the permanent Test deployment");
+}
+
+async function collectSnapshotTable(snapshot: string, table: string) {
+  const rows: Record<string, unknown>[] = [];
+  for await (const row of readSnapshotTable(snapshot, table)) rows.push(row);
+  return rows;
+}
+
+export async function copySnapshotTable(
+  snapshot: string,
+  table: DailyTable | "rankingMetricImports",
+  output: string,
+) {
+  const stream = createWriteStream(output, { flags: "w" });
+  for await (const row of readSnapshotTable(snapshot, table)) {
+    await writeLine(stream, row);
+  }
+  await closeStream(stream);
+}
+
+function serializeImportedDailyRow(
+  targetId: string,
+  idField: DailyIdField,
+  row: RankingMetricDay,
+  datasetVersion: string,
+  importedAt: number,
+  existing?: Record<string, unknown>,
+) {
+  return {
+    ...(existing ? systemFields(existing) : {}),
+    [idField]: targetId,
+    day: row.day,
+    downloads: row.downloads,
+    installs: row.installs,
+    bookmarks: row.bookmarks,
+    updatedAt: importedAt,
+    rankingDatasetVersion: datasetVersion,
+    rankingImportedAt: importedAt,
+  };
+}
+
+function systemFields(row: Record<string, unknown>) {
+  return {
+    ...(typeof row._id === "string" ? { _id: row._id } : {}),
+    ...(typeof row._creationTime === "number" ? { _creationTime: row._creationTime } : {}),
+  };
+}
+
+async function writeJsonLines(path: string, rows: Record<string, unknown>[]) {
+  const stream = createWriteStream(path, { flags: "wx" });
+  for (const row of rows) await writeLine(stream, row);
+  await closeStream(stream);
+}
+
+async function writeLine(stream: WriteStream, row: Record<string, unknown>) {
+  if (!stream.write(`${JSON.stringify(row)}\n`)) await once(stream, "drain");
+}
+
+async function closeStream(stream: WriteStream) {
+  stream.end();
+  await once(stream, "close");
+}
+
+async function assertEmptyDirectory(path: string) {
+  try {
+    if (!(await stat(path)).isDirectory()) throw new Error(`${path} is not a directory`);
+    if ((await readdir(path)).length > 0)
+      throw new Error(`Backup directory must be empty: ${path}`);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+  }
+}
+
+export function assertTestDeployment(deployment: string) {
+  if (deployment !== CLAWHUB_TEST_DEPLOYMENT) {
+    throw new Error(
+      `Ranking metric imports may only target ${CLAWHUB_TEST_DEPLOYMENT}; received ${deployment}`,
+    );
+  }
+}
+
+export function parseArgs(args: string[]) {
+  let mode: Mode = "import";
+  let deployment = CLAWHUB_TEST_DEPLOYMENT;
+  let dataset = "";
+  let datasetVersion = "";
+  let backupDir = "";
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--readback") mode = "readback";
+    else if (arg === "--cleanup") mode = "cleanup";
+    else if (arg === "--rollback") mode = "rollback";
+    else if (arg === "--deployment") deployment = args[++index] ?? "";
+    else if (arg.startsWith("--deployment=")) deployment = arg.slice("--deployment=".length);
+    else if (arg === "--dataset") dataset = args[++index] ?? "";
+    else if (arg.startsWith("--dataset=")) dataset = arg.slice("--dataset=".length);
+    else if (arg === "--dataset-version") datasetVersion = args[++index] ?? "";
+    else if (arg.startsWith("--dataset-version=")) {
+      datasetVersion = arg.slice("--dataset-version=".length);
+    } else if (arg === "--backup-dir") backupDir = args[++index] ?? "";
+    else if (arg.startsWith("--backup-dir=")) backupDir = arg.slice("--backup-dir=".length);
+    else throw new Error(`Unknown argument: ${arg}`);
+  }
+  assertTestDeployment(deployment);
+  if (mode !== "readback" && !backupDir) throw new Error("--backup-dir is required");
+  if ((mode === "import" || mode === "cleanup") && !dataset)
+    throw new Error("--dataset is required");
+  if (mode === "rollback" && dataset) throw new Error("--dataset is not valid with --rollback");
+  return {
+    mode: mode as Mode,
+    deployment,
+    dataset: dataset ? resolve(dataset) : "",
+    datasetVersion,
+    backupDir: backupDir ? resolve(backupDir) : "",
+  };
+}
+
+if (import.meta.main) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exit(1);
+  });
+}

--- a/scripts/ranking-metrics/rankingDataset.test.ts
+++ b/scripts/ranking-metrics/rankingDataset.test.ts
@@ -101,6 +101,24 @@ describe("ranking metric dataset", () => {
     ).toThrow("outside");
   });
 
+  it("treats package family and channel as part of the target identity", () => {
+    const packageTarget = targets[1];
+    if (packageTarget.kind !== "package") throw new Error("expected package fixture");
+    expect(() =>
+      buildRankingDataset({
+        datasetVersion: "ranking-metrics-2026-07-23-v1",
+        generatedAt: "2026-07-23T22:00:00.000Z",
+        startDay: 20_597,
+        endDay: 20_656,
+        targets: [
+          packageTarget,
+          { ...packageTarget, family: "bundle-plugin" },
+          { ...packageTarget, channel: "beta" },
+        ],
+      }),
+    ).not.toThrow();
+  });
+
   it("rejects negative aggregate counts", () => {
     expect(() =>
       buildRankingDataset({

--- a/scripts/ranking-metrics/rankingDataset.test.ts
+++ b/scripts/ranking-metrics/rankingDataset.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildRankingDataset,
+  parseRankingDataset,
+  rankingDatasetChecksum,
+  type RankingMetricTarget,
+} from "./rankingDataset";
+
+const targets: RankingMetricTarget[] = [
+  {
+    kind: "skill",
+    ownerHandle: "test-snapshot-user-0123456789ab",
+    slug: "calendar",
+    createdAt: 1_700_000_000_000,
+    days: [
+      { day: 20_655, downloads: 4, installs: 2, bookmarks: 1 },
+      { day: 20_656, downloads: 6, installs: 3, bookmarks: 0 },
+    ],
+  },
+  {
+    kind: "package",
+    normalizedName: "@openclaw/calendar",
+    family: "code-plugin",
+    channel: "stable",
+    createdAt: 1_700_000_000_000,
+    days: [{ day: 20_656, downloads: 8, installs: 5, bookmarks: 0 }],
+  },
+];
+
+describe("ranking metric dataset", () => {
+  it("builds a versioned allowlisted aggregate dataset", () => {
+    const dataset = buildRankingDataset({
+      datasetVersion: "ranking-metrics-2026-07-23-v1",
+      generatedAt: "2026-07-23T22:00:00.000Z",
+      startDay: 20_597,
+      endDay: 20_656,
+      targets,
+    });
+
+    expect(parseRankingDataset(JSON.stringify(dataset))).toEqual(dataset);
+    expect(dataset.counts).toEqual({
+      targets: 2,
+      skillTargets: 1,
+      packageTargets: 1,
+      dailyRows: 3,
+      downloads: 18,
+      installs: 10,
+      bookmarks: 1,
+    });
+    expect(dataset.checksum).toBe(rankingDatasetChecksum(dataset));
+  });
+
+  it.each([
+    ["user identity", { userId: "kn7secret" }],
+    ["device identity", { deviceId: "device-1" }],
+    ["session", { sessionToken: "secret" }],
+    ["IP address", { note: "198.51.100.42" }],
+    ["raw document id", { skillId: "kd7rawproductionid" }],
+  ])("rejects prohibited %s fields fail-closed", (_label, prohibited) => {
+    const dataset = buildRankingDataset({
+      datasetVersion: "ranking-metrics-2026-07-23-v1",
+      generatedAt: "2026-07-23T22:00:00.000Z",
+      startDay: 20_597,
+      endDay: 20_656,
+      targets,
+    });
+
+    const unsafe = { ...dataset, ...prohibited };
+    expect(() => parseRankingDataset(JSON.stringify(unsafe))).toThrow();
+  });
+
+  it("rejects duplicate target-day rows and rows outside the declared window", () => {
+    expect(() =>
+      buildRankingDataset({
+        datasetVersion: "ranking-metrics-2026-07-23-v1",
+        generatedAt: "2026-07-23T22:00:00.000Z",
+        startDay: 20_597,
+        endDay: 20_656,
+        targets: [
+          {
+            ...targets[0],
+            days: [
+              { day: 20_655, downloads: 1, installs: 1, bookmarks: 1 },
+              { day: 20_655, downloads: 2, installs: 2, bookmarks: 2 },
+            ],
+          },
+        ],
+      }),
+    ).toThrow("duplicate");
+
+    expect(() =>
+      buildRankingDataset({
+        datasetVersion: "ranking-metrics-2026-07-23-v1",
+        generatedAt: "2026-07-23T22:00:00.000Z",
+        startDay: 20_597,
+        endDay: 20_656,
+        targets: [
+          { ...targets[0], days: [{ day: 20_596, downloads: 1, installs: 1, bookmarks: 1 }] },
+        ],
+      }),
+    ).toThrow("outside");
+  });
+
+  it("rejects negative aggregate counts", () => {
+    expect(() =>
+      buildRankingDataset({
+        datasetVersion: "ranking-metrics-2026-07-23-v1",
+        generatedAt: "2026-07-23T22:00:00.000Z",
+        startDay: 20_597,
+        endDay: 20_656,
+        targets: [
+          {
+            ...targets[0],
+            days: [{ day: 20_656, downloads: 1, installs: 1, bookmarks: -1 }],
+          },
+        ],
+      }),
+    ).toThrow("bookmarks must be non-negative");
+  });
+});

--- a/scripts/ranking-metrics/rankingDataset.ts
+++ b/scripts/ranking-metrics/rankingDataset.ts
@@ -186,19 +186,17 @@ function validateTargets(
         return `skill:${ownerHandle}/${stringValue(skillTarget.slug, "slug")}`;
       }
       const packageTarget = recordWithKeys(rawTarget, PACKAGE_KEYS, `targets[${targetIndex}]`);
-      return `package:${stringValue(packageTarget.normalizedName, "normalizedName")}`;
+      const normalizedName = stringValue(packageTarget.normalizedName, "normalizedName");
+      if (packageTarget.family !== "code-plugin" && packageTarget.family !== "bundle-plugin") {
+        throw new Error(`package:${normalizedName}.family is invalid`);
+      }
+      const channel = stringValue(packageTarget.channel, `package:${normalizedName}.channel`);
+      return packageTargetIdentity(normalizedName, packageTarget.family, channel);
     })();
     if (identities.has(identity)) throw new Error(`duplicate target identity: ${identity}`);
     identities.add(identity);
 
     nonNegativeInteger(target.createdAt, `${identity}.createdAt`);
-    if (kind === "package") {
-      const packageTarget = recordWithKeys(rawTarget, PACKAGE_KEYS, `targets[${targetIndex}]`);
-      if (packageTarget.family !== "code-plugin" && packageTarget.family !== "bundle-plugin") {
-        throw new Error(`${identity}.family is invalid`);
-      }
-      stringValue(packageTarget.channel, `${identity}.channel`);
-    }
     if (!Array.isArray(target.days)) throw new Error(`${identity}.days must be an array`);
 
     const days = new Set<number>();
@@ -215,6 +213,10 @@ function validateTargets(
       nonNegativeInteger(row.bookmarks, `${identity}.${day}.bookmarks`);
     }
   }
+}
+
+export function packageTargetIdentity(normalizedName: string, family: string, channel: string) {
+  return `package:${JSON.stringify([normalizedName, family, channel])}`;
 }
 
 function countTargets(targets: RankingMetricTarget[]): RankingDataset["counts"] {

--- a/scripts/ranking-metrics/rankingDataset.ts
+++ b/scripts/ranking-metrics/rankingDataset.ts
@@ -1,0 +1,312 @@
+import { createHash } from "node:crypto";
+
+export const RANKING_DATASET_SCHEMA_VERSION = 1;
+
+export type RankingMetricDay = {
+  day: number;
+  downloads: number;
+  installs: number;
+  bookmarks: number;
+};
+
+export type RankingMetricSkillTarget = {
+  kind: "skill";
+  ownerHandle: string;
+  slug: string;
+  createdAt: number;
+  days: RankingMetricDay[];
+};
+
+export type RankingMetricPackageTarget = {
+  kind: "package";
+  normalizedName: string;
+  family: "code-plugin" | "bundle-plugin";
+  channel: string;
+  createdAt: number;
+  days: RankingMetricDay[];
+};
+
+export type RankingMetricTarget = RankingMetricSkillTarget | RankingMetricPackageTarget;
+
+export type RankingDataset = {
+  schemaVersion: typeof RANKING_DATASET_SCHEMA_VERSION;
+  datasetVersion: string;
+  generatedAt: string;
+  source: {
+    environment: "production";
+    access: "read-only";
+    windowDays: 60;
+  };
+  startDay: number;
+  endDay: number;
+  counts: {
+    targets: number;
+    skillTargets: number;
+    packageTargets: number;
+    dailyRows: number;
+    downloads: number;
+    installs: number;
+    bookmarks: number;
+  };
+  targets: RankingMetricTarget[];
+  checksum: string;
+};
+
+type BuildRankingDatasetInput = Pick<
+  RankingDataset,
+  "datasetVersion" | "generatedAt" | "startDay" | "endDay" | "targets"
+>;
+
+const DATASET_KEYS = [
+  "schemaVersion",
+  "datasetVersion",
+  "generatedAt",
+  "source",
+  "startDay",
+  "endDay",
+  "counts",
+  "targets",
+  "checksum",
+] as const;
+const SOURCE_KEYS = ["environment", "access", "windowDays"] as const;
+const COUNT_KEYS = [
+  "targets",
+  "skillTargets",
+  "packageTargets",
+  "dailyRows",
+  "downloads",
+  "installs",
+  "bookmarks",
+] as const;
+const SKILL_KEYS = ["kind", "ownerHandle", "slug", "createdAt", "days"] as const;
+const PACKAGE_KEYS = ["kind", "normalizedName", "family", "channel", "createdAt", "days"] as const;
+const DAY_KEYS = ["day", "downloads", "installs", "bookmarks"] as const;
+
+export function buildRankingDataset(input: BuildRankingDatasetInput): RankingDataset {
+  assertVersion(input.datasetVersion);
+  assertIsoTimestamp(input.generatedAt);
+  assertDayRange(input.startDay, input.endDay);
+  validateTargets(input.targets, input.startDay, input.endDay);
+
+  const counts = countTargets(input.targets);
+  const withoutChecksum: Omit<RankingDataset, "checksum"> = {
+    schemaVersion: RANKING_DATASET_SCHEMA_VERSION,
+    datasetVersion: input.datasetVersion,
+    generatedAt: input.generatedAt,
+    source: {
+      environment: "production",
+      access: "read-only",
+      windowDays: 60,
+    },
+    startDay: input.startDay,
+    endDay: input.endDay,
+    counts,
+    targets: input.targets,
+  };
+  const dataset = { ...withoutChecksum, checksum: checksumValue(withoutChecksum) };
+  validateDataset(dataset);
+  return dataset;
+}
+
+export function parseRankingDataset(input: string): RankingDataset {
+  const value: unknown = JSON.parse(input);
+  validateDataset(value);
+  return value;
+}
+
+export function rankingDatasetChecksum(dataset: RankingDataset) {
+  const { checksum: _checksum, ...withoutChecksum } = dataset;
+  return checksumValue(withoutChecksum);
+}
+
+function validateDataset(value: unknown): asserts value is RankingDataset {
+  const dataset = recordWithKeys(value, DATASET_KEYS, "dataset");
+  if (dataset.schemaVersion !== RANKING_DATASET_SCHEMA_VERSION) {
+    throw new Error(`Unsupported ranking dataset schema version: ${String(dataset.schemaVersion)}`);
+  }
+  const datasetVersion = stringValue(dataset.datasetVersion, "datasetVersion");
+  const generatedAt = stringValue(dataset.generatedAt, "generatedAt");
+  assertVersion(datasetVersion);
+  assertIsoTimestamp(generatedAt);
+
+  const source = recordWithKeys(dataset.source, SOURCE_KEYS, "source");
+  if (
+    source.environment !== "production" ||
+    source.access !== "read-only" ||
+    source.windowDays !== 60
+  ) {
+    throw new Error("Ranking dataset source contract is invalid");
+  }
+
+  const startDay = integerValue(dataset.startDay, "startDay");
+  const endDay = integerValue(dataset.endDay, "endDay");
+  assertDayRange(startDay, endDay);
+  if (!Array.isArray(dataset.targets)) throw new Error("targets must be an array");
+  validateTargets(dataset.targets, startDay, endDay);
+
+  const counts = recordWithKeys(dataset.counts, COUNT_KEYS, "counts");
+  const expectedCounts = countTargets(dataset.targets);
+  for (const key of COUNT_KEYS) {
+    if (integerValue(counts[key], `counts.${key}`) !== expectedCounts[key]) {
+      throw new Error(`counts.${key} does not match dataset rows`);
+    }
+  }
+
+  const checksum = stringValue(dataset.checksum, "checksum");
+  if (!/^[a-f0-9]{64}$/.test(checksum)) throw new Error("checksum must be a SHA-256 hex digest");
+  if (checksum !== rankingDatasetChecksum(dataset as RankingDataset)) {
+    throw new Error("Ranking dataset checksum does not match");
+  }
+}
+
+function validateTargets(
+  targets: unknown[],
+  startDay: number,
+  endDay: number,
+): asserts targets is RankingMetricTarget[] {
+  const identities = new Set<string>();
+  for (const [targetIndex, rawTarget] of targets.entries()) {
+    if (!isRecord(rawTarget)) throw new Error(`targets[${targetIndex}] must be an object`);
+    const kind = rawTarget.kind;
+    if (kind !== "skill" && kind !== "package") {
+      throw new Error(`targets[${targetIndex}].kind is invalid`);
+    }
+    const target =
+      kind === "skill"
+        ? recordWithKeys(rawTarget, SKILL_KEYS, `targets[${targetIndex}]`)
+        : recordWithKeys(rawTarget, PACKAGE_KEYS, `targets[${targetIndex}]`);
+
+    const identity = (() => {
+      if (kind === "skill") {
+        const skillTarget = recordWithKeys(rawTarget, SKILL_KEYS, `targets[${targetIndex}]`);
+        const ownerHandle = stringValue(skillTarget.ownerHandle, "ownerHandle");
+        if (!/^test-snapshot-(?:user|publisher)-[a-f0-9]{12}$/.test(ownerHandle)) {
+          throw new Error("ownerHandle must be a deterministic Test snapshot identity");
+        }
+        return `skill:${ownerHandle}/${stringValue(skillTarget.slug, "slug")}`;
+      }
+      const packageTarget = recordWithKeys(rawTarget, PACKAGE_KEYS, `targets[${targetIndex}]`);
+      return `package:${stringValue(packageTarget.normalizedName, "normalizedName")}`;
+    })();
+    if (identities.has(identity)) throw new Error(`duplicate target identity: ${identity}`);
+    identities.add(identity);
+
+    nonNegativeInteger(target.createdAt, `${identity}.createdAt`);
+    if (kind === "package") {
+      const packageTarget = recordWithKeys(rawTarget, PACKAGE_KEYS, `targets[${targetIndex}]`);
+      if (packageTarget.family !== "code-plugin" && packageTarget.family !== "bundle-plugin") {
+        throw new Error(`${identity}.family is invalid`);
+      }
+      stringValue(packageTarget.channel, `${identity}.channel`);
+    }
+    if (!Array.isArray(target.days)) throw new Error(`${identity}.days must be an array`);
+
+    const days = new Set<number>();
+    for (const [dayIndex, rawDay] of target.days.entries()) {
+      const row = recordWithKeys(rawDay, DAY_KEYS, `${identity}.days[${dayIndex}]`);
+      const day = integerValue(row.day, `${identity}.days[${dayIndex}].day`);
+      if (day < startDay || day > endDay) {
+        throw new Error(`${identity} day ${day} is outside the declared window`);
+      }
+      if (days.has(day)) throw new Error(`${identity} has duplicate day ${day}`);
+      days.add(day);
+      nonNegativeInteger(row.downloads, `${identity}.${day}.downloads`);
+      nonNegativeInteger(row.installs, `${identity}.${day}.installs`);
+      nonNegativeInteger(row.bookmarks, `${identity}.${day}.bookmarks`);
+    }
+  }
+}
+
+function countTargets(targets: RankingMetricTarget[]): RankingDataset["counts"] {
+  const counts: RankingDataset["counts"] = {
+    targets: targets.length,
+    skillTargets: 0,
+    packageTargets: 0,
+    dailyRows: 0,
+    downloads: 0,
+    installs: 0,
+    bookmarks: 0,
+  };
+  for (const target of targets) {
+    if (target.kind === "skill") counts.skillTargets += 1;
+    else counts.packageTargets += 1;
+    for (const row of target.days) {
+      counts.dailyRows += 1;
+      counts.downloads += row.downloads;
+      counts.installs += row.installs;
+      counts.bookmarks += row.bookmarks;
+    }
+  }
+  return counts;
+}
+
+function checksumValue(value: unknown) {
+  return createHash("sha256").update(stableStringify(value)).digest("hex");
+}
+
+function stableStringify(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(",")}]`;
+  if (isRecord(value)) {
+    return `{${Object.keys(value)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function recordWithKeys<const Keys extends readonly string[]>(
+  value: unknown,
+  keys: Keys,
+  label: string,
+): Record<Keys[number], unknown> {
+  if (!isRecord(value)) throw new Error(`${label} must be an object`);
+  const allowed = new Set<string>(keys);
+  for (const key of Object.keys(value)) {
+    if (!allowed.has(key)) throw new Error(`${label} contains prohibited field ${key}`);
+  }
+  for (const key of keys) {
+    if (!(key in value)) throw new Error(`${label} is missing ${key}`);
+  }
+  return value as Record<Keys[number], unknown>;
+}
+
+function assertVersion(value: string) {
+  if (!/^ranking-metrics-\d{4}-\d{2}-\d{2}-v\d+$/.test(value)) {
+    throw new Error("datasetVersion must be an explicit ranking-metrics YYYY-MM-DD version");
+  }
+}
+
+function assertIsoTimestamp(value: string) {
+  if (!Number.isFinite(Date.parse(value)) || !value.endsWith("Z")) {
+    throw new Error("generatedAt must be an ISO-8601 UTC timestamp");
+  }
+}
+
+function assertDayRange(startDay: number, endDay: number) {
+  if (!Number.isInteger(startDay) || !Number.isInteger(endDay) || endDay - startDay !== 59) {
+    throw new Error("Ranking datasets must declare an exact 60-day window");
+  }
+}
+
+function stringValue(value: unknown, label: string) {
+  if (typeof value !== "string" || !value) throw new Error(`${label} must be a non-empty string`);
+  return value;
+}
+
+function integerValue(value: unknown, label: string) {
+  if (typeof value !== "number" || !Number.isSafeInteger(value)) {
+    throw new Error(`${label} must be a safe integer`);
+  }
+  return value;
+}
+
+function nonNegativeInteger(value: unknown, label: string) {
+  const number = integerValue(value, label);
+  if (number < 0) throw new Error(`${label} must be non-negative`);
+  return number;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/specs/dev-seeding.md
+++ b/specs/dev-seeding.md
@@ -47,14 +47,20 @@ ranking-metrics-YYYY-MM-DD-vN --output <dataset.json>`. The sanitizer reads five
   bookmark creation counts by skill/day. The emitted JSON contains no Convex ids or user, device,
   session, IP, auth, moderation, or private telemetry fields and is rejected unless it covers an
   exact 60-day window.
-- `bun run seed:test:ranking-import -- --dataset <dataset.json> --backup-dir <empty-dir>` targets
-  only `academic-chihuahua-392`. It atomically replaces the three ranking tables from one ZIP,
-  preserves deterministic feature and skills.sh fixture rows as overlays, replaces provenance only
-  for the matching dataset version, and retains older import metadata. It records
-  version/checksum/count/time-range metadata and leaves an exact three-table backup. Immediately
-  before replacement it re-exports and hashes all three target tables, aborting without mutation if
-  the reserved Test lane changed after the backup snapshot. Use `--readback --dataset-version
-<version>` for
+- Before any mutating ranking import command, dispatch `Reserve Test` from exact current `main` with
+  the dataset version and expected SHA. Wait for it to enter `in_progress`, pass its run ID as
+  `--lane-run-id`, and cancel the reservation only after import, proof, and any cleanup or rollback
+  are complete. The reservation is read-only and shares the `deploy-test` concurrency group, so a
+  Test deploy cannot overlap the operation.
+- `bun run seed:test:ranking-import -- --dataset <dataset.json> --backup-dir <empty-dir>
+--lane-run-id <run-id>` targets only `academic-chihuahua-392`. It verifies that the reservation,
+  local checkout, and current `main` are the same revision, then atomically replaces the three
+  ranking tables from one ZIP. It preserves deterministic feature and skills.sh fixture rows as
+  overlays, replaces provenance only for the matching dataset version, and retains older import
+  metadata. It records version/checksum/count/time-range metadata and leaves an exact three-table
+  backup. Immediately before replacement it re-exports and hashes all three target tables and
+  revalidates the reservation, aborting without mutation if the lane or tables changed. Use
+  `--readback --dataset-version <version>` for
   24-hour/60-day proof, `--cleanup` with the original dataset to remove that version, or
   `--rollback --backup-dir <dir>` to restore the pre-import tables.
 - `internal.devSeed.seedCurrentUserFixtures` remains a dev-only internal action for explicit local

--- a/specs/dev-seeding.md
+++ b/specs/dev-seeding.md
@@ -40,6 +40,21 @@ Local fixture seeding is command-driven by default:
   baseline restore. It validates the archive, refuses every deployment except
   `academic-chihuahua-392`, and uses Convex `--replace-all` so cross-project table IDs restore
   correctly.
+- After creating a read-only production snapshot with `bunx convex export --prod`, run
+  `bun run seed:test:ranking-export -- --snapshot <snapshot.zip> --dataset-version
+ranking-metrics-YYYY-MM-DD-vN --output <dataset.json>`. The sanitizer reads five fixed tables:
+  public skills, public plugins, their daily aggregate rows, and active bookmarks used only to aggregate
+  bookmark creation counts by skill/day. The emitted JSON contains no Convex ids or user, device,
+  session, IP, auth, moderation, or private telemetry fields and is rejected unless it covers an
+  exact 60-day window.
+- `bun run seed:test:ranking-import -- --dataset <dataset.json> --backup-dir <empty-dir>` targets
+  only `academic-chihuahua-392`. It replaces prior imported ranking rows, preserves deterministic
+  feature and skills.sh fixture rows as overlays, records version/checksum/count/time-range
+  metadata, and leaves an exact three-table backup. Immediately before replacement it re-exports
+  and hashes all three target tables, aborting without mutation if the reserved Test lane changed
+  after the backup snapshot. Use `--readback --dataset-version <version>` for
+  24-hour/60-day proof, `--cleanup` with the original dataset to remove that version, or
+  `--rollback --backup-dir <dir>` to restore the pre-import tables.
 - `internal.devSeed.seedCurrentUserFixtures` remains a dev-only internal action for explicit local
   development tools/tests that need fixtures cloned to a local user.
 

--- a/specs/dev-seeding.md
+++ b/specs/dev-seeding.md
@@ -48,11 +48,13 @@ ranking-metrics-YYYY-MM-DD-vN --output <dataset.json>`. The sanitizer reads five
   session, IP, auth, moderation, or private telemetry fields and is rejected unless it covers an
   exact 60-day window.
 - `bun run seed:test:ranking-import -- --dataset <dataset.json> --backup-dir <empty-dir>` targets
-  only `academic-chihuahua-392`. It replaces prior imported ranking rows, preserves deterministic
-  feature and skills.sh fixture rows as overlays, records version/checksum/count/time-range
-  metadata, and leaves an exact three-table backup. Immediately before replacement it re-exports
-  and hashes all three target tables, aborting without mutation if the reserved Test lane changed
-  after the backup snapshot. Use `--readback --dataset-version <version>` for
+  only `academic-chihuahua-392`. It atomically replaces the three ranking tables from one ZIP,
+  preserves deterministic feature and skills.sh fixture rows as overlays, replaces provenance only
+  for the matching dataset version, and retains older import metadata. It records
+  version/checksum/count/time-range metadata and leaves an exact three-table backup. Immediately
+  before replacement it re-exports and hashes all three target tables, aborting without mutation if
+  the reserved Test lane changed after the backup snapshot. Use `--readback --dataset-version
+<version>` for
   24-hour/60-day proof, `--cleanup` with the original dataset to remove that version, or
   `--rollback --backup-dir <dir>` to restore the pre-import tables.
 - `internal.devSeed.seedCurrentUserFixtures` remains a dev-only internal action for explicit local

--- a/specs/dev-seeding.md
+++ b/specs/dev-seeding.md
@@ -55,11 +55,14 @@ ranking-metrics-YYYY-MM-DD-vN --output <dataset.json>`. The sanitizer reads five
 - `bun run seed:test:ranking-import -- --dataset <dataset.json> --backup-dir <empty-dir>
 --lane-run-id <run-id>` targets only `academic-chihuahua-392`. It verifies that the reservation,
   local checkout, and current `main` are the same revision, then atomically replaces the three
-  ranking tables from one ZIP. It preserves deterministic feature and skills.sh fixture rows as
-  overlays, replaces provenance only for the matching dataset version, and retains older import
-  metadata. It records version/checksum/count/time-range metadata and leaves an exact three-table
-  backup. Immediately before replacement it re-exports and hashes all three target tables and
-  revalidates the reservation, aborting without mutation if the lane or tables changed. Use
+  ranking tables from one ZIP. Before the baseline export it sets an expiring Test-only write lock;
+  skill and package daily-stat write funnels fail closed while that lock is active, and the command
+  verifies the lock again immediately before replacement. It preserves deterministic feature and
+  skills.sh fixture rows as overlays, replaces provenance only for the matching dataset version,
+  and retains older import metadata. It records version/checksum/count/time-range metadata and
+  leaves an exact three-table backup. Immediately before replacement it re-exports and hashes all
+  three target tables and revalidates the reservation, aborting without mutation if the lane, lock,
+  or tables changed. Use
   `--readback --dataset-version <version>` for
   24-hour/60-day proof, `--cleanup` with the original dataset to remove that version, or
   `--rollback --backup-dir <dir> --lane-run-id <run-id>` to restore the pre-import tables. Rollback

--- a/specs/dev-seeding.md
+++ b/specs/dev-seeding.md
@@ -62,7 +62,9 @@ ranking-metrics-YYYY-MM-DD-vN --output <dataset.json>`. The sanitizer reads five
   revalidates the reservation, aborting without mutation if the lane or tables changed. Use
   `--readback --dataset-version <version>` for
   24-hour/60-day proof, `--cleanup` with the original dataset to remove that version, or
-  `--rollback --backup-dir <dir>` to restore the pre-import tables.
+  `--rollback --backup-dir <dir> --lane-run-id <run-id>` to restore the pre-import tables. Rollback
+  also requires the current three-table state to match the exact post-operation digests recorded in
+  that backup, so an older backup cannot overwrite a subsequent import or fixture change.
 - `internal.devSeed.seedCurrentUserFixtures` remains a dev-only internal action for explicit local
   development tools/tests that need fixtures cloned to a local user.
 

--- a/specs/dev-seeding.md
+++ b/specs/dev-seeding.md
@@ -56,13 +56,13 @@ ranking-metrics-YYYY-MM-DD-vN --output <dataset.json>`. The sanitizer reads five
 --lane-run-id <run-id>` targets only `academic-chihuahua-392`. It verifies that the reservation,
   local checkout, and current `main` are the same revision, then atomically replaces the three
   ranking tables from one ZIP. Before the baseline export it sets an expiring Test-only write lock;
-  skill and package daily-stat write funnels fail closed while that lock is active, and the command
-  verifies the lock again immediately before replacement. It preserves deterministic feature and
+  skill/package daily-stat writes and the user, publisher, skill, and package identity writes used
+  for re-keying fail closed while that lock is active. It preserves deterministic feature and
   skills.sh fixture rows as overlays, replaces provenance only for the matching dataset version,
   and retains older import metadata. It records version/checksum/count/time-range metadata and
   leaves an exact three-table backup. Immediately before replacement it re-exports and hashes all
-  three target tables and revalidates the reservation, aborting without mutation if the lane, lock,
-  or tables changed. Use
+  seven source and target tables and revalidates the reservation, aborting without mutation if the
+  lane, lock, or tables changed. Use
   `--readback --dataset-version <version>` for
   24-hour/60-day proof, `--cleanup` with the original dataset to remove that version, or
   `--rollback --backup-dir <dir> --lane-run-id <run-id>` to restore the pre-import tables. Rollback


### PR DESCRIPTION
## Summary

- export a strict, checksummed allowlist of public skill/package identities and aggregate daily ranking metrics from a read-only production snapshot
- import only into permanent Test under an exact-main exclusive lane and expiring source-table write lock
- preserve feature and skills.sh overlays while providing exact readback, idempotent re-import, cleanup, and stale-safe rollback
- validate prohibited fields, target continuity, dataset counts, and the 24-hour/60-day windows

## Validation

- `bunx vitest run convex/functions.test.ts convex/lib/rankingMetricsImportLock.test.ts scripts/ranking-metrics/import-test-ranking-metrics.test.ts scripts/ranking-metrics/rankingDataset.test.ts scripts/ranking-metrics/export-prod-ranking-metrics.test.ts`
- `bun run ci:unit`
- `bun run ci:static`
- `bun run ci:types-build`
- `bun run ci:packages`
- `bun run ci:e2e-http`
- `bunx tsc --noEmit`
- `bunx tsc -p packages/schema/tsconfig.json --noEmit`
- `bunx tsc -p packages/clawhub/tsconfig.json --noEmit`
- branch autoreview: clean
