### PR TITLE
fix(catalog): show Official skills during backend rollout

### DIFF
--- a/convex/rolloutCapabilities.test.ts
+++ b/convex/rolloutCapabilities.test.ts
@@ -31,7 +31,7 @@ describe("getPublicCapabilitiesHandler", () => {
     await expect(getPublicCapabilitiesHandler({ db } as never, {})).resolves.toEqual({
       environment: "unknown",
       catalogDiscovery: {
-        apiVersion: 1,
+        apiVersion: 2,
       },
       skillsSh: {
         mode: "off",
@@ -70,7 +70,7 @@ describe("getPublicCapabilitiesHandler", () => {
     ).resolves.toEqual({
       environment: "test",
       catalogDiscovery: {
-        apiVersion: 1,
+        apiVersion: 2,
       },
       skillsSh: {
         mode: "test",

--- a/convex/rolloutCapabilities.ts
+++ b/convex/rolloutCapabilities.ts
@@ -21,7 +21,7 @@ export async function getPublicCapabilitiesHandler(
   return {
     environment: runtime.environment,
     catalogDiscovery: {
-      apiVersion: 1,
+      apiVersion: 2,
     },
     skillsSh: {
       mode: runtime.skillsSh.mode,

--- a/convex/skills.publicListCursor.test.ts
+++ b/convex/skills.publicListCursor.test.ts
@@ -304,6 +304,52 @@ describe("public skill list deterministic cursors", () => {
     );
   });
 
+  it("includes skills owned by official publishers in the Official feed", async () => {
+    const officialPublisherSkill = makeSearchDigest({
+      skillId: "skills:publisher-official",
+      slug: "publisher-official",
+      ownerPublisherId: "publishers:openclaw",
+      ownerHandle: "openclaw",
+      ownerKind: "org",
+      ownerName: undefined,
+      ownerDisplayName: "OpenClaw",
+    });
+    const communitySkill = makeSearchDigest({
+      skillId: "skills:community",
+      slug: "community",
+    });
+    getPageMock.mockResolvedValueOnce({
+      page: [officialPublisherSkill, communitySkill],
+      hasMore: false,
+      indexKeys: [
+        [undefined, officialPublisherSkill.createdAt, officialPublisherSkill._id],
+        [undefined, communitySkill.createdAt, communitySkill._id],
+      ],
+    });
+
+    const result = await listPublicPageV4Handler(
+      {
+        db: {
+          query: vi.fn((table: string) => {
+            if (table !== "officialPublishers") {
+              throw new Error(`Unexpected table: ${table}`);
+            }
+            return {
+              withIndex: vi.fn(() => ({
+                unique: vi.fn().mockResolvedValue({ publisherId: "publishers:openclaw" }),
+              })),
+            };
+          }),
+        },
+      } as never,
+      { officialOnly: true, sort: "newest", numItems: 10 },
+    );
+
+    expect(
+      (result.page as Array<{ skill: { slug: string } }>).map((entry) => entry.skill.slug),
+    ).toEqual(["publisher-official"]);
+  });
+
   it("applies Official and New eligibility at the backend cursor boundary", async () => {
     const officialNew = makeSearchDigest({
       skillId: "skills:official-new",

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -5606,6 +5606,7 @@ export const listPublicPageV4 = query({
       numItems,
       Math.min(MAX_FILTERED_PUBLIC_LIST_SCAN_ROWS, numItems * 12),
     );
+    const officialPublisherCache = new Map<string, boolean>();
 
     for (let pageCount = 0; pageCount < MAX_FILTERED_PUBLIC_LIST_SCAN_PAGES; pageCount += 1) {
       if (remainingRows <= 0) break;
@@ -5639,19 +5640,23 @@ export const listPublicPageV4 = query({
         ) {
           return { page: items, hasMore: false, nextCursor: null };
         }
-        if (
-          (!args.officialOnly || isSkillCatalogOfficial(digest)) &&
+        const passesFilters =
           (typeof args.createdAfter !== "number" || digest.createdAt >= args.createdAfter) &&
           digestPassesPublicListFilters(digest, {
             categorySlug,
             topic,
             categoryKeywords,
             excludeCategoryKeywords,
-          })
+          });
+        if (!passesFilters) continue;
+        if (
+          args.officialOnly &&
+          !(await isOfficialSkillBrowseDigest(ctx, digest, officialPublisherCache))
         ) {
-          const item = await buildPublicSkillEntryFromDigest(ctx, digest);
-          if (item) items.push(item);
+          continue;
         }
+        const item = await buildPublicSkillEntryFromDigest(ctx, digest);
+        if (item) items.push(item);
         if (items.length >= numItems) {
           const nextDigest = result.page[index + 1];
           if (
@@ -6399,6 +6404,21 @@ function decodeSkillCatalogCursor(raw: string | null | undefined): SkillCatalogC
 
 function isSkillCatalogOfficial(digest: Doc<"skillSearchDigest">) {
   return Boolean(digest.badges?.official);
+}
+
+async function isOfficialSkillBrowseDigest(
+  ctx: Pick<QueryCtx, "db">,
+  digest: Doc<"skillSearchDigest">,
+  publisherCache: Map<string, boolean>,
+) {
+  if (isSkillCatalogOfficial(digest)) return true;
+  if (!digest.ownerPublisherId) return false;
+  const publisherId = String(digest.ownerPublisherId);
+  const cached = publisherCache.get(publisherId);
+  if (cached !== undefined) return cached;
+  const official = await hasOfficialPublisherRow(ctx, digest.ownerPublisherId);
+  publisherCache.set(publisherId, official);
+  return official;
 }
 
 function isCuratedSkillDigest(digest: Pick<Doc<"skillSearchDigest">, "badges">) {

--- a/src/__tests__/home-listing-section.claw591.test.tsx
+++ b/src/__tests__/home-listing-section.claw591.test.tsx
@@ -69,7 +69,7 @@ describe("HomeListingSection", () => {
     fetchCanonicalTrendingPageMock.mockReset();
     fetchCatalogDiscoveryCapabilitiesMock.mockReset();
     fetchCatalogDiscoveryCapabilitiesMock.mockResolvedValue({
-      apiVersion: 1,
+      apiVersion: 2,
       canonicalTrendingEnabled: true,
     });
     convexQueryMock.mockResolvedValue({ page: [], hasMore: false, nextCursor: null });

--- a/src/__tests__/home-listing-section.test.tsx
+++ b/src/__tests__/home-listing-section.test.tsx
@@ -101,7 +101,7 @@ describe("HomeListingSection", () => {
     fetchPluginCatalogMock.mockReset();
     fetchCatalogDiscoveryCapabilitiesMock.mockReset();
     fetchCatalogDiscoveryCapabilitiesMock.mockResolvedValue({
-      apiVersion: 1,
+      apiVersion: 2,
       canonicalTrendingEnabled: true,
     });
     convexQueryMock.mockResolvedValue({

--- a/src/__tests__/skills-index-load-more.test.tsx
+++ b/src/__tests__/skills-index-load-more.test.tsx
@@ -62,7 +62,7 @@ describe("SkillsIndex load-more observer", () => {
     fetchCanonicalTrendingPageMock.mockReset();
     fetchCatalogDiscoveryCapabilitiesMock.mockReset();
     fetchCatalogDiscoveryCapabilitiesMock.mockResolvedValue({
-      apiVersion: 1,
+      apiVersion: 2,
       canonicalTrendingEnabled: true,
     });
   });

--- a/src/__tests__/skills-index.claw591.test.tsx
+++ b/src/__tests__/skills-index.claw591.test.tsx
@@ -68,7 +68,7 @@ describe("SkillsIndex", () => {
     fetchCanonicalTrendingPageMock.mockResolvedValue(canonicalPage([]));
     fetchCatalogDiscoveryCapabilitiesMock.mockReset();
     fetchCatalogDiscoveryCapabilitiesMock.mockResolvedValue({
-      apiVersion: 1,
+      apiVersion: 2,
       canonicalTrendingEnabled: true,
     });
   });
@@ -172,9 +172,9 @@ describe("SkillsIndex", () => {
         dir: "desc",
         numItems: 20,
         highlightedOnly: undefined,
-        officialOnly: undefined,
       }),
     );
+    expect(args).not.toHaveProperty("officialOnly");
     expect(typeof args.createdAfter).toBe("number");
     expect(Date.now() - Number(args.createdAfter)).toBeLessThanOrEqual(
       14 * 24 * 60 * 60 * 1000 + 1000,
@@ -241,6 +241,54 @@ describe("SkillsIndex", () => {
       }),
     );
     expect(getLastListPageArgs()).not.toHaveProperty("officialFirst");
+  });
+
+  it("scans legacy pages for official publishers without sending officialOnly", async () => {
+    searchMock = { tab: "official" };
+    fetchCatalogDiscoveryCapabilitiesMock.mockResolvedValue({
+      apiVersion: 0,
+      canonicalTrendingEnabled: false,
+    });
+    const official = {
+      ...makeListResult("official-skill", "Official Skill"),
+      ownerHandle: "sdk-team",
+      owner: { handle: "sdk-team", official: true },
+    };
+    const legacyPages = [
+      {
+        page: [makeListResult("community-1", "Community 1")],
+        hasMore: true,
+        nextCursor: "cursor-1",
+      },
+      {
+        page: [makeListResult("community-2", "Community 2")],
+        hasMore: true,
+        nextCursor: "cursor-2",
+      },
+      {
+        page: [makeListResult("community-3", "Community 3")],
+        hasMore: true,
+        nextCursor: "cursor-3",
+      },
+      { page: [official], hasMore: false, nextCursor: null },
+    ];
+    convexHttpMock.query.mockImplementation(
+      async (_functionReference: unknown, args: Record<string, unknown>) => {
+        if ("officialOnly" in args) {
+          throw new Error("Object contains extra field `officialOnly`");
+        }
+        return legacyPages.shift();
+      },
+    );
+
+    render(<SkillsIndex />);
+
+    expect(await screen.findByText("Official Skill")).toBeTruthy();
+    expect(screen.queryByText("Community 1")).toBeNull();
+    expect(convexHttpMock.query).toHaveBeenCalledTimes(4);
+    for (const [, args] of convexHttpMock.query.mock.calls) {
+      expect(args).not.toHaveProperty("officialOnly");
+    }
   });
 
   it("shows category navigation outside Trending and sends the selected category", async () => {

--- a/src/__tests__/skills-index.test.tsx
+++ b/src/__tests__/skills-index.test.tsx
@@ -57,7 +57,7 @@ describe("SkillsIndex", () => {
     setupDefaultConvexReactMocks();
     fetchCatalogDiscoveryCapabilitiesMock.mockReset();
     fetchCatalogDiscoveryCapabilitiesMock.mockResolvedValue({
-      apiVersion: 1,
+      apiVersion: 2,
       canonicalTrendingEnabled: true,
     });
   });

--- a/src/lib/badges.ts
+++ b/src/lib/badges.ts
@@ -5,6 +5,7 @@ type BadgeKind = Doc<"skillBadges">["kind"];
 type SkillBadgeMap = Partial<Record<BadgeKind, { byUserId: Id<"users">; at: number }>>;
 
 type SkillLike = { badges?: SkillBadgeMap | null };
+type SkillOwnerLike = object | null | undefined;
 
 type BadgeLabel = "Deprecated" | "Official";
 
@@ -14,6 +15,13 @@ export function isSkillHighlighted(skill: SkillLike) {
 
 export function isSkillOfficial(skill: SkillLike) {
   return Boolean(skill.badges?.official);
+}
+
+export function isOfficialSkillListing(skill: SkillLike, owner?: SkillOwnerLike) {
+  return (
+    isSkillOfficial(skill) ||
+    (owner !== null && owner !== undefined && "official" in owner && owner.official === true)
+  );
 }
 
 export function isSkillDeprecated(skill: SkillLike) {

--- a/src/lib/catalogDiscoveryCapabilities.test.ts
+++ b/src/lib/catalogDiscoveryCapabilities.test.ts
@@ -23,17 +23,29 @@ describe("fetchCatalogDiscoveryCapabilities", () => {
 
   it("enables canonical discovery only when the backend advertises it", async () => {
     convexQueryMock.mockResolvedValue({
-      catalogDiscovery: { apiVersion: 1 },
+      catalogDiscovery: { apiVersion: 2 },
       skillsSh: { runtimeEnabled: true },
     });
 
     await expect(fetchCatalogDiscoveryCapabilities()).resolves.toEqual({
-      apiVersion: 1,
+      apiVersion: 2,
       canonicalTrendingEnabled: true,
     });
   });
 
-  it("treats the previous response shape as a legacy backend", async () => {
+  it("preserves the previous catalog discovery contract version", async () => {
+    convexQueryMock.mockResolvedValue({
+      catalogDiscovery: { apiVersion: 1 },
+      skillsSh: { runtimeEnabled: false },
+    });
+
+    await expect(fetchCatalogDiscoveryCapabilities()).resolves.toEqual({
+      apiVersion: 1,
+      canonicalTrendingEnabled: false,
+    });
+  });
+
+  it("treats a response without catalog discovery capabilities as legacy", async () => {
     convexQueryMock.mockResolvedValue({
       skillsSh: { runtimeEnabled: false },
     });

--- a/src/lib/catalogDiscoveryCapabilities.ts
+++ b/src/lib/catalogDiscoveryCapabilities.ts
@@ -2,7 +2,7 @@ import { api } from "../../convex/_generated/api";
 import { convexHttp } from "../convex/client";
 
 type CatalogDiscoveryCapabilities = {
-  apiVersion: 0 | 1;
+  apiVersion: 0 | 1 | 2;
   canonicalTrendingEnabled: boolean;
 };
 
@@ -21,7 +21,12 @@ export async function fetchCatalogDiscoveryCapabilities(): Promise<CatalogDiscov
       skillsSh?: { runtimeEnabled?: unknown };
     };
     return {
-      apiVersion: response.catalogDiscovery?.apiVersion === 1 ? 1 : 0,
+      apiVersion:
+        response.catalogDiscovery?.apiVersion === 2
+          ? 2
+          : response.catalogDiscovery?.apiVersion === 1
+            ? 1
+            : 0,
       canonicalTrendingEnabled: response.skillsSh?.runtimeEnabled === true,
     };
   } catch {

--- a/src/lib/homeListingData.claw591.test.ts
+++ b/src/lib/homeListingData.claw591.test.ts
@@ -51,7 +51,7 @@ describe("homeListingData", () => {
     fetchCanonicalTrendingPageMock.mockReset();
     fetchCatalogDiscoveryCapabilitiesMock.mockReset();
     fetchCatalogDiscoveryCapabilitiesMock.mockResolvedValue({
-      apiVersion: 1,
+      apiVersion: 2,
       canonicalTrendingEnabled: true,
     });
     convexQueryMock.mockResolvedValue({ page: [], hasMore: false, nextCursor: null });
@@ -196,6 +196,52 @@ describe("homeListingData", () => {
       "skills:listPublicPageV4",
       expect.objectContaining({ officialOnly: true, sort: "newest" }),
     );
+  });
+
+  it("filters legacy Official pages by publisher status without the new argument", async () => {
+    fetchCatalogDiscoveryCapabilitiesMock.mockResolvedValue({
+      apiVersion: 1,
+      canonicalTrendingEnabled: false,
+    });
+    const official = {
+      ...makeNative("official-skill", 1, 0),
+      owner: { handle: "sdk-team", official: true },
+    };
+    const legacyPages = [
+      {
+        page: [makeNative("community-1", 4, 0)],
+        hasMore: true,
+        nextCursor: "cursor-1",
+      },
+      {
+        page: [makeNative("community-2", 3, 0)],
+        hasMore: true,
+        nextCursor: "cursor-2",
+      },
+      {
+        page: [makeNative("community-3", 2, 0)],
+        hasMore: true,
+        nextCursor: "cursor-3",
+      },
+      { page: [official], hasMore: false, nextCursor: null },
+    ];
+    convexQueryMock.mockImplementation(
+      async (_functionReference: unknown, args: Record<string, unknown>) => {
+        if ("officialOnly" in args) {
+          throw new Error("Object contains extra field `officialOnly`");
+        }
+        return legacyPages.shift();
+      },
+    );
+
+    await expect(fetchHomeSkillListing("official", [], HOME_LISTING_PAGE_SIZE)).resolves.toEqual({
+      page: [official],
+      hasMore: false,
+    });
+    expect(convexQueryMock).toHaveBeenCalledTimes(4);
+    for (const [, args] of convexQueryMock.mock.calls) {
+      expect(args).not.toHaveProperty("officialOnly");
+    }
   });
 
   it("keeps plugins out of Trending and supports New, Featured, and Official", async () => {

--- a/src/lib/homeListingData.test.ts
+++ b/src/lib/homeListingData.test.ts
@@ -50,7 +50,7 @@ describe("homeListingData", () => {
     fetchPluginCatalogMock.mockReset();
     fetchCatalogDiscoveryCapabilitiesMock.mockReset();
     fetchCatalogDiscoveryCapabilitiesMock.mockResolvedValue({
-      apiVersion: 1,
+      apiVersion: 2,
       canonicalTrendingEnabled: true,
     });
     convexQueryMock.mockResolvedValue({

--- a/src/lib/homeListingData.ts
+++ b/src/lib/homeListingData.ts
@@ -1,5 +1,6 @@
 import { api } from "../../convex/_generated/api";
 import { convexHttp } from "../convex/client";
+import { isOfficialSkillListing } from "./badges";
 import { fetchCatalogDiscoveryCapabilities } from "./catalogDiscoveryCapabilities";
 import { getSkillCategoriesForSkill } from "./categories";
 import { fetchPluginCatalog, type PackageListItem } from "./packageApi";
@@ -53,6 +54,7 @@ export const HOME_NEW_WINDOW_MS = 14 * 24 * 60 * 60 * 1_000;
 
 const PLUGIN_CATALOG_PAGE_LIMIT = 100;
 const LEGACY_NEW_PLUGIN_MAX_REQUESTS = 10;
+const LEGACY_OFFICIAL_SKILL_MAX_REQUESTS = 10;
 // Featured is intentionally a finite editorial feed: the latest 40 badge-history rows.
 const FEATURED_SKILL_LIMIT = 40;
 
@@ -138,7 +140,10 @@ export async function fetchHomeSkillListing(
   // highlightedOnly is a dedicated backend path ordered by skillBadges.by_kind_at;
   // the nominal sort below is ignored for Featured and never chooses its candidate set.
   const capabilities =
-    tab === "new" ? await fetchCatalogDiscoveryCapabilities() : { apiVersion: 1 as const };
+    tab === "new" || tab === "official"
+      ? await fetchCatalogDiscoveryCapabilities()
+      : { apiVersion: 2 as const };
+  const useBackendOfficialFilter = tab === "official" && capabilities.apiVersion >= 2;
   const newestCutoff = Date.now() - HOME_NEW_WINDOW_MS;
   const requestLimit = tab === "featured" ? FEATURED_SKILL_LIMIT : numItems;
   const categoriesToFetch = categorySlugs.length > 0 ? categorySlugs : [null];
@@ -147,15 +152,21 @@ export async function fetchHomeSkillListing(
       const page: HomeNativeSkillListingEntry[] = [];
       let cursor: string | null | undefined;
       let hasMore = false;
+      const maxRequests =
+        tab === "official" && !useBackendOfficialFilter
+          ? LEGACY_OFFICIAL_SKILL_MAX_REQUESTS
+          : Number.POSITIVE_INFINITY;
 
-      while (page.length < requestLimit) {
+      let requestCount = 0;
+      while (page.length < requestLimit && requestCount < maxRequests) {
+        requestCount += 1;
         const result = await convexHttp.query(api.skills.listPublicPageV4, {
           cursor: cursor ?? undefined,
           numItems: requestLimit - page.length,
           sort: tab === "new" || tab === "official" ? "newest" : "updated",
           dir: "desc",
           highlightedOnly: tab === "featured" ? true : undefined,
-          officialOnly: tab === "official" ? true : undefined,
+          ...(useBackendOfficialFilter ? { officialOnly: true } : {}),
           ...(tab === "new" && capabilities.apiVersion >= 1 ? { createdAfter: newestCutoff } : {}),
           categorySlug: categorySlug ?? undefined,
         });
@@ -163,6 +174,9 @@ export async function fetchHomeSkillListing(
         const resultPage = transportPage.filter(
           (entry) =>
             skillMatchesAnyHomeCategory(entry.skill, categorySlugs) &&
+            (tab !== "official" ||
+              useBackendOfficialFilter ||
+              isOfficialSkillListing(entry.skill, entry.owner)) &&
             (tab !== "new" ||
               capabilities.apiVersion >= 1 ||
               entry.skill.createdAt >= newestCutoff),

--- a/src/routes/skills/-useSkillsBrowseModel.ts
+++ b/src/routes/skills/-useSkillsBrowseModel.ts
@@ -3,6 +3,7 @@ import { useAction } from "convex/react";
 import { useCallback, useEffect, useMemo, useRef, useState, type RefObject } from "react";
 import { api } from "../../../convex/_generated/api";
 import { convexHttp } from "../../convex/client";
+import { isOfficialSkillListing } from "../../lib/badges";
 import { fetchCatalogDiscoveryCapabilities } from "../../lib/catalogDiscoveryCapabilities";
 import {
   ALL_CATEGORY_KEYWORDS,
@@ -22,6 +23,7 @@ const pageSize = 20;
 const featuredPageSize = 40;
 const newWindowMs = 14 * 24 * 60 * 60 * 1_000;
 const maxConsecutiveEmptyPagesPerFetch = 3;
+const legacyOfficialMaxRequestsPerFetch = 10;
 
 function isNavigationAbortError(err: unknown) {
   if (!(err instanceof Error)) return false;
@@ -204,17 +206,21 @@ export function useSkillsBrowseModel({
           return;
         }
         const capabilities =
-          catalogTab === "new"
+          catalogTab === "new" || catalogTab === "official"
             ? await fetchCatalogDiscoveryCapabilities()
-            : { apiVersion: 1 as const };
+            : { apiVersion: 2 as const };
+        const useBackendOfficialFilter = catalogTab === "official" && capabilities.apiVersion >= 2;
+        const legacyOfficialResults: SkillListEntry[] = [];
+        let legacyOfficialRequestCount = 0;
         while (true) {
+          legacyOfficialRequestCount += 1;
           const result = await convexHttp.query(api.skills.listPublicPageV4, {
             cursor: pageCursor ?? undefined,
             numItems: catalogTab === "featured" ? featuredPageSize : pageSize,
             ...(listSort ? { sort: listSort } : {}),
             dir,
             highlightedOnly: catalogTab === "featured" ? true : undefined,
-            officialOnly: catalogTab === "official" ? true : undefined,
+            ...(useBackendOfficialFilter ? { officialOnly: true } : {}),
             ...(catalogTab === "new" && capabilities.apiVersion >= 1
               ? { createdAfter: newCutoff }
               : {}),
@@ -227,10 +233,15 @@ export function useSkillsBrowseModel({
             excludeCategoryKeywords,
           });
           if (generation !== fetchGeneration.current) return;
-          const visiblePage =
-            catalogTab === "new" && capabilities.apiVersion === 0
-              ? result.page.filter((entry) => entry.skill.createdAt >= newCutoff)
-              : result.page;
+          const visiblePage = result.page.filter(
+            (entry) =>
+              (catalogTab !== "new" ||
+                capabilities.apiVersion >= 1 ||
+                entry.skill.createdAt >= newCutoff) &&
+              (catalogTab !== "official" ||
+                useBackendOfficialFilter ||
+                isOfficialSkillListing(entry.skill, entry.owner)),
+          );
           const reachedLegacyNewCutoff =
             catalogTab === "new" &&
             capabilities.apiVersion === 0 &&
@@ -243,6 +254,26 @@ export function useSkillsBrowseModel({
             result.nextCursor !== pageCursor
               ? result.nextCursor
               : null;
+
+          if (catalogTab === "official" && !useBackendOfficialFilter) {
+            legacyOfficialResults.push(...visiblePage);
+            if (
+              nextCursor &&
+              legacyOfficialResults.length < pageSize &&
+              legacyOfficialRequestCount < legacyOfficialMaxRequestsPerFetch
+            ) {
+              pageCursor = nextCursor;
+              continue;
+            }
+
+            setListResults((prev) =>
+              cursor ? [...prev, ...legacyOfficialResults] : legacyOfficialResults,
+            );
+            setListCursor(nextCursor);
+            setListAutoLoadPaused(legacyOfficialResults.length === 0 && Boolean(nextCursor));
+            setListStatus(nextCursor ? "idle" : "done");
+            return;
+          }
 
           // Filtered scans can yield empty transport pages before reaching visible results.
           if (visiblePage.length === 0 && nextCursor) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users opening the Official skills feed would see an empty
state while the frontend and Convex backend were on different catalog rollout
versions.

## Why This Change Was Made

In this PR, the frontend checks the catalog capability before sending the new
Official filter and falls back to a bounded client-side scan for older backends.
The v2 backend treats both skill badges and verified publisher ownership as
Official.

## User Impact

Users can browse Official skills during staggered frontend/backend deploys, and
skills published by verified official organizations appear in the feed.

## Evidence

- Production reproduction in a 390 × 844 browser viewport: the selected Official
  feed renders `No skills found`.
- Candidate proof on a real local ClawHub instance with a legacy rollout backend:
  the Official feed renders the deterministic `@catalog-atlas` fixture.
- `bunx vitest run convex/rolloutCapabilities.test.ts convex/skills.publicListCursor.test.ts src/lib/catalogDiscoveryCapabilities.test.ts src/__tests__/skills-index.claw591.test.tsx src/lib/homeListingData.claw591.test.ts` — 77 passed.
- `bun run ci:static`
- `bun run ci:unit` — 5,598 passed, 2 skipped.
- `bun run ci:types-build`
- `.agents/skills/autoreview/scripts/autoreview --mode local --codex-bin /Applications/ChatGPT.app/Contents/Resources/codex` — no accepted/actionable findings.

| Production: Official feed is empty | Candidate: official publisher skill is visible |
| --- | --- |
| <img src="https://raw.githubusercontent.com/openclaw/clawhub/qa-artifacts/clawhub-ui-proof/pr-3283/2026-07-27-official-skills-mobile/baseline/official-skills-mobile.png" width="390" alt="Production Official skills feed showing an empty state on mobile"> | <img src="https://raw.githubusercontent.com/openclaw/clawhub/qa-artifacts/clawhub-ui-proof/pr-3283/2026-07-27-official-skills-mobile/candidate/official-skills-mobile.png" width="390" alt="Candidate Official skills feed showing an official publisher skill on mobile"> |

[Raw proof files](https://github.com/openclaw/clawhub/tree/qa-artifacts/clawhub-ui-proof/pr-3283/2026-07-27-official-skills-mobile)
