### PR TITLE
feat: make catalog discovery trending-first

### DIFF
--- a/convex/devSeed.localFixtures.test.ts
+++ b/convex/devSeed.localFixtures.test.ts
@@ -1200,6 +1200,7 @@ describe("devSeed local fixtures", () => {
         flaggedPluginReadme: "# Flagged plugin",
         scannedPluginStorageId: "storage:scanned-plugin",
         scannedPluginReadme: "# Scanned plugin",
+        excludeFromPublicCatalog: true,
       } as never,
     );
     const reseedResult = (await seedLocalModerationFixturesHandler(
@@ -1235,6 +1236,15 @@ describe("devSeed local fixtures", () => {
     };
     expect(fixtureStorageId(flaggedSkillSlug)).toBe("storage:skill-next");
     expect(fixtureStorageId(scannedSkillSlug)).toBe("storage:scanned-skill-next");
+    expect(
+      tables.skills
+        ?.filter((skill) =>
+          [scannedSkillSlug, "local-truncation-plugin-runtime-integration-skill"].includes(
+            String(skill.slug),
+          ),
+        )
+        .every((skill) => skill.moderationStatus === "hidden"),
+    ).toBe(true);
     const deduplicatedReseedResult = (await seedLocalModerationFixturesHandler(
       createMutationCtx(db) as never,
       {

--- a/convex/devSeed.localFixtures.test.ts
+++ b/convex/devSeed.localFixtures.test.ts
@@ -1172,6 +1172,22 @@ describe("devSeed local fixtures", () => {
 
   it("seeds moderation and plugin fixtures for an explicit local user with scoped identifiers", async () => {
     const { db, tables } = createDb();
+    const staleProofPublisherId = (await db.insert("publishers", {
+      handle: "patrick-erichsen",
+      kind: "user",
+      displayName: "Patrick Erichsen",
+    })) as Id<"publishers">;
+    const staleProofSkillId = (await db.insert("skills", {
+      ownerPublisherId: staleProofPublisherId,
+      slug: "test",
+      summary:
+        "CLAW-526 Clean Preview Skill validates staged publishing through the hosted ClawHub Test UI.",
+      moderationStatus: "active",
+    })) as Id<"skills">;
+    await db.insert("skillSearchDigest", {
+      skillId: staleProofSkillId,
+      moderationStatus: "active",
+    });
     const userId = (await db.insert("users", {
       handle: "fuller-stack-dev",
       displayName: "Fuller Stack Dev",
@@ -1201,6 +1217,12 @@ describe("devSeed local fixtures", () => {
         scannedPluginStorageId: "storage:scanned-plugin",
         scannedPluginReadme: "# Scanned plugin",
         excludeFromPublicCatalog: true,
+        staleProofSkill: {
+          ownerHandle: "patrick-erichsen",
+          slug: "test",
+          summary:
+            "CLAW-526 Clean Preview Skill validates staged publishing through the hosted ClawHub Test UI.",
+        },
       } as never,
     );
     const reseedResult = (await seedLocalModerationFixturesHandler(
@@ -1245,6 +1267,13 @@ describe("devSeed local fixtures", () => {
         )
         .every((skill) => skill.moderationStatus === "hidden"),
     ).toBe(true);
+    expect(tables.skills?.find((skill) => skill._id === staleProofSkillId)).toMatchObject({
+      moderationStatus: "hidden",
+      moderationReason: "test.fixture",
+    });
+    expect(
+      tables.skillSearchDigest?.find((digest) => digest.skillId === staleProofSkillId),
+    ).toMatchObject({ moderationStatus: "hidden", moderationReason: "test.fixture" });
     const deduplicatedReseedResult = (await seedLocalModerationFixturesHandler(
       createMutationCtx(db) as never,
       {
@@ -1290,14 +1319,15 @@ describe("devSeed local fixtures", () => {
 
     expect(tables.users).toHaveLength(1);
     expect(tables.users?.[0]).toEqual(expect.objectContaining({ handle: "fuller-stack-dev" }));
+    const seededSkills = tables.skills?.filter((skill) => skill._id !== staleProofSkillId);
     expect(
-      tables.skills?.map((skill) => String(skill.slug)).sort((a, b) => a.localeCompare(b)),
+      seededSkills?.map((skill) => String(skill.slug)).sort((a, b) => a.localeCompare(b)),
     ).toEqual([
       scannedSkillSlug,
       flaggedSkillSlug,
       "local-truncation-plugin-runtime-integration-skill",
     ]);
-    expect(tables.skills?.every((skill) => skill.ownerUserId === userId)).toBe(true);
+    expect(seededSkills?.every((skill) => skill.ownerUserId === userId)).toBe(true);
     expect(
       tables.packages?.map((pkg) => String(pkg.name)).sort((a, b) => a.localeCompare(b)),
     ).toEqual([

--- a/convex/devSeed.ts
+++ b/convex/devSeed.ts
@@ -45,6 +45,7 @@ type SeedSkillSpec = {
 
 type SeedActionArgs = {
   reset?: boolean;
+  excludeFromPublicCatalog?: boolean;
   ownerUserId?: Id<"users">;
   flaggedSkillSlug?: string;
   scannedSkillSlug?: string;
@@ -861,6 +862,7 @@ async function seedLocalFixturesHandler(
     internal.devSeed.seedLocalModerationFixturesMutation,
     {
       reset: args.reset,
+      excludeFromPublicCatalog: args.excludeFromPublicCatalog,
       flaggedSkillSlug: args.flaggedSkillSlug,
       scannedSkillSlug: args.scannedSkillSlug,
       flaggedPluginName: args.flaggedPluginName,
@@ -903,6 +905,7 @@ export const seedTestFixtures: ReturnType<typeof internalAction> = internalActio
     assertTestSeedAllowed();
     return await seedLocalFixturesHandler(ctx, {
       reset: false,
+      excludeFromPublicCatalog: true,
       flaggedSkillSlug: "test-flagged-wallet-sync",
       scannedSkillSlug: "test-agentic-risk-demo",
       flaggedPluginName: "test-flagged-runtime-plugin",
@@ -2810,6 +2813,7 @@ function flaggedWalletClawScanAnalysis(now: number) {
 
 type SeedLocalModerationFixturesArgs = {
   reset?: boolean;
+  excludeFromPublicCatalog?: boolean;
   ownerUserId?: Id<"users">;
   flaggedSkillSlug?: string;
   scannedSkillSlug?: string;
@@ -2859,6 +2863,26 @@ export async function seedLocalModerationFixturesHandler(
     for (const skill of [existingSkill, existingScannedSkill, existingTruncationSkill]) {
       if (skill.ownerUserId !== userId || skill.ownerPublisherId !== publisherId) {
         await ctx.db.patch(skill._id, ownerPatch);
+      }
+    }
+    if (args.excludeFromPublicCatalog) {
+      for (const skill of [existingScannedSkill, existingTruncationSkill]) {
+        await ctx.db.patch(skill._id, {
+          moderationStatus: "hidden",
+          moderationReason: "test.fixture",
+          updatedAt: now,
+        });
+        const digest = await ctx.db
+          .query("skillSearchDigest")
+          .withIndex("by_skill", (q) => q.eq("skillId", skill._id))
+          .unique();
+        if (digest) {
+          await ctx.db.patch(digest._id, {
+            moderationStatus: "hidden",
+            moderationReason: "test.fixture",
+            updatedAt: now,
+          });
+        }
       }
     }
     await ctx.db.patch(existingScannedSkill._id, {
@@ -3124,8 +3148,8 @@ export async function seedLocalModerationFixturesHandler(
     tags: {},
     softDeletedAt: undefined,
     badges: { redactionApproved: undefined },
-    moderationStatus: "active",
-    moderationReason: "scanner.llm.suspicious",
+    moderationStatus: args.excludeFromPublicCatalog ? "hidden" : "active",
+    moderationReason: args.excludeFromPublicCatalog ? "test.fixture" : "scanner.llm.suspicious",
     moderationVerdict: "suspicious",
     moderationReasonCodes: ["suspicious.agentic_risk_fixture"],
     moderationEvidence: scannedSkillStaticScan.findings,
@@ -3220,8 +3244,8 @@ export async function seedLocalModerationFixturesHandler(
     tags: {},
     softDeletedAt: undefined,
     badges: { redactionApproved: undefined },
-    moderationStatus: "active",
-    moderationReason: undefined,
+    moderationStatus: args.excludeFromPublicCatalog ? "hidden" : "active",
+    moderationReason: args.excludeFromPublicCatalog ? "test.fixture" : undefined,
     moderationVerdict: "clean",
     moderationReasonCodes: [],
     moderationEvidence: undefined,
@@ -3675,6 +3699,7 @@ export async function seedLocalModerationFixturesHandler(
 export const seedLocalModerationFixturesMutation = internalMutation({
   args: {
     reset: v.optional(v.boolean()),
+    excludeFromPublicCatalog: v.optional(v.boolean()),
     ownerUserId: v.optional(v.id("users")),
     flaggedSkillSlug: v.optional(v.string()),
     scannedSkillSlug: v.optional(v.string()),

--- a/convex/devSeed.ts
+++ b/convex/devSeed.ts
@@ -46,11 +46,18 @@ type SeedSkillSpec = {
 type SeedActionArgs = {
   reset?: boolean;
   excludeFromPublicCatalog?: boolean;
+  staleProofSkill?: TestProofSkillIdentity;
   ownerUserId?: Id<"users">;
   flaggedSkillSlug?: string;
   scannedSkillSlug?: string;
   flaggedPluginName?: string;
   scannedPluginName?: string;
+};
+
+type TestProofSkillIdentity = {
+  ownerHandle: string;
+  slug: string;
+  summary: string;
 };
 
 type SeedActionResult = {
@@ -278,6 +285,12 @@ const FLAGGED_PLUGIN_NAME = "local-flagged-runtime-plugin";
 const SCANNED_PLUGIN_NAME = "local-scanned-runtime-plugin";
 const TRUNCATION_SKILL_SLUG = "local-truncation-plugin-runtime-integration-skill";
 const TRUNCATION_PLUGIN_NAME = "local-truncation-runtime-plugin";
+const CLAW_526_TEST_PROOF_SKILL: TestProofSkillIdentity = {
+  ownerHandle: "patrick-erichsen",
+  slug: "test",
+  summary:
+    "CLAW-526 Clean Preview Skill validates staged publishing through the hosted ClawHub Test UI.",
+};
 const TRUNCATION_FIXTURE_DISPLAY_NAME =
   "[120] Plugin Runtime Integration ABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHI";
 const SCANNED_SKILL_SUMMARY =
@@ -863,6 +876,7 @@ async function seedLocalFixturesHandler(
     {
       reset: args.reset,
       excludeFromPublicCatalog: args.excludeFromPublicCatalog,
+      staleProofSkill: args.staleProofSkill,
       flaggedSkillSlug: args.flaggedSkillSlug,
       scannedSkillSlug: args.scannedSkillSlug,
       flaggedPluginName: args.flaggedPluginName,
@@ -906,6 +920,7 @@ export const seedTestFixtures: ReturnType<typeof internalAction> = internalActio
     return await seedLocalFixturesHandler(ctx, {
       reset: false,
       excludeFromPublicCatalog: true,
+      staleProofSkill: CLAW_526_TEST_PROOF_SKILL,
       flaggedSkillSlug: "test-flagged-wallet-sync",
       scannedSkillSlug: "test-agentic-risk-demo",
       flaggedPluginName: "test-flagged-runtime-plugin",
@@ -2814,6 +2829,7 @@ function flaggedWalletClawScanAnalysis(now: number) {
 type SeedLocalModerationFixturesArgs = {
   reset?: boolean;
   excludeFromPublicCatalog?: boolean;
+  staleProofSkill?: TestProofSkillIdentity;
   ownerUserId?: Id<"users">;
   flaggedSkillSlug?: string;
   scannedSkillSlug?: string;
@@ -2829,6 +2845,43 @@ type SeedLocalModerationFixturesArgs = {
   scannedPluginReadme: string;
 };
 
+async function hideStaleTestProofSkill(
+  ctx: MutationCtx,
+  identity: TestProofSkillIdentity,
+  now: number,
+) {
+  const publisher = await ctx.db
+    .query("publishers")
+    .withIndex("by_handle", (q) => q.eq("handle", identity.ownerHandle))
+    .unique();
+  if (!publisher) return;
+  const skill = await ctx.db
+    .query("skills")
+    .withIndex("by_owner_publisher_slug", (q) =>
+      q.eq("ownerPublisherId", publisher._id).eq("slug", identity.slug),
+    )
+    .unique();
+  // The summary guard makes this an exact Test-proof cleanup, not a rule that
+  // hides arbitrary publisher content sharing a short fixture slug.
+  if (!skill || skill.summary !== identity.summary) return;
+  await ctx.db.patch(skill._id, {
+    moderationStatus: "hidden",
+    moderationReason: "test.fixture",
+    updatedAt: now,
+  });
+  const digest = await ctx.db
+    .query("skillSearchDigest")
+    .withIndex("by_skill", (q) => q.eq("skillId", skill._id))
+    .unique();
+  if (digest) {
+    await ctx.db.patch(digest._id, {
+      moderationStatus: "hidden",
+      moderationReason: "test.fixture",
+      updatedAt: now,
+    });
+  }
+}
+
 export async function seedLocalModerationFixturesHandler(
   ctx: MutationCtx,
   args: SeedLocalModerationFixturesArgs,
@@ -2842,6 +2895,9 @@ export async function seedLocalModerationFixturesHandler(
   const now = Date.now();
   const owner = await ensureSeedOwner(ctx, args.ownerUserId);
   await retireLegacyLocalOwnerPublishers(ctx, owner, now);
+  if (args.excludeFromPublicCatalog && args.staleProofSkill) {
+    await hideStaleTestProofSkill(ctx, args.staleProofSkill, now);
+  }
   const existingSkill = await findSeedSkillFixture(ctx, flaggedSkillSlug);
   const existingScannedSkill = await findScannedSkillFixture(ctx, scannedSkillSlug);
   const existingPlugin = await findSeedPluginFixture(ctx, flaggedPluginName);
@@ -3700,6 +3756,9 @@ export const seedLocalModerationFixturesMutation = internalMutation({
   args: {
     reset: v.optional(v.boolean()),
     excludeFromPublicCatalog: v.optional(v.boolean()),
+    staleProofSkill: v.optional(
+      v.object({ ownerHandle: v.string(), slug: v.string(), summary: v.string() }),
+    ),
     ownerUserId: v.optional(v.id("users")),
     flaggedSkillSlug: v.optional(v.string()),
     scannedSkillSlug: v.optional(v.string()),

--- a/convex/lib/globalStats.ts
+++ b/convex/lib/globalStats.ts
@@ -136,6 +136,31 @@ export async function setGlobalPublicPluginsCount(
   }
 }
 
+export async function setGlobalPublicExternalSkillsCount(
+  ctx: GlobalStatsWriteCtx,
+  count: number,
+  now = Date.now(),
+) {
+  const normalizedCount = Math.max(0, Math.trunc(Number.isFinite(count) ? count : 0));
+  const existing = await ctx.db
+    .query("globalStats")
+    .withIndex("by_key", (q) => q.eq("key", GLOBAL_STATS_KEY))
+    .unique();
+  if (existing) {
+    await ctx.db.patch(existing._id, {
+      activeExternalSkillsCount: normalizedCount,
+      updatedAt: now,
+    });
+    return;
+  }
+  await ctx.db.insert("globalStats", {
+    key: GLOBAL_STATS_KEY,
+    activeSkillsCount: 0,
+    activeExternalSkillsCount: normalizedCount,
+    updatedAt: now,
+  });
+}
+
 export async function adjustGlobalPublicSkillsCount(
   ctx: GlobalStatsWriteCtx,
   delta: number,
@@ -208,7 +233,7 @@ export async function readGlobalPublicSkillsCount(ctx: GlobalStatsReadCtx) {
       .query("globalStats")
       .withIndex("by_key", (q) => q.eq("key", GLOBAL_STATS_KEY))
       .unique();
-    return stats?.activeSkillsCount ?? null;
+    return stats ? stats.activeSkillsCount + (stats.activeExternalSkillsCount ?? 0) : null;
   } catch (error) {
     if (isGlobalStatsStorageNotReadyError(error)) return null;
     throw error;

--- a/convex/packages.public.test.ts
+++ b/convex/packages.public.test.ts
@@ -48,6 +48,7 @@ import {
   listPluginExportPageInternal,
   reservePackageNameInternal,
   listPublicPage,
+  listPublicNewPluginsPage,
   listPageForViewerInternal,
   listVersions,
   listVersionsForManager,
@@ -153,6 +154,20 @@ const listPublicPageHandler = (
     },
     {
       page: Array<{ name: string; featuredAt?: number }>;
+      isDone: boolean;
+      continueCursor: string;
+    }
+  >
+)._handler;
+const listPublicNewPluginsPageHandler = (
+  listPublicNewPluginsPage as unknown as WrappedHandler<
+    {
+      category?: string;
+      createdAfter: number;
+      paginationOpts: { cursor: string | null; numItems: number };
+    },
+    {
+      page: Array<{ name: string; createdAt: number }>;
       isDone: boolean;
       continueCursor: string;
     }
@@ -1821,8 +1836,8 @@ function readIndexField(row: Record<string, unknown>, field: string) {
   }, row);
 }
 
-function makePluginExportIndexKey(row: Record<string, unknown>) {
-  return [row.softDeletedAt, row.family, row.updatedAt, row._creationTime, row._id] as unknown[];
+function makePluginExportIndexKey(row: Record<string, unknown>, field = "updatedAt") {
+  return [row.softDeletedAt, row.family, row[field], row._creationTime, row._id] as unknown[];
 }
 
 function makePluginExportCtx(
@@ -1876,7 +1891,10 @@ function makePluginExportCtx(
                 lte: (field: string, value: unknown) => unknown;
               }) => unknown,
             ) => {
-              if (indexName !== "by_active_family_updated") {
+              if (
+                indexName !== "by_active_family_updated" &&
+                indexName !== "by_active_family_created"
+              ) {
                 throw new Error(`Unexpected packageSearchDigest index ${indexName}`);
               }
               const filters: Array<{
@@ -1921,8 +1939,10 @@ function makePluginExportCtx(
                       }),
                     )
                     .sort((a, b) => {
-                      const updatedDiff = Number(a.updatedAt) - Number(b.updatedAt);
-                      if (updatedDiff !== 0) return order === "desc" ? -updatedDiff : updatedDiff;
+                      const sortField =
+                        indexName === "by_active_family_created" ? "createdAt" : "updatedAt";
+                      const metricDiff = Number(a[sortField]) - Number(b[sortField]);
+                      if (metricDiff !== 0) return order === "desc" ? -metricDiff : metricDiff;
                       const idDiff = String(a._id).localeCompare(String(b._id));
                       return order === "desc" ? -idDiff : idDiff;
                     });
@@ -1934,7 +1954,13 @@ function makePluginExportCtx(
                     },
                     async *iterWithKeys() {
                       for (const row of matches) {
-                        yield [row, makePluginExportIndexKey(row)];
+                        yield [
+                          row,
+                          makePluginExportIndexKey(
+                            row,
+                            indexName === "by_active_family_created" ? "createdAt" : "updatedAt",
+                          ),
+                        ];
                       }
                     },
                   };
@@ -2672,6 +2698,49 @@ function makeSoftDeletePackageCtx(options?: {
 }
 
 describe("packages public queries", () => {
+  it("pages eligible plugins by immutable creation time without scanning the catalog client-side", async () => {
+    const ctx = makePluginExportCtx([
+      makeDigest("updated-old", {
+        family: "code-plugin",
+        createdAt: 50,
+        updatedAt: 500,
+        _creationTime: 1,
+      }),
+      makeDigest("newest-bundle", {
+        family: "bundle-plugin",
+        createdAt: 300,
+        updatedAt: 300,
+        _creationTime: 2,
+      }),
+      makeDigest("newer-code", {
+        family: "code-plugin",
+        createdAt: 200,
+        updatedAt: 200,
+        _creationTime: 3,
+      }),
+      makeDigest("native-skill", {
+        family: "skill",
+        createdAt: 400,
+        updatedAt: 400,
+        _creationTime: 4,
+      }),
+    ]);
+
+    const first = await listPublicNewPluginsPageHandler(ctx, {
+      createdAfter: 100,
+      paginationOpts: { cursor: null, numItems: 1 },
+    });
+    const second = await listPublicNewPluginsPageHandler(ctx, {
+      createdAfter: 100,
+      paginationOpts: { cursor: first.continueCursor, numItems: 1 },
+    });
+
+    expect(first.page.map((entry) => entry.name)).toEqual(["newest-bundle"]);
+    expect(first.isDone).toBe(false);
+    expect(second.page.map((entry) => entry.name)).toEqual(["newer-code"]);
+    expect(second.isDone).toBe(true);
+  });
+
   it("keeps partially consumed plugin export family pages active", async () => {
     const ctx = makePluginExportCtx([
       makePluginExportDigest("newer-code", "code-plugin", 300),

--- a/convex/packages.ts
+++ b/convex/packages.ts
@@ -948,7 +948,7 @@ const STABLE_PACKAGE_DISCOVERY_CURSOR_PREFIX = "pkgstable:";
 type StablePackageFamily = (typeof STABLE_PACKAGE_FAMILIES)[number];
 type StablePackageDiscoverySourceState = { key: IndexKey | null; done: boolean };
 type StablePackageDiscoveryCursorState = {
-  sort: "updated" | "downloads" | "recommended" | "installs";
+  sort: "updated" | "created" | "downloads" | "recommended" | "installs";
   sources: Record<StablePackageFamily, StablePackageDiscoverySourceState>;
 };
 const OFFICIAL_FIRST_PACKAGE_CATEGORY_CURSOR_PREFIX = "pkgofficialfirst:";
@@ -3366,6 +3366,27 @@ export const listPublicPage = query({
   },
 });
 
+export const listPublicNewPluginsPage = query({
+  args: {
+    category: v.optional(v.string()),
+    createdAfter: v.number(),
+    paginationOpts: paginationOptsValidator,
+  },
+  handler: async (ctx, args) => {
+    const category = isPluginCategorySlug(args.category) ? args.category : undefined;
+    if (args.category && !category) {
+      return { page: [], isDone: true, continueCursor: "" };
+    }
+    return await listStablePackageDiscoveryPage(ctx, {
+      families: ["code-plugin", "bundle-plugin"],
+      category,
+      sort: "created",
+      createdAfter: args.createdAfter,
+      paginationOpts: args.paginationOpts,
+    });
+  },
+});
+
 export const listAuditPage = query({
   args: {
     paginationOpts: paginationOptsValidator,
@@ -3533,14 +3554,15 @@ function encodeStablePackageDiscoveryCursor(state: StablePackageDiscoveryCursorS
 
 function readStablePackageDiscoveryCursorSort(
   raw: string | null | undefined,
-): "updated" | "recommended" | null {
+): "updated" | "created" | "recommended" | null {
   if (!raw?.startsWith(STABLE_PACKAGE_DISCOVERY_CURSOR_PREFIX)) return null;
   try {
     const parsed = JSON.parse(raw.slice(STABLE_PACKAGE_DISCOVERY_CURSOR_PREFIX.length)) as {
       v?: unknown;
       sort?: unknown;
     };
-    return parsed.v === 1 && (parsed.sort === "updated" || parsed.sort === "recommended")
+    return parsed.v === 1 &&
+      (parsed.sort === "updated" || parsed.sort === "created" || parsed.sort === "recommended")
       ? parsed.sort
       : null;
   } catch {
@@ -3972,12 +3994,13 @@ export const countPublicPlugins = query({
 function compareStablePackageDiscoveryCandidates(
   a: PackageDigestLike,
   b: PackageDigestLike,
-  sort: "updated" | "downloads" | "recommended" | "installs",
+  sort: "updated" | "created" | "downloads" | "recommended" | "installs",
 ) {
   const metric = (candidate: PackageDigestLike) => {
     if (sort === "downloads") return candidate.stats?.downloads ?? 0;
     if (sort === "installs") return candidate.stats?.installs ?? 0;
     if (sort === "recommended") return candidate.recommendedScore ?? 0;
+    if (sort === "created") return candidate.createdAt;
     return candidate.updatedAt;
   };
   const metricDiff = metric(b) - metric(a);
@@ -3992,12 +4015,14 @@ function compareStablePackageDiscoveryCandidates(
 async function listStablePackageDiscoveryPage(
   ctx: DbReaderCtx,
   args: {
+    families?: StablePackageFamily[];
     channel?: PackageChannel;
     isOfficial?: boolean;
     category?: PluginCategorySlug;
     topic?: string;
     excludedScanStatuses?: PackageListScanStatus[];
-    sort?: "updated" | "downloads" | "recommended" | "installs";
+    sort?: "updated" | "created" | "downloads" | "recommended" | "installs";
+    createdAfter?: number;
     viewerUserId?: Id<"users">;
     paginationOpts: { cursor: string | null; numItems: number };
   },
@@ -4023,6 +4048,10 @@ async function listStablePackageDiscoveryPage(
     if (recommendationScoresMissing) sort = "updated";
   }
   const cursor = decodeStablePackageDiscoveryCursor(args.paginationOpts.cursor, sort);
+  const families = args.families ?? [...STABLE_PACKAGE_FAMILIES];
+  for (const family of STABLE_PACKAGE_FAMILIES) {
+    if (!families.includes(family)) cursor.sources[family].done = true;
+  }
   const scanLimit = Math.min(MAX_PUBLIC_LIST_PAGE_SIZE, Math.max(targetCount * 5, 50));
   const loadFamily = async (family: StablePackageFamily) => {
     const state = cursor.sources[family];
@@ -4030,13 +4059,17 @@ async function listStablePackageDiscoveryPage(
       return { family, rows: [] as PackageDigestLike[], keys: [] as IndexKey[], hasMore: false };
     }
     const eqPrefix: IndexKey = [undefined, family];
-    if (sort === "updated") {
+    if (sort === "updated" || sort === "created") {
+      const index = sort === "created" ? "by_active_family_created" : "by_active_family_updated";
       const result = await getPage(ctx, {
         table: "packageSearchDigest",
-        index: "by_active_family_updated",
+        index,
         startIndexKey: state.key ?? eqPrefix,
         startInclusive: state.key === null,
-        endIndexKey: eqPrefix,
+        endIndexKey:
+          sort === "created" && args.createdAfter !== undefined
+            ? [undefined, family, args.createdAfter]
+            : eqPrefix,
         endInclusive: true,
         order: "desc",
         absoluteMaxRows: scanLimit,
@@ -4073,9 +4106,7 @@ async function listStablePackageDiscoveryPage(
       hasMore: result.hasMore,
     };
   };
-  const familyPages = await Promise.all(
-    STABLE_PACKAGE_FAMILIES.map(async (family) => await loadFamily(family)),
-  );
+  const familyPages = await Promise.all(families.map(async (family) => await loadFamily(family)));
   const membershipCache = new Map<string, Promise<boolean>>();
   const page: PublicPackageListItem[] = [];
   const consumedByFamily = new Map<StablePackageFamily, number>();
@@ -4101,7 +4132,7 @@ async function listStablePackageDiscoveryPage(
     const consumed = consumedByFamily.get(source.family) ?? 0;
     cursor.sources[source.family].done = consumed === source.rows.length && !source.hasMore;
   }
-  const hasMore = STABLE_PACKAGE_FAMILIES.some((family) => !cursor.sources[family].done);
+  const hasMore = families.some((family) => !cursor.sources[family].done);
   return {
     page,
     isDone: !hasMore,

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -2223,6 +2223,7 @@ const packageSearchDigest = defineTable({
     "updatedAt",
   ])
   .index("by_active_family_updated", ["softDeletedAt", "family", "updatedAt"])
+  .index("by_active_family_created", ["softDeletedAt", "family", "createdAt"])
   .index("by_active_family_channel_updated", ["softDeletedAt", "family", "channel", "updatedAt"])
   .index("by_active_family_official_updated", [
     "softDeletedAt",
@@ -2604,6 +2605,7 @@ const skillStatBackfillState = defineTable({
 const globalStats = defineTable({
   key: v.string(),
   activeSkillsCount: v.number(),
+  activeExternalSkillsCount: v.optional(v.number()),
   activePluginsCount: v.optional(v.number()),
   updatedAt: v.number(),
 }).index("by_key", ["key"]);

--- a/convex/skills.countPublicSkills.test.ts
+++ b/convex/skills.countPublicSkills.test.ts
@@ -16,14 +16,18 @@ const countPublicSkillsHandler = (
 )._handler;
 
 describe("skills.countPublicSkills", () => {
-  it("returns precomputed global stats count when available", async () => {
+  it("returns the deduplicated native plus public skills.sh catalog count", async () => {
     const ctx = {
       db: {
         query: vi.fn((table: string) => {
           if (table === "globalStats") {
             return {
               withIndex: () => ({
-                unique: async () => ({ _id: "globalStats:1", activeSkillsCount: 123 }),
+                unique: async () => ({
+                  _id: "globalStats:1",
+                  activeSkillsCount: 123,
+                  activeExternalSkillsCount: 7,
+                }),
               }),
             };
           }
@@ -33,7 +37,7 @@ describe("skills.countPublicSkills", () => {
     };
 
     const result = await countPublicSkillsHandler(ctx, {});
-    expect(result).toBe(123);
+    expect(result).toBe(130);
   });
 
   it("returns zero when the global stats row is missing", async () => {

--- a/convex/skills.publicListCursor.test.ts
+++ b/convex/skills.publicListCursor.test.ts
@@ -44,6 +44,8 @@ type PublicListArgs = {
     | "name";
   dir?: "asc" | "desc";
   highlightedOnly?: boolean;
+  officialOnly?: boolean;
+  createdAfter?: number;
   nonSuspiciousOnly?: boolean;
   capabilityTag?: string;
   topic?: string;
@@ -300,6 +302,81 @@ describe("public skill list deterministic cursors", () => {
     expect((result.page as Array<{ owner?: { official?: boolean } }>)[0]?.owner?.official).toBe(
       true,
     );
+  });
+
+  it("applies Official and New eligibility at the backend cursor boundary", async () => {
+    const officialNew = makeSearchDigest({
+      skillId: "skills:official-new",
+      slug: "official-new",
+      badges: { official: { byUserId: "users:admin", at: 200 } },
+      createdAt: 200,
+    });
+    const communityNew = makeSearchDigest({
+      skillId: "skills:community-new",
+      slug: "community-new",
+      createdAt: 200,
+    });
+    const officialOld = makeSearchDigest({
+      skillId: "skills:official-old",
+      slug: "official-old",
+      badges: { official: { byUserId: "users:admin", at: 50 } },
+      createdAt: 50,
+    });
+    getPageMock.mockResolvedValueOnce({
+      page: [officialNew, communityNew, officialOld],
+      hasMore: false,
+      indexKeys: [
+        [undefined, 200, officialNew.updatedAt, officialNew._id],
+        [undefined, 200, communityNew.updatedAt, communityNew._id],
+        [undefined, 50, officialOld.updatedAt, officialOld._id],
+      ],
+    });
+
+    const result = await listPublicPageV4Handler({} as never, {
+      officialOnly: true,
+      createdAfter: 100,
+      sort: "newest",
+      numItems: 10,
+    });
+
+    expect(
+      (result.page as Array<{ skill: { slug: string } }>).map((entry) => entry.skill.slug),
+    ).toEqual(["official-new"]);
+  });
+
+  it("ends descending New pagination when the creation window boundary is reached", async () => {
+    const recent = makeSearchDigest({
+      skillId: "skills:recent",
+      slug: "recent",
+      createdAt: 200,
+    });
+    const old = makeSearchDigest({
+      skillId: "skills:old",
+      slug: "old",
+      createdAt: 99,
+    });
+    getPageMock.mockResolvedValueOnce({
+      page: [recent, old],
+      hasMore: true,
+      indexKeys: [
+        [undefined, recent.createdAt, recent.updatedAt, recent._id],
+        [undefined, old.createdAt, old.updatedAt, old._id],
+      ],
+    });
+
+    const result = await listPublicPageV4Handler({} as never, {
+      createdAfter: 100,
+      sort: "newest",
+      dir: "desc",
+      numItems: 10,
+    });
+
+    expect(
+      (result.page as Array<{ skill: { slug: string } }>).map((entry) => entry.skill.slug),
+    ).toEqual(["recent"]);
+    expect(result.hasMore).toBe(false);
+    expect(result.nextCursor).toBeNull();
+    expect(getPageMock).toHaveBeenCalledTimes(1);
   });
 
   it("uses the topic digest index for topic-filtered recommended browse", async () => {

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -5426,6 +5426,8 @@ export const listPublicPageV4 = query({
     ),
     dir: v.optional(v.union(v.literal("asc"), v.literal("desc"))),
     highlightedOnly: v.optional(v.boolean()),
+    officialOnly: v.optional(v.boolean()),
+    createdAfter: v.optional(v.number()),
     nonSuspiciousOnly: v.optional(v.boolean()),
     categorySlug: v.optional(v.string()),
     topic: v.optional(v.string()),
@@ -5564,6 +5566,8 @@ export const listPublicPageV4 = query({
     const hasDigestFilters =
       Boolean(categorySlug) ||
       Boolean(topic) ||
+      Boolean(args.officialOnly) ||
+      typeof args.createdAfter === "number" ||
       categoryKeywords.length > 0 ||
       excludeCategoryKeywords.length > 0;
 
@@ -5628,6 +5632,16 @@ export const listPublicPageV4 = query({
         const digest = result.page[index];
         const cursor = result.indexKeys[index];
         if (
+          sort === "newest" &&
+          dir === "desc" &&
+          typeof args.createdAfter === "number" &&
+          digest.createdAt < args.createdAfter
+        ) {
+          return { page: items, hasMore: false, nextCursor: null };
+        }
+        if (
+          (!args.officialOnly || isSkillCatalogOfficial(digest)) &&
+          (typeof args.createdAfter !== "number" || digest.createdAt >= args.createdAfter) &&
           digestPassesPublicListFilters(digest, {
             categorySlug,
             topic,
@@ -5639,6 +5653,16 @@ export const listPublicPageV4 = query({
           if (item) items.push(item);
         }
         if (items.length >= numItems) {
+          const nextDigest = result.page[index + 1];
+          if (
+            sort === "newest" &&
+            dir === "desc" &&
+            typeof args.createdAfter === "number" &&
+            nextDigest &&
+            nextDigest.createdAt < args.createdAfter
+          ) {
+            return { page: items, hasMore: false, nextCursor: null };
+          }
           hasMore = result.hasMore || index < result.page.length - 1;
           nextCursor = hasMore ? encodeIndexKey(indexName, cursor) : null;
           return { page: items, hasMore, nextCursor };

--- a/convex/statsMaintenance.test.ts
+++ b/convex/statsMaintenance.test.ts
@@ -23,6 +23,8 @@ vi.mock("./_generated/api", () => ({
       setSkillStatBackfillStateInternal: Symbol("setSkillStatBackfillStateInternal"),
       reconcileSkillStarCounts: Symbol("reconcileSkillStarCounts"),
       countPublicDigestPageInternal: Symbol("countPublicDigestPageInternal"),
+      listExactNativeExternalIdsPageInternal: Symbol("listExactNativeExternalIdsPageInternal"),
+      listPublicExternalSkillIdsPageInternal: Symbol("listPublicExternalSkillIdsPageInternal"),
       countPublicPackageDigestPageInternal: Symbol("countPublicPackageDigestPageInternal"),
       writeGlobalStatsInternal: Symbol("writeGlobalStatsInternal"),
     },
@@ -33,7 +35,10 @@ const {
   __test,
   backfillPackageRecommendationScoresInternal,
   backfillSkillDigestRecommendationScoresInternal,
+  countPublicDigestPageInternal,
   countPublicPackageDigestPageInternal,
+  listExactNativeExternalIdsPageInternal,
+  listPublicExternalSkillIdsPageInternal,
   reconcileSkillStarCountsHandler,
   runRecommendationScoreBackfillInternal,
   updateGlobalStatsAction,
@@ -60,6 +65,25 @@ const countPublicPackageDigestPageHandler = getHandler<
   { cursor?: string; pageSize?: number },
   { count: number; isDone: boolean; cursor: string }
 >(countPublicPackageDigestPageInternal as never);
+
+const countPublicDigestPageHandler = getHandler<
+  { cursor?: string; pageSize?: number },
+  { count: number; isDone: boolean; cursor: string }
+>(countPublicDigestPageInternal as never);
+
+const listPublicExternalSkillIdsPageHandler = getHandler<
+  { cursor?: string; pageSize?: number },
+  { externalIds: string[]; isDone: boolean; cursor: string }
+>(listPublicExternalSkillIdsPageInternal as never);
+
+const listExactNativeExternalIdsPageHandler = getHandler<
+  { cursor?: string; pageSize?: number },
+  {
+    matches: Array<{ externalId: string; nativeSkillId: string }>;
+    isDone: boolean;
+    cursor: string;
+  }
+>(listExactNativeExternalIdsPageInternal as never);
 
 const backfillSkillDigestRecommendationScoresHandler = getHandler<
   { cursor?: string; batchSize?: number; dryRun?: boolean },
@@ -99,7 +123,7 @@ const runRecommendationScoreBackfillHandler = getHandler<
 
 const updateGlobalStatsActionHandler = getHandler<
   Record<string, never>,
-  { activeSkillsCount: number; activePluginsCount: number }
+  { activeSkillsCount: number; activeExternalSkillsCount: number; activePluginsCount: number }
 >(updateGlobalStatsAction as never);
 
 // ---------------------------------------------------------------------------
@@ -237,6 +261,49 @@ describe("buildSkillStatPatch", () => {
 });
 
 describe("public package digest count maintenance", () => {
+  it("counts one eligible native listing and excludes duplicates and non-public rows", async () => {
+    const paginate = vi.fn().mockResolvedValue({
+      page: [
+        {
+          skillId: "skills:public",
+          moderationStatus: "active",
+          softDeletedAt: undefined,
+          canonicalSkillId: undefined,
+        },
+        {
+          moderationStatus: "active",
+          softDeletedAt: undefined,
+          canonicalSkillId: "skills:canonical",
+        },
+        { moderationStatus: "hidden", softDeletedAt: undefined, canonicalSkillId: undefined },
+        { moderationStatus: "active", softDeletedAt: 123, canonicalSkillId: undefined },
+        {
+          moderationStatus: "active",
+          moderationVerdict: "malicious",
+          softDeletedAt: undefined,
+          canonicalSkillId: undefined,
+        },
+      ],
+      continueCursor: "next",
+      isDone: true,
+    });
+    const ctx = {
+      db: {
+        query: vi.fn((table: string) => {
+          expect(table).toBe("skillSearchDigest");
+          return { paginate };
+        }),
+      },
+    };
+
+    await expect(countPublicDigestPageHandler(ctx, {})).resolves.toEqual({
+      count: 1,
+      nativeSkillIds: ["skills:public"],
+      isDone: true,
+      cursor: "next",
+    });
+  });
+
   it("counts only public code and bundle plugin digests", async () => {
     const paginate = vi.fn().mockResolvedValue({
       page: [
@@ -296,20 +363,150 @@ describe("public package digest count maintenance", () => {
     expect(result).toEqual({ count: 2, isDone: true, cursor: "next" });
   });
 
-  it("writes skills and plugin counts in one global stats update", async () => {
+  it("returns only eligible public skills.sh identities for action-level deduplication", async () => {
+    const paginate = vi.fn().mockResolvedValue({
+      page: [
+        {
+          externalId: "owner/repo/public",
+          active: true,
+          publicVisible: true,
+          installable: true,
+          sourceFreshnessStatus: "observed-only",
+        },
+        {
+          externalId: "owner/repo/stale",
+          active: true,
+          publicVisible: true,
+          installable: true,
+          sourceFreshnessStatus: "stale",
+        },
+      ],
+      continueCursor: "next",
+      isDone: true,
+    });
+    const ctx = {
+      db: {
+        query: vi.fn(() => ({ withIndex: () => ({ paginate }) })),
+      },
+    };
+
+    await expect(listPublicExternalSkillIdsPageHandler(ctx, {})).resolves.toEqual({
+      externalIds: ["owner/repo/public"],
+      isDone: true,
+      cursor: "next",
+    });
+  });
+
+  it("returns exact-native reconciliations for cross-source deduplication", async () => {
+    const paginate = vi.fn().mockResolvedValue({
+      page: [
+        {
+          externalId: "owner/repo/native-match",
+          reconciliation: { kind: "exact-native", nativeSkillId: "skills:native" },
+        },
+        { externalId: "owner/repo/external", reconciliation: { kind: "new" } },
+        { externalId: "owner/repo/unreconciled" },
+      ],
+      continueCursor: "next",
+      isDone: true,
+    });
+    const ctx = {
+      db: {
+        query: vi.fn((table: string) => {
+          expect(table).toBe("skillsShCatalogEntries");
+          return { withIndex: () => ({ paginate }) };
+        }),
+      },
+    };
+
+    await expect(listExactNativeExternalIdsPageHandler(ctx, {})).resolves.toEqual({
+      matches: [
+        {
+          externalId: "owner/repo/native-match",
+          nativeSkillId: "skills:native",
+        },
+      ],
+      isDone: true,
+      cursor: "next",
+    });
+  });
+
+  it("deduplicates identities within and across native and skills.sh sources", async () => {
     const runQuery = vi
       .fn()
-      .mockResolvedValueOnce({ count: 70_300, isDone: true, cursor: "" })
+      .mockResolvedValueOnce({
+        count: 70_300,
+        nativeSkillIds: ["skills:native"],
+        isDone: true,
+        cursor: "",
+      })
+      .mockResolvedValueOnce({
+        matches: [
+          {
+            externalId: "owner/repo/native-match",
+            nativeSkillId: "skills:native",
+          },
+        ],
+        isDone: true,
+        cursor: "",
+      })
+      .mockResolvedValueOnce({
+        externalIds: [
+          "owner/repo/native-match",
+          "owner/repo/one",
+          "owner/repo/one",
+          "owner/repo/two",
+        ],
+        isDone: true,
+        cursor: "",
+      })
       .mockResolvedValueOnce({ count: 321, isDone: true, cursor: "" });
     const runMutation = vi.fn();
 
     const result = await updateGlobalStatsActionHandler({ runQuery, runMutation }, {});
 
-    expect(result).toEqual({ activeSkillsCount: 70_300, activePluginsCount: 321 });
-    expect(runMutation).toHaveBeenCalledWith(expect.anything(), {
+    expect(result).toEqual({
       activeSkillsCount: 70_300,
+      activeExternalSkillsCount: 2,
       activePluginsCount: 321,
     });
+    expect(runMutation).toHaveBeenCalledWith(expect.anything(), {
+      activeSkillsCount: 70_300,
+      activeExternalSkillsCount: 2,
+      activePluginsCount: 321,
+    });
+  });
+
+  it("keeps a public mirror count when its exact-native match is not publicly countable", async () => {
+    const runQuery = vi
+      .fn()
+      .mockResolvedValueOnce({
+        count: 0,
+        nativeSkillIds: [],
+        isDone: true,
+        cursor: "",
+      })
+      .mockResolvedValueOnce({
+        matches: [
+          {
+            externalId: "owner/repo/native-match",
+            nativeSkillId: "skills:hidden",
+          },
+        ],
+        isDone: true,
+        cursor: "",
+      })
+      .mockResolvedValueOnce({
+        externalIds: ["owner/repo/native-match"],
+        isDone: true,
+        cursor: "",
+      })
+      .mockResolvedValueOnce({ count: 0, isDone: true, cursor: "" });
+    const runMutation = vi.fn();
+
+    await expect(
+      updateGlobalStatsActionHandler({ runQuery, runMutation }, {}),
+    ).resolves.toMatchObject({ activeExternalSkillsCount: 1 });
   });
 });
 

--- a/convex/statsMaintenance.ts
+++ b/convex/statsMaintenance.ts
@@ -6,6 +6,7 @@ import { internalAction, internalMutation, internalQuery } from "./functions";
 import {
   isPublicPluginDoc,
   isPublicSkillDoc,
+  setGlobalPublicExternalSkillsCount,
   setGlobalPublicPluginsCount,
   setGlobalPublicSkillsCount,
 } from "./lib/globalStats";
@@ -13,6 +14,7 @@ import {
   computeRecommendationScore,
   RECOMMENDATION_SCORE_VERSION,
 } from "./lib/recommendationScore";
+import { isPublicSkillsShMirrorDigest } from "./lib/skillsShMirrorPublic";
 
 const DEFAULT_BATCH_SIZE = 200;
 const MAX_BATCH_SIZE = 1000;
@@ -567,10 +569,63 @@ export const countPublicDigestPageInternal = internalQuery({
       .paginate({ cursor: args.cursor ?? null, numItems: pageSize });
 
     let count = 0;
+    const nativeSkillIds: string[] = [];
     for (const digest of page) {
-      if (isPublicSkillDoc(digest)) count++;
+      if (isPublicSkillDoc(digest) && !digest.canonicalSkillId) {
+        count++;
+        nativeSkillIds.push(digest.skillId);
+      }
     }
-    return { count, isDone, cursor: continueCursor };
+    return { count, nativeSkillIds, isDone, cursor: continueCursor };
+  },
+});
+
+export const listPublicExternalSkillIdsPageInternal = internalQuery({
+  args: { cursor: v.optional(v.string()), pageSize: v.optional(v.number()) },
+  handler: async (ctx, args) => {
+    const pageSize = clampInt(args.pageSize ?? 500, 100, 1000);
+    const { page, isDone, continueCursor } = await ctx.db
+      .query("skillsShMirrorDigests")
+      .withIndex("by_active_visible_installable_fresh_slug", (q) =>
+        q
+          .eq("active", true)
+          .eq("publicVisible", true)
+          .eq("installable", true)
+          .eq("sourceFreshnessStatus", "observed-only"),
+      )
+      .paginate({ cursor: args.cursor ?? null, numItems: pageSize });
+    return {
+      externalIds: page
+        .filter((digest) => isPublicSkillsShMirrorDigest(digest))
+        .map((digest) => digest.externalId),
+      isDone,
+      cursor: continueCursor,
+    };
+  },
+});
+
+export const listExactNativeExternalIdsPageInternal = internalQuery({
+  args: { cursor: v.optional(v.string()), pageSize: v.optional(v.number()) },
+  handler: async (ctx, args) => {
+    const pageSize = clampInt(args.pageSize ?? 500, 100, 1000);
+    const { page, isDone, continueCursor } = await ctx.db
+      .query("skillsShCatalogEntries")
+      .withIndex("by_external_id")
+      .paginate({ cursor: args.cursor ?? null, numItems: pageSize });
+    return {
+      matches: page.flatMap((entry) =>
+        entry.reconciliation?.kind === "exact-native" && entry.reconciliation.nativeSkillId
+          ? [
+              {
+                externalId: entry.externalId,
+                nativeSkillId: entry.reconciliation.nativeSkillId,
+              },
+            ]
+          : [],
+      ),
+      isDone,
+      cursor: continueCursor,
+    };
   },
 });
 
@@ -595,6 +650,7 @@ export const writeGlobalStatsInternal = internalMutation({
   args: {
     count: v.optional(v.number()),
     activeSkillsCount: v.optional(v.number()),
+    activeExternalSkillsCount: v.optional(v.number()),
     activePluginsCount: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
@@ -602,6 +658,9 @@ export const writeGlobalStatsInternal = internalMutation({
       await setGlobalPublicSkillsCount(ctx, args.activeSkillsCount);
     } else if (args.count !== undefined) {
       await setGlobalPublicSkillsCount(ctx, args.count);
+    }
+    if (args.activeExternalSkillsCount !== undefined) {
+      await setGlobalPublicExternalSkillsCount(ctx, args.activeExternalSkillsCount);
     }
     if (args.activePluginsCount !== undefined) {
       await setGlobalPublicPluginsCount(ctx, args.activePluginsCount);
@@ -618,6 +677,7 @@ export const updateGlobalStatsAction = internalAction({
   args: {},
   handler: async (ctx) => {
     let activeSkillsCount = 0;
+    const countedNativeSkillIds = new Set<string>();
     let skillCursor: string | undefined;
 
     // eslint-disable-next-line no-constant-condition
@@ -625,12 +685,55 @@ export const updateGlobalStatsAction = internalAction({
       const result = (await ctx.runQuery(internal.statsMaintenance.countPublicDigestPageInternal, {
         cursor: skillCursor,
         pageSize: 1000,
-      })) as { count: number; isDone: boolean; cursor: string };
+      })) as { count: number; nativeSkillIds: string[]; isDone: boolean; cursor: string };
 
       activeSkillsCount += result.count;
+      for (const skillId of result.nativeSkillIds) countedNativeSkillIds.add(skillId);
       if (result.isDone) break;
       skillCursor = result.cursor;
     }
+
+    const exactNativeExternalIds = new Set<string>();
+    let reconciliationCursor: string | undefined;
+    // Load the persisted reconciliation boundary in pages so mirror rows that
+    // resolve to a native skill are counted only once without per-row lookups.
+    // A route collision remains a distinct public skills.sh identity and is not
+    // a duplicate; exact-native is the only reconciliation that aliases a row.
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      const result = (await ctx.runQuery(
+        internal.statsMaintenance.listExactNativeExternalIdsPageInternal,
+        { cursor: reconciliationCursor, pageSize: 500 },
+      )) as {
+        matches: Array<{ externalId: string; nativeSkillId: string }>;
+        isDone: boolean;
+        cursor: string;
+      };
+      for (const match of result.matches) {
+        if (countedNativeSkillIds.has(match.nativeSkillId)) {
+          exactNativeExternalIds.add(match.externalId);
+        }
+      }
+      if (result.isDone) break;
+      reconciliationCursor = result.cursor;
+    }
+
+    const publicExternalSkillIds = new Set<string>();
+    let externalSkillCursor: string | undefined;
+    // Deduplicate by the permanent skills.sh identity, not by page position.
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      const result = (await ctx.runQuery(
+        internal.statsMaintenance.listPublicExternalSkillIdsPageInternal,
+        { cursor: externalSkillCursor, pageSize: 500 },
+      )) as { externalIds: string[]; isDone: boolean; cursor: string };
+      for (const externalId of result.externalIds) {
+        if (!exactNativeExternalIds.has(externalId)) publicExternalSkillIds.add(externalId);
+      }
+      if (result.isDone) break;
+      externalSkillCursor = result.cursor;
+    }
+    const activeExternalSkillsCount = publicExternalSkillIds.size;
 
     let activePluginsCount = 0;
     let pluginCursor: string | undefined;
@@ -652,8 +755,9 @@ export const updateGlobalStatsAction = internalAction({
 
     await ctx.runMutation(internal.statsMaintenance.writeGlobalStatsInternal, {
       activeSkillsCount,
+      activeExternalSkillsCount,
       activePluginsCount,
     });
-    return { activeSkillsCount, activePluginsCount };
+    return { activeSkillsCount, activeExternalSkillsCount, activePluginsCount };
   },
 });

--- a/scripts/playwright-local-auth-config.test.ts
+++ b/scripts/playwright-local-auth-config.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  buildLocalAuthTrendingSnapshotArgs,
   resolveLocalAuthDeployment,
   resolveLocalAuthRunnerConfig,
 } from "./playwright-local-auth-config";
@@ -64,6 +65,33 @@ describe("playwright local-auth runner config", () => {
       resolveLocalAuthRunnerConfig({}, ["--", "--retries", "2", "e2e/example.pw.test.ts"]),
     ).toMatchObject({
       playwrightArgs: ["--retries", "2", "e2e/example.pw.test.ts"],
+    });
+  });
+
+  it("builds a valid empty canonical snapshot for the isolated runtime", () => {
+    expect(buildLocalAuthTrendingSnapshotArgs(86_400_000)).toEqual({
+      start: {
+        snapshotId: "local-auth-canonical-trending-v1",
+        generatedAt: 86_400_000,
+        expiresAt: 259_200_000,
+        windowStartDay: 0,
+        windowEndDay: 1,
+      },
+      finalize: {
+        snapshotId: "local-auth-canonical-trending-v1",
+        completedAt: 86_400_000,
+        totalItems: 0,
+        sourceCounts: {
+          clawhubTrending: 0,
+          clawhubRising: 0,
+          skillsShTrending: 0,
+        },
+        operations: {
+          documentsRead: 0,
+          documentsWritten: 2,
+          functionCalls: 2,
+        },
+      },
     });
   });
 });

--- a/scripts/playwright-local-auth-config.ts
+++ b/scripts/playwright-local-auth-config.ts
@@ -3,6 +3,9 @@ const DEFAULT_CONVEX_SITE_URL = "http://127.0.0.1:3211";
 export const DEFAULT_LOCAL_AUTH_CONVEX_DEPLOYMENT = "anonymous:anonymous-agent";
 const DEFAULT_PLAYWRIGHT_ARGS = ["--project=chromium", "e2e/local-auth"];
 const DEFAULT_PLAYWRIGHT_RETRIES = "1";
+const LOCAL_AUTH_TRENDING_SNAPSHOT_ID = "local-auth-canonical-trending-v1";
+const DAY_MS = 24 * 60 * 60 * 1_000;
+const SNAPSHOT_RETENTION_MS = 2 * DAY_MS;
 
 type RunnerEnv = Record<string, string | undefined>;
 
@@ -12,6 +15,34 @@ export type LocalAuthRunnerConfig = {
   convexUrl: string;
   playwrightArgs: string[];
 };
+
+export function buildLocalAuthTrendingSnapshotArgs(now: number) {
+  const windowEndDay = Math.floor(now / DAY_MS);
+  return {
+    start: {
+      snapshotId: LOCAL_AUTH_TRENDING_SNAPSHOT_ID,
+      generatedAt: now,
+      expiresAt: now + SNAPSHOT_RETENTION_MS,
+      windowStartDay: Math.max(0, windowEndDay - 1),
+      windowEndDay,
+    },
+    finalize: {
+      snapshotId: LOCAL_AUTH_TRENDING_SNAPSHOT_ID,
+      completedAt: now,
+      totalItems: 0,
+      sourceCounts: {
+        clawhubTrending: 0,
+        clawhubRising: 0,
+        skillsShTrending: 0,
+      },
+      operations: {
+        documentsRead: 0,
+        documentsWritten: 2,
+        functionCalls: 2,
+      },
+    },
+  };
+}
 
 function stripPackageManagerSeparator(args: string[]) {
   return args[0] === "--" ? args.slice(1) : args;

--- a/scripts/run-playwright-local-auth.ts
+++ b/scripts/run-playwright-local-auth.ts
@@ -14,6 +14,7 @@ import { createServer } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+  buildLocalAuthTrendingSnapshotArgs,
   resolveLocalAuthDeployment,
   resolveLocalAuthRunnerConfig,
 } from "./playwright-local-auth-config";
@@ -479,6 +480,7 @@ async function main() {
     AUTH_GITHUB_ID: process.env.AUTH_GITHUB_ID ?? "local-dev",
     AUTH_GITHUB_SECRET: process.env.AUTH_GITHUB_SECRET ?? "local-dev",
     CLAWHUB_DISABLE_CRONS: "1",
+    CLAWHUB_SKILLS_SH_ROLLOUT_MODE: "test",
     CLAWHUB_EMAIL_CAPTURE_FILE: process.env.CLAWHUB_EMAIL_CAPTURE_FILE ?? emailCaptureFile,
     CONVEX_AGENT_MODE: process.env.CONVEX_AGENT_MODE ?? "anonymous",
     CONVEX_SITE_URL: convexSiteUrl,
@@ -504,6 +506,7 @@ async function main() {
       `AUTH_GITHUB_ID=${e2eEnv.AUTH_GITHUB_ID}`,
       `AUTH_GITHUB_SECRET=${e2eEnv.AUTH_GITHUB_SECRET}`,
       "CLAWHUB_DISABLE_CRONS=1",
+      "CLAWHUB_SKILLS_SH_ROLLOUT_MODE=test",
       `CLAWHUB_EMAIL_CAPTURE_FILE=${e2eEnv.CLAWHUB_EMAIL_CAPTURE_FILE}`,
       ...(deployment ? [`CONVEX_DEPLOYMENT=${deployment}`] : []),
       `CONVEX_SITE_URL=${convexSiteUrl}`,
@@ -552,6 +555,7 @@ async function main() {
     { name: "AUTH_GITHUB_ID", value: e2eEnv.AUTH_GITHUB_ID ?? "local-dev" },
     { name: "AUTH_GITHUB_SECRET", value: e2eEnv.AUTH_GITHUB_SECRET ?? "local-dev" },
     { name: "CLAWHUB_DISABLE_CRONS", value: "1" },
+    { name: "CLAWHUB_SKILLS_SH_ROLLOUT_MODE", value: "test" },
     { name: "CLAWHUB_EMAIL_CAPTURE_FILE", value: e2eEnv.CLAWHUB_EMAIL_CAPTURE_FILE ?? "" },
     { name: "CLAWHUB_STAGED_PREPUBLICATION_PUBLISHES", value: "1" },
     { name: "DEV_AUTH_CONVEX_DEPLOYMENT", value: localAuthDeployment },
@@ -568,6 +572,19 @@ async function main() {
 
   console.log("Waiting for local Convex functions.");
   await runConvexFunctionWhenReady("appMeta:getDeploymentInfo", {}, e2eEnv);
+
+  console.log("Materializing an empty canonical Trending snapshot for the isolated runtime.");
+  const trendingSnapshot = buildLocalAuthTrendingSnapshotArgs(Date.now());
+  await runConvexFunctionWhenReady(
+    "canonicalTrending:startSnapshotInternal",
+    trendingSnapshot.start,
+    e2eEnv,
+  );
+  await runConvexFunctionWhenReady(
+    "canonicalTrending:finalizeSnapshotInternal",
+    trendingSnapshot.finalize,
+    e2eEnv,
+  );
 
   console.log("Building ClawHub for local-auth Playwright e2e.");
   runRequired("bun", ["run", "build"], e2eEnv);

--- a/src/__tests__/home-listing-section.claw591.test.tsx
+++ b/src/__tests__/home-listing-section.claw591.test.tsx
@@ -1,0 +1,267 @@
+/* @vitest-environment jsdom */
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const navigateMock = vi.fn();
+const convexQueryMock = vi.fn();
+const convexActionMock = vi.fn();
+const fetchPluginCatalogMock = vi.fn();
+const fetchCanonicalTrendingPageMock = vi.fn();
+
+vi.mock("@tanstack/react-router", () => ({
+  Link: ({
+    children,
+    className,
+    to,
+  }: {
+    children: React.ReactNode;
+    className?: string;
+    to?: string;
+  }) => (
+    <a className={className} href={to ?? "/"}>
+      {children}
+    </a>
+  ),
+  useNavigate: () => navigateMock,
+}));
+
+vi.mock("../convex/client", () => ({
+  convexHttp: {
+    query: (...args: unknown[]) => convexQueryMock(...args),
+    action: (...args: unknown[]) => convexActionMock(...args),
+  },
+}));
+
+vi.mock("../../convex/_generated/api", () => ({
+  api: {
+    packages: { listPublicNewPluginsPage: "packages:listPublicNewPluginsPage" },
+    skills: { listPublicPageV4: "skills:listPublicPageV4" },
+    search: { searchNativeSkills: "search:searchNativeSkills" },
+  },
+}));
+
+vi.mock("../lib/packageApi", () => ({
+  fetchPluginCatalog: (...args: unknown[]) => fetchPluginCatalogMock(...args),
+}));
+
+vi.mock("../lib/trendingApi", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../lib/trendingApi")>();
+  return {
+    ...original,
+    fetchCanonicalTrendingPage: (...args: unknown[]) => fetchCanonicalTrendingPageMock(...args),
+  };
+});
+
+import { HomeListingSection } from "../components/HomeListingSection";
+
+describe("HomeListingSection", () => {
+  beforeEach(() => {
+    navigateMock.mockReset();
+    convexQueryMock.mockReset();
+    convexActionMock.mockReset();
+    fetchPluginCatalogMock.mockReset();
+    fetchCanonicalTrendingPageMock.mockReset();
+    convexQueryMock.mockResolvedValue({ page: [], hasMore: false, nextCursor: null });
+    convexActionMock.mockResolvedValue([]);
+    fetchPluginCatalogMock.mockResolvedValue({ items: [], nextCursor: null });
+    fetchCanonicalTrendingPageMock.mockResolvedValue(canonicalPage([]));
+  });
+
+  it("defaults the homepage to Skills and canonical Trending with exact tab order", () => {
+    const first = makeTrending("first", "First Skill", 17, 9000);
+    const second = makeTrending("second", "Second Skill", 3, 8000);
+    render(<HomeListingSection initialListing={initialTrending([first, second])} />);
+
+    expect(screen.getByRole("button", { name: "Skills" }).getAttribute("aria-pressed")).toBe(
+      "true",
+    );
+    expect(screen.getByRole("tab", { name: "Trending" }).getAttribute("aria-selected")).toBe(
+      "true",
+    );
+    expect(screen.getAllByRole("tab").map((tab) => tab.textContent)).toEqual([
+      "Trending",
+      "New",
+      "Featured",
+      "Official",
+    ]);
+    expect(screen.queryByRole("tab", { name: "Top" })).toBeNull();
+    expect(screen.queryByRole("combobox", { name: "Category" })).toBeNull();
+    expect(
+      Array.from(
+        document.querySelectorAll(".home-v2-listing-row-name"),
+        (node) => node.textContent,
+      ),
+    ).toEqual(["First Skill", "Second Skill"]);
+    expect(screen.getByText("17")).toBeTruthy();
+    expect(screen.getByText("3")).toBeTruthy();
+    expect(screen.queryByText("9K")).toBeNull();
+    expect(screen.queryByText("8K")).toBeNull();
+    expect(screen.queryByText("skills.sh")).toBeNull();
+  });
+
+  it("shows New, Featured, and Official for plugins but never plugin Trending", async () => {
+    render(<HomeListingSection initialListing={initialTrending([])} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Plugins" }));
+
+    expect(screen.getByRole("tab", { name: "New" }).getAttribute("aria-selected")).toBe("true");
+    expect(screen.getAllByRole("tab").map((tab) => tab.textContent)).toEqual([
+      "New",
+      "Featured",
+      "Official",
+    ]);
+    expect(screen.queryByRole("tab", { name: "Trending" })).toBeNull();
+    expect(screen.queryByRole("tab", { name: "Top" })).toBeNull();
+    await waitFor(() =>
+      expect(convexQueryMock).toHaveBeenCalledWith(
+        "packages:listPublicNewPluginsPage",
+        expect.any(Object),
+      ),
+    );
+  });
+
+  it("uses the native New, Featured, and Official eligibility contracts", async () => {
+    render(<HomeListingSection initialListing={initialTrending([])} />);
+
+    fireEvent.click(screen.getByRole("tab", { name: "New" }));
+    await waitFor(() => {
+      expect(convexQueryMock).toHaveBeenCalledWith(
+        "skills:listPublicPageV4",
+        expect.objectContaining({ sort: "newest", createdAfter: expect.any(Number) }),
+      );
+    });
+    expect(screen.getByRole("combobox", { name: "Category" })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("tab", { name: "Featured" }));
+    await waitFor(() => {
+      expect(convexQueryMock).toHaveBeenCalledWith(
+        "skills:listPublicPageV4",
+        expect.objectContaining({ highlightedOnly: true, numItems: 40 }),
+      );
+    });
+
+    fireEvent.click(screen.getByRole("tab", { name: "Official" }));
+    await waitFor(() => {
+      expect(convexQueryMock).toHaveBeenCalledWith(
+        "skills:listPublicPageV4",
+        expect.objectContaining({ officialOnly: true }),
+      );
+    });
+  });
+
+  it("preserves the explicit Load more interaction", async () => {
+    const first = makeTrending("first", "First Skill", 17, 9000);
+    const second = makeTrending("second", "Second Skill", 3, 8000);
+    fetchCanonicalTrendingPageMock.mockResolvedValue(canonicalPage([first, second]));
+    render(<HomeListingSection initialListing={initialTrending([first], true)} />);
+
+    expect(screen.getByRole("button", { name: "Load more" })).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Load more" }));
+
+    expect(await screen.findByTitle("Second Skill")).toBeTruthy();
+    expect(fetchCanonicalTrendingPageMock).toHaveBeenCalledWith(
+      expect.objectContaining({ cursor: null, limit: 20 }),
+    );
+  });
+
+  it("keeps search as a separate relevance-first interaction", async () => {
+    convexActionMock.mockResolvedValue([
+      {
+        skill: makeNativeSkill("search-hit", "Search Hit"),
+        ownerHandle: "builder",
+      },
+    ]);
+    render(<HomeListingSection initialListing={initialTrending([])} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Search catalog" }));
+    fireEvent.change(screen.getByRole("searchbox", { name: "Search skills" }), {
+      target: { value: "search" },
+    });
+
+    expect(await screen.findByText("Search Hit")).toBeTruthy();
+    expect(convexActionMock).toHaveBeenCalledWith(
+      "search:searchNativeSkills",
+      expect.objectContaining({ query: "search" }),
+    );
+  });
+
+  it("supports list and grid presentation without changing feed order", () => {
+    const first = makeTrending("first", "First Skill", 17, 9000);
+    const second = makeTrending("second", "Second Skill", 3, 8000);
+    render(<HomeListingSection initialListing={initialTrending([first, second])} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Grid view" }));
+    expect(document.querySelector(".home-v2-listing-grid")).toBeTruthy();
+    expect(
+      Array.from(
+        document.querySelectorAll(".home-v2-listing-card-name"),
+        (node) => node.textContent,
+      ),
+    ).toEqual(["First Skill", "Second Skill"]);
+  });
+});
+
+function initialTrending(items: ReturnType<typeof makeTrending>[], hasMore = false) {
+  return {
+    kind: "skills" as const,
+    tab: "trending" as const,
+    categorySlugs: [] as [],
+    fetchLimit: 20 as const,
+    items: items.map((trending) => ({ trending })),
+    hasMore,
+  };
+}
+
+function canonicalPage(items: ReturnType<typeof makeTrending>[], nextCursor: string | null = null) {
+  return {
+    kind: "skills" as const,
+    snapshotId: "snapshot-1",
+    snapshotCursor: "snapshot-cursor",
+    generatedAt: "2026-07-26T00:00:00.000Z",
+    windowHours: 24 as const,
+    rankingVersion: "skills-trending-v1",
+    totalItems: items.length,
+    items,
+    nextCursor,
+  };
+}
+
+function makeTrending(slug: string, displayName: string, installs: number, lifetime: number) {
+  return {
+    id: `clawhub:${slug}`,
+    source: "clawhub" as const,
+    slug,
+    displayName,
+    summary: `${displayName} summary`,
+    canonicalUrl: `/builder/${slug}`,
+    publisher: {
+      kind: "user" as const,
+      handle: "builder",
+      displayName: "Builder",
+      image: null,
+      official: false,
+    },
+    official: false,
+    featured: false,
+    metrics: {
+      trending24hInstalls: installs,
+      trending24hBookmarks: null,
+      lifetimeInstalls: lifetime,
+      lifetimeInstallsPeriod: "lifetime" as const,
+      updatedAt: 1,
+    },
+  };
+}
+
+function makeNativeSkill(slug: string, displayName: string) {
+  return {
+    _id: `skills:${slug}`,
+    slug,
+    displayName,
+    summary: `${displayName} summary`,
+    stats: { comments: 0, downloads: 0, installs: 0, stars: 0, versions: 1 },
+    tags: {},
+    createdAt: 1,
+    updatedAt: 1,
+  };
+}

--- a/src/__tests__/home-listing-section.test.tsx
+++ b/src/__tests__/home-listing-section.test.tsx
@@ -67,31 +67,21 @@ const featuredPlugin = {
 
 function initialPluginListing({
   items = [featuredPlugin],
-  pluginsFeatured = true,
-  skillsFeatured = true,
 }: {
   items?: (typeof featuredPlugin)[];
-  pluginsFeatured?: boolean;
-  skillsFeatured?: boolean;
 } = {}) {
   return {
     kind: "plugins" as const,
-    tab: pluginsFeatured ? ("featured" as const) : ("popular" as const),
+    tab: "featured" as const,
     categorySlugs: [] as [],
     fetchLimit: 20 as const,
     items,
     hasMore: false,
-    featuredAvailability: {
-      plugins: pluginsFeatured,
-      skills: skillsFeatured,
-    },
   };
 }
 
 function renderSkillsListing() {
-  const result = render(
-    <HomeListingSection initialListing={initialPluginListing({ skillsFeatured: false })} />,
-  );
+  const result = render(<HomeListingSection initialListing={initialPluginListing()} />);
   fireEvent.click(screen.getByRole("button", { name: "Skills" }));
   fireEvent.click(screen.getByRole("tab", { name: "New" }));
   return result;
@@ -206,7 +196,6 @@ describe("HomeListingSection", () => {
       <HomeListingSection
         initialListing={initialPluginListing({
           items: [{ ...featuredPlugin, name: "long-plugin", displayName: pluginName }],
-          skillsFeatured: false,
         })}
       />,
     );

--- a/src/__tests__/home-listing-section.test.tsx
+++ b/src/__tests__/home-listing-section.test.tsx
@@ -93,6 +93,7 @@ function renderSkillsListing() {
     <HomeListingSection initialListing={initialPluginListing({ skillsFeatured: false })} />,
   );
   fireEvent.click(screen.getByRole("button", { name: "Skills" }));
+  fireEvent.click(screen.getByRole("tab", { name: "New" }));
   return result;
 }
 
@@ -135,7 +136,7 @@ describe("HomeListingSection", () => {
     });
   });
 
-  it("renders Featured plugins as a list by default", async () => {
+  it("renders a provided Featured plugin listing as a list", async () => {
     render(<HomeListingSection initialListing={initialPluginListing()} />);
 
     const contentTypeButtons = screen
@@ -155,58 +156,15 @@ describe("HomeListingSection", () => {
       "true",
     );
     expect(screen.getAllByRole("tab").map((tab) => tab.textContent)).toEqual([
+      "New",
       "Featured",
-      "Top",
-      "Trending",
+      "Official",
     ]);
-    expect(screen.queryByRole("tab", { name: "New" })).toBeNull();
-    expect(screen.queryByRole("tab", { name: "Official" })).toBeNull();
     expect(screen.getByText("Demo Plugin")).toBeTruthy();
     expect(document.querySelector(".home-v2-listing-list")).toBeTruthy();
     expect(document.querySelector(".marketplace-icon-image")?.getAttribute("src")).toBe(
       featuredPlugin.icon,
     );
-  });
-
-  it("hides Featured and selects Top when plugins have no Featured results", () => {
-    render(
-      <HomeListingSection
-        initialListing={initialPluginListing({ items: [], pluginsFeatured: false })}
-      />,
-    );
-
-    expect(screen.queryByRole("tab", { name: "Featured" })).toBeNull();
-    expect(screen.getByRole("tab", { name: "Top" }).getAttribute("aria-selected")).toBe("true");
-    expect(screen.getAllByRole("tab").map((tab) => tab.textContent)).toEqual(["Top", "Trending"]);
-  });
-
-  it("selects Featured when switching to skills that have Featured results", async () => {
-    render(<HomeListingSection initialListing={initialPluginListing()} />);
-    fireEvent.click(screen.getByRole("button", { name: "Skills" }));
-
-    expect(screen.getByRole("tab", { name: "Featured" }).getAttribute("aria-selected")).toBe(
-      "true",
-    );
-    expect(screen.getAllByRole("tab").map((tab) => tab.textContent)).toEqual([
-      "Featured",
-      "Top",
-      "Trending",
-    ]);
-    expect(screen.queryByRole("tab", { name: "New" })).toBeNull();
-    await waitFor(() => {
-      expect(convexQueryMock).toHaveBeenCalledWith(
-        "skills:listPublicPageV4",
-        expect.objectContaining({ highlightedOnly: true }),
-      );
-    });
-  });
-
-  it("hides Featured and selects Top when skills have no Featured results", () => {
-    render(<HomeListingSection initialListing={initialPluginListing({ skillsFeatured: false })} />);
-    fireEvent.click(screen.getByRole("button", { name: "Skills" }));
-
-    expect(screen.queryByRole("tab", { name: "Featured" })).toBeNull();
-    expect(screen.getByRole("tab", { name: "Top" }).getAttribute("aria-selected")).toBe("true");
   });
 
   it("previews long skill and plugin names while retaining their full labels", async () => {
@@ -244,26 +202,35 @@ describe("HomeListingSection", () => {
       nextCursor: null,
     });
 
-    renderSkillsListing();
+    render(
+      <HomeListingSection
+        initialListing={initialPluginListing({
+          items: [{ ...featuredPlugin, name: "long-plugin", displayName: pluginName }],
+          skillsFeatured: false,
+        })}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Skills" }));
+    fireEvent.click(screen.getByRole("tab", { name: "New" }));
 
     await waitFor(() => {
       expect(screen.getByText(`${"S".repeat(69)}…`).getAttribute("title")).toBe(skillName);
     });
 
     fireEvent.click(screen.getByRole("button", { name: "Plugins" }));
-    fireEvent.click(screen.getByRole("tab", { name: "Top" }));
+    fireEvent.click(screen.getByRole("tab", { name: "Featured" }));
 
     await waitFor(() => {
       expect(screen.getByText(`${"P".repeat(69)}…`).getAttribute("title")).toBe(pluginName);
     });
   });
 
-  it("renders an initial Skills Top listing without refetching on mount", async () => {
+  it("renders an initial Skills New listing without refetching on mount", async () => {
     render(
       <HomeListingSection
         initialListing={{
           kind: "skills",
-          tab: "popular",
+          tab: "new",
           categorySlugs: [],
           fetchLimit: 20,
           items: [
@@ -285,10 +252,6 @@ describe("HomeListingSection", () => {
             },
           ],
           hasMore: true,
-          featuredAvailability: {
-            plugins: true,
-            skills: true,
-          },
         }}
       />,
     );
@@ -298,17 +261,6 @@ describe("HomeListingSection", () => {
     await waitFor(() => {
       expect(convexQueryMock).not.toHaveBeenCalled();
     });
-  });
-
-  it("loads the plugin Top tab", async () => {
-    render(<HomeListingSection initialListing={initialPluginListing()} />);
-    fireEvent.click(screen.getByRole("tab", { name: "Top" }));
-
-    await waitFor(() => {
-      expect(screen.getByText("Demo Plugin")).toBeTruthy();
-      expect(screen.getByText("120")).toBeTruthy();
-    });
-    expect(fetchPluginCatalogMock).toHaveBeenCalled();
   });
 
   it("opens listing search from the toolbar icon and with slash", async () => {
@@ -487,83 +439,17 @@ describe("HomeListingSection", () => {
     expect(screen.queryByRole("button", { name: "Load more" })).toBeNull();
   });
 
-  it("loads the existing trending skills leaderboard for the Trending tab", async () => {
-    convexQueryMock.mockImplementation((name) => {
-      if (name === "skills:listPublicTrendingPage") {
-        return Promise.resolve({
-          items: [
-            {
-              skill: {
-                _id: "skills:trending",
-                slug: "trending-skill",
-                displayName: "Trending Skill",
-                summary: "Hot this week.",
-                stats: { stars: 12, downloads: 340, installs: 999 },
-              },
-              ownerHandle: "builder",
-            },
-          ],
-        });
-      }
-      return Promise.resolve({
-        page: [
-          {
-            skill: {
-              _id: "skills:1",
-              slug: "demo-skill",
-              displayName: "Demo Skill",
-              summary: "A helpful skill.",
-              stats: { stars: 12, downloads: 340 },
-            },
-            ownerHandle: "builder",
-          },
-        ],
-      });
-    });
-
-    renderSkillsListing();
-
-    await waitFor(() => {
-      expect(screen.getByText("Demo Skill")).toBeTruthy();
-    });
-
-    convexQueryMock.mockClear();
-    fireEvent.click(screen.getByRole("tab", { name: "Trending" }));
-
-    await waitFor(() => {
-      expect(convexQueryMock).toHaveBeenCalledWith("skills:listPublicTrendingPage", { limit: 20 });
-      expect(screen.getByText("Trending Skill")).toBeTruthy();
-    });
-    expect(screen.getByLabelText("Popularity").textContent).toBe("12340");
-    expect(screen.queryByText("999")).toBeNull();
-  });
-
   it("reuses cached skill tabs instead of refetching when switching back", async () => {
-    convexQueryMock.mockImplementation((name) => {
-      if (name === "skills:listPublicTrendingPage") {
-        return Promise.resolve({
-          items: [
-            {
-              skill: {
-                _id: "skills:trending",
-                slug: "trending-skill",
-                displayName: "Trending Skill",
-                summary: "Hot this week.",
-                stats: { installs: 999 },
-              },
-              ownerHandle: "builder",
-            },
-          ],
-        });
-      }
+    convexQueryMock.mockImplementation((_name, args: { highlightedOnly?: boolean }) => {
+      const featured = args.highlightedOnly === true;
       return Promise.resolve({
         page: [
           {
             skill: {
-              _id: "skills:top",
-              slug: "top-skill",
-              displayName: "Top Skill",
-              summary: "Popular.",
+              _id: featured ? "skills:featured" : "skills:new",
+              slug: featured ? "featured-skill" : "new-skill",
+              displayName: featured ? "Featured Skill" : "New Skill",
+              summary: featured ? "Editorial." : "Recently published.",
               stats: { installs: 100 },
             },
             ownerHandle: "builder",
@@ -577,21 +463,21 @@ describe("HomeListingSection", () => {
     renderSkillsListing();
 
     await waitFor(() => {
-      expect(screen.getByText("Top Skill")).toBeTruthy();
+      expect(screen.getByText("New Skill")).toBeTruthy();
     });
     expect(convexQueryMock).toHaveBeenCalledTimes(1);
 
-    fireEvent.click(screen.getByRole("tab", { name: "Trending" }));
+    fireEvent.click(screen.getByRole("tab", { name: "Featured" }));
 
     await waitFor(() => {
-      expect(screen.getByText("Trending Skill")).toBeTruthy();
+      expect(screen.getByText("Featured Skill")).toBeTruthy();
     });
     expect(convexQueryMock).toHaveBeenCalledTimes(2);
 
-    fireEvent.click(screen.getByRole("tab", { name: "Top" }));
+    fireEvent.click(screen.getByRole("tab", { name: "New" }));
 
     await waitFor(() => {
-      expect(screen.getByText("Top Skill")).toBeTruthy();
+      expect(screen.getByText("New Skill")).toBeTruthy();
     });
     expect(convexQueryMock).toHaveBeenCalledTimes(2);
   });
@@ -611,6 +497,7 @@ describe("HomeListingSection", () => {
 
     render(<HomeListingSection initialListing={initialPluginListing()} />);
     fireEvent.click(screen.getByRole("button", { name: "Skills" }));
+    fireEvent.click(screen.getByRole("tab", { name: "Featured" }));
     fireEvent.click(screen.getByRole("button", { name: "Search catalog" }));
     fireEvent.change(screen.getByRole("searchbox"), { target: { value: "search" } });
 
@@ -639,40 +526,13 @@ describe("HomeListingSection", () => {
     });
   });
 
-  it("requests trending plugins from the catalog API", async () => {
-    fetchPluginCatalogMock.mockResolvedValue({
-      items: [
-        {
-          name: "trending-plugin",
-          displayName: "Trending Plugin",
-          family: "code-plugin",
-          channel: "community",
-          isOfficial: false,
-          createdAt: 1,
-          updatedAt: 2,
-          stats: { stars: 4, downloads: 8, installs: 9, versions: 1 },
-        },
-      ],
-      nextCursor: null,
-    });
-
-    render(<HomeListingSection initialListing={initialPluginListing()} />);
-    fireEvent.click(screen.getByRole("tab", { name: "Trending" }));
-
-    await waitFor(() => {
-      expect(screen.getByText("Trending Plugin").textContent).toBe("Trending Plugin");
-    });
-    const latestRequest = fetchPluginCatalogMock.mock.calls.at(-1)?.[0] as Record<string, unknown>;
-    expect(latestRequest).toEqual(expect.objectContaining({ sort: "trending", limit: 20 }));
-  });
-
   it("reuses cached plugin tabs instead of refetching when switching back", async () => {
-    fetchPluginCatalogMock.mockImplementation((args: { sort?: string }) =>
+    fetchPluginCatalogMock.mockImplementation((args: { isOfficial?: boolean }) =>
       Promise.resolve({
         items: [
           {
-            name: args.sort === "trending" ? "trending-plugin" : "top-plugin",
-            displayName: args.sort === "trending" ? "Trending Plugin" : "Top Plugin",
+            name: args.isOfficial ? "official-plugin" : "new-plugin",
+            displayName: args.isOfficial ? "Official Plugin" : "New Plugin",
             family: "code-plugin",
             channel: "community",
             isOfficial: false,
@@ -683,7 +543,7 @@ describe("HomeListingSection", () => {
             stats: {
               stars: 1,
               downloads: 2,
-              installs: args.sort === "trending" ? 50 : 75,
+              installs: args.isOfficial ? 50 : 75,
               versions: 1,
             },
           },
@@ -693,26 +553,26 @@ describe("HomeListingSection", () => {
     );
 
     render(<HomeListingSection initialListing={initialPluginListing()} />);
-    fireEvent.click(screen.getByRole("tab", { name: "Trending" }));
+    fireEvent.click(screen.getByRole("tab", { name: "Official" }));
 
     await waitFor(() => {
-      expect(screen.getByText("Trending Plugin")).toBeTruthy();
+      expect(screen.getByText("Official Plugin")).toBeTruthy();
     });
     expect(fetchPluginCatalogMock).toHaveBeenCalledTimes(1);
 
-    fireEvent.click(screen.getByRole("tab", { name: "Top" }));
+    fireEvent.click(screen.getByRole("tab", { name: "Featured" }));
 
     await waitFor(() => {
-      expect(screen.getByText("Top Plugin")).toBeTruthy();
+      expect(screen.getByText("Demo Plugin")).toBeTruthy();
     });
-    expect(fetchPluginCatalogMock).toHaveBeenCalledTimes(2);
+    expect(fetchPluginCatalogMock).toHaveBeenCalledTimes(1);
 
-    fireEvent.click(screen.getByRole("tab", { name: "Trending" }));
+    fireEvent.click(screen.getByRole("tab", { name: "Official" }));
 
     await waitFor(() => {
-      expect(screen.getByText("Trending Plugin")).toBeTruthy();
+      expect(screen.getByText("Official Plugin")).toBeTruthy();
     });
-    expect(fetchPluginCatalogMock).toHaveBeenCalledTimes(2);
+    expect(fetchPluginCatalogMock).toHaveBeenCalledTimes(1);
   });
 
   it("uses the skills cursor when loading beyond the first page", async () => {

--- a/src/__tests__/home-route.test.tsx
+++ b/src/__tests__/home-route.test.tsx
@@ -5,26 +5,33 @@ import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const initialListingFixture = {
-  kind: "plugins",
-  tab: "featured",
+  kind: "skills",
+  tab: "trending",
   categorySlugs: [],
   fetchLimit: 20,
   items: [
     {
-      name: "initial-plugin",
-      displayName: "Initial Plugin",
-      family: "code-plugin",
-      channel: "community",
-      isOfficial: false,
-      createdAt: 1,
-      updatedAt: 2,
+      trending: {
+        id: "clawhub:initial-skill",
+        source: "clawhub",
+        slug: "initial-skill",
+        displayName: "Initial Skill",
+        summary: "Initial summary",
+        canonicalUrl: "/owner/initial-skill",
+        publisher: null,
+        official: false,
+        featured: false,
+        metrics: {
+          lifetimeInstalls: 1,
+          lifetimeInstallsPeriod: "lifetime",
+          trending24hBookmarks: null,
+          trending24hInstalls: 2,
+          updatedAt: 3,
+        },
+      },
     },
   ],
   hasMore: false,
-  featuredAvailability: {
-    plugins: true,
-    skills: true,
-  },
 };
 
 const homeListingSectionMock = vi.fn();

--- a/src/__tests__/skills-index-load-more.test.tsx
+++ b/src/__tests__/skills-index-load-more.test.tsx
@@ -1,5 +1,5 @@
 /* @vitest-environment jsdom */
-import { act, render } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { SkillsIndex } from "../routes/skills/index";
@@ -11,7 +11,16 @@ import {
 } from "./helpers/convexReactMocks";
 
 const navigateMock = vi.fn();
+const fetchCanonicalTrendingPageMock = vi.fn();
 let searchMock: Record<string, unknown> = {};
+
+vi.mock("../lib/trendingApi", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../lib/trendingApi")>();
+  return {
+    ...original,
+    fetchCanonicalTrendingPage: (...args: unknown[]) => fetchCanonicalTrendingPageMock(...args),
+  };
+});
 
 vi.mock("@tanstack/react-router", () => ({
   createFileRoute: () => (_config: { component: unknown; validateSearch: unknown }) => ({
@@ -44,91 +53,82 @@ describe("SkillsIndex load-more observer", () => {
     navigateMock.mockReset();
     searchMock = {};
     setupDefaultConvexReactMocks();
+    fetchCanonicalTrendingPageMock.mockReset();
   });
 
   afterEach(() => {
     vi.unstubAllGlobals();
   });
 
-  it("triggers one load-more fetch for repeated intersection callbacks", async () => {
-    // First call returns a page with a cursor, second call (load more) tracks calls
-    let loadMoreCallCount = 0;
-    convexHttpMock.query
+  it("loads the next canonical page only after an explicit click and preserves API order", async () => {
+    fetchCanonicalTrendingPageMock
       .mockResolvedValueOnce({
-        page: [makeListResult("skill-0", "Skill 0")],
-        hasMore: true,
-        nextCursor: "cursor-1",
+        kind: "skills",
+        snapshotId: "snapshot-1",
+        snapshotCursor: "snapshot-cursor",
+        generatedAt: "2026-07-26T00:00:00.000Z",
+        windowHours: 24,
+        rankingVersion: "skills-trending-v1",
+        totalItems: 2,
+        items: [makeTrendingResult("first", "First", 9)],
+        nextCursor: "opaque cursor 2",
       })
-      .mockImplementation(() => {
-        loadMoreCallCount++;
-        // Never resolve to keep in loading state
-        return new Promise(() => {});
+      .mockResolvedValueOnce({
+        kind: "skills",
+        snapshotId: "snapshot-1",
+        snapshotCursor: "snapshot-cursor",
+        generatedAt: "2026-07-26T00:00:00.000Z",
+        windowHours: 24,
+        rankingVersion: "skills-trending-v1",
+        totalItems: 2,
+        items: [makeTrendingResult("second", "Second", 4)],
+        nextCursor: null,
       });
-
-    type ObserverInstance = {
-      callback: IntersectionObserverCallback;
-      observe: ReturnType<typeof vi.fn>;
-      disconnect: ReturnType<typeof vi.fn>;
-    };
-
-    const observers: ObserverInstance[] = [];
-    class IntersectionObserverMock {
-      callback: IntersectionObserverCallback;
-      observe = vi.fn();
-      disconnect = vi.fn();
-      unobserve = vi.fn();
-      takeRecords = vi.fn(() => []);
-      root = null;
-      rootMargin = "0px";
-      thresholds: number[] = [];
-
-      constructor(callback: IntersectionObserverCallback) {
-        this.callback = callback;
-        observers.push(this);
-      }
-    }
-    vi.stubGlobal(
-      "IntersectionObserver",
-      IntersectionObserverMock as unknown as typeof IntersectionObserver,
-    );
-
     render(<SkillsIndex />);
     await act(async () => {});
 
-    // Find the observer (there may be multiple from re-renders; use the last one)
-    const observer = observers[observers.length - 1];
-    const entries = [{ isIntersecting: true }] as Array<IntersectionObserverEntry>;
+    expect(screen.getByText("First")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Load more" })).toBeTruthy();
+    expect(fetchCanonicalTrendingPageMock).toHaveBeenCalledTimes(1);
 
     await act(async () => {
-      observer.callback(entries, observer as unknown as IntersectionObserver);
-      observer.callback(entries, observer as unknown as IntersectionObserver);
-      observer.callback(entries, observer as unknown as IntersectionObserver);
+      fireEvent.click(screen.getByRole("button", { name: "Load more" }));
     });
 
-    // Only one load-more fetch should have been triggered
-    expect(loadMoreCallCount).toBe(1);
+    expect(fetchCanonicalTrendingPageMock).toHaveBeenNthCalledWith(2, {
+      cursor: "opaque cursor 2",
+      limit: 20,
+    });
+    expect([
+      screen.getByTitle("First").textContent,
+      screen.getByTitle("Second").textContent,
+    ]).toEqual(["First", "Second"]);
   });
 });
 
-function makeListResult(slug: string, displayName: string) {
+function makeTrendingResult(slug: string, displayName: string, installs: number) {
   return {
-    skill: {
-      _id: `skill_${slug}`,
-      slug,
-      displayName,
-      summary: `${displayName} summary`,
-      tags: {},
-      stats: {
-        downloads: 0,
-        installs: 0,
-        stars: 0,
-        versions: 1,
-        comments: 0,
-      },
-      createdAt: 0,
-      updatedAt: 0,
+    id: `clawhub:${slug}`,
+    source: "clawhub" as const,
+    slug,
+    displayName,
+    summary: `${displayName} summary`,
+    canonicalUrl: `/owner/${slug}`,
+    publisher: {
+      kind: "user" as const,
+      handle: "owner",
+      displayName: "Owner",
+      image: null,
+      official: false,
     },
-    latestVersion: null,
-    ownerHandle: null,
+    official: false,
+    featured: false,
+    metrics: {
+      trending24hInstalls: installs,
+      trending24hBookmarks: null,
+      lifetimeInstalls: 1000,
+      lifetimeInstallsPeriod: "lifetime" as const,
+      updatedAt: 1,
+    },
   };
 }

--- a/src/__tests__/skills-index.claw591.test.tsx
+++ b/src/__tests__/skills-index.claw591.test.tsx
@@ -172,15 +172,21 @@ describe("SkillsIndex", () => {
   });
 
   it("loads Official through the backend official-publisher filter", async () => {
-    searchMock = { tab: "official" };
+    searchMock = { tab: "official", category: "development" };
     convexHttpMock.query.mockResolvedValue({ page: [], hasMore: false, nextCursor: null });
 
     render(<SkillsIndex />);
     await act(async () => {});
 
     expect(getLastListPageArgs()).toEqual(
-      expect.objectContaining({ officialOnly: true, sort: "newest", numItems: 20 }),
+      expect.objectContaining({
+        categorySlug: "development",
+        officialOnly: true,
+        sort: "newest",
+        numItems: 20,
+      }),
     );
+    expect(getLastListPageArgs()).not.toHaveProperty("officialFirst");
   });
 
   it("shows category navigation outside Trending and sends the selected category", async () => {

--- a/src/__tests__/skills-index.claw591.test.tsx
+++ b/src/__tests__/skills-index.claw591.test.tsx
@@ -1,0 +1,436 @@
+/* @vitest-environment jsdom */
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Route as SkillsRoute, SkillsIndex } from "../routes/skills/index";
+import {
+  convexHttpMock,
+  convexReactMocks,
+  resetConvexReactMocks,
+  setupDefaultConvexReactMocks,
+} from "./helpers/convexReactMocks";
+
+const navigateMock = vi.fn();
+const fetchCanonicalTrendingPageMock = vi.fn();
+let searchMock: Record<string, unknown> = {};
+let loaderDataMock: unknown = null;
+
+vi.mock("../lib/trendingApi", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../lib/trendingApi")>();
+  return {
+    ...original,
+    fetchCanonicalTrendingPage: (...args: unknown[]) => fetchCanonicalTrendingPageMock(...args),
+  };
+});
+
+vi.mock("@tanstack/react-router", () => ({
+  createFileRoute: () => (config: { component: unknown; validateSearch: unknown }) => ({
+    __config: config,
+    useLoaderData: () => loaderDataMock,
+    useNavigate: () => navigateMock,
+    useSearch: () => searchMock,
+  }),
+  useRouterState: (options: { select: (state: unknown) => unknown }) =>
+    options.select({ location: { searchStr: "" } }),
+  redirect: (options: unknown) => ({ redirect: options }),
+  Link: (props: { children: ReactNode; to?: string }) => (
+    <a href={props.to ?? "/"}>{props.children}</a>
+  ),
+}));
+
+vi.mock("convex/react", () => ({
+  ConvexReactClient: class {},
+  useAction: (...args: unknown[]) => convexReactMocks.useAction(...args),
+  useQuery: (...args: unknown[]) => convexReactMocks.useQuery(...args),
+}));
+
+vi.mock("../../src/convex/client", () => ({
+  convexHttp: {
+    action: (...args: unknown[]) => convexHttpMock.action(...args),
+    query: (...args: unknown[]) => convexHttpMock.query(...args),
+  },
+}));
+
+describe("SkillsIndex", () => {
+  beforeEach(() => {
+    resetConvexReactMocks();
+    navigateMock.mockReset();
+    searchMock = {};
+    loaderDataMock = null;
+    setupDefaultConvexReactMocks();
+    fetchCanonicalTrendingPageMock.mockReset();
+    fetchCanonicalTrendingPageMock.mockResolvedValue(canonicalPage([]));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("normalizes supported tab, topic, and legacy category URLs", () => {
+    const validateSearch = getValidateSearch();
+
+    expect(validateSearch({}).tab).toBe("trending");
+    expect(validateSearch({ tab: "official", topic: "github" })).toEqual(
+      expect.objectContaining({ tab: "official", topic: "github" }),
+    );
+    expect(validateSearch({ category: "workflows" }).category).toBe("automation");
+    expect(validateSearch({ category: "workflows" }).tab).toBe("new");
+    expect(validateSearch({ topic: "github" }).tab).toBe("new");
+    expect(validateSearch({ tab: "trending", category: "workflows" }).tab).toBe("trending");
+    expect(validateSearch({ category: "mcp-tools" }).category).toBe("integrations");
+    expect(validateSearch({ category: "unknown" }).category).toBeUndefined();
+    expect(validateSearch({ category: "unknown" }).tab).toBe("trending");
+  });
+
+  it("defaults to canonical Trending and exposes the exact accepted tabs", async () => {
+    render(<SkillsIndex />);
+    await act(async () => {});
+
+    expect(fetchCanonicalTrendingPageMock).toHaveBeenCalledWith({ cursor: null, limit: 20 });
+    expect(convexHttpMock.query).not.toHaveBeenCalled();
+    expect(screen.getByRole("radio", { name: "Trending" }).getAttribute("aria-checked")).toBe(
+      "true",
+    );
+    expect(tabLabels()).toEqual(["Trending", "New", "Featured", "Official"]);
+    expect(screen.queryByRole("radio", { name: "Top" })).toBeNull();
+    expect(screen.queryByRole("radio", { name: "All" })).toBeNull();
+    expect(screen.queryByRole("combobox", { name: "Sort" })).toBeNull();
+    expect(screen.queryByLabelText("Skill categories")).toBeNull();
+  });
+
+  it("renders canonical Trending rows in API order with only 24-hour installs", async () => {
+    fetchCanonicalTrendingPageMock.mockResolvedValue(
+      canonicalPage([
+        makeTrending("first", "First Skill", 17, 9000),
+        makeTrending("second", "Second Skill", 3, 8000),
+      ]),
+    );
+
+    render(<SkillsIndex />);
+
+    expect(await screen.findByTitle("First Skill")).toBeTruthy();
+    const names = Array.from(
+      document.querySelectorAll(".skill-list-item-name"),
+      (node) => node.textContent,
+    );
+    expect(names).toEqual(["First Skill", "Second Skill"]);
+    expect(screen.getByText("17")).toBeTruthy();
+    expect(screen.getByText("3")).toBeTruthy();
+    expect(screen.queryByText("9K")).toBeNull();
+    expect(screen.queryByText("8K")).toBeNull();
+    expect(screen.queryByText("skills.sh")).toBeNull();
+    expect(screen.queryByText(/Not scanned by ClawHub/i)).toBeNull();
+  });
+
+  it("loads New from the native 14-day chronological feed", async () => {
+    searchMock = { tab: "new" };
+    convexHttpMock.query.mockResolvedValue({
+      page: [makeListResult("new-skill", "New Skill")],
+      hasMore: false,
+      nextCursor: null,
+    });
+
+    render(<SkillsIndex />);
+    expect(await screen.findByText("New Skill")).toBeTruthy();
+
+    const args = getLastListPageArgs();
+    expect(args).toEqual(
+      expect.objectContaining({
+        sort: "newest",
+        dir: "desc",
+        numItems: 20,
+        highlightedOnly: undefined,
+        officialOnly: undefined,
+      }),
+    );
+    expect(typeof args.createdAfter).toBe("number");
+    expect(Date.now() - Number(args.createdAfter)).toBeLessThanOrEqual(
+      14 * 24 * 60 * 60 * 1000 + 1000,
+    );
+  });
+
+  it("loads the latest 40 Featured skills from editorial history", async () => {
+    searchMock = { tab: "featured" };
+    convexHttpMock.query.mockResolvedValue({
+      page: [makeListResult("featured-skill", "Featured Skill")],
+      hasMore: true,
+      nextCursor: "must-not-continue",
+    });
+
+    render(<SkillsIndex />);
+    expect(await screen.findByText("Featured Skill")).toBeTruthy();
+
+    expect(getLastListPageArgs()).toEqual(
+      expect.objectContaining({
+        highlightedOnly: true,
+        numItems: 40,
+        sort: "updated",
+      }),
+    );
+    expect(screen.queryByRole("button", { name: "Load more" })).toBeNull();
+  });
+
+  it("loads Official through the backend official-publisher filter", async () => {
+    searchMock = { tab: "official" };
+    convexHttpMock.query.mockResolvedValue({ page: [], hasMore: false, nextCursor: null });
+
+    render(<SkillsIndex />);
+    await act(async () => {});
+
+    expect(getLastListPageArgs()).toEqual(
+      expect.objectContaining({ officialOnly: true, sort: "newest", numItems: 20 }),
+    );
+  });
+
+  it("shows category navigation outside Trending and sends the selected category", async () => {
+    searchMock = { tab: "new", category: "development" };
+    convexHttpMock.query.mockResolvedValue({ page: [], hasMore: false, nextCursor: null });
+
+    render(<SkillsIndex />);
+    await act(async () => {});
+
+    expect(screen.getByLabelText("Skill categories")).toBeTruthy();
+    expect(screen.getByRole("combobox", { name: "Category" })).toBeTruthy();
+    expect(getLastListPageArgs()).toEqual(expect.objectContaining({ categorySlug: "development" }));
+    expect(getLastListPageArgs()).not.toHaveProperty("officialFirst");
+  });
+
+  it("switches feeds through URL state and clears filters that would rerank Trending", async () => {
+    searchMock = { tab: "new", category: "development", topic: "github", q: "agent" };
+    render(<SkillsIndex />);
+
+    fireEvent.click(screen.getByRole("radio", { name: "Trending" }));
+
+    const call = getLastNavigateCall();
+    expect(
+      call.search({ tab: "new", category: "development", topic: "github", q: "agent" }),
+    ).toEqual({
+      tab: "trending",
+      category: undefined,
+      topic: undefined,
+      q: undefined,
+      sort: undefined,
+      dir: undefined,
+      featured: undefined,
+      highlighted: undefined,
+    });
+  });
+
+  it("renders the full eligible backend count on the default page", async () => {
+    convexReactMocks.useQuery.mockReturnValue(70_300);
+
+    render(<SkillsIndex />);
+    await act(async () => {});
+
+    expect(screen.getByRole("heading", { name: "Skills 70.3K" })).toBeTruthy();
+  });
+
+  it("hides the global count on subset feeds", async () => {
+    searchMock = { tab: "featured" };
+    convexReactMocks.useQuery.mockReturnValue(70_300);
+    convexHttpMock.query.mockResolvedValue({ page: [], hasMore: false, nextCursor: null });
+
+    render(<SkillsIndex />);
+    await act(async () => {});
+
+    expect(screen.getByRole("heading", { name: "Skills" })).toBeTruthy();
+    expect(screen.queryByText("70.3K")).toBeNull();
+  });
+
+  it("keeps search relevance separate and skips feed requests", async () => {
+    searchMock = { q: "remind" };
+    const action = vi.fn().mockResolvedValue([]);
+    convexReactMocks.useAction.mockReturnValue(action);
+    vi.useFakeTimers();
+
+    render(<SkillsIndex />);
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
+
+    expect(fetchCanonicalTrendingPageMock).not.toHaveBeenCalled();
+    expect(convexHttpMock.query).not.toHaveBeenCalled();
+    expect(action).toHaveBeenCalledWith({
+      query: "remind",
+      highlightedOnly: false,
+      categorySlug: undefined,
+      topic: undefined,
+      limit: 20,
+    });
+  });
+
+  it("clears browse-only category and topic constraints when entering search", async () => {
+    searchMock = { tab: "new", category: "development", topic: "github" };
+    convexHttpMock.query.mockResolvedValue({ page: [], hasMore: false, nextCursor: null });
+    vi.useFakeTimers();
+
+    render(<SkillsIndex />);
+    fireEvent.click(screen.getByRole("button", { name: "Search skills" }));
+    fireEvent.change(screen.getByPlaceholderText("Search skills..."), {
+      target: { value: "agent" },
+    });
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
+
+    expect(
+      getLastNavigateCall().search({ tab: "new", category: "development", topic: "github" }),
+    ).toEqual({
+      tab: "new",
+      category: undefined,
+      dir: undefined,
+      topic: undefined,
+      q: "agent",
+      sort: undefined,
+    });
+  });
+
+  it("uses loader-provided search results without a duplicate refresh", () => {
+    searchMock = { q: "japanese-conversation-scorer" };
+    loaderDataMock = {
+      key: "japanese-conversation-scorer::0::::",
+      limit: 25,
+      results: [makeSearchResult("japanese-conversation-scorer", "Japanese Conversation Scorer")],
+    };
+    const action = vi.fn().mockResolvedValue([]);
+    convexReactMocks.useAction.mockReturnValue(action);
+
+    render(<SkillsIndex />);
+
+    expect(screen.getByText("Japanese Conversation Scorer")).toBeTruthy();
+    expect(screen.queryByText("24h installs")).toBeNull();
+    expect(screen.getByText("Popularity")).toBeTruthy();
+    expect(action).not.toHaveBeenCalled();
+  });
+
+  it("keeps the existing list/grid and search controls", async () => {
+    render(<SkillsIndex />);
+    await act(async () => {});
+
+    fireEvent.click(screen.getByRole("button", { name: "Grid" }));
+    expect(getLastNavigateCall().search({})).toEqual({ view: "grid" });
+
+    fireEvent.click(screen.getByRole("button", { name: "Search skills" }));
+    expect(screen.getByPlaceholderText("Search skills...")).toBeTruthy();
+  });
+});
+
+function getValidateSearch() {
+  return (
+    SkillsRoute as unknown as {
+      __config: {
+        validateSearch: (search: Record<string, unknown>) => Record<string, unknown>;
+      };
+    }
+  ).__config.validateSearch;
+}
+
+function tabLabels() {
+  return Array.from(
+    screen.getByRole("radiogroup", { name: "Skill view" }).querySelectorAll('[role="radio"]'),
+    (node) => node.textContent,
+  );
+}
+
+function getLastNavigateCall() {
+  return navigateMock.mock.calls.at(-1)?.[0] as {
+    search: (prev: Record<string, unknown>) => Record<string, unknown>;
+    replace?: boolean;
+  };
+}
+
+function getLastListPageArgs() {
+  const call = convexHttpMock.query.mock.calls.at(-1);
+  return (call?.[1] ?? {}) as Record<string, unknown>;
+}
+
+function canonicalPage(items: ReturnType<typeof makeTrending>[], nextCursor: string | null = null) {
+  return {
+    kind: "skills" as const,
+    snapshotId: "snapshot-1",
+    snapshotCursor: "snapshot-cursor",
+    generatedAt: "2026-07-26T00:00:00.000Z",
+    windowHours: 24 as const,
+    rankingVersion: "skills-trending-v1",
+    totalItems: items.length,
+    items,
+    nextCursor,
+  };
+}
+
+function makeTrending(slug: string, displayName: string, installs: number, lifetime: number) {
+  return {
+    id: `clawhub:${slug}`,
+    source: "clawhub" as const,
+    slug,
+    displayName,
+    summary: `${displayName} summary`,
+    canonicalUrl: `/owner/${slug}`,
+    publisher: {
+      kind: "user" as const,
+      handle: "owner",
+      displayName: "Owner",
+      image: null,
+      official: false,
+    },
+    official: false,
+    featured: false,
+    metrics: {
+      trending24hInstalls: installs,
+      trending24hBookmarks: null,
+      lifetimeInstalls: lifetime,
+      lifetimeInstallsPeriod: "lifetime" as const,
+      updatedAt: 1,
+    },
+  };
+}
+
+function makeListResult(slug: string, displayName: string) {
+  return {
+    skill: {
+      _id: `skill_${slug}`,
+      slug,
+      displayName,
+      summary: `${displayName} summary`,
+      tags: {},
+      stats: { downloads: 0, installs: 0, stars: 0, versions: 1, comments: 0 },
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    },
+    latestVersion: null,
+    ownerHandle: "owner",
+  };
+}
+
+function makeSearchResult(slug: string, displayName: string) {
+  const skill = makeListResult(slug, displayName).skill;
+  return {
+    id: `clawhub:${slug}`,
+    source: "clawhub" as const,
+    slug,
+    displayName,
+    summary: skill.summary,
+    score: 1,
+    canonicalUrl: `/owner/${slug}`,
+    links: { canonical: `/owner/${slug}`, source: null },
+    official: false,
+    featured: false,
+    publisher: null,
+    install: { kind: "clawhub" as const, reference: slug, sourceUrl: null },
+    sourceIdentity: { id: slug, owner: null, repo: null, host: null, lifetimeInstalls: null },
+    trust: {
+      visibility: "public" as const,
+      installability: "installable" as const,
+      clawHubVerdict: null,
+      upstreamScanners: null,
+      sourceFreshness: "native" as const,
+    },
+    metrics: { rolling60DayInstalls: null, bookmarks: null, updatedAt: skill.updatedAt },
+    native: { skill, version: null, owner: null, ownerHandle: "owner" },
+    ownerHandle: "owner",
+    version: null,
+    downloads: 0,
+    updatedAt: skill.updatedAt,
+  };
+}

--- a/src/__tests__/skills-index.test.tsx
+++ b/src/__tests__/skills-index.test.tsx
@@ -44,7 +44,9 @@ describe("SkillsIndex", () => {
   beforeEach(() => {
     resetConvexReactMocks();
     navigateMock.mockReset();
-    searchMock = {};
+    // Keep legacy browse/search regressions on the native New feed. Trending has
+    // its own canonical API seam and focused CLAW-591 coverage.
+    searchMock = { tab: "new" };
     loaderDataMock = null;
     setupDefaultConvexReactMocks();
   });
@@ -96,26 +98,18 @@ describe("SkillsIndex", () => {
     expect(args).toEqual(
       expect.objectContaining({
         dir: "desc",
-        highlightedOnly: false,
+        highlightedOnly: undefined,
         cursor: undefined,
-        numItems: 25,
+        numItems: 20,
+        sort: "newest",
       }),
     );
-    expect(args).not.toHaveProperty("sort");
     expect(args).not.toHaveProperty("officialFirst");
-    expect(screen.getByRole("radio", { name: "All" }).getAttribute("aria-checked")).toBe("true");
-    const sortOptions = Array.from(
+    expect(screen.getByRole("radio", { name: "New" }).getAttribute("aria-checked")).toBe("true");
+    const tabs = Array.from(
       screen.getByRole("radiogroup", { name: "Skill view" }).querySelectorAll('[role="radio"]'),
     ).map((option) => option.textContent);
-    expect(sortOptions).toEqual(["All", "Trending", "Top", "Most bookmarked", "Featured"]);
-  });
-
-  it("offers Top without exposing downloads as a browse view", async () => {
-    render(<SkillsIndex />);
-    await act(async () => {});
-
-    expect(screen.getByRole("radio", { name: "Top" })).toBeTruthy();
-    expect(screen.queryByRole("radio", { name: "Most downloaded" })).toBeNull();
+    expect(tabs).toEqual(["Trending", "New", "Featured", "Official"]);
   });
 
   it("renders desktop category navigation and keeps the responsive category dropdown", async () => {
@@ -134,35 +128,6 @@ describe("SkillsIndex", () => {
     expect(navigateMock).toHaveBeenCalled();
   });
 
-  it("separates primary views from secondary sort options", async () => {
-    render(<SkillsIndex />);
-    await act(async () => {});
-
-    const views = Array.from(
-      screen.getByRole("radiogroup", { name: "Skill view" }).querySelectorAll('[role="radio"]'),
-    ).map((option) => option.textContent);
-    fireEvent.click(screen.getByRole("combobox", { name: "Sort" }));
-    const sortOptions = screen.getAllByRole("option").map((option) => option.textContent);
-
-    expect(views).toEqual(["All", "Trending", "Top", "Most bookmarked", "Featured"]);
-    expect(sortOptions).toEqual(["Recently updated", "Newest", "Name"]);
-  });
-
-  it("preserves a secondary sort when switching to Featured", async () => {
-    searchMock = { sort: "updated", dir: "desc" };
-    render(<SkillsIndex />);
-
-    fireEvent.click(screen.getByRole("radio", { name: "Featured" }));
-
-    const lastCall = getLastNavigateCall();
-    expect(lastCall.search({ sort: "updated", dir: "desc" })).toEqual({
-      sort: "updated",
-      dir: "desc",
-      featured: true,
-      highlighted: undefined,
-    });
-  });
-
   it("renders an empty state when no skills are returned", async () => {
     render(<SkillsIndex />);
     await act(async () => {});
@@ -171,6 +136,7 @@ describe("SkillsIndex", () => {
   });
 
   it("renders the total skills count in the unfiltered page title", async () => {
+    searchMock = {};
     convexReactMocks.useQuery.mockReturnValue(70_300);
 
     render(<SkillsIndex />);
@@ -404,7 +370,9 @@ describe("SkillsIndex", () => {
     expect(actionFn).toHaveBeenCalledWith({
       query: "remind",
       highlightedOnly: false,
-      limit: 25,
+      categorySlug: undefined,
+      topic: undefined,
+      limit: 20,
     });
     await act(async () => {
       await vi.runAllTimersAsync();
@@ -412,7 +380,9 @@ describe("SkillsIndex", () => {
     expect(actionFn).toHaveBeenCalledWith({
       query: "remind",
       highlightedOnly: false,
-      limit: 25,
+      categorySlug: undefined,
+      topic: undefined,
+      limit: 20,
     });
   });
 
@@ -431,11 +401,12 @@ describe("SkillsIndex", () => {
       query: "helper",
       highlightedOnly: false,
       categorySlug: "development",
-      limit: 25,
+      topic: undefined,
+      limit: 20,
     });
   });
 
-  it("keeps All as the visible default search view", async () => {
+  it("keeps the accepted feed tabs visible while search uses relevance", async () => {
     searchMock = { q: "notion" };
     const actionFn = vi.fn().mockResolvedValue([]);
     convexReactMocks.useAction.mockReturnValue(actionFn);
@@ -443,24 +414,14 @@ describe("SkillsIndex", () => {
 
     render(<SkillsIndex />);
 
-    expect(screen.getByRole("radio", { name: "All" }).getAttribute("aria-checked")).toBe("true");
+    expect(screen.getByRole("radio", { name: "Trending" }).getAttribute("aria-checked")).toBe(
+      "true",
+    );
     expect(screen.queryByRole("radio", { name: "Relevance" })).toBeNull();
-    const sortOptions = Array.from(
+    const tabs = Array.from(
       screen.getByRole("radiogroup", { name: "Skill view" }).querySelectorAll('[role="radio"]'),
     ).map((option) => option.textContent);
-    expect(sortOptions[0]).toBe("All");
-  });
-
-  it("keeps recommended sort stable while typing a search", async () => {
-    vi.useFakeTimers();
-
-    render(<SkillsIndex />);
-
-    const input = screen.getByPlaceholderText("Search skills...");
-    fireEvent.change(input, { target: { value: "agent" } });
-
-    expect(screen.getByRole("radio", { name: "All" }).getAttribute("aria-checked")).toBe("true");
-    expect(screen.queryByRole("radio", { name: "Relevance" })).toBeNull();
+    expect(tabs).toEqual(["Trending", "New", "Featured", "Official"]);
   });
 
   it("keeps the skills sort option list stable while typing a search", async () => {
@@ -579,56 +540,13 @@ describe("SkillsIndex", () => {
     });
   });
 
-  it("does not reuse a stale recommended direction when choosing an explicit browse sort", async () => {
-    searchMock = { sort: "recommended", dir: "asc" };
-    render(<SkillsIndex />);
-
-    fireEvent.click(screen.getByRole("radio", { name: "Top" }));
-
-    const lastCall = getLastNavigateCall();
-    expect(lastCall.replace).toBe(true);
-    expect(lastCall.search({ sort: "recommended", dir: "asc" })).toEqual({
-      sort: "downloads",
-      dir: "desc",
-    });
-  });
-
-  it("does not reuse a stale relevance direction when choosing an explicit search sort", async () => {
-    searchMock = { q: "notion", sort: "relevance", dir: "asc" };
-    render(<SkillsIndex />);
-
-    fireEvent.click(screen.getByRole("radio", { name: "Top" }));
-
-    const lastCall = getLastNavigateCall();
-    expect(lastCall.replace).toBe(true);
-    expect(lastCall.search({ q: "notion", sort: "relevance", dir: "asc" })).toEqual({
-      q: "notion",
-      sort: "downloads",
-      dir: "desc",
-    });
-  });
-
-  it("clears direction when returning to the All view", async () => {
-    searchMock = { sort: "downloads", dir: "asc" };
-    render(<SkillsIndex />);
-
-    fireEvent.click(screen.getByRole("radio", { name: "All" }));
-
-    const lastCall = getLastNavigateCall();
-    expect(lastCall.replace).toBe(true);
-    expect(lastCall.search({ sort: "downloads", dir: "asc" })).toEqual({
-      sort: undefined,
-      dir: undefined,
-    });
-  });
-
   it("loads more results when search pagination is requested", async () => {
     searchMock = { q: "remind" };
     vi.stubGlobal("IntersectionObserver", undefined);
     const actionFn = vi
       .fn()
-      .mockResolvedValueOnce(makeSearchResults(25))
-      .mockResolvedValueOnce(makeSearchResults(50));
+      .mockResolvedValueOnce(makeSearchResults(20))
+      .mockResolvedValueOnce(makeSearchResults(40));
     convexReactMocks.useAction.mockReturnValue(actionFn);
     vi.useFakeTimers();
 
@@ -648,7 +566,9 @@ describe("SkillsIndex", () => {
     expect(actionFn).toHaveBeenLastCalledWith({
       query: "remind",
       highlightedOnly: false,
-      limit: 50,
+      categorySlug: undefined,
+      topic: undefined,
+      limit: 40,
     });
     expect(screen.queryByText(/\d+ loaded/)).toBeNull();
   });
@@ -752,7 +672,6 @@ describe("SkillsIndex", () => {
     expect(args).toEqual(
       expect.objectContaining({
         categorySlug: "development",
-        officialFirst: true,
         categoryKeywords: expect.arrayContaining(["developer"]),
         excludeCategoryKeywords: undefined,
       }),
@@ -871,7 +790,7 @@ describe("SkillsIndex", () => {
     expect(screen.queryByRole("radio", { name: "All topics" })).toBeNull();
   });
 
-  it("preserves backend official-first ordering on category pages", async () => {
+  it("preserves backend ordering on New category pages without client reranking", async () => {
     searchMock = { category: "development" };
     convexHttpMock.query.mockResolvedValue({
       page: [
@@ -894,7 +813,7 @@ describe("SkillsIndex", () => {
       (node) => node.textContent,
     );
     expect(titles).toEqual(["Official Dev", "Community Dev"]);
-    expect(getLastListPageArgs()).toEqual(expect.objectContaining({ officialFirst: true }));
+    expect(getLastListPageArgs()).not.toHaveProperty("officialFirst");
   });
 
   it("does not render the warning filter", async () => {
@@ -922,7 +841,7 @@ describe("SkillsIndex", () => {
         highlightedOnly: true,
       }),
     );
-    expect(args).not.toHaveProperty("sort");
+    expect(args.sort).toBe("updated");
   });
 
   it("shows load-more button when more results are available", async () => {

--- a/src/components/HomeListingSection.tsx
+++ b/src/components/HomeListingSection.tsx
@@ -26,11 +26,11 @@ import { api } from "../../convex/_generated/api";
 import { convexHttp } from "../convex/client";
 import { PLUGIN_CATEGORIES, SKILL_CATEGORIES, type BrowseCategory } from "../lib/categories";
 import {
-  fetchHomeFeaturedAvailability as fetchFeaturedAvailability,
   fetchHomePluginListing as fetchPluginListing,
   fetchHomeSkillListing as fetchSkillListing,
   HOME_LISTING_PAGE_SIZE,
   homeListingCacheKey as listingCacheKey,
+  isHomeTrendingSkillEntry,
   itemMatchesAnyHomeCategory as itemMatchesAnyCategory,
   skillMatchesAnyHomeCategory as skillMatchesAnyCategory,
   uniqueHomePlugins as uniquePlugins,
@@ -38,6 +38,7 @@ import {
   type HomeListingCacheEntry,
   type HomeListingInitialData,
   type HomeListingKind as ListingKind,
+  type HomeNativeSkillListingEntry,
   type HomeListingTab as ListingTab,
   type HomeSkillListingEntry as SkillPageEntry,
 } from "../lib/homeListingData";
@@ -55,15 +56,19 @@ import { BrowseResultsSkeleton } from "./skeletons/BrowseResultsSkeleton";
 type ListingView = "list" | "grid";
 
 const SKILL_LISTING_TABS: Array<{ id: ListingTab; label: string }> = [
-  { id: "featured", label: "Featured" },
-  { id: "popular", label: "Top" },
   { id: "trending", label: "Trending" },
+  { id: "new", label: "New" },
+  { id: "featured", label: "Featured" },
+  { id: "official", label: "Official" },
 ];
 
-const PLUGIN_LISTING_TABS: Array<{ id: ListingTab; label: string }> = [
+const PLUGIN_LISTING_TABS: Array<{
+  id: Exclude<ListingTab, "trending">;
+  label: string;
+}> = [
+  { id: "new", label: "New" },
   { id: "featured", label: "Featured" },
-  { id: "popular", label: "Top" },
-  { id: "trending", label: "Trending" },
+  { id: "official", label: "Official" },
 ];
 
 const LISTING_PAGE_SIZE = HOME_LISTING_PAGE_SIZE;
@@ -172,7 +177,7 @@ function HomeListingResults({
   );
 }
 
-function skillLink(entry: SkillPageEntry) {
+function skillLink(entry: HomeNativeSkillListingEntry) {
   const owner =
     entry.ownerHandle?.trim() ||
     entry.owner?.handle?.trim() ||
@@ -181,6 +186,36 @@ function skillLink(entry: SkillPageEntry) {
 }
 
 function HomeListingSkillRow({ entry, showStats }: { entry: SkillPageEntry; showStats: boolean }) {
+  if (isHomeTrendingSkillEntry(entry)) {
+    const item = entry.trending;
+    const owner = item.publisher?.handle;
+    return (
+      <Link to={item.canonicalUrl} className="home-v2-listing-row">
+        <span className="home-v2-listing-row-icon" aria-hidden="true">
+          <MarketplaceIcon kind="skill" label={item.displayName} size="sm" />
+        </span>
+        <div className="home-v2-listing-row-body">
+          <div className="home-v2-listing-row-title">
+            <span className="home-v2-listing-row-name" title={item.displayName}>
+              {truncateText(item.displayName, PUBLIC_CATALOG_NAME_PREVIEW_LENGTH)}
+            </span>
+            {owner ? <span className="home-v2-listing-row-by">@{owner}</span> : null}
+          </div>
+          <p className="home-v2-listing-row-summary">
+            {truncateText(item.summary || "Agent-ready skill pack.", 80)}
+          </p>
+        </div>
+        {typeof item.metrics.trending24hInstalls === "number" ? (
+          <div className="home-v2-listing-row-stats" aria-label="24-hour installs">
+            <span>
+              <Download size={13} aria-hidden="true" />
+              {formatCompactStat(item.metrics.trending24hInstalls)}
+            </span>
+          </div>
+        ) : null}
+      </Link>
+    );
+  }
   const handle = entry.ownerHandle || entry.owner?.handle;
   const name = presentationTitle(entry.skill.displayName, entry.skill.slug);
 
@@ -265,6 +300,36 @@ function HomeListingPluginRow({ plugin }: { plugin: PackageListItem }) {
 }
 
 function HomeListingSkillCard({ entry, showStats }: { entry: SkillPageEntry; showStats: boolean }) {
+  if (isHomeTrendingSkillEntry(entry)) {
+    const item = entry.trending;
+    const owner = item.publisher?.handle;
+    return (
+      <Link to={item.canonicalUrl} className="home-v2-listing-card oc-card oc-card-interactive">
+        <div className="home-v2-listing-card-head">
+          <span className="home-v2-listing-card-icon" aria-hidden="true">
+            <MarketplaceIcon kind="skill" label={item.displayName} size="sm" />
+          </span>
+          <div className="home-v2-listing-card-id">
+            <span className="home-v2-listing-card-name" title={item.displayName}>
+              {truncateText(item.displayName, PUBLIC_CATALOG_NAME_PREVIEW_LENGTH)}
+            </span>
+            {owner ? <span className="home-v2-listing-card-by">@{owner}</span> : null}
+          </div>
+        </div>
+        <p className="home-v2-listing-card-summary">
+          {truncateText(item.summary || "Agent-ready skill pack.", 80)}
+        </p>
+        {typeof item.metrics.trending24hInstalls === "number" ? (
+          <div className="home-v2-listing-card-stats" aria-label="24-hour installs">
+            <span>
+              <Download size={13} aria-hidden="true" />
+              {formatCompactStat(item.metrics.trending24hInstalls)}
+            </span>
+          </div>
+        ) : null}
+      </Link>
+    );
+  }
   const handle = entry.ownerHandle || entry.owner?.handle;
   const name = presentationTitle(entry.skill.displayName, entry.skill.slug);
 
@@ -388,8 +453,8 @@ export function HomeListingSection({ initialListing = null }: HomeListingSection
   listingCacheRef.current ??= createInitialListingCache(initialListing);
   const listingCache = listingCacheRef.current;
 
-  const [kind, setKind] = useState<ListingKind>(initialListing?.kind ?? "plugins");
-  const [tab, setTab] = useState<ListingTab>(initialListing?.tab ?? "featured");
+  const [kind, setKind] = useState<ListingKind>(initialListing?.kind ?? "skills");
+  const [tab, setTab] = useState<ListingTab>(initialListing?.tab ?? "trending");
   const [view, setView] = useState<ListingView>("list");
   const [categorySlugs, setCategorySlugs] = useState<string[]>([]);
   const [visibleCount, setVisibleCount] = useState(LISTING_PAGE_SIZE);
@@ -399,14 +464,6 @@ export function HomeListingSection({ initialListing = null }: HomeListingSection
   );
   const [plugins, setPlugins] = useState<PackageListItem[]>(
     initialListing?.kind === "plugins" ? initialListing.items : [],
-  );
-  const [featuredAvailability, setFeaturedAvailability] = useState<
-    Record<ListingKind, boolean | null>
-  >(
-    initialListing?.featuredAvailability ?? {
-      plugins: null,
-      skills: null,
-    },
   );
   const [status, setStatus] = useState<"loading" | "idle" | "error">(
     initialListing ? "idle" : "loading",
@@ -431,9 +488,7 @@ export function HomeListingSection({ initialListing = null }: HomeListingSection
     [categorySlugs, listingCategories],
   );
 
-  const visibleTabs = (kind === "skills" ? SKILL_LISTING_TABS : PLUGIN_LISTING_TABS).filter(
-    (item) => item.id !== "featured" || featuredAvailability[kind] === true,
-  );
+  const visibleTabs = kind === "skills" ? SKILL_LISTING_TABS : PLUGIN_LISTING_TABS;
 
   const activeItems = isSearchMode
     ? kind === "skills"
@@ -482,26 +537,6 @@ export function HomeListingSection({ initialListing = null }: HomeListingSection
   }, [searchOpen, trimmedSearch]);
 
   useEffect(() => {
-    if (featuredAvailability[kind] !== null) return undefined;
-    const controller = new AbortController();
-    fetchFeaturedAvailability(kind, controller.signal)
-      .then((available) => {
-        if (controller.signal.aborted) return;
-        setFeaturedAvailability((current) => ({ ...current, [kind]: available }));
-        if (!available) {
-          setTab((current) => (current === "featured" ? "popular" : current));
-        }
-      })
-      .catch(() => {
-        if (controller.signal.aborted) return;
-        setFeaturedAvailability((current) => ({ ...current, [kind]: false }));
-        setTab((current) => (current === "featured" ? "popular" : current));
-      });
-
-    return () => controller.abort();
-  }, [featuredAvailability, kind]);
-
-  useEffect(() => {
     if (isSearchMode) return undefined;
     const cacheKey = listingCacheKey({ kind, tab, categorySlugs, fetchLimit });
     const cached = listingCache.get(cacheKey);
@@ -528,7 +563,7 @@ export function HomeListingSection({ initialListing = null }: HomeListingSection
 
     const load =
       kind === "skills"
-        ? fetchSkillListing(tab, categorySlugs, fetchLimit).then((result) => {
+        ? fetchSkillListing(tab, categorySlugs, fetchLimit, controller.signal).then((result) => {
             if (controller.signal.aborted) return;
             listingCache.set(cacheKey, {
               kind: "skills",
@@ -539,7 +574,12 @@ export function HomeListingSection({ initialListing = null }: HomeListingSection
             setListingHasMore(result.hasMore);
             setStatus("idle");
           })
-        : fetchPluginListing(tab, categorySlugs, fetchLimit, controller.signal).then((result) => {
+        : fetchPluginListing(
+            tab === "trending" ? "new" : tab,
+            categorySlugs,
+            fetchLimit,
+            controller.signal,
+          ).then((result) => {
             if (controller.signal.aborted) return;
             listingCache.set(cacheKey, {
               kind: "plugins",
@@ -630,7 +670,8 @@ export function HomeListingSection({ initialListing = null }: HomeListingSection
                   q: trimmedSearch,
                   category: categorySlug ?? undefined,
                   featured: tab === "featured" ? true : undefined,
-                  sort: tab === "trending" ? "trending" : "downloads",
+                  sort: "updated",
+                  isOfficial: tab === "official" ? true : undefined,
                   limit: fetchLimit,
                   signal: controller.signal,
                 }),
@@ -706,8 +747,7 @@ export function HomeListingSection({ initialListing = null }: HomeListingSection
     if (nextKind === kind) return;
     setKind(nextKind);
     setCategorySlugs([]);
-    const nextFeaturedAvailability = featuredAvailability[nextKind];
-    setTab(nextFeaturedAvailability === false ? "popular" : "featured");
+    setTab(nextKind === "skills" ? "trending" : "new");
   };
 
   const removeCategory = (slug: string) => {
@@ -760,7 +800,10 @@ export function HomeListingSection({ initialListing = null }: HomeListingSection
                   role="tab"
                   aria-selected={tab === item.id}
                   className={`home-v2-listing-tab${tab === item.id ? " is-active" : ""}`}
-                  onClick={() => setTab(item.id)}
+                  onClick={() => {
+                    setTab(item.id);
+                    if (item.id === "trending") setCategorySlugs([]);
+                  }}
                 >
                   {item.label}
                 </button>
@@ -784,11 +827,13 @@ export function HomeListingSection({ initialListing = null }: HomeListingSection
                 <Search size={16} aria-hidden="true" />
               </button>
 
-              <HomeListingCategorySelect
-                categories={listingCategories}
-                value={categorySlugs}
-                onChange={setCategorySlugs}
-              />
+              {kind === "skills" && tab === "trending" ? null : (
+                <HomeListingCategorySelect
+                  categories={listingCategories}
+                  value={categorySlugs}
+                  onChange={setCategorySlugs}
+                />
+              )}
 
               <div
                 className="home-v2-listing-view clawhub-segmented oc-segmented"
@@ -894,7 +939,11 @@ export function HomeListingSection({ initialListing = null }: HomeListingSection
           <span className="home-v2-listing-head-label">
             {kind === "skills" ? "Skill" : "Plugin"}
           </span>
-          {showSkillStats ? <span className="home-v2-listing-head-stat">Popularity</span> : null}
+          {kind === "skills" && tab === "trending" ? (
+            <span className="home-v2-listing-head-stat">24h installs</span>
+          ) : showSkillStats ? (
+            <span className="home-v2-listing-head-stat">Popularity</span>
+          ) : null}
         </div>
       ) : null}
 
@@ -923,13 +972,17 @@ export function HomeListingSection({ initialListing = null }: HomeListingSection
             {visibleSkills.map((entry) =>
               view === "grid" ? (
                 <HomeListingSkillCard
-                  key={entry.skill._id}
+                  key={
+                    isHomeTrendingSkillEntry(entry) ? entry.trending.id : String(entry.skill._id)
+                  }
                   entry={entry}
                   showStats={showSkillStats}
                 />
               ) : (
                 <HomeListingSkillRow
-                  key={entry.skill._id}
+                  key={
+                    isHomeTrendingSkillEntry(entry) ? entry.trending.id : String(entry.skill._id)
+                  }
                   entry={entry}
                   showStats={showSkillStats}
                 />

--- a/src/lib/homeListingData.claw591.test.ts
+++ b/src/lib/homeListingData.claw591.test.ts
@@ -1,0 +1,296 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const convexQueryMock = vi.fn();
+const fetchPluginCatalogMock = vi.fn();
+const fetchCanonicalTrendingPageMock = vi.fn();
+
+vi.mock("../convex/client", () => ({
+  convexHttp: { query: (...args: unknown[]) => convexQueryMock(...args) },
+}));
+
+vi.mock("../../convex/_generated/api", () => ({
+  api: {
+    packages: { listPublicNewPluginsPage: "packages:listPublicNewPluginsPage" },
+    skills: { listPublicPageV4: "skills:listPublicPageV4" },
+  },
+}));
+
+vi.mock("./packageApi", () => ({
+  fetchPluginCatalog: (...args: unknown[]) => fetchPluginCatalogMock(...args),
+}));
+
+vi.mock("./trendingApi", async (importOriginal) => {
+  const original = await importOriginal<typeof import("./trendingApi")>();
+  return {
+    ...original,
+    fetchCanonicalTrendingPage: (...args: unknown[]) => fetchCanonicalTrendingPageMock(...args),
+  };
+});
+
+import {
+  fetchHomePluginListing,
+  fetchHomeSkillListing,
+  fetchInitialHomeListing,
+  HOME_LISTING_PAGE_SIZE,
+  HOME_NEW_WINDOW_MS,
+} from "./homeListingData";
+
+describe("homeListingData", () => {
+  beforeEach(() => {
+    convexQueryMock.mockReset();
+    fetchPluginCatalogMock.mockReset();
+    fetchCanonicalTrendingPageMock.mockReset();
+    convexQueryMock.mockResolvedValue({ page: [], hasMore: false, nextCursor: null });
+    fetchPluginCatalogMock.mockResolvedValue({ items: [], nextCursor: null });
+    fetchCanonicalTrendingPageMock.mockResolvedValue(canonicalPage([], null));
+  });
+
+  it("loads canonical Trending skills as the initial homepage catalog", async () => {
+    const item = makeTrending("first", "First", 12);
+    fetchCanonicalTrendingPageMock.mockResolvedValue(canonicalPage([item], "next-cursor"));
+
+    await expect(fetchInitialHomeListing()).resolves.toEqual({
+      kind: "skills",
+      tab: "trending",
+      categorySlugs: [],
+      fetchLimit: HOME_LISTING_PAGE_SIZE,
+      items: [{ trending: item }],
+      hasMore: true,
+    });
+  });
+
+  it("preserves canonical order and forwards opaque cursors across pages", async () => {
+    const first = makeTrending("first", "First", 12);
+    const second = makeTrending("second", "Second", 8);
+    fetchCanonicalTrendingPageMock
+      .mockResolvedValueOnce(canonicalPage([first], "opaque cursor 2"))
+      .mockResolvedValueOnce(canonicalPage([second], null));
+
+    const result = await fetchHomeSkillListing("trending", [], 2);
+
+    expect(
+      result.page.map((entry) => ("trending" in entry ? entry.trending.id : "native")),
+    ).toEqual([first.id, second.id]);
+    expect(fetchCanonicalTrendingPageMock).toHaveBeenNthCalledWith(1, {
+      cursor: null,
+      limit: 2,
+      signal: undefined,
+    });
+    expect(fetchCanonicalTrendingPageMock).toHaveBeenNthCalledWith(2, {
+      cursor: "opaque cursor 2",
+      limit: 1,
+      signal: undefined,
+    });
+  });
+
+  it("loads New from the native 14-day chronological feed", async () => {
+    const now = Date.now();
+    await fetchHomeSkillListing("new", [], HOME_LISTING_PAGE_SIZE);
+
+    expect(convexQueryMock).toHaveBeenCalledWith(
+      "skills:listPublicPageV4",
+      expect.objectContaining({
+        sort: "newest",
+        dir: "desc",
+        numItems: HOME_LISTING_PAGE_SIZE,
+        createdAfter: expect.any(Number),
+      }),
+    );
+    const args = convexQueryMock.mock.calls[0]?.[1] as { createdAfter: number };
+    expect(now - args.createdAfter).toBeGreaterThanOrEqual(HOME_NEW_WINDOW_MS - 10);
+  });
+
+  it("requests the latest 40 Featured skills and preserves editorial order", async () => {
+    convexQueryMock.mockResolvedValue({
+      page: [makeNative("newest", 200, 1), makeNative("older", 100, 10_000)],
+      hasMore: false,
+      nextCursor: null,
+    });
+
+    const result = await fetchHomeSkillListing("featured", [], HOME_LISTING_PAGE_SIZE);
+
+    expect(result.page.map((entry) => ("skill" in entry ? entry.skill.slug : "trending"))).toEqual([
+      "newest",
+      "older",
+    ]);
+    expect(convexQueryMock).toHaveBeenCalledWith(
+      "skills:listPublicPageV4",
+      expect.objectContaining({ highlightedOnly: true, numItems: 40 }),
+    );
+  });
+
+  it("ends the finite Featured feed after exposing the latest 40", async () => {
+    convexQueryMock.mockResolvedValue({
+      page: Array.from({ length: 40 }, (_, index) =>
+        makeNative(`featured-${index}`, 40 - index, 0),
+      ),
+      hasMore: true,
+      nextCursor: "ignored-after-40",
+    });
+
+    await expect(fetchHomeSkillListing("featured", [], 40)).resolves.toMatchObject({
+      hasMore: false,
+    });
+  });
+
+  it("uses the backend official-publisher contract for Official skills", async () => {
+    await fetchHomeSkillListing("official", [], HOME_LISTING_PAGE_SIZE);
+
+    expect(convexQueryMock).toHaveBeenCalledWith(
+      "skills:listPublicPageV4",
+      expect.objectContaining({ officialOnly: true, sort: "newest" }),
+    );
+  });
+
+  it("keeps plugins out of Trending and supports New, Featured, and Official", async () => {
+    const plugin = makePlugin("plugin");
+    fetchPluginCatalogMock.mockResolvedValue({ items: [plugin], nextCursor: null });
+
+    await fetchHomePluginListing("new", [], 20);
+    await fetchHomePluginListing("featured", [], 20);
+    await fetchHomePluginListing("official", [], 20);
+
+    expect(convexQueryMock).toHaveBeenCalledWith(
+      "packages:listPublicNewPluginsPage",
+      expect.any(Object),
+    );
+    expect(fetchPluginCatalogMock).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ featured: true, isOfficial: undefined }),
+    );
+    expect(fetchPluginCatalogMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ featured: undefined, isOfficial: true }),
+    );
+  });
+
+  it("loads New plugins from the bounded server-side creation-time feed", async () => {
+    const now = Date.now();
+    convexQueryMock
+      .mockResolvedValueOnce({
+        page: [makePlugin("newer", now - 100, now - 1_000)],
+        isDone: false,
+        continueCursor: "opaque-next",
+      })
+      .mockResolvedValueOnce({
+        page: [makePlugin("new", now - 200)],
+        isDone: true,
+        continueCursor: "",
+      });
+
+    const result = await fetchHomePluginListing("new", [], 20);
+
+    expect(result.items.map((item) => item.name)).toEqual(["newer", "new"]);
+    expect(convexQueryMock).toHaveBeenNthCalledWith(
+      1,
+      "packages:listPublicNewPluginsPage",
+      expect.objectContaining({
+        createdAfter: expect.any(Number),
+        paginationOpts: { cursor: null, numItems: 20 },
+      }),
+    );
+    expect(convexQueryMock).toHaveBeenNthCalledWith(
+      2,
+      "packages:listPublicNewPluginsPage",
+      expect.objectContaining({
+        paginationOpts: { cursor: "opaque-next", numItems: 19 },
+      }),
+    );
+    expect(fetchPluginCatalogMock).not.toHaveBeenCalled();
+    expect(result.hasMore).toBe(false);
+  });
+
+  it("keeps the New plugin continuation after filling the visible window", async () => {
+    convexQueryMock.mockResolvedValue({
+      page: Array.from({ length: 20 }, (_, index) => makePlugin(`new-${index}`)),
+      isDone: false,
+      continueCursor: "more-new",
+    });
+
+    const result = await fetchHomePluginListing("new", [], 20);
+
+    expect(convexQueryMock).toHaveBeenCalledWith(
+      "packages:listPublicNewPluginsPage",
+      expect.objectContaining({ paginationOpts: { cursor: null, numItems: 20 } }),
+    );
+    expect(result.hasMore).toBe(true);
+  });
+
+  it("stops New plugin cursor requests after navigation aborts", async () => {
+    const controller = new AbortController();
+    convexQueryMock.mockImplementationOnce(async () => {
+      controller.abort();
+      return {
+        page: [makePlugin("stale")],
+        isDone: false,
+        continueCursor: "must-not-request",
+      };
+    });
+
+    await expect(fetchHomePluginListing("new", [], 40, controller.signal)).rejects.toMatchObject({
+      name: "AbortError",
+    });
+    expect(convexQueryMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+function canonicalPage(items: ReturnType<typeof makeTrending>[], nextCursor: string | null) {
+  return {
+    kind: "skills" as const,
+    snapshotId: "snapshot-1",
+    snapshotCursor: "snapshot-cursor",
+    generatedAt: "2026-07-26T00:00:00.000Z",
+    windowHours: 24 as const,
+    rankingVersion: "skills-trending-v1",
+    totalItems: items.length,
+    items,
+    nextCursor,
+  };
+}
+
+function makeTrending(slug: string, displayName: string, installs: number) {
+  return {
+    id: `clawhub:${slug}`,
+    source: "clawhub" as const,
+    slug,
+    displayName,
+    summary: `${displayName} summary`,
+    canonicalUrl: `/owner/${slug}`,
+    publisher: null,
+    official: false,
+    featured: false,
+    metrics: {
+      trending24hInstalls: installs,
+      trending24hBookmarks: null,
+      lifetimeInstalls: 1000,
+      lifetimeInstallsPeriod: "lifetime" as const,
+      updatedAt: 1,
+    },
+  };
+}
+
+function makeNative(slug: string, featuredAt: number, downloads: number) {
+  return {
+    skill: {
+      _id: `skills:${slug}`,
+      slug,
+      displayName: slug,
+      createdAt: featuredAt,
+      updatedAt: featuredAt,
+      badges: { highlighted: { at: featuredAt } },
+      stats: { downloads },
+    },
+  };
+}
+
+function makePlugin(name: string, createdAt = Date.now(), updatedAt = Date.now()) {
+  return {
+    name,
+    displayName: name,
+    family: "code-plugin" as const,
+    channel: "community" as const,
+    isOfficial: false,
+    createdAt,
+    updatedAt,
+  };
+}

--- a/src/lib/homeListingData.test.ts
+++ b/src/lib/homeListingData.test.ts
@@ -112,7 +112,9 @@ describe("homeListingData", () => {
       HOME_LISTING_PAGE_SIZE,
     );
 
-    expect(result.page.map((entry) => entry.skill.slug)).toEqual(["newest", "older"]);
+    expect(
+      result.page.map((entry) => ("skill" in entry ? entry.skill.slug : entry.trending.slug)),
+    ).toEqual(["newest", "older"]);
     expect(convexQueryMock).toHaveBeenCalledTimes(2);
     expect(convexQueryMock).toHaveBeenNthCalledWith(
       1,

--- a/src/lib/homeListingData.test.ts
+++ b/src/lib/homeListingData.test.ts
@@ -23,10 +23,8 @@ vi.mock("./packageApi", () => ({
 }));
 
 import {
-  fetchHomeFeaturedAvailability,
   fetchHomePluginListing,
   fetchHomeSkillListing,
-  fetchInitialHomeListing,
   HOME_LISTING_PAGE_SIZE,
 } from "./homeListingData";
 
@@ -60,47 +58,6 @@ describe("homeListingData", () => {
     });
   });
 
-  it("loads Featured plugins as the initial catalog when they exist", async () => {
-    fetchPluginCatalogMock.mockResolvedValue({
-      items: [featuredPlugin],
-      nextCursor: null,
-    });
-
-    await expect(fetchInitialHomeListing()).resolves.toEqual({
-      kind: "plugins",
-      tab: "featured",
-      categorySlugs: [],
-      fetchLimit: HOME_LISTING_PAGE_SIZE,
-      items: [featuredPlugin],
-      hasMore: false,
-      featuredAvailability: {
-        plugins: true,
-        skills: true,
-      },
-    });
-    expect(fetchPluginCatalogMock).toHaveBeenCalledWith(
-      expect.objectContaining({ featured: true, limit: HOME_LISTING_PAGE_SIZE }),
-    );
-  });
-
-  it("falls back to Top plugins when no Featured plugins exist", async () => {
-    fetchPluginCatalogMock
-      .mockResolvedValueOnce({ items: [], nextCursor: null })
-      .mockResolvedValueOnce({
-        items: [{ ...featuredPlugin, name: "top-plugin" }],
-        nextCursor: null,
-      });
-
-    const result = await fetchInitialHomeListing();
-
-    expect(result.kind).toBe("plugins");
-    expect(result.tab).toBe("popular");
-    expect(result.featuredAvailability.plugins).toBe(false);
-    expect(fetchPluginCatalogMock).toHaveBeenLastCalledWith(
-      expect.objectContaining({ sort: "downloads", featured: undefined }),
-    );
-  });
-
   it("uses the highlighted browse path for Featured skills", async () => {
     await fetchHomeSkillListing("featured", [], HOME_LISTING_PAGE_SIZE);
 
@@ -108,8 +65,8 @@ describe("homeListingData", () => {
       "skills:listPublicPageV4",
       expect.objectContaining({
         highlightedOnly: true,
-        numItems: 200,
-        sort: "downloads",
+        numItems: 40,
+        sort: "updated",
       }),
     );
   });
@@ -212,130 +169,5 @@ describe("homeListingData", () => {
       2,
       expect.objectContaining({ category: "gateway" }),
     );
-  });
-
-  it("uses a one-item request when probing Featured skill availability", async () => {
-    await expect(fetchHomeFeaturedAvailability("skills")).resolves.toBe(true);
-
-    expect(convexQueryMock).toHaveBeenCalledWith(
-      "skills:listPublicPageV4",
-      expect.objectContaining({
-        highlightedOnly: true,
-        numItems: 1,
-      }),
-    );
-  });
-
-  it("preserves global Trending order while filtering multiple plugin categories", async () => {
-    fetchPluginCatalogMock
-      .mockResolvedValueOnce({
-        items: [
-          { ...featuredPlugin, name: "unmatched-first", categories: ["productivity"] },
-          { ...featuredPlugin, name: "security-second", categories: ["security"] },
-          { ...featuredPlugin, name: "development-third", categories: ["development"] },
-        ],
-        nextCursor: "page-2",
-      })
-      .mockResolvedValueOnce({
-        items: [
-          { ...featuredPlugin, name: "security-fourth", categories: ["security"] },
-          { ...featuredPlugin, name: "unmatched-fifth", categories: ["productivity"] },
-        ],
-        nextCursor: null,
-      });
-
-    const result = await fetchHomePluginListing("trending", ["development", "security"], 3);
-
-    expect(result.items.map((item) => item.name)).toEqual([
-      "security-second",
-      "development-third",
-      "security-fourth",
-    ]);
-    expect(fetchPluginCatalogMock).toHaveBeenNthCalledWith(
-      1,
-      expect.objectContaining({
-        category: undefined,
-        sort: "trending",
-        limit: 100,
-      }),
-    );
-    expect(fetchPluginCatalogMock).toHaveBeenNthCalledWith(
-      2,
-      expect.objectContaining({
-        category: undefined,
-        cursor: "page-2",
-        sort: "trending",
-      }),
-    );
-  });
-
-  it("uses the API category filter for a single Trending plugin category", async () => {
-    fetchPluginCatalogMock.mockResolvedValue({
-      items: [{ ...featuredPlugin, name: "security-plugin", categories: ["security"] }],
-      nextCursor: null,
-    });
-
-    await fetchHomePluginListing("trending", ["security"], 3);
-
-    expect(fetchPluginCatalogMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        category: "security",
-        sort: "trending",
-        limit: 3,
-      }),
-    );
-  });
-
-  it("filters the complete bounded Trending leaderboard for multiple categories", async () => {
-    fetchPluginCatalogMock
-      .mockResolvedValueOnce({
-        items: Array.from({ length: 100 }, (_, index) => ({
-          ...featuredPlugin,
-          name: `unmatched-${index}`,
-          categories: ["other"],
-        })),
-        nextCursor: "page-2",
-      })
-      .mockResolvedValueOnce({
-        items: [
-          ...Array.from({ length: 99 }, (_, index) => ({
-            ...featuredPlugin,
-            name: `unmatched-${index + 100}`,
-            categories: ["other"],
-          })),
-          { ...featuredPlugin, name: "security-last", categories: ["security"] },
-        ],
-        nextCursor: null,
-      });
-
-    const result = await fetchHomePluginListing("trending", ["development", "security"], 20);
-
-    expect(result.items.map((item) => item.name)).toEqual(["security-last"]);
-    expect(result.hasMore).toBe(false);
-    expect(fetchPluginCatalogMock).toHaveBeenCalledTimes(2);
-  });
-
-  it("fails closed if the Trending API exceeds its shared leaderboard contract", async () => {
-    fetchPluginCatalogMock
-      .mockResolvedValueOnce({
-        items: Array.from({ length: 100 }, (_, index) => ({
-          ...featuredPlugin,
-          name: `unmatched-${index}`,
-          categories: ["other"],
-        })),
-        nextCursor: "page-2",
-      })
-      .mockResolvedValueOnce({
-        items: Array.from({ length: 100 }, (_, index) => ({
-          ...featuredPlugin,
-          name: `unmatched-${index + 100}`,
-          categories: ["other"],
-        })),
-        nextCursor: "unexpected-page-3",
-      });
-
-    await expect(
-      fetchHomePluginListing("trending", ["development", "security"], 20),
-    ).rejects.toThrow("exceeded 200-item contract");
   });
 });

--- a/src/lib/homeListingData.ts
+++ b/src/lib/homeListingData.ts
@@ -1,18 +1,30 @@
-import { PACKAGE_TRENDING_LEADERBOARD_LIMIT } from "clawhub-schema";
 import { api } from "../../convex/_generated/api";
 import { convexHttp } from "../convex/client";
 import { getSkillCategoriesForSkill } from "./categories";
 import { fetchPluginCatalog, type PackageListItem } from "./packageApi";
 import type { PublicSkill, PublicUser } from "./publicUser";
+import { fetchCanonicalTrendingPage, type CanonicalTrendingItem } from "./trendingApi";
 
 export type HomeListingKind = "skills" | "plugins";
-export type HomeListingTab = "featured" | "popular" | "trending";
+export type HomeListingTab = "trending" | "new" | "featured" | "official";
 
-export type HomeSkillListingEntry = {
+export type HomeNativeSkillListingEntry = {
   skill: PublicSkill;
   ownerHandle?: string | null;
   owner?: PublicUser | null;
 };
+
+type HomeTrendingSkillListingEntry = {
+  trending: CanonicalTrendingItem;
+};
+
+export type HomeSkillListingEntry = HomeNativeSkillListingEntry | HomeTrendingSkillListingEntry;
+
+export function isHomeTrendingSkillEntry(
+  entry: HomeSkillListingEntry,
+): entry is HomeTrendingSkillListingEntry {
+  return "trending" in entry;
+}
 
 export type HomeListingCacheEntry =
   | { kind: "skills"; items: HomeSkillListingEntry[]; hasMore: boolean }
@@ -23,7 +35,6 @@ type HomeListingInitialDataBase = {
   categorySlugs: [];
   fetchLimit: typeof HOME_LISTING_PAGE_SIZE;
   hasMore: boolean;
-  featuredAvailability: Record<HomeListingKind, boolean>;
 };
 
 export type HomeListingInitialData =
@@ -37,10 +48,11 @@ export type HomeListingInitialData =
     });
 
 export const HOME_LISTING_PAGE_SIZE = 20;
+export const HOME_NEW_WINDOW_MS = 14 * 24 * 60 * 60 * 1_000;
 
 const PLUGIN_CATALOG_PAGE_LIMIT = 100;
-// Highlighted skill responses are cursorless, so request the backend's full public maximum.
-const FEATURED_SKILL_LIST_LIMIT = 200;
+// Featured is intentionally a finite editorial feed: the latest 40 badge-history rows.
+const FEATURED_SKILL_LIMIT = 40;
 
 export function homeListingCacheKey({
   kind,
@@ -71,62 +83,51 @@ export function skillMatchesAnyHomeCategory(skill: PublicSkill, categorySlugs: r
   return categorySlugs.some((slug) => categories.some((category) => category.slug === slug));
 }
 
-export function uniqueHomeSkillEntries(entries: HomeSkillListingEntry[]) {
-  const byId = new Map<string, HomeSkillListingEntry>();
-  for (const entry of entries) {
-    byId.set(String(entry.skill._id), entry);
-  }
+export function uniqueHomeSkillEntries(entries: HomeNativeSkillListingEntry[]) {
+  const byId = new Map<string, HomeNativeSkillListingEntry>();
+  for (const entry of entries) byId.set(String(entry.skill._id), entry);
   return [...byId.values()];
 }
 
 export function uniqueHomePlugins(items: PackageListItem[]) {
   const byName = new Map<string, PackageListItem>();
-  for (const item of items) {
-    byName.set(item.name, item);
-  }
+  for (const item of items) byName.set(item.name, item);
   return [...byName.values()];
-}
-
-function sortHomeSkillEntries(entries: HomeSkillListingEntry[]) {
-  return [...entries].sort((left, right) => {
-    return (right.skill.stats?.downloads ?? 0) - (left.skill.stats?.downloads ?? 0);
-  });
-}
-
-function sortFeaturedHomeSkillEntries(entries: HomeSkillListingEntry[]) {
-  return [...entries].sort((left, right) => {
-    return (right.skill.badges?.highlighted?.at ?? 0) - (left.skill.badges?.highlighted?.at ?? 0);
-  });
-}
-
-function sortFeaturedHomePlugins(items: PackageListItem[]) {
-  return [...items].sort((left, right) => (right.featuredAt ?? 0) - (left.featuredAt ?? 0));
 }
 
 export async function fetchHomeSkillListing(
   tab: HomeListingTab,
   categorySlugs: readonly string[],
   numItems: number,
+  signal?: AbortSignal,
 ) {
   if (tab === "trending") {
-    const requestLimit = categorySlugs.length > 0 ? 200 : numItems;
-    const result = await convexHttp.query(api.skills.listPublicTrendingPage, {
-      limit: requestLimit,
-    });
-    const items = ((result as { items?: HomeSkillListingEntry[] }).items ?? []).filter((entry) =>
-      skillMatchesAnyHomeCategory(entry.skill, categorySlugs),
-    );
-    return {
-      page: uniqueHomeSkillEntries(items).slice(0, numItems),
-      hasMore: items.length > numItems || (items.length >= numItems && numItems < 200),
-    };
+    const items: HomeTrendingSkillListingEntry[] = [];
+    let cursor: string | null = null;
+    let hasMore = false;
+    const maxRequests =
+      numItems < HOME_LISTING_PAGE_SIZE ? numItems : Math.ceil(numItems / HOME_LISTING_PAGE_SIZE);
+    for (let pageIndex = 0; pageIndex < maxRequests; pageIndex += 1) {
+      const result = await fetchCanonicalTrendingPage({
+        cursor,
+        limit: Math.min(HOME_LISTING_PAGE_SIZE, numItems - items.length),
+        signal,
+      });
+      items.push(...result.items.map((trending) => ({ trending })));
+      cursor = result.nextCursor;
+      hasMore = cursor !== null;
+      if (!cursor || items.length >= numItems) break;
+    }
+    return { page: items, hasMore };
   }
 
-  const requestLimit = tab === "featured" ? FEATURED_SKILL_LIST_LIMIT : numItems;
+  // highlightedOnly is a dedicated backend path ordered by skillBadges.by_kind_at;
+  // the nominal sort below is ignored for Featured and never chooses its candidate set.
+  const requestLimit = tab === "featured" ? FEATURED_SKILL_LIMIT : numItems;
   const categoriesToFetch = categorySlugs.length > 0 ? categorySlugs : [null];
   const results = await Promise.all(
     categoriesToFetch.map(async (categorySlug) => {
-      const page: HomeSkillListingEntry[] = [];
+      const page: HomeNativeSkillListingEntry[] = [];
       let cursor: string | null | undefined;
       let hasMore = false;
 
@@ -134,14 +135,14 @@ export async function fetchHomeSkillListing(
         const result = await convexHttp.query(api.skills.listPublicPageV4, {
           cursor: cursor ?? undefined,
           numItems: requestLimit - page.length,
-          sort: "downloads",
+          sort: tab === "new" || tab === "official" ? "newest" : "updated",
           dir: "desc",
           highlightedOnly: tab === "featured" ? true : undefined,
+          officialOnly: tab === "official" ? true : undefined,
+          createdAfter: tab === "new" ? Date.now() - HOME_NEW_WINDOW_MS : undefined,
           categorySlug: categorySlug ?? undefined,
         });
-        if (Array.isArray(result)) break;
-
-        const resultPage = ((result as { page?: HomeSkillListingEntry[] }).page ?? []).filter(
+        const resultPage = ((result as { page?: HomeNativeSkillListingEntry[] }).page ?? []).filter(
           (entry) => skillMatchesAnyHomeCategory(entry.skill, categorySlugs),
         );
         page.push(...resultPage);
@@ -155,126 +156,122 @@ export async function fetchHomeSkillListing(
       return { page, hasMore };
     }),
   );
-  const pages = results.flatMap((result) => result.page);
-  const unique = uniqueHomeSkillEntries(pages);
-  const sorted =
-    tab === "featured" ? sortFeaturedHomeSkillEntries(unique) : sortHomeSkillEntries(unique);
-  const hasMore =
-    sorted.length > numItems || (tab !== "featured" && results.some((result) => result.hasMore));
-  const page = sorted.slice(0, numItems);
-  return { page, hasMore };
+  const items = uniqueHomeSkillEntries(results.flatMap((result) => result.page)).sort(
+    (left, right) => {
+      if (tab === "featured") {
+        return (
+          (right.skill.badges?.highlighted?.at ?? 0) - (left.skill.badges?.highlighted?.at ?? 0)
+        );
+      }
+      if (tab === "new" || tab === "official") {
+        return right.skill.createdAt - left.skill.createdAt;
+      }
+      return 0;
+    },
+  );
+  return {
+    page: items.slice(0, numItems),
+    hasMore:
+      tab === "featured"
+        ? numItems < FEATURED_SKILL_LIMIT &&
+          (items.length > numItems || results.some((result) => result.hasMore))
+        : items.length > numItems || results.some((result) => result.hasMore),
+  };
 }
 
 export async function fetchHomePluginListing(
-  tab: HomeListingTab,
+  tab: Exclude<HomeListingTab, "trending">,
   categorySlugs: readonly string[],
   limit: number,
   signal?: AbortSignal,
 ) {
-  const featured = tab === "featured";
-  const trending = tab === "trending";
-  const usesGlobalTrendingFilter = trending && categorySlugs.length > 1;
-  const categoriesToFetch = usesGlobalTrendingFilter
-    ? [null]
-    : categorySlugs.length > 0
-      ? categorySlugs
-      : [null];
+  const categoriesToFetch = categorySlugs.length > 0 ? categorySlugs : [null];
+  const newestCutoff = Date.now() - HOME_NEW_WINDOW_MS;
+  if (tab === "new") {
+    const results = await Promise.all(
+      categoriesToFetch.map(async (categorySlug) => {
+        const page: PackageListItem[] = [];
+        let cursor: string | null = null;
+        let isDone = false;
+        while (page.length < limit && !isDone) {
+          signal?.throwIfAborted();
+          const result = (await convexHttp.query(api.packages.listPublicNewPluginsPage, {
+            category: categorySlug ?? undefined,
+            createdAfter: newestCutoff,
+            paginationOpts: {
+              cursor,
+              numItems: Math.min(HOME_LISTING_PAGE_SIZE, limit - page.length),
+            },
+          })) as {
+            page: PackageListItem[];
+            isDone: boolean;
+            continueCursor: string;
+          };
+          signal?.throwIfAborted();
+          page.push(
+            ...(result.page.filter(
+              (item) => item.family === "code-plugin" || item.family === "bundle-plugin",
+            ) as PackageListItem[]),
+          );
+          isDone = result.isDone;
+          if (isDone || !result.continueCursor || result.continueCursor === cursor) break;
+          cursor = result.continueCursor;
+        }
+        return { page, isDone };
+      }),
+    );
+    const items = uniqueHomePlugins(results.flatMap((result) => result.page)).sort(
+      (left, right) => right.createdAt - left.createdAt,
+    );
+    return {
+      items: items.slice(0, limit),
+      hasMore: items.length > limit || results.some((result) => !result.isDone),
+    };
+  }
   const results = await Promise.all(
     categoriesToFetch.map(async (categorySlug) => {
       const items: PackageListItem[] = [];
       let cursor: string | null | undefined;
       let hasMore = false;
-      let trendingCandidatesScanned = 0;
 
       while (items.length < limit) {
         const result = await fetchPluginCatalog({
           category: categorySlug ?? undefined,
           cursor: cursor ?? undefined,
-          featured: featured ? true : undefined,
-          sort: trending ? "trending" : "downloads",
-          limit: usesGlobalTrendingFilter
-            ? PLUGIN_CATALOG_PAGE_LIMIT
-            : Math.min(limit - items.length, PLUGIN_CATALOG_PAGE_LIMIT),
+          featured: tab === "featured" ? true : undefined,
+          isOfficial: tab === "official" ? true : undefined,
+          sort: "updated",
+          limit: Math.min(limit - items.length, PLUGIN_CATALOG_PAGE_LIMIT),
           signal,
         });
-        trendingCandidatesScanned += result.items.length;
-        items.push(
-          ...result.items.filter((item) => itemMatchesAnyHomeCategory(item, categorySlugs)),
-        );
-
-        hasMore = result.nextCursor != null;
-        if (
-          usesGlobalTrendingFilter &&
-          trendingCandidatesScanned >= PACKAGE_TRENDING_LEADERBOARD_LIMIT &&
-          result.nextCursor
-        ) {
-          throw new Error(
-            `Trending plugin feed exceeded ${PACKAGE_TRENDING_LEADERBOARD_LIMIT}-item contract`,
-          );
-        }
+        const page = result.items.filter((item) => itemMatchesAnyHomeCategory(item, categorySlugs));
+        items.push(...page);
+        hasMore = result.nextCursor !== null;
         if (!result.nextCursor || result.nextCursor === cursor) break;
         cursor = result.nextCursor;
       }
-
       return { items, hasMore };
     }),
   );
-  let items = uniqueHomePlugins(results.flatMap((result) => result.items));
-  if (featured) {
-    items = sortFeaturedHomePlugins(items);
-  } else if (tab === "popular") {
-    items.sort((a, b) => (b.stats?.downloads ?? 0) - (a.stats?.downloads ?? 0));
-  }
-  const page = items.slice(0, limit);
+  const items = uniqueHomePlugins(results.flatMap((result) => result.items)).sort((left, right) => {
+    if (tab === "featured") return (right.featuredAt ?? 0) - (left.featuredAt ?? 0);
+    return right.updatedAt - left.updatedAt;
+  });
   return {
-    items: page,
+    items: items.slice(0, limit),
     hasMore: items.length > limit || results.some((result) => result.hasMore),
   };
 }
 
-export async function fetchHomeFeaturedAvailability(kind: HomeListingKind, signal?: AbortSignal) {
-  if (kind === "skills") {
-    const result = await convexHttp.query(api.skills.listPublicPageV4, {
-      numItems: 1,
-      sort: "downloads",
-      dir: "desc",
-      highlightedOnly: true,
-    });
-    return (
-      !Array.isArray(result) &&
-      ((result as { page?: HomeSkillListingEntry[] }).page?.length ?? 0) > 0
-    );
-  }
-
-  const result = await fetchPluginCatalog({
-    featured: true,
-    sort: "downloads",
-    limit: 1,
-    signal,
-  });
-  return result.items.length > 0;
-}
-
 export async function fetchInitialHomeListing(): Promise<HomeListingInitialData> {
-  const [featuredPlugins, hasFeaturedSkills] = await Promise.all([
-    fetchHomePluginListing("featured", [], HOME_LISTING_PAGE_SIZE),
-    fetchHomeFeaturedAvailability("skills").catch(() => false),
-  ]);
-  const hasFeaturedPlugins = featuredPlugins.items.length > 0;
-  const result = hasFeaturedPlugins
-    ? featuredPlugins
-    : await fetchHomePluginListing("popular", [], HOME_LISTING_PAGE_SIZE);
+  const result = await fetchHomeSkillListing("trending", [], HOME_LISTING_PAGE_SIZE);
   return {
-    kind: "plugins",
-    tab: hasFeaturedPlugins ? "featured" : "popular",
+    kind: "skills",
+    tab: "trending",
     categorySlugs: [],
     fetchLimit: HOME_LISTING_PAGE_SIZE,
-    items: result.items,
+    items: result.page,
     hasMore: result.hasMore,
-    featuredAvailability: {
-      plugins: hasFeaturedPlugins,
-      skills: hasFeaturedSkills,
-    },
   };
 }
 

--- a/src/lib/trendingApi.test.ts
+++ b/src/lib/trendingApi.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fetchCanonicalTrendingPage } from "./trendingApi";
+
+describe("fetchCanonicalTrendingPage", () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+    vi.stubEnv("VITE_CONVEX_SITE_URL", "https://catalog.example");
+  });
+
+  it("requests the canonical skills feed with its opaque stable cursor", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          kind: "skills",
+          snapshotId: "snapshot-1",
+          snapshotCursor: "snapshot-cursor",
+          generatedAt: "2026-07-26T00:00:00.000Z",
+          windowHours: 24,
+          rankingVersion: "skills-trending-v1",
+          totalItems: 21,
+          items: [],
+          nextCursor: "next-cursor",
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      fetchCanonicalTrendingPage({ cursor: "opaque cursor", limit: 20 }),
+    ).resolves.toEqual(
+      expect.objectContaining({ snapshotId: "snapshot-1", nextCursor: "next-cursor" }),
+    );
+
+    const url = new URL(String(fetchMock.mock.calls[0]?.[0]));
+    expect(url.pathname).toBe("/api/v1/trending");
+    expect(url.searchParams.get("kind")).toBe("skills");
+    expect(url.searchParams.get("limit")).toBe("20");
+    expect(url.searchParams.get("cursor")).toBe("opaque cursor");
+  });
+
+  it("fails closed on a malformed canonical response", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValue(
+          new Response(JSON.stringify({ items: [{ id: "missing-contract" }] }), { status: 200 }),
+        ),
+    );
+
+    await expect(fetchCanonicalTrendingPage({ limit: 20 })).rejects.toThrow(
+      "Invalid canonical Trending response",
+    );
+  });
+});

--- a/src/lib/trendingApi.test.ts
+++ b/src/lib/trendingApi.test.ts
@@ -53,4 +53,91 @@ describe("fetchCanonicalTrendingPage", () => {
       "Invalid canonical Trending response",
     );
   });
+
+  it("fails closed on an unsafe canonical link", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify(
+            canonicalPage({
+              canonicalUrl: "javascript:alert(document.domain)",
+            }),
+          ),
+          { status: 200 },
+        ),
+      ),
+    );
+
+    await expect(fetchCanonicalTrendingPage({ limit: 20 })).rejects.toThrow(
+      "Invalid canonical Trending response",
+    );
+  });
+
+  it("fails closed when consumed publisher or metric fields are malformed", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify(
+            canonicalPage({
+              publisher: "not-a-publisher",
+              metrics: {
+                trending24hInstalls: 3,
+                trending24hBookmarks: null,
+                lifetimeInstalls: null,
+                lifetimeInstallsPeriod: "weekly",
+                updatedAt: "yesterday",
+              },
+            }),
+          ),
+          { status: 200 },
+        ),
+      ),
+    );
+
+    await expect(fetchCanonicalTrendingPage({ limit: 20 })).rejects.toThrow(
+      "Invalid canonical Trending response",
+    );
+  });
 });
+
+function canonicalPage(itemOverrides: Record<string, unknown>) {
+  return {
+    kind: "skills",
+    snapshotId: "snapshot-1",
+    snapshotCursor: "snapshot-cursor",
+    generatedAt: "2026-07-26T00:00:00.000Z",
+    windowHours: 24,
+    rankingVersion: "skills-trending-v1",
+    totalItems: 1,
+    items: [
+      {
+        id: "clawhub:skill-1",
+        source: "clawhub",
+        slug: "skill-1",
+        displayName: "Skill One",
+        summary: "A useful skill",
+        canonicalUrl: "/owner/skill-1",
+        publisher: {
+          kind: "user",
+          handle: "owner",
+          displayName: "Owner",
+          image: null,
+          official: false,
+        },
+        official: false,
+        featured: false,
+        metrics: {
+          trending24hInstalls: 3,
+          trending24hBookmarks: null,
+          lifetimeInstalls: 10,
+          lifetimeInstallsPeriod: "lifetime",
+          updatedAt: 1,
+        },
+        ...itemOverrides,
+      },
+    ],
+    nextCursor: null,
+  };
+}

--- a/src/lib/trendingApi.ts
+++ b/src/lib/trendingApi.ts
@@ -1,0 +1,105 @@
+import { publicApiUrl } from "./publicApiUrl";
+
+export type CanonicalTrendingItem = {
+  id: string;
+  source: "clawhub" | "skills-sh";
+  slug: string;
+  displayName: string;
+  summary: string | null;
+  canonicalUrl: string;
+  publisher: {
+    kind: "user" | "org";
+    handle: string | null;
+    displayName: string | null;
+    image: string | null;
+    official: boolean;
+  } | null;
+  official: boolean;
+  featured: boolean;
+  metrics: {
+    trending24hInstalls: number | null;
+    trending24hBookmarks: number | null;
+    lifetimeInstalls: number | null;
+    lifetimeInstallsPeriod: "lifetime";
+    updatedAt: number;
+  };
+};
+
+type CanonicalTrendingPage = {
+  kind: "skills";
+  snapshotId: string;
+  snapshotCursor: string;
+  generatedAt: string;
+  windowHours: 24;
+  rankingVersion: string;
+  totalItems: number;
+  items: CanonicalTrendingItem[];
+  nextCursor: string | null;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function isCanonicalTrendingItem(value: unknown): value is CanonicalTrendingItem {
+  if (!isRecord(value) || !isRecord(value.metrics)) return false;
+  return (
+    typeof value.id === "string" &&
+    (value.source === "clawhub" || value.source === "skills-sh") &&
+    typeof value.slug === "string" &&
+    typeof value.displayName === "string" &&
+    (typeof value.summary === "string" || value.summary === null) &&
+    typeof value.canonicalUrl === "string" &&
+    (typeof value.metrics.trending24hInstalls === "number" ||
+      value.metrics.trending24hInstalls === null)
+  );
+}
+
+function parseCanonicalTrendingPage(value: unknown): CanonicalTrendingPage {
+  if (
+    !isRecord(value) ||
+    value.kind !== "skills" ||
+    typeof value.snapshotId !== "string" ||
+    typeof value.snapshotCursor !== "string" ||
+    typeof value.generatedAt !== "string" ||
+    value.windowHours !== 24 ||
+    typeof value.rankingVersion !== "string" ||
+    typeof value.totalItems !== "number" ||
+    !Array.isArray(value.items) ||
+    !value.items.every(isCanonicalTrendingItem) ||
+    !(typeof value.nextCursor === "string" || value.nextCursor === null)
+  ) {
+    throw new Error("Invalid canonical Trending response");
+  }
+  return value as CanonicalTrendingPage;
+}
+
+export async function fetchCanonicalTrendingPage({
+  cursor,
+  limit,
+  signal,
+}: {
+  cursor?: string | null;
+  limit: number;
+  signal?: AbortSignal;
+}) {
+  const url = publicApiUrl("/api/v1/trending");
+  url.searchParams.set("kind", "skills");
+  url.searchParams.set("limit", String(limit));
+  // nextCursor is opaque and already encodes both snapshotId and page offset.
+  // snapshotCursor is metadata for offset zero, not an additional request field.
+  if (cursor) url.searchParams.set("cursor", cursor);
+
+  const response = await fetch(url.toString(), {
+    method: "GET",
+    credentials:
+      typeof window !== "undefined" && url.origin === window.location.origin ? "include" : "omit",
+    headers: { Accept: "application/json" },
+    signal,
+  });
+  if (!response.ok) {
+    const message = (await response.text()).trim();
+    throw new Error(message || `Trending request failed with status ${response.status}`);
+  }
+  return parseCanonicalTrendingPage(await response.json());
+}

--- a/src/lib/trendingApi.ts
+++ b/src/lib/trendingApi.ts
@@ -41,6 +41,44 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
 
+function isNullableString(value: unknown): value is string | null {
+  return typeof value === "string" || value === null;
+}
+
+function isNullableNumber(value: unknown): value is number | null {
+  return (typeof value === "number" && Number.isFinite(value)) || value === null;
+}
+
+function isCanonicalPath(value: unknown): value is string {
+  if (typeof value !== "string" || !value.startsWith("/") || value.startsWith("//")) return false;
+  try {
+    const base = new URL("https://clawhub.invalid");
+    const parsed = new URL(value, base);
+    return (
+      parsed.origin === base.origin &&
+      parsed.username === "" &&
+      parsed.password === "" &&
+      parsed.search === "" &&
+      parsed.hash === "" &&
+      parsed.pathname === value
+    );
+  } catch {
+    return false;
+  }
+}
+
+function isCanonicalPublisher(value: unknown): value is CanonicalTrendingItem["publisher"] {
+  if (value === null) return true;
+  if (!isRecord(value)) return false;
+  return (
+    (value.kind === "user" || value.kind === "org") &&
+    isNullableString(value.handle) &&
+    isNullableString(value.displayName) &&
+    isNullableString(value.image) &&
+    typeof value.official === "boolean"
+  );
+}
+
 function isCanonicalTrendingItem(value: unknown): value is CanonicalTrendingItem {
   if (!isRecord(value) || !isRecord(value.metrics)) return false;
   return (
@@ -48,10 +86,17 @@ function isCanonicalTrendingItem(value: unknown): value is CanonicalTrendingItem
     (value.source === "clawhub" || value.source === "skills-sh") &&
     typeof value.slug === "string" &&
     typeof value.displayName === "string" &&
-    (typeof value.summary === "string" || value.summary === null) &&
-    typeof value.canonicalUrl === "string" &&
-    (typeof value.metrics.trending24hInstalls === "number" ||
-      value.metrics.trending24hInstalls === null)
+    isNullableString(value.summary) &&
+    isCanonicalPath(value.canonicalUrl) &&
+    isCanonicalPublisher(value.publisher) &&
+    typeof value.official === "boolean" &&
+    typeof value.featured === "boolean" &&
+    isNullableNumber(value.metrics.trending24hInstalls) &&
+    isNullableNumber(value.metrics.trending24hBookmarks) &&
+    isNullableNumber(value.metrics.lifetimeInstalls) &&
+    value.metrics.lifetimeInstallsPeriod === "lifetime" &&
+    typeof value.metrics.updatedAt === "number" &&
+    Number.isFinite(value.metrics.updatedAt)
   );
 }
 

--- a/src/routes/skills/-SkillsResults.tsx
+++ b/src/routes/skills/-SkillsResults.tsx
@@ -16,10 +16,12 @@ import { useMediaQuery } from "../../lib/useMediaQuery";
 import {
   buildSkillHref,
   isExternalSkillListEntry,
+  isTrendingSkillListEntry,
   type SkillListEntry,
   type SkillSearchEntry,
+  type TrendingSkillListEntry,
 } from "./-types";
-import type { SkillsView } from "./-useSkillsBrowseModel";
+import type { SkillsCatalogTab, SkillsView } from "./-useSkillsBrowseModel";
 
 type SkillsResultsProps = {
   isLoadingSkills: boolean;
@@ -32,7 +34,75 @@ type SkillsResultsProps = {
   canAutoLoad: boolean;
   loadMoreRef: RefObject<HTMLDivElement | null>;
   loadMore: () => void;
+  catalogTab: SkillsCatalogTab;
 };
+
+function TrendingSkillListItem({ item }: { item: TrendingSkillListEntry }) {
+  const trending = item.trending;
+  const owner = trending.publisher?.handle;
+  return (
+    <Link to={trending.canonicalUrl} className="skill-list-item skill-list-item-skill">
+      <MarketplaceIcon kind="skill" label={trending.displayName} />
+      <div className="skill-list-item-body">
+        <div className="skill-list-item-main">
+          <span className="skill-list-item-identity">
+            <span className="skill-list-item-name" title={trending.displayName}>
+              {truncateText(trending.displayName, 48)}
+            </span>
+            {owner ? <span className="skill-list-item-owner">@{owner}</span> : null}
+          </span>
+        </div>
+        {trending.summary ? (
+          <p className="skill-list-item-summary">{truncateText(trending.summary, 80)}</p>
+        ) : null}
+      </div>
+      <div className="skill-list-item-meta" aria-label="24-hour installs">
+        {typeof trending.metrics.trending24hInstalls === "number" ? (
+          <span className="skill-list-item-meta-item">
+            <Download size={14} aria-hidden="true" />
+            {formatCompactStat(trending.metrics.trending24hInstalls)}
+          </span>
+        ) : null}
+      </div>
+    </Link>
+  );
+}
+
+function TrendingSkillCard({ item }: { item: TrendingSkillListEntry }) {
+  const trending = item.trending;
+  const owner = trending.publisher?.handle;
+  return (
+    <Link
+      to={trending.canonicalUrl}
+      className="card flex min-w-0 flex-col gap-3 p-5 transition-colors hover:border-[color:var(--oc-border-strong)]"
+    >
+      <div className="flex items-start gap-3">
+        <MarketplaceIcon kind="skill" label={trending.displayName} />
+        <div className="min-w-0 flex-1">
+          <h3 className="truncate font-semibold text-[color:var(--oc-text-primary)]">
+            {trending.displayName}
+          </h3>
+          {owner ? (
+            <p className="mt-1 truncate text-xs text-[color:var(--oc-text-muted)]">@{owner}</p>
+          ) : null}
+        </div>
+      </div>
+      {trending.summary ? (
+        <p className="line-clamp-3 text-sm leading-6 text-[color:var(--oc-text-secondary)]">
+          {trending.summary}
+        </p>
+      ) : null}
+      {typeof trending.metrics.trending24hInstalls === "number" ? (
+        <div className="skill-card-grid-meta" aria-label="24-hour installs">
+          <span>
+            <Download size={14} aria-hidden="true" />
+            {formatCompactStat(trending.metrics.trending24hInstalls)}
+          </span>
+        </div>
+      ) : null}
+    </Link>
+  );
+}
 
 function ExternalSkillSearchListItem({ result }: { result: SkillSearchEntry }) {
   const owner = result.sourceIdentity.owner ?? result.sourceIdentity.host;
@@ -123,9 +193,11 @@ export function SkillsResults({
   canAutoLoad,
   loadMoreRef,
   loadMore,
+  catalogTab,
 }: SkillsResultsProps) {
   const isMobileBrowse = useMediaQuery("(max-width: 760px)");
   const effectiveView = isMobileBrowse ? "list" : view;
+  const showTrendingLayout = !hasQuery && catalogTab === "trending";
 
   return (
     <>
@@ -149,6 +221,9 @@ export function SkillsResults({
       ) : effectiveView === "grid" ? (
         <div className="grid browse-results-grid">
           {sorted.map((entry) => {
+            if (isTrendingSkillListEntry(entry)) {
+              return <TrendingSkillCard key={entry.trending.id} item={entry} />;
+            }
             if (isExternalSkillListEntry(entry)) {
               return <ExternalSkillSearchCard key={entry.external.id} result={entry.external} />;
             }
@@ -183,11 +258,16 @@ export function SkillsResults({
           <div className="browse-list-head" aria-hidden="true">
             <span className="browse-list-head-icon-spacer" />
             <span className="browse-list-head-label">Skill</span>
-            <span className="browse-list-head-label">Category</span>
-            <span className="browse-list-head-label browse-list-head-stat">Popularity</span>
+            {showTrendingLayout ? null : <span className="browse-list-head-label">Category</span>}
+            <span className="browse-list-head-label browse-list-head-stat">
+              {showTrendingLayout ? "24h installs" : "Popularity"}
+            </span>
           </div>
           <div className="results-list">
             {sorted.map((entry) => {
+              if (isTrendingSkillListEntry(entry)) {
+                return <TrendingSkillListItem key={entry.trending.id} item={entry} />;
+              }
               if (isExternalSkillListEntry(entry)) {
                 return (
                   <ExternalSkillSearchListItem key={entry.external.id} result={entry.external} />

--- a/src/routes/skills/-types.ts
+++ b/src/routes/skills/-types.ts
@@ -1,5 +1,6 @@
 import type { Doc } from "../../../convex/_generated/dataModel";
 import type { PublicPublisher, PublicSkill } from "../../lib/publicUser";
+import type { CanonicalTrendingItem } from "../../lib/trendingApi";
 
 export type NativeSkillListEntry = {
   skill: PublicSkill;
@@ -85,10 +86,18 @@ export type ExternalSkillListEntry = {
   searchScore: number;
 };
 
-export type SkillListEntry = NativeSkillListEntry | ExternalSkillListEntry;
+export type TrendingSkillListEntry = {
+  trending: CanonicalTrendingItem;
+};
+
+export type SkillListEntry = NativeSkillListEntry | ExternalSkillListEntry | TrendingSkillListEntry;
 
 export function isExternalSkillListEntry(entry: SkillListEntry): entry is ExternalSkillListEntry {
   return "external" in entry;
+}
+
+export function isTrendingSkillListEntry(entry: SkillListEntry): entry is TrendingSkillListEntry {
+  return "trending" in entry;
 }
 
 export function buildSkillHref(skill: PublicSkill, ownerHandle?: string | null) {

--- a/src/routes/skills/-useSkillsBrowseModel.ts
+++ b/src/routes/skills/-useSkillsBrowseModel.ts
@@ -197,7 +197,9 @@ export function useSkillsBrowseModel({
             createdAfter: catalogTab === "new" ? newCutoff : undefined,
             categorySlug: activeCategory?.slug,
             topic: activeTopic,
-            ...(activeCategory && catalogTab !== "new" ? { officialFirst: true } : {}),
+            ...(activeCategory && catalogTab !== "new" && catalogTab !== "official"
+              ? { officialFirst: true }
+              : {}),
             categoryKeywords,
             excludeCategoryKeywords,
           });

--- a/src/routes/skills/-useSkillsBrowseModel.ts
+++ b/src/routes/skills/-useSkillsBrowseModel.ts
@@ -8,10 +8,18 @@ import {
   getSkillCategoryBySlug,
   getSkillCategoriesForSkill,
 } from "../../lib/categories";
+import { fetchCanonicalTrendingPage } from "../../lib/trendingApi";
 import { parseDir, parseSort, toListSort, type SortDir, type SortKey } from "./-params";
-import { isExternalSkillListEntry, type SkillListEntry, type SkillSearchEntry } from "./-types";
+import {
+  isExternalSkillListEntry,
+  isTrendingSkillListEntry,
+  type SkillListEntry,
+  type SkillSearchEntry,
+} from "./-types";
 
-const pageSize = 25;
+const pageSize = 20;
+const featuredPageSize = 40;
+const newWindowMs = 14 * 24 * 60 * 60 * 1_000;
 const maxConsecutiveEmptyPagesPerFetch = 3;
 
 function isNavigationAbortError(err: unknown) {
@@ -22,6 +30,7 @@ function isNavigationAbortError(err: unknown) {
 }
 
 export type SkillsView = "grid" | "list";
+export type SkillsCatalogTab = "trending" | "new" | "featured" | "official";
 type LegacySkillsView = SkillsView | "cards";
 
 export function normalizeSkillsView(value: unknown): SkillsView | undefined {
@@ -40,7 +49,21 @@ export type SkillsSearchState = {
   topic?: string;
   view?: LegacySkillsView;
   focus?: "search";
+  tab?: SkillsCatalogTab;
 };
+
+export function normalizeSkillsCatalogTab(
+  value: unknown,
+  legacy?: Pick<SkillsSearchState, "featured" | "highlighted" | "sort" | "category" | "topic">,
+): SkillsCatalogTab {
+  if (value === "trending" || value === "new" || value === "featured" || value === "official") {
+    return value;
+  }
+  if (legacy?.featured || legacy?.highlighted) return "featured";
+  if (legacy?.sort === "newest") return "new";
+  if (legacy?.category || legacy?.topic) return "new";
+  return "trending";
+}
 
 export type InitialSkillsSearchData = {
   key: string;
@@ -102,7 +125,16 @@ export function useSkillsBrowseModel({
   const excludeCategoryKeywords =
     activeCategory?.slug === "other" ? ALL_CATEGORY_KEYWORDS : undefined;
   const hasQuery = trimmedQuery.length > 0;
-  const requestedSort = search.sort === "default" ? "recommended" : search.sort;
+  const catalogTab = normalizeSkillsCatalogTab(search.tab, search);
+  const requestedSort = hasQuery
+    ? search.sort === "default"
+      ? "recommended"
+      : search.sort
+    : catalogTab === "new" || catalogTab === "official"
+      ? "newest"
+      : catalogTab === "featured"
+        ? "updated"
+        : "trending";
   const sort: SortKey =
     requestedSort === "relevance" && !hasQuery
       ? "recommended"
@@ -132,44 +164,49 @@ export function useSkillsBrowseModel({
   const [listResults, setListResults] = useState<SkillListEntry[]>([]);
   const [listCursor, setListCursor] = useState<string | null>(null);
   const [listStatus, setListStatus] = useState<ListStatus>("loading");
-  const [listAutoLoadPaused, setListAutoLoadPaused] = useState(false);
+  const [, setListAutoLoadPaused] = useState(false);
   const fetchGeneration = useRef(0);
+  const newCutoff = useMemo(() => Date.now() - newWindowMs, [catalogTab]);
 
   const fetchPage = useCallback(
     async (cursor: string | null, generation: number) => {
       let pageCursor = cursor;
       let consecutiveEmptyPages = 0;
       try {
-        if (sort === "trending") {
-          const result = await convexHttp.query(api.skills.listPublicTrendingPage, {
+        if (catalogTab === "trending") {
+          const result = await fetchCanonicalTrendingPage({
+            cursor: pageCursor,
             limit: pageSize,
-            nonSuspiciousOnly: true,
-            categorySlug: activeCategory?.slug,
-            topic: activeTopic,
           });
           if (generation !== fetchGeneration.current) return;
-          setListResults(result.items);
-          setListCursor(null);
+          const entries = result.items.map((trending) => ({ trending }));
+          setListResults((prev) => (cursor ? [...prev, ...entries] : entries));
+          setListCursor(result.nextCursor);
           setListAutoLoadPaused(false);
-          setListStatus("done");
+          setListStatus(result.nextCursor ? "idle" : "done");
           return;
         }
         while (true) {
           const result = await convexHttp.query(api.skills.listPublicPageV4, {
             cursor: pageCursor ?? undefined,
-            numItems: pageSize,
+            numItems: catalogTab === "featured" ? featuredPageSize : pageSize,
             ...(listSort ? { sort: listSort } : {}),
             dir,
-            highlightedOnly: featuredOnly,
+            highlightedOnly: catalogTab === "featured" ? true : undefined,
+            officialOnly: catalogTab === "official" ? true : undefined,
+            createdAfter: catalogTab === "new" ? newCutoff : undefined,
             categorySlug: activeCategory?.slug,
             topic: activeTopic,
-            ...(activeCategory ? { officialFirst: true } : {}),
+            ...(activeCategory && catalogTab !== "new" ? { officialFirst: true } : {}),
             categoryKeywords,
             excludeCategoryKeywords,
           });
           if (generation !== fetchGeneration.current) return;
           const nextCursor =
-            result.hasMore && result.nextCursor != null && result.nextCursor !== pageCursor
+            catalogTab !== "featured" &&
+            result.hasMore &&
+            result.nextCursor != null &&
+            result.nextCursor !== pageCursor
               ? result.nextCursor
               : null;
 
@@ -202,11 +239,13 @@ export function useSkillsBrowseModel({
     [
       activeCategory?.slug,
       activeTopic,
+      catalogTab,
       categoryKeywords,
       dir,
       excludeCategoryKeywords,
       featuredOnly,
       listSort,
+      newCutoff,
       sort,
     ],
   );
@@ -328,6 +367,7 @@ export function useSkillsBrowseModel({
       ? baseItems.filter(
           (entry) =>
             isExternalSkillListEntry(entry) ||
+            isTrendingSkillListEntry(entry) ||
             getCatalogTopicSlugs(entry.skill.topics).includes(activeTopic),
         )
       : baseItems;
@@ -335,6 +375,7 @@ export function useSkillsBrowseModel({
       ? topicItems.filter(
           (entry) =>
             isExternalSkillListEntry(entry) ||
+            isTrendingSkillListEntry(entry) ||
             getSkillCategoriesForSkill(entry.skill).some(
               (category) => category.slug === activeCategory.slug,
             ),
@@ -348,6 +389,7 @@ export function useSkillsBrowseModel({
     const multiplier = dir === "asc" ? 1 : -1;
     const results = [...categoryItems];
     results.sort((a, b) => {
+      if (isTrendingSkillListEntry(a) || isTrendingSkillListEntry(b)) return 0;
       const aSkill = isExternalSkillListEntry(a) ? a.external : a.skill;
       const bSkill = isExternalSkillListEntry(b) ? b.external : b.skill;
       const aDownloads = isExternalSkillListEntry(a) ? 0 : a.skill.stats.downloads;
@@ -390,8 +432,7 @@ export function useSkillsBrowseModel({
     ? !isSearching && searchResults.length === searchLimit && searchResults.length > 0
     : canLoadMoreList;
   const isLoadingMore = hasQuery ? isSearching && searchResults.length > 0 : isLoadingMoreList;
-  const canAutoLoad =
-    typeof IntersectionObserver !== "undefined" && (hasQuery || !listAutoLoadPaused);
+  const canAutoLoad = false;
 
   const loadMore = useCallback(() => {
     if (loadMoreInFlightRef.current || isLoadingMore || !canLoadMore) return;
@@ -412,23 +453,6 @@ export function useSkillsBrowseModel({
   }, [isLoadingMore]);
 
   useEffect(() => {
-    if (!canLoadMore || !canAutoLoad) return () => {};
-    const target = loadMoreRef.current;
-    if (!target) return () => {};
-    const observer = new IntersectionObserver(
-      (entries) => {
-        if (entries.some((entry) => entry.isIntersecting)) {
-          observer.disconnect();
-          loadMore();
-        }
-      },
-      { rootMargin: "200px" },
-    );
-    observer.observe(target);
-    return () => observer.disconnect();
-  }, [canAutoLoad, canLoadMore, loadMore]);
-
-  useEffect(() => {
     return () => window.clearTimeout(navigateTimer.current);
   }, []);
 
@@ -445,6 +469,7 @@ export function useSkillsBrowseModel({
             return {
               ...prev,
               q: trimmed ? next : undefined,
+              ...(enteringSearch ? { category: undefined, topic: undefined } : null),
               ...(enteringSearch && parseSort(prev.sort) === "recommended"
                 ? { sort: undefined, dir: undefined }
                 : null),
@@ -555,6 +580,7 @@ export function useSkillsBrowseModel({
     activeFilters,
     activeCategory: activeCategory?.slug,
     activeTopic,
+    catalogTab,
     canAutoLoad,
     canLoadMore,
     dir,

--- a/src/routes/skills/index.tsx
+++ b/src/routes/skills/index.tsx
@@ -12,7 +12,6 @@ import {
   BrowseSearchInput,
   BrowseSearchPanel,
   BrowseSearchTrigger,
-  BrowseSortSelect,
   BrowseTabs,
   BrowseTopicChips,
   BrowseViewToggle,
@@ -26,29 +25,23 @@ import {
 } from "../../lib/browseTopicSearch";
 import { resolveSkillBrowseCategorySlug, SKILL_CATEGORIES } from "../../lib/categories";
 import { useBrowseTopicSearch } from "../../lib/useBrowseTopicSearch";
-import { parseDir, parseSort } from "./-params";
+import { parseSort } from "./-params";
 import { SkillsResults } from "./-SkillsResults";
 import type { SkillSearchEntry } from "./-types";
 import {
   buildSkillsSearchKey,
   type InitialSkillsSearchData,
   normalizeSkillsView,
+  normalizeSkillsCatalogTab,
   useSkillsBrowseModel,
   type SkillsSearchState,
 } from "./-useSkillsBrowseModel";
 
 const SKILLS_VIEW_OPTIONS = [
-  { value: "all", label: "All" },
   { value: "trending", label: "Trending" },
-  { value: "top", label: "Top" },
-  { value: "stars", label: "Most bookmarked" },
+  { value: "new", label: "New" },
   { value: "featured", label: "Featured" },
-];
-
-const SKILLS_SORT_OPTIONS = [
-  { value: "updated", label: "Recently updated" },
-  { value: "newest", label: "Newest" },
-  { value: "name", label: "Name" },
+  { value: "official", label: "Official" },
 ];
 const SKILLS_INITIAL_SEARCH_LIMIT = 25;
 
@@ -58,22 +51,34 @@ function parseSkillCategorySlug(value: unknown) {
 
 export const Route = createFileRoute("/skills/")({
   validateSearch: (search): SkillsSearchState => {
+    const category = parseSkillCategorySlug(search.category);
+    const topic = parseBrowseTopicFromSearchInput(search as Record<string, unknown>);
+    const sort = typeof search.sort === "string" ? parseSort(search.sort) : undefined;
+    const featured =
+      search.featured === "1" || search.featured === "true" || search.featured === true
+        ? true
+        : undefined;
+    const highlighted =
+      search.highlighted === "1" || search.highlighted === "true" || search.highlighted === true
+        ? true
+        : undefined;
     return {
       q: typeof search.q === "string" && search.q.trim() ? search.q : undefined,
-      sort: typeof search.sort === "string" ? parseSort(search.sort) : undefined,
+      sort,
       dir: search.dir === "asc" || search.dir === "desc" ? search.dir : undefined,
-      highlighted:
-        search.highlighted === "1" || search.highlighted === "true" || search.highlighted === true
-          ? true
-          : undefined,
-      featured:
-        search.featured === "1" || search.featured === "true" || search.featured === true
-          ? true
-          : undefined,
-      category: parseSkillCategorySlug(search.category),
-      topic: parseBrowseTopicFromSearchInput(search as Record<string, unknown>),
+      highlighted,
+      featured,
+      category,
+      topic,
       view: normalizeSkillsView(search.view),
       focus: search.focus === "search" ? "search" : undefined,
+      tab: normalizeSkillsCatalogTab(search.tab, {
+        category,
+        featured,
+        highlighted,
+        sort,
+        topic,
+      }),
     };
   },
   loaderDeps: ({ search }) => ({
@@ -134,18 +139,12 @@ export function SkillsIndex() {
     inputRef: searchInputRef,
   });
 
-  const activeView = model.featuredOnly
-    ? "featured"
-    : model.sort === "trending"
-      ? "trending"
-      : model.sort === "downloads"
-        ? "top"
-        : model.sort === "stars"
-          ? "stars"
-          : "all";
-  const activeSort = ["updated", "newest", "name"].includes(model.sort) ? model.sort : undefined;
+  const activeView = model.catalogTab;
   const hasActiveFilters =
-    model.hasQuery || Boolean(model.activeCategory) || Boolean(activeTopic) || model.featuredOnly;
+    model.catalogTab !== "trending" ||
+    model.hasQuery ||
+    Boolean(model.activeCategory) ||
+    Boolean(activeTopic);
   const totalSkillsCount = useQuery(api.skills.countPublicSkills, {});
   const categoryTopics = useQuery(
     api.catalogTopics.listTopByCategory,
@@ -165,37 +164,20 @@ export function SkillsIndex() {
           if (value === "trending") {
             return {
               ...prev,
-              sort: "trending",
-              dir: "desc",
+              q: undefined,
+              tab: "trending",
+              sort: undefined,
+              dir: undefined,
+              category: undefined,
+              topic: undefined,
               featured: undefined,
               highlighted: undefined,
             };
           }
-          if (value === "top" || value === "stars") {
-            const sort = value === "top" ? "downloads" : "stars";
-            return {
-              ...prev,
-              sort,
-              dir: "desc",
-              featured: undefined,
-              highlighted: undefined,
-            };
-          }
-
-          if (value === "featured") {
-            const sort = parseSort(prev.sort);
-            const keepSort = sort === "updated" || sort === "newest" || sort === "name";
-            return {
-              ...prev,
-              sort: keepSort ? sort : undefined,
-              dir: keepSort ? parseDir(prev.dir, sort) : undefined,
-              featured: true,
-              highlighted: undefined,
-            };
-          }
-
           return {
             ...prev,
+            q: undefined,
+            tab: value as "new" | "featured" | "official",
             sort: undefined,
             dir: undefined,
             featured: undefined,
@@ -206,26 +188,6 @@ export function SkillsIndex() {
       });
     },
     [navigate],
-  );
-
-  const handleSortChange = useCallback(
-    (value: string | undefined) => {
-      if (!value) {
-        void navigate({
-          search: (prev: SkillsSearchState) => ({
-            ...prev,
-            sort: undefined,
-            dir: undefined,
-            featured: activeView === "featured" ? true : undefined,
-            highlighted: undefined,
-          }),
-          replace: true,
-        });
-        return;
-      }
-      model.onSortChange(value);
-    },
-    [activeView, model.onSortChange, navigate],
   );
 
   const handleCategoryChange = useCallback(
@@ -289,23 +251,20 @@ export function SkillsIndex() {
             }}
           />
           <BrowseControlsDivider />
-          <BrowseSortSelect
-            options={SKILLS_SORT_OPTIONS}
-            value={activeSort}
-            onChange={handleSortChange}
-          />
           <BrowseActions>
             <BrowseSearchTrigger
               open={browseSearch.open}
               onOpen={browseSearch.openSearch}
               label="Search skills"
             />
-            <BrowseCategorySelect
-              categories={SKILL_CATEGORIES}
-              value={model.activeCategory}
-              onChange={handleCategoryChange}
-              responsive
-            />
+            {activeView === "trending" ? null : (
+              <BrowseCategorySelect
+                categories={SKILL_CATEGORIES}
+                value={model.activeCategory}
+                onChange={handleCategoryChange}
+                responsive
+              />
+            )}
             <BrowseViewToggle view={model.view} onToggle={model.onToggleView} />
           </BrowseActions>
           <BrowseSearchPanel open={browseSearch.open}>
@@ -320,20 +279,26 @@ export function SkillsIndex() {
             />
           </BrowseSearchPanel>
         </BrowseControlsRow>
-        <BrowseTopicChips
-          topics={categoryTopics ?? []}
-          activeTopic={activeTopic}
-          onChange={handleTopicChange}
-          loading={Boolean(model.activeCategory && categoryTopics === undefined)}
-        />
+        {activeView === "trending" ? null : (
+          <BrowseTopicChips
+            topics={categoryTopics ?? []}
+            activeTopic={activeTopic}
+            onChange={handleTopicChange}
+            loading={Boolean(model.activeCategory && categoryTopics === undefined)}
+          />
+        )}
       </BrowseControls>
-      <div className="browse-layout browse-layout-with-sidebar">
-        <BrowseCategorySidebar
-          ariaLabel="Skill categories"
-          categories={SKILL_CATEGORIES}
-          value={model.activeCategory}
-          onChange={handleCategoryChange}
-        />
+      <div
+        className={`browse-layout${activeView === "trending" ? "" : " browse-layout-with-sidebar"}`}
+      >
+        {activeView === "trending" ? null : (
+          <BrowseCategorySidebar
+            ariaLabel="Skill categories"
+            categories={SKILL_CATEGORIES}
+            value={model.activeCategory}
+            onChange={handleCategoryChange}
+          />
+        )}
         <div className="browse-results">
           <SkillsResults
             isLoadingSkills={model.isLoadingSkills}
@@ -346,6 +311,7 @@ export function SkillsIndex() {
             canAutoLoad={model.canAutoLoad}
             loadMoreRef={model.loadMoreRef}
             loadMore={model.loadMore}
+            catalogTab={model.catalogTab}
           />
         </div>
       </div>


### PR DESCRIPTION
## Summary

- make the homepage and `/skills` default to the canonical Trending feed with `New`, `Featured`, and `Official` in the accepted order
- preserve stable cursor pagination and canonical API ordering without client reranking
- derive the `/skills` total from eligible native plus skills.sh public catalog records while excluding plugins, duplicates, and non-public fixtures
- retire stale permanent-Test catalog fixtures through the guarded Test seed path
- prepare disposable local-auth runtimes with a valid empty canonical Trending snapshot so strict browser error assertions exercise the real API boundary

## Validation

- `bun run ci:static`
- `bun run ci:unit` (9,115 passed, 3 skipped)
- `bun run ci:types-build`
- `bun run ci:packages`
- focused CLAW-591 UI/backend suites
- local-auth account-cleanup shard (2/2 passed)
- isolated Convex push and runtime query
- public Chromium route smoke on an isolated preview port
- explicit schema and CLI package TypeScript checks
- autoreview clean for the local-auth fix and complete branch against `origin/main`
- exact-head CI [30218876753](https://github.com/openclaw/clawhub/actions/runs/30218876753) passed at `cbd012a9d7340ad1d2d3fc0d3efe2d2f056ca0a9`, including all eight local-auth shards and aggregate

Permanent-Test homepage and `/skills` desktop/mobile proof follows the guarded merge and exact-main deploy.
