### PR TITLE
fix: match homepage hero accent

### DIFF
--- a/src/__tests__/ui-design-contract.test.ts
+++ b/src/__tests__/ui-design-contract.test.ts
@@ -350,9 +350,7 @@ describe("restored UI design contract", () => {
 
     expect(homeSource).toContain('className="home-v2-main oc-app-surface"');
     expect(homeSource).toContain("home-v2-headline oc-hero-title");
-    expect(cssRule(css, ".home-v2-static-headline")).toContain(
-      "color: var(--oc-palette-coral-light-deep)",
-    );
+    expect(cssRule(css, ".home-v2-static-headline")).toContain("color: var(--oc-accent-primary)");
     expect(css.lastIndexOf(".home-v2-static-headline")).toBeGreaterThan(
       css.lastIndexOf(".home-v2-action-word"),
     );

--- a/src/styles.css
+++ b/src/styles.css
@@ -24811,7 +24811,7 @@ a.search-empty-action {
   color: var(--hv2-accent);
 }
 .home-v2-static-headline {
-  color: var(--oc-palette-coral-light-deep);
+  color: var(--oc-accent-primary);
 }
 .home-v2-sep {
   display: inline-block;


### PR DESCRIPTION
## Summary

- render the homepage hero headline with the canonical OpenClaw primary accent (`#f5654a` in dark mode)
- update the UI design-contract assertion to lock the semantic token

## Validation

- `bun run ci:static`
- `bun run ci:unit` — 5,377 passed, 1 skipped
- `bun run build`
- `bunx tsc -p packages/schema/tsconfig.json --noEmit`
- `bunx tsc -p packages/clawhub/tsconfig.json --noEmit`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --stream-engine-output` — clean
- real local ClawHub browser proof at `http://127.0.0.1:4273/`; computed headline color `rgb(245, 101, 74)`
