### PR TITLE
feat: update skill and plugin publish form UI accessibility 

### DIFF
--- a/src/__tests__/plugins-publish-route.test.tsx
+++ b/src/__tests__/plugins-publish-route.test.tsx
@@ -539,7 +539,7 @@ describe("plugins publish route", () => {
 
     await waitFor(() => {
       expect(screen.getByRole("button", { name: "Categories" }).textContent).toContain("Tools");
-      expect(screen.getByRole("button", { name: "Remove GPU development topic" })).toBeTruthy();
+      expect(screen.getByRole("button", { name: "Remove GPU development keyword" })).toBeTruthy();
     });
 
     const packageJson = withRelativePath(
@@ -637,10 +637,10 @@ describe("plugins publish route", () => {
 
     await waitFor(() => {
       expect(screen.getByRole("button", { name: "Categories" }).textContent).toContain("Tools");
-      expect(screen.getByRole("button", { name: "Remove GPU development topic" })).toBeTruthy();
+      expect(screen.getByRole("button", { name: "Remove GPU development keyword" })).toBeTruthy();
     });
     selectCategory("Tools");
-    fireEvent.click(screen.getByRole("button", { name: "Remove GPU development topic" }));
+    fireEvent.click(screen.getByRole("button", { name: "Remove GPU development keyword" }));
     fireEvent.change(screen.getByPlaceholderText("Full commit SHA"), {
       target: { value: "abc123" },
     });
@@ -1128,6 +1128,7 @@ describe("plugins publish route", () => {
     expect(
       screen.getByRole("button", { name: "Publish plugin" }).getAttribute("disabled"),
     ).not.toBeNull();
+    expect(screen.queryByRole("heading", { name: "Plugin submitted" })).toBeNull();
   });
 
   it("shows a canonical submitted modal for an existing plugin uploaded from the generic route", async () => {

--- a/src/__tests__/skills-publish-route.test.tsx
+++ b/src/__tests__/skills-publish-route.test.tsx
@@ -108,6 +108,21 @@ describe("Upload route", () => {
     expect(guideLink.getAttribute("target")).toBe("_blank");
   });
 
+  it("marks license acceptance as required after selecting skill files", async () => {
+    render(<Upload />);
+
+    const file = new File(["---\nname: example\n---\n# Example"], "SKILL.md", {
+      type: "text/markdown",
+    });
+    fireEvent.change(screen.getByTestId("upload-input"), { target: { files: [file] } });
+
+    const licenseCheckbox = await screen.findByRole("checkbox", {
+      name: /i have the rights to publish this skill under mit-0.*required/i,
+    });
+    expect(licenseCheckbox.getAttribute("required")).not.toBeNull();
+    expect(licenseCheckbox.getAttribute("aria-required")).toBe("true");
+  });
+
   it("drops invalid legacy category metadata and offers explicit generation on republish", async () => {
     useSearchMock.mockReturnValue({ updateSlug: "uncategorized-skill" });
     useQueryMock.mockImplementation((fn: unknown, args: unknown) => {
@@ -132,7 +147,7 @@ describe("Upload route", () => {
 
     await waitFor(() => {
       expect(screen.getByText("0/3")).toBeTruthy();
-      expect(screen.getByRole("button", { name: "Generate categories" })).toBeTruthy();
+      expect(screen.getByRole("button", { name: "Suggestions for categories" })).toBeTruthy();
     });
   });
 
@@ -157,7 +172,7 @@ describe("Upload route", () => {
 
     render(<Upload />);
 
-    fireEvent.click(await screen.findByRole("button", { name: "Generate categories" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Suggestions for categories" }));
     expect(screen.getByRole("button", { name: "Categories" }).textContent).toContain("Automation");
   });
 
@@ -178,7 +193,7 @@ describe("Upload route", () => {
     fireEvent.change(screen.getByTestId("upload-input"), { target: { files: [file] } });
 
     await waitFor(() => {
-      fireEvent.click(screen.getByRole("button", { name: "Generate categories" }));
+      fireEvent.click(screen.getByRole("button", { name: "Suggestions for categories" }));
       expect(screen.getByRole("button", { name: "Categories" }).textContent).toContain(
         "Automation",
       );
@@ -342,7 +357,7 @@ describe("Upload route", () => {
       );
     });
     selectCategory("Development");
-    fireEvent.click(screen.getByRole("button", { name: "Remove GPU development topic" }));
+    fireEvent.click(screen.getByRole("button", { name: "Remove GPU development keyword" }));
 
     fireEvent.change(screen.getByPlaceholderText("Describe what changed in this skill..."), {
       target: { value: "Clear category override." },

--- a/src/components/CatalogMetadataFields.tsx
+++ b/src/components/CatalogMetadataFields.tsx
@@ -1,12 +1,13 @@
 import {
   CATALOG_CATEGORY_LIMIT,
+  CATALOG_TOPIC_LIMIT,
   INTERNAL_UNCATEGORIZED_CATEGORY,
   PLUGIN_CATEGORY_DEFINITIONS,
   SKILL_CATEGORY_DEFINITIONS,
 } from "clawhub-schema";
-import { ChevronDown, Sparkles } from "lucide-react";
+import { ChevronDown, Lightbulb, Sparkles } from "lucide-react";
 import { getCategoryIconComponent } from "../lib/categoryIcons";
-import { CatalogTopicInput } from "./CatalogTopicInput";
+import { CatalogTopicInput, parseCatalogTopicsInput } from "./CatalogTopicInput";
 import { Button } from "./ui/button";
 import {
   DropdownMenu,
@@ -21,6 +22,7 @@ export { formatCatalogTopicsInput, parseCatalogTopicsInput } from "./CatalogTopi
 type CatalogMetadataFieldsProps = {
   kind: "skill" | "plugin";
   idPrefix?: string;
+  presentation?: "default" | "publish";
   categories: string[];
   suggestedCategories?: string[];
   topics: string;
@@ -32,6 +34,7 @@ type CatalogMetadataFieldsProps = {
 export function CatalogMetadataFields({
   kind,
   idPrefix,
+  presentation = "default",
   categories: selectedCategories,
   suggestedCategories,
   topics,
@@ -39,9 +42,11 @@ export function CatalogMetadataFields({
   onCategoriesChange,
   onTopicsChange,
 }: CatalogMetadataFieldsProps) {
+  const isPublishPresentation = presentation === "publish";
   const categories = kind === "skill" ? SKILL_CATEGORY_DEFINITIONS : PLUGIN_CATEGORY_DEFINITIONS;
   const prefix = kind === "skill" ? "skill" : "plugin";
   const fieldIdPrefix = idPrefix ?? prefix;
+  const topicCountId = `${fieldIdPrefix}TopicsCount`;
   const selected = new Set(selectedCategories);
   const limitReached = selectedCategories.length >= CATALOG_CATEGORY_LIMIT;
   const selectedLabels = categories
@@ -79,15 +84,19 @@ export function CatalogMetadataFields({
           variant="ghost"
           size="xs"
           disabled={disabled}
-          aria-label="Generate categories"
+          aria-label={isPublishPresentation ? "Suggestions for categories" : "Generate categories"}
           onClick={() =>
             onCategoriesChange(
               generatedCategories.length ? generatedCategories : [INTERNAL_UNCATEGORIZED_CATEGORY],
             )
           }
         >
-          <Sparkles className="h-3.5 w-3.5" aria-hidden="true" />
-          Generate
+          {isPublishPresentation ? (
+            <Lightbulb className="h-3.5 w-3.5" aria-hidden="true" />
+          ) : (
+            <Sparkles className="h-3.5 w-3.5" aria-hidden="true" />
+          )}
+          {isPublishPresentation ? "Suggestions" : "Generate"}
         </Button>
       ) : null}
       <span className="text-xs font-medium text-[color:var(--ink-soft)]">
@@ -97,7 +106,10 @@ export function CatalogMetadataFields({
   );
 
   return (
-    <div className="catalog-metadata-fields col-span-full">
+    <div
+      className="catalog-metadata-fields col-span-full"
+      data-presentation={isPublishPresentation ? "publish" : undefined}
+    >
       <div className="catalog-metadata-field flex min-w-0 flex-col gap-2">
         <div className="catalog-metadata-field-header">
           <Label htmlFor={`${fieldIdPrefix}Categories`}>Categories</Label>
@@ -158,7 +170,23 @@ export function CatalogMetadataFields({
       </div>
       <div className="catalog-metadata-field flex min-w-0 flex-col gap-2">
         <div className="catalog-metadata-field-header">
-          <Label htmlFor={`${fieldIdPrefix}Topics`}>Topics</Label>
+          <Label htmlFor={`${fieldIdPrefix}Topics`}>
+            {isPublishPresentation ? "Search keywords" : "Topics"}
+            {isPublishPresentation ? (
+              <span
+                id={topicCountId}
+                className="ml-2 text-xs font-medium text-[color:var(--ink-soft)]"
+                aria-live="polite"
+              >
+                <span aria-hidden="true">
+                  {parseCatalogTopicsInput(topics).length}/{CATALOG_TOPIC_LIMIT}
+                </span>
+                <span className="sr-only">
+                  {parseCatalogTopicsInput(topics).length} of {CATALOG_TOPIC_LIMIT} keywords used
+                </span>
+              </span>
+            ) : null}
+          </Label>
           <div
             className="catalog-metadata-field-actions min-h-[30px] shrink-0"
             aria-hidden="true"
@@ -168,6 +196,8 @@ export function CatalogMetadataFields({
           id={`${fieldIdPrefix}Topics`}
           value={topics}
           disabled={disabled}
+          describedBy={isPublishPresentation ? topicCountId : undefined}
+          vocabulary={isPublishPresentation ? "keywords" : "topics"}
           onChange={onTopicsChange}
         />
       </div>

--- a/src/components/CatalogTopicInput.test.tsx
+++ b/src/components/CatalogTopicInput.test.tsx
@@ -73,4 +73,38 @@ describe("CatalogTopicInput", () => {
     expect(screen.getByText("#ci, cd")).toBeTruthy();
     expect(screen.getByText("#gpu development")).toBeTruthy();
   });
+
+  it("uses keyword vocabulary consistently", () => {
+    function KeywordHarness() {
+      const [value, setValue] = useState("email, calendar, search, automation, productivity");
+      return (
+        <CatalogTopicInput id="keywords" value={value} vocabulary="keywords" onChange={setValue} />
+      );
+    }
+
+    render(<KeywordHarness />);
+
+    expect(screen.getByPlaceholderText("Maximum 5 keywords")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Remove email keyword" }));
+    expect(screen.getByPlaceholderText("Add keywords")).toBeTruthy();
+  });
+
+  it("associates supporting count text with the keyword input", () => {
+    render(
+      <>
+        <span id="keyword-count">0 of 5 keywords used</span>
+        <CatalogTopicInput
+          id="keywords"
+          value=""
+          describedBy="keyword-count"
+          vocabulary="keywords"
+          onChange={() => {}}
+        />
+      </>,
+    );
+
+    expect(screen.getByLabelText("Search keywords").getAttribute("aria-describedby")).toBe(
+      "keyword-count",
+    );
+  });
 });

--- a/src/components/CatalogTopicInput.tsx
+++ b/src/components/CatalogTopicInput.tsx
@@ -7,6 +7,8 @@ type CatalogTopicInputProps = {
   id: string;
   value: string;
   disabled?: boolean;
+  describedBy?: string;
+  vocabulary?: "topics" | "keywords";
   onChange: (value: string) => void;
 };
 
@@ -50,12 +52,21 @@ export function formatCatalogTopicsInput(values: readonly string[]) {
     .join(", ");
 }
 
-export function CatalogTopicInput({ id, value, disabled, onChange }: CatalogTopicInputProps) {
+export function CatalogTopicInput({
+  id,
+  value,
+  disabled,
+  describedBy,
+  vocabulary = "topics",
+  onChange,
+}: CatalogTopicInputProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const [draft, setDraft] = useState("");
   const topics = parseCatalogTopicsInput(value);
   const limitReached = topics.length >= CATALOG_TOPIC_LIMIT;
+  const usesKeywordVocabulary = vocabulary === "keywords";
+  const itemLabel = usesKeywordVocabulary ? "keyword" : "topic";
 
   function commitDraft() {
     const topic = draft.trim();
@@ -104,7 +115,7 @@ export function CatalogTopicInput({ id, value, disabled, onChange }: CatalogTopi
             type="button"
             className="inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-[var(--radius-pill)] text-ink-soft transition-colors hover:bg-active-bg hover:text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--accent)]/35 disabled:cursor-not-allowed disabled:opacity-60"
             disabled={disabled}
-            aria-label={`Remove ${topic} topic`}
+            aria-label={`Remove ${topic} ${itemLabel}`}
             title={`Remove ${topic}`}
             onClick={(event) => {
               event.stopPropagation();
@@ -121,11 +132,18 @@ export function CatalogTopicInput({ id, value, disabled, onChange }: CatalogTopi
         className="catalog-topic-input min-w-[9rem] flex-1 bg-transparent py-1 text-[color:var(--ink)] outline-none placeholder:text-input-placeholder disabled:cursor-not-allowed disabled:opacity-60"
         value={draft}
         disabled={disabled}
-        aria-label="Topics"
+        aria-label={usesKeywordVocabulary ? "Search keywords" : "Topics"}
+        aria-describedby={describedBy}
         autoCapitalize="none"
         autoCorrect="off"
         spellCheck={false}
-        placeholder={limitReached ? "Maximum 5 topics" : "Add a topic"}
+        placeholder={
+          limitReached
+            ? `Maximum 5 ${usesKeywordVocabulary ? "keywords" : "topics"}`
+            : usesKeywordVocabulary
+              ? "Add keywords"
+              : "Add a topic"
+        }
         onChange={(event) => setDraft(event.target.value)}
         onKeyDown={(event) => {
           if (event.nativeEvent.isComposing) return;

--- a/src/components/DevPersonaFab.test.tsx
+++ b/src/components/DevPersonaFab.test.tsx
@@ -73,9 +73,9 @@ vi.mock("./ui/select", () => ({
   SelectValue: () => <span>Auth</span>,
 }));
 
-function setHostname(hostname: string) {
+function setLocation(hostname: string, pathname = "/") {
   Object.defineProperty(window, "location", {
-    value: { hostname },
+    value: { hostname, pathname },
     configurable: true,
   });
 }
@@ -97,7 +97,7 @@ describe("DevPersonaFab", () => {
     vi.stubGlobal("fetch", fetchMock);
     process.env.VITE_ENABLE_DEV_AUTH = "1";
     delete process.env.VITE_DEV_AUTH_SECRET;
-    setHostname("localhost");
+    setLocation("localhost");
   });
 
   it("stays hidden unless local dev auth is enabled", () => {
@@ -109,7 +109,15 @@ describe("DevPersonaFab", () => {
   });
 
   it("stays hidden away from localhost", () => {
-    setHostname("clawhub.ai");
+    setLocation("clawhub.ai");
+
+    render(<DevPersonaFab />);
+
+    expect(screen.queryByRole("button", { name: /open local dev personas/i })).toBeNull();
+  });
+
+  it.each(["/skills/publish", "/plugins/publish"])("stays hidden on the %s form", (pathname) => {
+    setLocation("localhost", pathname);
 
     render(<DevPersonaFab />);
 

--- a/src/components/DevPersonaFab.tsx
+++ b/src/components/DevPersonaFab.tsx
@@ -60,7 +60,10 @@ function isLocalDevPersonaEnabled() {
   if (getRuntimeEnv("VITE_ENABLE_DEV_AUTH") !== "1") return false;
   if (typeof window === "undefined") return false;
   const hostname = window.location.hostname.toLowerCase();
-  return hostname === "localhost" || hostname === "127.0.0.1";
+  const isPublishForm =
+    window.location.pathname === "/skills/publish" ||
+    window.location.pathname === "/plugins/publish";
+  return !isPublishForm && (hostname === "localhost" || hostname === "127.0.0.1");
 }
 
 async function withDevAuthTimeout<T>(operation: Promise<T>) {

--- a/src/routes/plugins/publish.tsx
+++ b/src/routes/plugins/publish.tsx
@@ -316,6 +316,7 @@ export function PublishPluginRoute() {
   const isMetadataLocked = files.length === 0;
   const isNewPluginPublishEmpty = files.length === 0 && !search.name;
   const metadataDisabled = isMetadataLocked || isSubmitting;
+  const sourceFieldsRequired = family === "code-plugin";
   const ownerScopeError = useMemo(() => {
     return (
       getPackageScopeOwnerMismatch(name, selectedPublisher?.handle ?? ownerHandle)?.message ?? null
@@ -326,12 +327,12 @@ export function PublishPluginRoute() {
     const blockers: string[] = [];
     if (!name.trim()) blockers.push("Plugin name is required.");
     if (!version.trim()) blockers.push("Version is required.");
-    if (family === "code-plugin") {
+    if (sourceFieldsRequired) {
       if (!sourceRepo.trim()) blockers.push("GitHub repository is required.");
       if (!sourceCommit.trim()) blockers.push("Commit SHA is required.");
     }
     return blockers;
-  }, [family, isMetadataLocked, name, sourceCommit, sourceRepo, version]);
+  }, [isMetadataLocked, name, sourceCommit, sourceFieldsRequired, sourceRepo, version]);
   const hasPackageBlocker =
     Boolean(validationError) || Boolean(ownerScopeError) || codePluginFieldIssues.length > 0;
   const hasPublished =
@@ -594,13 +595,21 @@ export function PublishPluginRoute() {
         {!isNewPluginPublishEmpty ? (
           <div className="contents">
             <Card
-              className={isMetadataLocked ? "pointer-events-none opacity-60" : ""}
+              className={`publish-skill-metadata ${
+                isMetadataLocked ? "pointer-events-none opacity-60" : ""
+              }`}
               aria-disabled={isMetadataLocked}
             >
+              <h2 className="font-display text-lg font-bold leading-tight text-[color:var(--ink)]">
+                Details
+              </h2>
               <div className="flex flex-col gap-5">
                 <div className="grid gap-x-4 gap-y-4 md:grid-cols-2">
                   <div className="flex flex-col gap-2">
-                    <Label htmlFor="pluginName">Plugin name</Label>
+                    <Label htmlFor="pluginName">
+                      Plugin name
+                      <RequiredIndicator />
+                    </Label>
                     <Input
                       id="pluginName"
                       placeholder="Plugin name"
@@ -620,16 +629,10 @@ export function PublishPluginRoute() {
                     />
                   </div>
                   <div className="flex flex-col gap-2">
-                    <Label htmlFor="pluginFamily">Package type</Label>
-                    <div
-                      id="pluginFamily"
-                      className="min-h-[44px] w-full rounded-[var(--radius-sm)] border border-[rgba(29,59,78,0.22)] bg-[rgba(255,255,255,0.94)] px-3.5 py-[13px] text-sm text-[color:var(--ink)] dark:border-[rgba(255,255,255,0.12)] dark:bg-[rgba(14,28,37,0.84)]"
-                    >
-                      {family === "code-plugin" ? "Code plugin" : "Bundle plugin"}
-                    </div>
-                  </div>
-                  <div className="flex flex-col gap-2">
-                    <Label htmlFor="pluginVersion">Version</Label>
+                    <Label htmlFor="pluginVersion">
+                      Version
+                      <RequiredIndicator />
+                    </Label>
                     <VersionInput
                       id="pluginVersion"
                       placeholder="Version"
@@ -638,8 +641,18 @@ export function PublishPluginRoute() {
                       onValueChange={setVersion}
                     />
                   </div>
+                  <div className="flex flex-col gap-2">
+                    <Label htmlFor="pluginFamily">Package type</Label>
+                    <div
+                      id="pluginFamily"
+                      className="min-h-[44px] w-full rounded-[var(--radius-sm)] border border-[rgba(29,59,78,0.22)] bg-[rgba(255,255,255,0.94)] px-3.5 py-[13px] text-sm text-[color:var(--ink)] dark:border-[rgba(255,255,255,0.12)] dark:bg-[rgba(14,28,37,0.84)]"
+                    >
+                      {family === "code-plugin" ? "Code plugin" : "Bundle plugin"}
+                    </div>
+                  </div>
                   <CatalogMetadataFields
                     kind="plugin"
+                    presentation="publish"
                     categories={categories}
                     suggestedCategories={suggestedCategories}
                     topics={topics}
@@ -719,6 +732,7 @@ export function PublishPluginRoute() {
                     <FieldLabelWithHelp
                       htmlFor="pluginSourceRepo"
                       help="Use owner/repo, for example openclaw/demo-plugin."
+                      required={sourceFieldsRequired}
                     >
                       GitHub repository
                     </FieldLabelWithHelp>
@@ -727,6 +741,7 @@ export function PublishPluginRoute() {
                       placeholder="owner/repo"
                       value={sourceRepo}
                       disabled={metadataDisabled}
+                      required={sourceFieldsRequired}
                       onChange={(event) => setSourceRepo(event.target.value)}
                     />
                   </div>
@@ -734,6 +749,7 @@ export function PublishPluginRoute() {
                     <FieldLabelWithHelp
                       htmlFor="pluginSourceCommit"
                       help="Use the exact Git commit SHA for this release, preferably the full hash."
+                      required={sourceFieldsRequired}
                     >
                       Commit SHA
                     </FieldLabelWithHelp>
@@ -742,6 +758,7 @@ export function PublishPluginRoute() {
                       placeholder="Full commit SHA"
                       value={sourceCommit}
                       disabled={metadataDisabled}
+                      required={sourceFieldsRequired}
                       onChange={(event) => setSourceCommit(event.target.value)}
                     />
                     {readmeAssetWarning ? (
@@ -1026,10 +1043,29 @@ export function PublishPluginRoute() {
   );
 }
 
-function FieldLabelWithHelp(props: { htmlFor: string; help: string; children: ReactNode }) {
+function RequiredIndicator() {
+  return (
+    <>
+      <span className="text-status-error-fg" aria-hidden="true">
+        *
+      </span>
+      <span className="sr-only"> (required)</span>
+    </>
+  );
+}
+
+function FieldLabelWithHelp(props: {
+  htmlFor: string;
+  help: string;
+  children: ReactNode;
+  required?: boolean;
+}) {
   return (
     <div className="flex items-center gap-1.5">
-      <Label htmlFor={props.htmlFor}>{props.children}</Label>
+      <Label htmlFor={props.htmlFor}>
+        {props.children}
+        {props.required ? <RequiredIndicator /> : null}
+      </Label>
       <span
         tabIndex={0}
         role="img"

--- a/src/routes/skills/publish.tsx
+++ b/src/routes/skills/publish.tsx
@@ -782,19 +782,17 @@ export function Upload() {
   }
 
   return (
-    <main className={isNewSkillPublishEmpty ? "publish-empty-main" : "py-10"}>
+    <main className={isNewSkillPublishEmpty ? "publish-empty-main" : "publish-skill-main"}>
       <Container
         size="narrow"
         className={isNewSkillPublishEmpty ? "publish-empty-container" : undefined}
       >
         <header
-          className={
-            isNewSkillPublishEmpty
-              ? "publish-empty-header"
-              : "mb-6 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between"
-          }
+          className={isNewSkillPublishEmpty ? "publish-empty-header" : "publish-skill-header"}
         >
-          <div className={isNewSkillPublishEmpty ? "publish-empty-heading" : undefined}>
+          <div
+            className={isNewSkillPublishEmpty ? "publish-empty-heading" : "publish-skill-heading"}
+          >
             <h1 className="font-display text-2xl font-bold text-[color:var(--ink)]">
               {isNewSkillPublishEmpty ? "Publish Skill" : "Publish a skill"}
             </h1>
@@ -808,7 +806,7 @@ export function Upload() {
             className={
               isNewSkillPublishEmpty
                 ? "publish-empty-actions flex flex-wrap items-center gap-2"
-                : "flex flex-wrap items-center gap-2"
+                : "publish-skill-actions flex flex-wrap items-center gap-2"
             }
           >
             {isNewSkillPublishEmpty ? (
@@ -833,7 +831,7 @@ export function Upload() {
           className={
             isNewSkillPublishEmpty
               ? "publish-empty-skill-form flex flex-col gap-6"
-              : "flex flex-col gap-6"
+              : "publish-skill-form flex flex-col gap-6"
           }
         >
           {/* File upload panel */}
@@ -852,7 +850,7 @@ export function Upload() {
 
           {files.length > 0 ? (
             <div
-              className={`overflow-hidden rounded-[var(--radius-md)] border transition-colors ${
+              className={`publish-skill-files overflow-hidden rounded-[var(--radius-md)] border transition-colors ${
                 isDragging
                   ? "border-[color:var(--accent)] bg-[color:var(--accent)]/5"
                   : "border-[color:var(--line)] bg-[color:var(--surface-muted)]"
@@ -864,7 +862,7 @@ export function Upload() {
               onDragLeave={() => setIsDragging(false)}
               onDrop={handleFilesDrop}
             >
-              <div className="flex flex-col gap-4 px-4 pt-4 pb-2 md:flex-row md:items-center md:justify-between">
+              <div className="publish-skill-files-header flex flex-col gap-4 px-4 pt-4 pb-2 md:flex-row md:items-center md:justify-between">
                 <div className="flex min-w-0 items-center gap-3">
                   <div
                     className="flex h-8 w-8 shrink-0 items-center justify-center rounded-[var(--radius-sm)] border border-[color:var(--line)] bg-[color:var(--surface)]"
@@ -901,7 +899,7 @@ export function Upload() {
                   </button>
                 </div>
               </div>
-              <div className="mt-2 overflow-hidden rounded-t-[calc(var(--radius-md)+8px)] border-t border-[color:var(--line)] bg-[color:var(--surface)]">
+              <div className="publish-skill-files-body mt-2 overflow-hidden rounded-t-[calc(var(--radius-md)+8px)] border-t border-[color:var(--line)] bg-[color:var(--surface)]">
                 <div className="flex max-h-[300px] flex-col gap-1 overflow-y-auto p-3">
                   {!hasRequiredFile ? (
                     <div className="flex items-center gap-2 rounded-[var(--radius-sm)] border border-status-error-fg/35 bg-status-error-bg px-3 py-1.5 text-sm text-status-error-fg">
@@ -918,7 +916,7 @@ export function Upload() {
                     return (
                       <div
                         key={`${index}:${path}`}
-                        className="flex items-center gap-2 rounded-[var(--radius-sm)] bg-[color:var(--surface-muted)] px-3 py-1.5 text-sm text-[color:var(--ink-soft)]"
+                        className="publish-skill-file-row flex items-center gap-2 rounded-[var(--radius-sm)] bg-[color:var(--surface-muted)] px-3 py-1.5 text-sm text-[color:var(--ink-soft)]"
                       >
                         <span className="min-w-0 flex-1 truncate font-mono" title={path}>
                           {path}
@@ -1028,9 +1026,9 @@ export function Upload() {
           )}
 
           {/* Metadata panel */}
-          <Card>
-            <CardContent className="gap-5">
-              <div className="grid gap-x-4 gap-y-4 md:grid-cols-2">
+          <Card className="publish-skill-section publish-skill-metadata">
+            <CardContent className="publish-skill-section-content gap-5">
+              <div className="publish-skill-primary-grid grid gap-x-4 gap-y-4 md:grid-cols-2">
                 <div className="flex flex-col gap-2">
                   <Label htmlFor="displayName">Display name</Label>
                   <Input
@@ -1117,6 +1115,7 @@ export function Upload() {
               <div>
                 <CatalogMetadataFields
                   kind="skill"
+                  presentation="publish"
                   categories={categories}
                   suggestedCategories={suggestedCategories}
                   topics={topics}
@@ -1177,8 +1176,8 @@ export function Upload() {
             </CardContent>
           </Card>
 
-          <Card>
-            <CardContent className="gap-4">
+          <Card className="publish-skill-section publish-skill-version">
+            <CardContent className="publish-skill-section-content gap-4">
               <div className="grid gap-x-4 gap-y-4 md:grid-cols-2">
                 <div className="flex flex-col gap-2">
                   <Label htmlFor="version">Version</Label>
@@ -1212,10 +1211,16 @@ export function Upload() {
             </CardContent>
           </Card>
 
-          <Card>
-            <CardContent className="gap-4">
+          <Card className="publish-skill-section publish-skill-license">
+            <CardContent className="publish-skill-section-content gap-4">
               <div>
-                <CardTitle>License</CardTitle>
+                <CardTitle>
+                  License
+                  <span className="text-status-error-fg" aria-hidden="true">
+                    *
+                  </span>
+                  <span className="sr-only"> (required)</span>
+                </CardTitle>
                 <p className="text-sm text-[color:var(--ink-soft)]">
                   {PLATFORM_SKILL_LICENSE} · {PLATFORM_SKILL_LICENSE_NAME}
                 </p>
@@ -1230,9 +1235,11 @@ export function Upload() {
                 </p>
               </div>
               <div className="flex flex-col gap-2">
-                <label className="flex cursor-pointer items-start gap-3 rounded-[var(--radius-sm)] border border-[color:var(--line)] bg-[color:var(--surface-muted)] p-3 text-sm">
+                <label className="publish-skill-license-acceptance flex cursor-pointer items-start gap-3 rounded-[var(--radius-sm)] border border-[color:var(--line)] bg-[color:var(--surface-muted)] p-3 text-sm">
                   <input
                     type="checkbox"
+                    required
+                    aria-required="true"
                     className="mt-0.5 h-4 w-4 accent-[color:var(--accent)]"
                     checked={acceptedLicenseTerms}
                     onChange={(event) => {
@@ -1241,6 +1248,7 @@ export function Upload() {
                   />
                   <span>
                     I have the rights to publish this skill under {PLATFORM_SKILL_LICENSE}.
+                    <span className="sr-only"> (required)</span>
                   </span>
                 </label>
               </div>
@@ -1248,8 +1256,8 @@ export function Upload() {
           </Card>
 
           {showChangelogField ? (
-            <Card>
-              <CardContent>
+            <Card className="publish-skill-section publish-skill-changelog">
+              <CardContent className="publish-skill-section-content">
                 <div>
                   <CardTitle>Changelog</CardTitle>
                   <p className="text-sm text-[color:var(--ink-soft)]">
@@ -1288,7 +1296,7 @@ export function Upload() {
           ) : null}
 
           {/* Submit row */}
-          <div className="flex items-center justify-between gap-4">
+          <div className="publish-skill-submit flex items-center justify-between gap-4">
             <div className="flex flex-col gap-2">
               {error ? (
                 <div className="text-sm font-medium text-status-error-fg" role="alert">

--- a/src/styles.css
+++ b/src/styles.css
@@ -2652,7 +2652,146 @@ code {
   gap: 0;
 }
 
+.publish-skill-main {
+  padding-block: 40px 128px;
+}
+
+.publish-skill-header {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: var(--oc-space-4);
+  margin-bottom: var(--oc-space-5);
+}
+
+.publish-skill-heading {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: var(--oc-space-1);
+}
+
+.publish-skill-heading h1,
+.publish-skill-heading p {
+  margin: 0;
+}
+
+.publish-skill-actions {
+  justify-self: end;
+}
+
+.publish-skill-files {
+  border-radius: var(--oc-radius-surface);
+}
+
+.publish-skill-files-header {
+  min-height: 66px;
+  padding: var(--oc-space-4);
+}
+
+.publish-skill-files-body {
+  margin-top: 0;
+  border-radius: 0;
+  background: var(--oc-bg-elevated);
+}
+
+.publish-skill-file-row {
+  min-height: 40px;
+  border-radius: var(--oc-radius-inset);
+  background: color-mix(in srgb, var(--oc-bg-surface) 84%, var(--oc-bg-elevated));
+}
+
+.publish-skill-section {
+  padding: var(--oc-space-5);
+}
+
+.publish-skill-section-content {
+  gap: var(--oc-space-5);
+}
+
+.publish-skill-primary-grid {
+  row-gap: var(--oc-space-5);
+}
+
+.publish-skill-metadata textarea {
+  min-height: 100px;
+  resize: vertical;
+}
+
+.publish-skill-metadata
+  .catalog-metadata-fields[data-presentation="publish"]
+  .catalog-metadata-field:first-child
+  .catalog-metadata-field-header {
+  display: grid;
+  grid-template-columns: auto auto minmax(0, 1fr);
+  align-items: center;
+  column-gap: var(--oc-space-2);
+}
+
+.publish-skill-metadata
+  .catalog-metadata-fields[data-presentation="publish"]
+  .catalog-metadata-field:first-child
+  .catalog-metadata-field-actions {
+  display: contents;
+}
+
+.publish-skill-metadata
+  .catalog-metadata-fields[data-presentation="publish"]
+  .catalog-metadata-field:first-child
+  .catalog-metadata-field-actions
+  > button {
+  grid-column: 3;
+  justify-self: end;
+}
+
+.publish-skill-metadata
+  .catalog-metadata-fields[data-presentation="publish"]
+  .catalog-metadata-field:first-child
+  .catalog-metadata-field-actions
+  > span {
+  grid-column: 2;
+  grid-row: 1;
+}
+
+.publish-skill-license-acceptance {
+  min-height: 44px;
+  align-items: center;
+  border-radius: var(--oc-radius-inset);
+  background: var(--oc-bg-surface);
+}
+
+.publish-skill-license-acceptance input {
+  margin-top: 0;
+}
+
 @media (max-width: 640px) {
+  .publish-skill-main {
+    padding-block: 24px 80px;
+  }
+
+  .publish-skill-header {
+    grid-template-columns: 1fr;
+    align-items: flex-start;
+    margin-bottom: var(--oc-space-5);
+  }
+
+  .publish-skill-actions {
+    justify-self: start;
+  }
+
+  .publish-skill-section {
+    padding: var(--oc-space-4);
+  }
+
+  .publish-skill-submit {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .publish-skill-submit > button {
+    width: 100%;
+  }
+
   .publish-empty-main {
     min-height: 560px;
     padding-top: 24px;


### PR DESCRIPTION
## Summary

- align the populated skill publish form with the updated design using the existing form components
- apply the matching details hierarchy and required-field treatment to the plugin publish form
- rename publish-only topic UI to **Search keywords** with an accessible `0/5` counter
- replace the publish category sparkle action with the lightbulb **Suggestions** treatment
- hide the local persona wrench launcher on both publish routes

## Why

The publish forms had drifted from the approved UI reference. This keeps the existing form behavior and shared components while updating only the presentation and related accessibility semantics.

## Screenshots

Publish plugin current 
<img width="1693" height="880" alt="image" src="https://github.com/user-attachments/assets/81597974-5fdb-4cd0-bf12-bda3e03a0bbc" />
Publish plugin proposed
<img width="2346" height="1586" alt="image" src="https://github.com/user-attachments/assets/c538ca2b-3dc8-454c-93f9-f998b3288ef4" />
<img width="2340" height="1588" alt="image" src="https://github.com/user-attachments/assets/43c1b7d5-db5b-4590-90fe-3ee132dd3229" />

Publish skill current 
<img width="1698" height="709" alt="image" src="https://github.com/user-attachments/assets/1e83b58e-c076-47de-9aea-9d729eca3bb9" />
Publish skill proposed
<img width="2334" height="1608" alt="image" src="https://github.com/user-attachments/assets/68e0da5f-f7e2-418d-b871-959f3f82bdee" />
<img width="2360" height="1620" alt="image" src="https://github.com/user-attachments/assets/5a2f7a52-4651-4876-ac1b-1dc9e7e0152a" />
