### PR TITLE
fix(home): contain app category scroller on mobile

### DIFF
--- a/src/__tests__/ui-design-contract.test.ts
+++ b/src/__tests__/ui-design-contract.test.ts
@@ -19,8 +19,7 @@ function cssRule(css: string, selector: string) {
 function cssMediaContaining(css: string, query: string, required: readonly string[]) {
   let start = css.indexOf(`@media ${query}`);
   while (start >= 0) {
-    const nextMedia = css.indexOf("@media ", start + 1);
-    const block = css.slice(start, nextMedia === -1 ? undefined : nextMedia);
+    const block = balancedCssBlock(css, start, `@media ${query}`);
     if (required.every((snippet) => block.includes(snippet))) return block;
     start = css.indexOf(`@media ${query}`, start + 1);
   }
@@ -34,6 +33,22 @@ function cssBlock(css: string, selector: string) {
   const end = css.indexOf("\n}", start);
   expect(end, `Unclosed CSS block for ${selector}`).toBeGreaterThan(start);
   return css.slice(start, end + 2);
+}
+
+function balancedCssBlock(css: string, start: number, label: string) {
+  const open = css.indexOf("{", start);
+  expect(open, `Missing opening brace for ${label}`).toBeGreaterThanOrEqual(0);
+
+  let depth = 0;
+  for (let index = open; index < css.length; index += 1) {
+    if (css[index] === "{") depth += 1;
+    if (css[index] !== "}") continue;
+
+    depth -= 1;
+    if (depth === 0) return css.slice(start, index + 1);
+  }
+
+  throw new Error(`Unclosed CSS block for ${label}`);
 }
 
 function tokenValue(css: string, selector: string, token: string) {
@@ -386,13 +401,15 @@ describe("restored UI design contract", () => {
   });
 
   it("keeps the mobile app-category scroller within the page width", () => {
-    const css = styles();
-
-    cssMediaContaining(css, "(max-width: 760px)", [
-      ".home-v2-apps-categories {\n    width: 100%;",
-      "min-width: 0;",
-      "overflow-x: auto;",
+    const mobileBlock = cssMediaContaining(styles(), "(max-width: 760px)", [
+      ".home-v2-apps-categories {",
     ]);
+    const scroller = mobileBlock.match(/\.home-v2-apps-categories \{([^}]*)\}/)?.[1];
+
+    expect(scroller, "Missing .home-v2-apps-categories rule").toBeTruthy();
+    expect(scroller).toMatch(/width:\s*100%/);
+    expect(scroller).toMatch(/min-width:\s*0/);
+    expect(scroller).toMatch(/overflow-x:\s*auto/);
   });
 
   it("requires the restored footer columns and mobile section toggles", () => {

--- a/src/__tests__/ui-design-contract.test.ts
+++ b/src/__tests__/ui-design-contract.test.ts
@@ -385,6 +385,16 @@ describe("restored UI design contract", () => {
     expect(cssRule(css, ".home-v2-listing-row::before")).toContain("border-radius: 0");
   });
 
+  it("keeps the mobile app-category scroller within the page width", () => {
+    const css = styles();
+
+    cssMediaContaining(css, "(max-width: 760px)", [
+      ".home-v2-apps-categories {\n    width: 100%;",
+      "min-width: 0;",
+      "overflow-x: auto;",
+    ]);
+  });
+
   it("requires the restored footer columns and mobile section toggles", () => {
     const footerSource = footer();
     const navSource = navItems();

--- a/src/styles.css
+++ b/src/styles.css
@@ -27851,6 +27851,8 @@ a.home-v2-apps-see-all:focus-visible svg {
   }
 
   .home-v2-apps-categories {
+    width: 100%;
+    min-width: 0;
     flex-wrap: nowrap;
     overflow-x: auto;
     overflow-y: hidden;


### PR DESCRIPTION
## Summary

- constrain the mobile app-category strip to the available content width while preserving its internal horizontal scroll
- add a focused CSS contract regression test scoped to the exact mobile rule
- preserve the deliberate Skills Trending behavior from #3270: categories remain available on New, Featured, and Official, but not on the canonical Trending feed

## Root cause

The category strip keeps its desktop `width: fit-content` after becoming a horizontal scroller on mobile. At a 375 px page width, that makes the strip 449 px wide and expands the document to 469 px.

In this PR, the strip is proposed to fill its 335 px content area while its 493 px of category tabs remain scrollable inside it.

## Validation

- `bunx vitest run src/__tests__/ui-design-contract.test.ts` (18 passed)
- mutation check: removing `min-width: 0` fails the scoped contract on that declaration
- `bun run ci:static`
- `bun run ci:unit` (5,878 passed, 2 skipped)
- autoreview: no accepted/actionable findings
- real-browser mobile check at a 390 × 844 viewport: document width 469 px before, 375 px in this PR

## UI proof

See the [published before/after screenshots](https://github.com/openclaw/clawhub/pull/3281#issuecomment-5095721395).
