### PR TITLE
fix(catalog): tolerate frontend-backend rollout drift

### DIFF
--- a/convex/rolloutCapabilities.test.ts
+++ b/convex/rolloutCapabilities.test.ts
@@ -30,6 +30,9 @@ describe("getPublicCapabilitiesHandler", () => {
 
     await expect(getPublicCapabilitiesHandler({ db } as never, {})).resolves.toEqual({
       environment: "unknown",
+      catalogDiscovery: {
+        apiVersion: 1,
+      },
       skillsSh: {
         mode: "off",
         runtimeEnabled: false,
@@ -66,6 +69,9 @@ describe("getPublicCapabilitiesHandler", () => {
       }),
     ).resolves.toEqual({
       environment: "test",
+      catalogDiscovery: {
+        apiVersion: 1,
+      },
       skillsSh: {
         mode: "test",
         runtimeEnabled: true,

--- a/convex/rolloutCapabilities.ts
+++ b/convex/rolloutCapabilities.ts
@@ -20,6 +20,9 @@ export async function getPublicCapabilitiesHandler(
   );
   return {
     environment: runtime.environment,
+    catalogDiscovery: {
+      apiVersion: 1,
+    },
     skillsSh: {
       mode: runtime.skillsSh.mode,
       runtimeEnabled: runtime.skillsSh.runtimeEnabled,

--- a/src/__tests__/home-listing-section.claw591.test.tsx
+++ b/src/__tests__/home-listing-section.claw591.test.tsx
@@ -7,6 +7,7 @@ const convexQueryMock = vi.fn();
 const convexActionMock = vi.fn();
 const fetchPluginCatalogMock = vi.fn();
 const fetchCanonicalTrendingPageMock = vi.fn();
+const fetchCatalogDiscoveryCapabilitiesMock = vi.fn();
 
 vi.mock("@tanstack/react-router", () => ({
   Link: ({
@@ -44,6 +45,11 @@ vi.mock("../lib/packageApi", () => ({
   fetchPluginCatalog: (...args: unknown[]) => fetchPluginCatalogMock(...args),
 }));
 
+vi.mock("../lib/catalogDiscoveryCapabilities", () => ({
+  fetchCatalogDiscoveryCapabilities: (...args: unknown[]) =>
+    fetchCatalogDiscoveryCapabilitiesMock(...args),
+}));
+
 vi.mock("../lib/trendingApi", async (importOriginal) => {
   const original = await importOriginal<typeof import("../lib/trendingApi")>();
   return {
@@ -61,6 +67,11 @@ describe("HomeListingSection", () => {
     convexActionMock.mockReset();
     fetchPluginCatalogMock.mockReset();
     fetchCanonicalTrendingPageMock.mockReset();
+    fetchCatalogDiscoveryCapabilitiesMock.mockReset();
+    fetchCatalogDiscoveryCapabilitiesMock.mockResolvedValue({
+      apiVersion: 1,
+      canonicalTrendingEnabled: true,
+    });
     convexQueryMock.mockResolvedValue({ page: [], hasMore: false, nextCursor: null });
     convexActionMock.mockResolvedValue([]);
     fetchPluginCatalogMock.mockResolvedValue({ items: [], nextCursor: null });

--- a/src/__tests__/home-listing-section.test.tsx
+++ b/src/__tests__/home-listing-section.test.tsx
@@ -6,6 +6,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const navigateMock = vi.fn();
 const convexQueryMock = vi.fn();
 const fetchPluginCatalogMock = vi.fn();
+const fetchCatalogDiscoveryCapabilitiesMock = vi.fn();
 
 vi.mock("@tanstack/react-router", () => ({
   Link: ({
@@ -47,6 +48,11 @@ vi.mock("../../convex/_generated/api", () => ({
 
 vi.mock("../lib/packageApi", () => ({
   fetchPluginCatalog: (...args: unknown[]) => fetchPluginCatalogMock(...args),
+}));
+
+vi.mock("../lib/catalogDiscoveryCapabilities", () => ({
+  fetchCatalogDiscoveryCapabilities: (...args: unknown[]) =>
+    fetchCatalogDiscoveryCapabilitiesMock(...args),
 }));
 
 import { HomeListingSection } from "../components/HomeListingSection";
@@ -93,6 +99,11 @@ describe("HomeListingSection", () => {
     convexQueryMock.mockReset();
     convexActionMock.mockReset();
     fetchPluginCatalogMock.mockReset();
+    fetchCatalogDiscoveryCapabilitiesMock.mockReset();
+    fetchCatalogDiscoveryCapabilitiesMock.mockResolvedValue({
+      apiVersion: 1,
+      canonicalTrendingEnabled: true,
+    });
     convexQueryMock.mockResolvedValue({
       page: [
         {

--- a/src/__tests__/skills-index-load-more.test.tsx
+++ b/src/__tests__/skills-index-load-more.test.tsx
@@ -12,6 +12,7 @@ import {
 
 const navigateMock = vi.fn();
 const fetchCanonicalTrendingPageMock = vi.fn();
+const fetchCatalogDiscoveryCapabilitiesMock = vi.fn();
 let searchMock: Record<string, unknown> = {};
 
 vi.mock("../lib/trendingApi", async (importOriginal) => {
@@ -21,6 +22,11 @@ vi.mock("../lib/trendingApi", async (importOriginal) => {
     fetchCanonicalTrendingPage: (...args: unknown[]) => fetchCanonicalTrendingPageMock(...args),
   };
 });
+
+vi.mock("../lib/catalogDiscoveryCapabilities", () => ({
+  fetchCatalogDiscoveryCapabilities: (...args: unknown[]) =>
+    fetchCatalogDiscoveryCapabilitiesMock(...args),
+}));
 
 vi.mock("@tanstack/react-router", () => ({
   createFileRoute: () => (_config: { component: unknown; validateSearch: unknown }) => ({
@@ -54,6 +60,11 @@ describe("SkillsIndex load-more observer", () => {
     searchMock = {};
     setupDefaultConvexReactMocks();
     fetchCanonicalTrendingPageMock.mockReset();
+    fetchCatalogDiscoveryCapabilitiesMock.mockReset();
+    fetchCatalogDiscoveryCapabilitiesMock.mockResolvedValue({
+      apiVersion: 1,
+      canonicalTrendingEnabled: true,
+    });
   });
 
   afterEach(() => {

--- a/src/__tests__/skills-index.claw591.test.tsx
+++ b/src/__tests__/skills-index.claw591.test.tsx
@@ -12,6 +12,7 @@ import {
 
 const navigateMock = vi.fn();
 const fetchCanonicalTrendingPageMock = vi.fn();
+const fetchCatalogDiscoveryCapabilitiesMock = vi.fn();
 let searchMock: Record<string, unknown> = {};
 let loaderDataMock: unknown = null;
 
@@ -22,6 +23,11 @@ vi.mock("../lib/trendingApi", async (importOriginal) => {
     fetchCanonicalTrendingPage: (...args: unknown[]) => fetchCanonicalTrendingPageMock(...args),
   };
 });
+
+vi.mock("../lib/catalogDiscoveryCapabilities", () => ({
+  fetchCatalogDiscoveryCapabilities: (...args: unknown[]) =>
+    fetchCatalogDiscoveryCapabilitiesMock(...args),
+}));
 
 vi.mock("@tanstack/react-router", () => ({
   createFileRoute: () => (config: { component: unknown; validateSearch: unknown }) => ({
@@ -60,6 +66,11 @@ describe("SkillsIndex", () => {
     setupDefaultConvexReactMocks();
     fetchCanonicalTrendingPageMock.mockReset();
     fetchCanonicalTrendingPageMock.mockResolvedValue(canonicalPage([]));
+    fetchCatalogDiscoveryCapabilitiesMock.mockReset();
+    fetchCatalogDiscoveryCapabilitiesMock.mockResolvedValue({
+      apiVersion: 1,
+      canonicalTrendingEnabled: true,
+    });
   });
 
   afterEach(() => {
@@ -123,6 +134,26 @@ describe("SkillsIndex", () => {
     expect(screen.queryByText(/Not scanned by ClawHub/i)).toBeNull();
   });
 
+  it("renders legacy Trending while the canonical rollout is disabled", async () => {
+    fetchCatalogDiscoveryCapabilitiesMock.mockResolvedValue({
+      apiVersion: 0,
+      canonicalTrendingEnabled: false,
+    });
+    convexHttpMock.query.mockResolvedValue({
+      items: [makeListResult("legacy-trending", "Legacy Trending")],
+      nextCursor: null,
+    });
+
+    render(<SkillsIndex />);
+
+    expect(await screen.findByText("Legacy Trending")).toBeTruthy();
+    expect(fetchCanonicalTrendingPageMock).not.toHaveBeenCalled();
+    expect(convexHttpMock.query).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ limit: 20 }),
+    );
+  });
+
   it("loads New from the native 14-day chronological feed", async () => {
     searchMock = { tab: "new" };
     convexHttpMock.query.mockResolvedValue({
@@ -148,6 +179,29 @@ describe("SkillsIndex", () => {
     expect(Date.now() - Number(args.createdAfter)).toBeLessThanOrEqual(
       14 * 24 * 60 * 60 * 1000 + 1000,
     );
+  });
+
+  it("uses the legacy New contract and applies the 14-day cutoff locally", async () => {
+    searchMock = { tab: "new" };
+    const recent = makeListResult("recent", "Recent Skill");
+    const old = makeListResult("old", "Old Skill");
+    old.skill.createdAt = Date.now() - 15 * 24 * 60 * 60 * 1_000;
+    fetchCatalogDiscoveryCapabilitiesMock.mockResolvedValue({
+      apiVersion: 0,
+      canonicalTrendingEnabled: false,
+    });
+    convexHttpMock.query.mockResolvedValue({
+      page: [recent, old],
+      hasMore: true,
+      nextCursor: "must-not-scan",
+    });
+
+    render(<SkillsIndex />);
+
+    expect(await screen.findByText("Recent Skill")).toBeTruthy();
+    expect(screen.queryByText("Old Skill")).toBeNull();
+    expect(getLastListPageArgs()).not.toHaveProperty("createdAfter");
+    expect(screen.queryByRole("button", { name: "Load more" })).toBeNull();
   });
 
   it("loads the latest 40 Featured skills from editorial history", async () => {

--- a/src/__tests__/skills-index.test.tsx
+++ b/src/__tests__/skills-index.test.tsx
@@ -11,8 +11,14 @@ import {
 } from "./helpers/convexReactMocks";
 
 const navigateMock = vi.fn();
+const fetchCatalogDiscoveryCapabilitiesMock = vi.fn();
 let searchMock: Record<string, unknown> = {};
 let loaderDataMock: unknown = null;
+
+vi.mock("../lib/catalogDiscoveryCapabilities", () => ({
+  fetchCatalogDiscoveryCapabilities: (...args: unknown[]) =>
+    fetchCatalogDiscoveryCapabilitiesMock(...args),
+}));
 
 vi.mock("@tanstack/react-router", () => ({
   createFileRoute: () => (config: { component: unknown; validateSearch: unknown }) => ({
@@ -49,6 +55,11 @@ describe("SkillsIndex", () => {
     searchMock = { tab: "new" };
     loaderDataMock = null;
     setupDefaultConvexReactMocks();
+    fetchCatalogDiscoveryCapabilitiesMock.mockReset();
+    fetchCatalogDiscoveryCapabilitiesMock.mockResolvedValue({
+      apiVersion: 1,
+      canonicalTrendingEnabled: true,
+    });
   });
 
   afterEach(() => {

--- a/src/lib/catalogDiscoveryCapabilities.test.ts
+++ b/src/lib/catalogDiscoveryCapabilities.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const convexQueryMock = vi.fn();
+
+vi.mock("../convex/client", () => ({
+  convexHttp: { query: (...args: unknown[]) => convexQueryMock(...args) },
+}));
+
+vi.mock("../../convex/_generated/api", () => ({
+  api: {
+    rolloutCapabilities: {
+      getPublicCapabilities: "rolloutCapabilities:getPublicCapabilities",
+    },
+  },
+}));
+
+import { fetchCatalogDiscoveryCapabilities } from "./catalogDiscoveryCapabilities";
+
+describe("fetchCatalogDiscoveryCapabilities", () => {
+  beforeEach(() => {
+    convexQueryMock.mockReset();
+  });
+
+  it("enables canonical discovery only when the backend advertises it", async () => {
+    convexQueryMock.mockResolvedValue({
+      catalogDiscovery: { apiVersion: 1 },
+      skillsSh: { runtimeEnabled: true },
+    });
+
+    await expect(fetchCatalogDiscoveryCapabilities()).resolves.toEqual({
+      apiVersion: 1,
+      canonicalTrendingEnabled: true,
+    });
+  });
+
+  it("treats the previous response shape as a legacy backend", async () => {
+    convexQueryMock.mockResolvedValue({
+      skillsSh: { runtimeEnabled: false },
+    });
+
+    await expect(fetchCatalogDiscoveryCapabilities()).resolves.toEqual({
+      apiVersion: 0,
+      canonicalTrendingEnabled: false,
+    });
+  });
+
+  it("falls back conservatively when the capabilities query is unavailable", async () => {
+    convexQueryMock.mockRejectedValue(new Error("Could not find public function"));
+
+    await expect(fetchCatalogDiscoveryCapabilities()).resolves.toEqual({
+      apiVersion: 0,
+      canonicalTrendingEnabled: false,
+    });
+  });
+});

--- a/src/lib/catalogDiscoveryCapabilities.ts
+++ b/src/lib/catalogDiscoveryCapabilities.ts
@@ -1,0 +1,32 @@
+import { api } from "../../convex/_generated/api";
+import { convexHttp } from "../convex/client";
+
+type CatalogDiscoveryCapabilities = {
+  apiVersion: 0 | 1;
+  canonicalTrendingEnabled: boolean;
+};
+
+const LEGACY_CATALOG_DISCOVERY_CAPABILITIES: CatalogDiscoveryCapabilities = {
+  apiVersion: 0,
+  canonicalTrendingEnabled: false,
+};
+
+export async function fetchCatalogDiscoveryCapabilities(): Promise<CatalogDiscoveryCapabilities> {
+  try {
+    const response = (await convexHttp.query(
+      api.rolloutCapabilities.getPublicCapabilities,
+      {},
+    )) as {
+      catalogDiscovery?: { apiVersion?: unknown };
+      skillsSh?: { runtimeEnabled?: unknown };
+    };
+    return {
+      apiVersion: response.catalogDiscovery?.apiVersion === 1 ? 1 : 0,
+      canonicalTrendingEnabled: response.skillsSh?.runtimeEnabled === true,
+    };
+  } catch {
+    // Older deployments may not expose the capabilities query at all. Treat
+    // unknown backends as legacy so a frontend-first release remains usable.
+    return LEGACY_CATALOG_DISCOVERY_CAPABILITIES;
+  }
+}

--- a/src/lib/homeListingData.claw591.test.ts
+++ b/src/lib/homeListingData.claw591.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const convexQueryMock = vi.fn();
 const fetchPluginCatalogMock = vi.fn();
 const fetchCanonicalTrendingPageMock = vi.fn();
+const fetchCatalogDiscoveryCapabilitiesMock = vi.fn();
 
 vi.mock("../convex/client", () => ({
   convexHttp: { query: (...args: unknown[]) => convexQueryMock(...args) },
@@ -11,12 +12,20 @@ vi.mock("../convex/client", () => ({
 vi.mock("../../convex/_generated/api", () => ({
   api: {
     packages: { listPublicNewPluginsPage: "packages:listPublicNewPluginsPage" },
-    skills: { listPublicPageV4: "skills:listPublicPageV4" },
+    skills: {
+      listPublicPageV4: "skills:listPublicPageV4",
+      listPublicTrendingPage: "skills:listPublicTrendingPage",
+    },
   },
 }));
 
 vi.mock("./packageApi", () => ({
   fetchPluginCatalog: (...args: unknown[]) => fetchPluginCatalogMock(...args),
+}));
+
+vi.mock("./catalogDiscoveryCapabilities", () => ({
+  fetchCatalogDiscoveryCapabilities: (...args: unknown[]) =>
+    fetchCatalogDiscoveryCapabilitiesMock(...args),
 }));
 
 vi.mock("./trendingApi", async (importOriginal) => {
@@ -40,6 +49,11 @@ describe("homeListingData", () => {
     convexQueryMock.mockReset();
     fetchPluginCatalogMock.mockReset();
     fetchCanonicalTrendingPageMock.mockReset();
+    fetchCatalogDiscoveryCapabilitiesMock.mockReset();
+    fetchCatalogDiscoveryCapabilitiesMock.mockResolvedValue({
+      apiVersion: 1,
+      canonicalTrendingEnabled: true,
+    });
     convexQueryMock.mockResolvedValue({ page: [], hasMore: false, nextCursor: null });
     fetchPluginCatalogMock.mockResolvedValue({ items: [], nextCursor: null });
     fetchCanonicalTrendingPageMock.mockResolvedValue(canonicalPage([], null));
@@ -83,6 +97,25 @@ describe("homeListingData", () => {
     });
   });
 
+  it("falls back to legacy Trending when the canonical rollout is disabled", async () => {
+    const legacy = makeNative("legacy-trending", Date.now(), 10);
+    fetchCatalogDiscoveryCapabilitiesMock.mockResolvedValue({
+      apiVersion: 0,
+      canonicalTrendingEnabled: false,
+    });
+    convexQueryMock.mockResolvedValue({ items: [legacy], nextCursor: null });
+
+    await expect(fetchHomeSkillListing("trending", [], HOME_LISTING_PAGE_SIZE)).resolves.toEqual({
+      page: [legacy],
+      hasMore: false,
+    });
+    expect(convexQueryMock).toHaveBeenCalledWith("skills:listPublicTrendingPage", {
+      limit: HOME_LISTING_PAGE_SIZE,
+      categorySlug: undefined,
+    });
+    expect(fetchCanonicalTrendingPageMock).not.toHaveBeenCalled();
+  });
+
   it("loads New from the native 14-day chronological feed", async () => {
     const now = Date.now();
     await fetchHomeSkillListing("new", [], HOME_LISTING_PAGE_SIZE);
@@ -98,6 +131,29 @@ describe("homeListingData", () => {
     );
     const args = convexQueryMock.mock.calls[0]?.[1] as { createdAfter: number };
     expect(now - args.createdAfter).toBeGreaterThanOrEqual(HOME_NEW_WINDOW_MS - 10);
+  });
+
+  it("omits new-only arguments and filters the cutoff against a legacy backend", async () => {
+    const now = Date.now();
+    const recent = makeNative("recent", now - 1_000, 0);
+    const old = makeNative("old", now - HOME_NEW_WINDOW_MS - 1, 0);
+    fetchCatalogDiscoveryCapabilitiesMock.mockResolvedValue({
+      apiVersion: 0,
+      canonicalTrendingEnabled: false,
+    });
+    convexQueryMock.mockResolvedValue({
+      page: [recent, old],
+      hasMore: true,
+      nextCursor: "must-not-scan",
+    });
+
+    const result = await fetchHomeSkillListing("new", [], HOME_LISTING_PAGE_SIZE);
+
+    expect(result).toEqual({ page: [recent], hasMore: false });
+    expect(convexQueryMock).toHaveBeenCalledWith(
+      "skills:listPublicPageV4",
+      expect.not.objectContaining({ createdAfter: expect.any(Number) }),
+    );
   });
 
   it("requests the latest 40 Featured skills and preserves editorial order", async () => {
@@ -198,6 +254,29 @@ describe("homeListingData", () => {
     );
     expect(fetchPluginCatalogMock).not.toHaveBeenCalled();
     expect(result.hasMore).toBe(false);
+  });
+
+  it("falls back to the legacy plugin catalog and applies the creation cutoff locally", async () => {
+    const now = Date.now();
+    const recent = makePlugin("recent", now - 1_000, now - 100);
+    const old = makePlugin("old", now - HOME_NEW_WINDOW_MS - 1, now - 200);
+    fetchCatalogDiscoveryCapabilitiesMock.mockResolvedValue({
+      apiVersion: 0,
+      canonicalTrendingEnabled: false,
+    });
+    fetchPluginCatalogMock.mockResolvedValue({
+      items: [old, recent],
+      nextCursor: null,
+    });
+
+    await expect(fetchHomePluginListing("new", [], 20)).resolves.toEqual({
+      items: [recent],
+      hasMore: false,
+    });
+    expect(fetchPluginCatalogMock).toHaveBeenCalledWith(
+      expect.objectContaining({ sort: "updated", limit: 100 }),
+    );
+    expect(convexQueryMock).not.toHaveBeenCalled();
   });
 
   it("keeps the New plugin continuation after filling the visible window", async () => {

--- a/src/lib/homeListingData.test.ts
+++ b/src/lib/homeListingData.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const convexQueryMock = vi.fn();
 const fetchPluginCatalogMock = vi.fn();
+const fetchCatalogDiscoveryCapabilitiesMock = vi.fn();
 
 vi.mock("../convex/client", () => ({
   convexHttp: {
@@ -20,6 +21,11 @@ vi.mock("../../convex/_generated/api", () => ({
 
 vi.mock("./packageApi", () => ({
   fetchPluginCatalog: (...args: unknown[]) => fetchPluginCatalogMock(...args),
+}));
+
+vi.mock("./catalogDiscoveryCapabilities", () => ({
+  fetchCatalogDiscoveryCapabilities: (...args: unknown[]) =>
+    fetchCatalogDiscoveryCapabilitiesMock(...args),
 }));
 
 import {
@@ -42,6 +48,11 @@ describe("homeListingData", () => {
   beforeEach(() => {
     convexQueryMock.mockReset();
     fetchPluginCatalogMock.mockReset();
+    fetchCatalogDiscoveryCapabilitiesMock.mockReset();
+    fetchCatalogDiscoveryCapabilitiesMock.mockResolvedValue({
+      apiVersion: 1,
+      canonicalTrendingEnabled: true,
+    });
     convexQueryMock.mockResolvedValue({
       page: [
         {

--- a/src/lib/homeListingData.ts
+++ b/src/lib/homeListingData.ts
@@ -1,5 +1,6 @@
 import { api } from "../../convex/_generated/api";
 import { convexHttp } from "../convex/client";
+import { fetchCatalogDiscoveryCapabilities } from "./catalogDiscoveryCapabilities";
 import { getSkillCategoriesForSkill } from "./categories";
 import { fetchPluginCatalog, type PackageListItem } from "./packageApi";
 import type { PublicSkill, PublicUser } from "./publicUser";
@@ -51,6 +52,7 @@ export const HOME_LISTING_PAGE_SIZE = 20;
 export const HOME_NEW_WINDOW_MS = 14 * 24 * 60 * 60 * 1_000;
 
 const PLUGIN_CATALOG_PAGE_LIMIT = 100;
+const LEGACY_NEW_PLUGIN_MAX_REQUESTS = 10;
 // Featured is intentionally a finite editorial feed: the latest 40 badge-history rows.
 const FEATURED_SKILL_LIMIT = 40;
 
@@ -102,6 +104,18 @@ export async function fetchHomeSkillListing(
   signal?: AbortSignal,
 ) {
   if (tab === "trending") {
+    const capabilities = await fetchCatalogDiscoveryCapabilities();
+    if (!capabilities.canonicalTrendingEnabled) {
+      const result = await convexHttp.query(api.skills.listPublicTrendingPage, {
+        limit: numItems,
+        categorySlug: categorySlugs.length === 1 ? categorySlugs[0] : undefined,
+      });
+      const page = ((result as { items?: HomeNativeSkillListingEntry[] }).items ?? []).filter(
+        (entry) => skillMatchesAnyHomeCategory(entry.skill, categorySlugs),
+      );
+      return { page, hasMore: false };
+    }
+
     const items: HomeTrendingSkillListingEntry[] = [];
     let cursor: string | null = null;
     let hasMore = false;
@@ -123,6 +137,9 @@ export async function fetchHomeSkillListing(
 
   // highlightedOnly is a dedicated backend path ordered by skillBadges.by_kind_at;
   // the nominal sort below is ignored for Featured and never chooses its candidate set.
+  const capabilities =
+    tab === "new" ? await fetchCatalogDiscoveryCapabilities() : { apiVersion: 1 as const };
+  const newestCutoff = Date.now() - HOME_NEW_WINDOW_MS;
   const requestLimit = tab === "featured" ? FEATURED_SKILL_LIMIT : numItems;
   const categoriesToFetch = categorySlugs.length > 0 ? categorySlugs : [null];
   const results = await Promise.all(
@@ -139,16 +156,29 @@ export async function fetchHomeSkillListing(
           dir: "desc",
           highlightedOnly: tab === "featured" ? true : undefined,
           officialOnly: tab === "official" ? true : undefined,
-          createdAfter: tab === "new" ? Date.now() - HOME_NEW_WINDOW_MS : undefined,
+          ...(tab === "new" && capabilities.apiVersion >= 1 ? { createdAfter: newestCutoff } : {}),
           categorySlug: categorySlug ?? undefined,
         });
-        const resultPage = ((result as { page?: HomeNativeSkillListingEntry[] }).page ?? []).filter(
-          (entry) => skillMatchesAnyHomeCategory(entry.skill, categorySlugs),
+        const transportPage = (result as { page?: HomeNativeSkillListingEntry[] }).page ?? [];
+        const resultPage = transportPage.filter(
+          (entry) =>
+            skillMatchesAnyHomeCategory(entry.skill, categorySlugs) &&
+            (tab !== "new" ||
+              capabilities.apiVersion >= 1 ||
+              entry.skill.createdAt >= newestCutoff),
         );
         page.push(...resultPage);
 
         const nextCursor = (result as { nextCursor?: string | null }).nextCursor ?? null;
         hasMore = Boolean((result as { hasMore?: boolean }).hasMore ?? nextCursor);
+        if (
+          tab === "new" &&
+          capabilities.apiVersion === 0 &&
+          transportPage.some((entry) => entry.skill.createdAt < newestCutoff)
+        ) {
+          hasMore = false;
+          break;
+        }
         if (!nextCursor || nextCursor === cursor) break;
         cursor = nextCursor;
       }
@@ -188,6 +218,55 @@ export async function fetchHomePluginListing(
   const categoriesToFetch = categorySlugs.length > 0 ? categorySlugs : [null];
   const newestCutoff = Date.now() - HOME_NEW_WINDOW_MS;
   if (tab === "new") {
+    const capabilities = await fetchCatalogDiscoveryCapabilities();
+    if (capabilities.apiVersion === 0) {
+      const results = await Promise.all(
+        categoriesToFetch.map(async (categorySlug) => {
+          const items: PackageListItem[] = [];
+          let cursor: string | null | undefined;
+          let hasMore = false;
+          for (
+            let requestIndex = 0;
+            requestIndex < LEGACY_NEW_PLUGIN_MAX_REQUESTS && items.length < limit;
+            requestIndex += 1
+          ) {
+            const result = await fetchPluginCatalog({
+              category: categorySlug ?? undefined,
+              cursor: cursor ?? undefined,
+              sort: "updated",
+              limit: PLUGIN_CATALOG_PAGE_LIMIT,
+              signal,
+            });
+            const reachedCutoff = result.items.some((item) => item.updatedAt < newestCutoff);
+            items.push(
+              ...result.items.filter(
+                (item) =>
+                  item.createdAt >= newestCutoff && itemMatchesAnyHomeCategory(item, categorySlugs),
+              ),
+            );
+            hasMore = !reachedCutoff && result.nextCursor !== null;
+            if (
+              reachedCutoff ||
+              !result.nextCursor ||
+              result.nextCursor === cursor ||
+              items.length >= limit
+            ) {
+              break;
+            }
+            cursor = result.nextCursor;
+          }
+          return { items, hasMore };
+        }),
+      );
+      const items = uniqueHomePlugins(results.flatMap((result) => result.items)).sort(
+        (left, right) => right.createdAt - left.createdAt,
+      );
+      return {
+        items: items.slice(0, limit),
+        hasMore: items.length > limit || results.some((result) => result.hasMore),
+      };
+    }
+
     const results = await Promise.all(
       categoriesToFetch.map(async (categorySlug) => {
         const page: PackageListItem[] = [];

--- a/src/routes/skills/-useSkillsBrowseModel.ts
+++ b/src/routes/skills/-useSkillsBrowseModel.ts
@@ -3,6 +3,7 @@ import { useAction } from "convex/react";
 import { useCallback, useEffect, useMemo, useRef, useState, type RefObject } from "react";
 import { api } from "../../../convex/_generated/api";
 import { convexHttp } from "../../convex/client";
+import { fetchCatalogDiscoveryCapabilities } from "../../lib/catalogDiscoveryCapabilities";
 import {
   ALL_CATEGORY_KEYWORDS,
   getSkillCategoryBySlug,
@@ -174,18 +175,38 @@ export function useSkillsBrowseModel({
       let consecutiveEmptyPages = 0;
       try {
         if (catalogTab === "trending") {
-          const result = await fetchCanonicalTrendingPage({
-            cursor: pageCursor,
+          const capabilities = await fetchCatalogDiscoveryCapabilities();
+          if (capabilities.canonicalTrendingEnabled) {
+            const result = await fetchCanonicalTrendingPage({
+              cursor: pageCursor,
+              limit: pageSize,
+            });
+            if (generation !== fetchGeneration.current) return;
+            const entries = result.items.map((trending) => ({ trending }));
+            setListResults((prev) => (cursor ? [...prev, ...entries] : entries));
+            setListCursor(result.nextCursor);
+            setListAutoLoadPaused(false);
+            setListStatus(result.nextCursor ? "idle" : "done");
+            return;
+          }
+
+          const result = await convexHttp.query(api.skills.listPublicTrendingPage, {
             limit: pageSize,
+            categorySlug: activeCategory?.slug,
+            topic: activeTopic,
           });
           if (generation !== fetchGeneration.current) return;
-          const entries = result.items.map((trending) => ({ trending }));
-          setListResults((prev) => (cursor ? [...prev, ...entries] : entries));
-          setListCursor(result.nextCursor);
+          const entries = (result as { items: SkillListEntry[] }).items;
+          setListResults(entries);
+          setListCursor(null);
           setListAutoLoadPaused(false);
-          setListStatus(result.nextCursor ? "idle" : "done");
+          setListStatus("done");
           return;
         }
+        const capabilities =
+          catalogTab === "new"
+            ? await fetchCatalogDiscoveryCapabilities()
+            : { apiVersion: 1 as const };
         while (true) {
           const result = await convexHttp.query(api.skills.listPublicPageV4, {
             cursor: pageCursor ?? undefined,
@@ -194,7 +215,9 @@ export function useSkillsBrowseModel({
             dir,
             highlightedOnly: catalogTab === "featured" ? true : undefined,
             officialOnly: catalogTab === "official" ? true : undefined,
-            createdAfter: catalogTab === "new" ? newCutoff : undefined,
+            ...(catalogTab === "new" && capabilities.apiVersion >= 1
+              ? { createdAfter: newCutoff }
+              : {}),
             categorySlug: activeCategory?.slug,
             topic: activeTopic,
             ...(activeCategory && catalogTab !== "new" && catalogTab !== "official"
@@ -204,8 +227,17 @@ export function useSkillsBrowseModel({
             excludeCategoryKeywords,
           });
           if (generation !== fetchGeneration.current) return;
+          const visiblePage =
+            catalogTab === "new" && capabilities.apiVersion === 0
+              ? result.page.filter((entry) => entry.skill.createdAt >= newCutoff)
+              : result.page;
+          const reachedLegacyNewCutoff =
+            catalogTab === "new" &&
+            capabilities.apiVersion === 0 &&
+            result.page.some((entry) => entry.skill.createdAt < newCutoff);
           const nextCursor =
             catalogTab !== "featured" &&
+            !reachedLegacyNewCutoff &&
             result.hasMore &&
             result.nextCursor != null &&
             result.nextCursor !== pageCursor
@@ -213,7 +245,7 @@ export function useSkillsBrowseModel({
               : null;
 
           // Filtered scans can yield empty transport pages before reaching visible results.
-          if (result.page.length === 0 && nextCursor) {
+          if (visiblePage.length === 0 && nextCursor) {
             consecutiveEmptyPages += 1;
             if (consecutiveEmptyPages < maxConsecutiveEmptyPagesPerFetch) {
               pageCursor = nextCursor;
@@ -221,9 +253,9 @@ export function useSkillsBrowseModel({
             }
           }
 
-          setListResults((prev) => (cursor ? [...prev, ...result.page] : result.page));
+          setListResults((prev) => (cursor ? [...prev, ...visiblePage] : visiblePage));
           setListCursor(nextCursor);
-          setListAutoLoadPaused(result.page.length === 0 && Boolean(nextCursor));
+          setListAutoLoadPaused(visiblePage.length === 0 && Boolean(nextCursor));
           setListStatus(nextCursor ? "idle" : "done");
           return;
         }


### PR DESCRIPTION
## Summary

- advertise the catalog discovery API version through the existing public rollout capabilities query
- fall back to the legacy Trending and New query contracts when the frontend reaches an older Convex deployment
- preserve the 14-day New window client-side for legacy skill and plugin feeds

## Linked Issue

Closes #3272

## Screenshots / Recordings

N/A — this changes data loading behavior without changing the layout.

## Behavioural Proof

Connected the local frontend to the current production Convex deployment, which still reports the legacy capabilities shape (`apiVersion: 0`, canonical Trending disabled):

- homepage Trending rendered the legacy leaderboard, starting with `sonoscli`, `gog`, and `github`
- homepage New rendered recent skills, starting with `activity-planner`
- `/skills?tab=trending` rendered the legacy leaderboard
- `/skills?tab=new` rendered recent skills
- no `Listings took a coffee break` error appeared

## Security / Trust Impact

No security or trust policy changes. All fallback queries are existing public catalog reads.

## Data / Deploy Impact

- no migration, backfill, environment variable, or rollout-mode change
- `catalogDiscovery.apiVersion` is an additive field on the existing public capabilities response
- frontend-first and backend-first deploy orders are both supported

## Verification

- `bun run ci:static`
- `bun run ci:unit` (431 files passed, 5594 tests passed, 2 skipped)
- `bunx tsc --noEmit`
- focused catalog tests (59 passed)
- live production-backend function and browser validation
