### PR TITLE
fix: use skill icons in social cards

### DIFF
--- a/convex/httpApiV1.handlers.test.ts
+++ b/convex/httpApiV1.handlers.test.ts
@@ -1968,6 +1968,7 @@ describe("httpApiV1 handlers", () => {
           slug: "demo",
           displayName: "Demo",
           summary: "Summary",
+          icon: `/api/v1/skill-icons/${"a".repeat(64)}`,
           updatedAt: 1,
           stats: { downloads: 50 },
         },
@@ -1996,6 +1997,7 @@ describe("httpApiV1 handlers", () => {
           slug: "demo",
           displayName: "Demo",
           summary: "Summary",
+          icon: `/api/v1/skill-icons/${"a".repeat(64)}`,
           version: "1.0.0",
           downloads: 50,
           updatedAt: 1,
@@ -2690,6 +2692,7 @@ describe("httpApiV1 handlers", () => {
             slug: "demo",
             displayName: "Demo",
             summary: "s",
+            icon: `/api/v1/skill-icons/${"a".repeat(64)}`,
             topics: ["Automation", "Email"],
             tags: { latest: "versions:1" },
             stats: { downloads: 0, stars: 0, versions: 1, comments: 0 },
@@ -2728,6 +2731,7 @@ describe("httpApiV1 handlers", () => {
     expect(response.status).toBe(200);
     const json = await response.json();
     expect(json.skill.slug).toBe("demo");
+    expect(json.skill.icon).toBe(`/api/v1/skill-icons/${"a".repeat(64)}`);
     expect(json.skill.topics).toEqual(["Automation", "Email"]);
     expect(json.latestVersion.version).toBe("1.0.0");
     expect(json.moderation).toEqual({

--- a/convex/httpApiV1/skillsV1.ts
+++ b/convex/httpApiV1/skillsV1.ts
@@ -191,6 +191,7 @@ type GetBySlugResult = {
     slug: string;
     displayName: string;
     summary?: string;
+    icon?: string;
     topics?: string[];
     tags: Record<string, Id<"skillVersions">>;
     stats: unknown;
@@ -1902,6 +1903,7 @@ export async function skillsGetRouterV1Handler(ctx: ActionCtx, request: Request)
           slug: result.skill.slug,
           displayName: result.skill.displayName,
           summary: result.skill.summary ?? null,
+          icon: result.skill.icon ?? null,
           description: description ?? result.latestVersion?.parsed?.description ?? null,
           topics: result.skill.topics,
           tags,

--- a/convex/lib/canonicalSkillSearchResponse.ts
+++ b/convex/lib/canonicalSkillSearchResponse.ts
@@ -4,6 +4,7 @@ type LegacySearchResult = {
     slug?: unknown;
     displayName?: unknown;
     summary?: unknown;
+    icon?: unknown;
     updatedAt?: unknown;
     stats?: { downloads?: unknown };
   } | null;
@@ -61,6 +62,7 @@ export function serializeCanonicalSkillSearchResults(results: unknown[]) {
       displayName:
         typeof legacy.skill?.displayName === "string" ? legacy.skill.displayName : undefined,
       summary: typeof legacy.skill?.summary === "string" ? legacy.skill.summary : null,
+      icon: typeof legacy.skill?.icon === "string" ? legacy.skill.icon : null,
       version: typeof legacy.version?.version === "string" ? legacy.version.version : null,
       downloads:
         typeof legacy.skill?.stats?.downloads === "number"

--- a/convex/search.test.ts
+++ b/convex/search.test.ts
@@ -1239,6 +1239,7 @@ describe("search helpers", () => {
         id: "skills:calendar",
         slug: "calendar",
         displayName: "Calendar",
+        icon: `/api/v1/skill-icons/${"a".repeat(64)}`,
         downloads: 1_000_000,
       }),
       version: null,
@@ -1281,6 +1282,7 @@ describe("search helpers", () => {
     expect(result[0]).toMatchObject({
       canonicalUrl: "/openclaw/skills/calendar",
       install: { reference: "openclaw/calendar" },
+      icon: `/api/v1/skill-icons/${"a".repeat(64)}`,
       metrics: { rolling60DayInstalls: 12, bookmarks: 3 },
     });
     expect((result[0]?.native as { owner?: unknown })?.owner).not.toHaveProperty("bio");
@@ -1291,6 +1293,7 @@ describe("search helpers", () => {
         source: "https://skills.sh/acme/skills/calendar",
       },
       install: { reference: "skills-sh:acme/skills/calendar" },
+      icon: null,
       sourceIdentity: { lifetimeInstalls: 10_000_000 },
     });
   });
@@ -2887,6 +2890,7 @@ function makePublicSkill(params: {
   slug: string;
   displayName: string;
   summary?: string;
+  icon?: string;
   downloads?: number;
   ownerPublisherId?: string;
   installs?: number;
@@ -2901,6 +2905,7 @@ function makePublicSkill(params: {
     slug: params.slug,
     displayName: params.displayName,
     summary: params.summary ?? `${params.displayName} summary`,
+    icon: params.icon,
     ownerUserId: "users:owner",
     ownerPublisherId: params.ownerPublisherId,
     canonicalSkillId: undefined,

--- a/convex/search.ts
+++ b/convex/search.ts
@@ -540,6 +540,7 @@ type CanonicalSkillSearchResult = {
   slug: string;
   displayName: string;
   summary: string | null;
+  icon: string | null;
   score: number;
   canonicalUrl: string;
   links: {
@@ -675,6 +676,7 @@ function buildNativeCanonicalResult(
     slug: entry.skill.slug,
     displayName: entry.skill.displayName,
     summary: entry.skill.summary ?? null,
+    icon: entry.skill.icon ?? null,
     score: canonicalScore(relevance),
     canonicalUrl,
     links: { canonical: canonicalUrl, source: null },
@@ -748,6 +750,7 @@ function buildExternalCanonicalResult(
     slug: digest.slug,
     displayName: digest.displayName,
     summary: digest.searchSummary ?? null,
+    icon: null,
     score: canonicalScore(relevance),
     canonicalUrl,
     links: { canonical: canonicalUrl, source: digest.sourceUrl },

--- a/server/og/fetchSkillOgMeta.test.ts
+++ b/server/og/fetchSkillOgMeta.test.ts
@@ -15,6 +15,7 @@ describe("fetchSkillOgMeta", () => {
         skill: {
           displayName: "Gifgrep",
           summary: "Search GIFs fast",
+          icon: `/api/v1/skill-icons/${"a".repeat(64)}`,
           stats: { downloads: 99, installsAllTime: 1200 },
           statsDownloads: 1200,
         },
@@ -34,5 +35,6 @@ describe("fetchSkillOgMeta", () => {
       },
     );
     expect(meta?.stats.downloads).toBe(1200);
+    expect(meta?.icon).toBe(`https://clawhub.ai/api/v1/skill-icons/${"a".repeat(64)}`);
   });
 });

--- a/server/og/fetchSkillOgMeta.ts
+++ b/server/og/fetchSkillOgMeta.ts
@@ -3,11 +3,13 @@ import { readCanonicalStat, type SkillStatReadable } from "../../convex/lib/skil
 type SkillApiPayload = SkillStatReadable & {
   displayName?: string;
   summary?: string | null;
+  icon?: string | null;
 };
 
 export type SkillOgMeta = {
   displayName: string | null;
   summary: string | null;
+  icon: string | null;
   owner: string | null;
   ownerImage: string | null;
   version: string | null;
@@ -20,6 +22,17 @@ export type SkillOgMeta = {
     isMalwareBlocked: boolean;
   } | null;
 };
+
+function resolveSkillIconUrl(value: unknown, apiBase: string) {
+  if (typeof value !== "string") return null;
+  const icon = value.trim();
+  if (!icon.startsWith("https://") && !icon.startsWith("/api/v1/skill-icons/")) return null;
+  try {
+    return new URL(icon, `${apiBase.replace(/\/+$/, "")}/`).toString();
+  } catch {
+    return null;
+  }
+}
 
 export async function fetchSkillOgMeta(
   slug: string,
@@ -45,6 +58,7 @@ export async function fetchSkillOgMeta(
     return {
       displayName: payload.skill?.displayName ?? null,
       summary: payload.skill?.summary ?? null,
+      icon: resolveSkillIconUrl(payload.skill?.icon, apiBase),
       owner: payload.owner?.handle ?? null,
       ownerImage: payload.owner?.image ?? null,
       version: payload.latestVersion?.version ?? null,

--- a/server/og/skillOgSvg.ts
+++ b/server/og/skillOgSvg.ts
@@ -4,6 +4,8 @@ export type SkillOgSvgParams = {
   markDataUrl: string;
   watermarkDataUrl?: string | null;
   avatarDataUrl?: string | null;
+  avatarShape?: "circle" | "rounded";
+  avatarFit?: "cover" | "contain";
   title: string;
   description: string;
   ownerLabel: string;
@@ -17,7 +19,8 @@ export function buildSkillOgSvg(params: SkillOgSvgParams) {
     markDataUrl: params.markDataUrl,
     watermarkDataUrl: params.watermarkDataUrl,
     avatarDataUrl: params.avatarDataUrl,
-    avatarShape: "circle",
+    avatarShape: params.avatarShape ?? "circle",
+    avatarFit: params.avatarFit,
     surfaceLabel: "Skill",
     eyebrow: params.ownerLabel,
     title: params.title,

--- a/server/og/skillRoute.test.ts
+++ b/server/og/skillRoute.test.ts
@@ -11,6 +11,8 @@ const getWatermarkDataUrlMock = vi.fn();
 const ensureResvgWasmMock = vi.fn();
 const getFontBuffersMock = vi.fn();
 const buildSkillOgSvgMock = vi.fn();
+const fetchImageDataUrlMock = vi.fn();
+const fetchPublicOgImageDataUrlMock = vi.fn();
 const renderAsPngMock = vi.fn();
 const freeMock = vi.fn();
 const resvgCtorMock = vi.fn();
@@ -50,7 +52,8 @@ vi.mock("./ogAssets", () => ({
 }));
 
 vi.mock("./fetchImageDataUrl", () => ({
-  fetchImageDataUrl: vi.fn(async () => null),
+  fetchImageDataUrl: (...args: unknown[]) => fetchImageDataUrlMock(...args),
+  fetchPublisherProfileImageDataUrl: (...args: unknown[]) => fetchPublicOgImageDataUrlMock(...args),
 }));
 
 vi.mock("./skillOgSvg", () => ({
@@ -71,6 +74,8 @@ beforeEach(() => {
   ensureResvgWasmMock.mockReset();
   getFontBuffersMock.mockReset();
   buildSkillOgSvgMock.mockReset();
+  fetchImageDataUrlMock.mockReset();
+  fetchPublicOgImageDataUrlMock.mockReset();
   renderAsPngMock.mockReset();
   freeMock.mockReset();
   resvgCtorMock.mockReset();
@@ -80,6 +85,8 @@ beforeEach(() => {
   ensureResvgWasmMock.mockResolvedValue(undefined);
   getFontBuffersMock.mockResolvedValue([new Uint8Array([1, 2, 3])]);
   buildSkillOgSvgMock.mockReturnValue("<svg>skill</svg>");
+  fetchImageDataUrlMock.mockResolvedValue(null);
+  fetchPublicOgImageDataUrlMock.mockResolvedValue(null);
   renderAsPngMock.mockReturnValue(new Uint8Array([7, 8, 9]));
 });
 
@@ -122,6 +129,8 @@ describe("skill og route", () => {
       markDataUrl: "data:image/png;base64,AAA=",
       watermarkDataUrl: "data:image/png;base64,WWW=",
       avatarDataUrl: null,
+      avatarShape: "circle",
+      avatarFit: "cover",
       title: "Gifgrep",
       description: "Search GIFs fast",
       ownerLabel: "@steipete",
@@ -156,6 +165,7 @@ describe("skill og route", () => {
       version: null,
       displayName: "Gifgrep",
       summary: "Search GIFs fast",
+      icon: null,
       ownerImage: null,
       stats: { downloads: 1200 },
       moderation: { verdict: "clean", isSuspicious: false, isMalwareBlocked: false },
@@ -180,6 +190,72 @@ describe("skill og route", () => {
           { value: "1.2k", label: "Downloads" },
           { value: "PASS", label: "Audit" },
         ],
+      }),
+    );
+  });
+
+  it("prefers the skill icon over the publisher profile image", async () => {
+    const iconUrl = "https://clawhub.ai/api/v1/skill-icons/aaaaaaaa";
+    const ownerImage = "https://avatars.githubusercontent.com/u/1?v=4";
+    getQueryMock.mockReturnValue({ slug: "playwright-interactive" });
+    fetchSkillOgMetaMock.mockResolvedValue({
+      owner: "tridefender",
+      version: "1.0.0",
+      displayName: "Playwright Interactive",
+      summary: "Control a browser interactively",
+      icon: iconUrl,
+      ownerImage,
+      stats: { downloads: 42 },
+      moderation: { verdict: "clean", isSuspicious: false, isMalwareBlocked: false },
+    });
+    fetchPublicOgImageDataUrlMock.mockImplementation(async (url: string | null | undefined) =>
+      url === iconUrl ? "data:image/png;base64,ICON" : null,
+    );
+
+    const handler = (await import("../routes/og/skill.png")).default;
+    await handler({} as never);
+
+    expect(fetchPublicOgImageDataUrlMock).toHaveBeenCalledTimes(1);
+    expect(fetchPublicOgImageDataUrlMock).toHaveBeenCalledWith(iconUrl);
+    expect(buildSkillOgSvgMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        avatarDataUrl: "data:image/png;base64,ICON",
+        avatarShape: "rounded",
+        avatarFit: "contain",
+      }),
+    );
+  });
+
+  it("falls back to the publisher profile image when the skill icon cannot render", async () => {
+    const iconUrl = "https://clawhub.ai/api/v1/skill-icons/aaaaaaaa";
+    const ownerImage = "https://avatars.githubusercontent.com/u/1?v=4";
+    getQueryMock.mockReturnValue({ slug: "playwright-interactive" });
+    fetchSkillOgMetaMock.mockResolvedValue({
+      owner: "tridefender",
+      version: "1.0.0",
+      displayName: "Playwright Interactive",
+      summary: "Control a browser interactively",
+      icon: iconUrl,
+      ownerImage,
+      stats: { downloads: 42 },
+      moderation: { verdict: "clean", isSuspicious: false, isMalwareBlocked: false },
+    });
+    fetchPublicOgImageDataUrlMock.mockImplementation(async (url: string | null | undefined) =>
+      url === ownerImage ? "data:image/png;base64,PROFILE" : null,
+    );
+
+    const handler = (await import("../routes/og/skill.png")).default;
+    await handler({} as never);
+
+    expect(fetchPublicOgImageDataUrlMock.mock.calls.map(([url]) => url)).toEqual([
+      iconUrl,
+      ownerImage,
+    ]);
+    expect(buildSkillOgSvgMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        avatarDataUrl: "data:image/png;base64,PROFILE",
+        avatarShape: "circle",
+        avatarFit: "cover",
       }),
     );
   });

--- a/server/routes/og/skill.png.ts
+++ b/server/routes/og/skill.png.ts
@@ -1,6 +1,6 @@
 import { Resvg } from "@resvg/resvg-wasm";
 import { defineEventHandler, getQuery, getRequestHost, setHeader } from "h3";
-import { fetchImageDataUrl } from "../../og/fetchImageDataUrl";
+import { fetchImageDataUrl, fetchPublisherProfileImageDataUrl } from "../../og/fetchImageDataUrl";
 import { fetchSkillOgMeta } from "../../og/fetchSkillOgMeta";
 import { resolveOgDownloadsDisplay } from "../../og/formatOgStats";
 import {
@@ -86,12 +86,19 @@ export default defineEventHandler(async (event) => {
     getWatermarkDataUrl(),
     ensureResvgWasm().then(() => getFontBuffers()),
   ]);
-  const avatarDataUrl = await fetchImageDataUrl(avatarFromQuery || meta?.ownerImage);
+  const skillIconDataUrl = avatarFromQuery
+    ? null
+    : await fetchPublisherProfileImageDataUrl(meta?.icon);
+  const avatarDataUrl = avatarFromQuery
+    ? await fetchImageDataUrl(avatarFromQuery)
+    : (skillIconDataUrl ?? (await fetchPublisherProfileImageDataUrl(meta?.ownerImage)));
 
   const svg = buildSkillOgSvg({
     markDataUrl,
     watermarkDataUrl,
     avatarDataUrl,
+    avatarShape: skillIconDataUrl ? "rounded" : "circle",
+    avatarFit: skillIconDataUrl ? "contain" : "cover",
     title,
     description,
     ownerLabel,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where shared skill links showed the publisher profile picture even when the skill had its own icon.

## Why This Change Was Made

Skill detail and search API responses now expose the existing hosted icon metadata. The social-card renderer prefers a renderable skill icon, using the publisher profile picture only when the icon is absent or cannot be loaded.

## User Impact

Social previews identify the skill itself when an icon is available, while preserving the existing publisher-avatar fallback for older or iconless skills.

## Evidence

- Real browser proof against the local ClawHub OG route with a public skill icon; verified the icon renders with contained sizing and the Carapace rounded radius.
- `bun run test convex/httpApiV1.handlers.test.ts convex/search.test.ts server/og/fetchSkillOgMeta.test.ts server/og/skillRoute.test.ts` (498 passed)
- `bun run ci:static`
- `bun run ci:unit` (5,564 passed, 2 skipped)
- `bun run ci:types-build`
- Autoreview: clean, no accepted/actionable findings
