### PR TITLE
fix: regenerate the skill changelog preview after the file set changes

### DIFF
--- a/src/__tests__/skills-publish-route.test.tsx
+++ b/src/__tests__/skills-publish-route.test.tsx
@@ -1117,4 +1117,109 @@ describe("Upload route", () => {
     expect(args).not.toBeUndefined();
     expect(Object.hasOwn(args!, "icon")).toBe(false);
   });
+
+  it("regenerates the changelog preview when the bundle swaps one file for another", async () => {
+    useSearchMock.mockReturnValue({ updateSlug: "changelog-cache-skill" });
+    useQueryMock.mockImplementation((fn: unknown, args: unknown) => {
+      if (args === "skip") return undefined;
+      const name = fn ? getFunctionName(fn as Parameters<typeof getFunctionName>[0]) : "";
+      if (name === "skills:getBySlug") {
+        return {
+          skill: { slug: "changelog-cache-skill", displayName: "Changelog Cache Skill" },
+          latestVersion: { version: "1.0.0" },
+          owner: { handle: "alice", displayName: "Alice" },
+        };
+      }
+      if (name === "publishers:listMine") return [];
+      return null;
+    });
+    generateChangelogPreview.mockResolvedValue({ changelog: "- Updated skill." });
+
+    render(<Upload />);
+
+    // The same SKILL.md instance is reused for both selections, so its size and
+    // lastModified stay identical. Only a sibling file is swapped, which keeps
+    // the path count at two while the paths themselves differ.
+    const readme = new File(
+      ["---\nname: changelog-cache-skill\n---\n# Changelog Cache Skill"],
+      "SKILL.md",
+      { type: "text/markdown", lastModified: 1_700_000_000_000 },
+    );
+    const alpha = new File(["echo alpha"], "scripts/alpha.sh", {
+      type: "text/plain",
+      lastModified: 1_700_000_000_000,
+    });
+    const beta = new File(["echo beta"], "scripts/beta.sh", {
+      type: "text/plain",
+      lastModified: 1_700_000_000_000,
+    });
+
+    const input = screen.getByTestId("upload-input") as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [readme, alpha] } });
+
+    await waitFor(() => {
+      expect(generateChangelogPreview).toHaveBeenCalledTimes(1);
+    });
+    expect(generateChangelogPreview).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ filePaths: ["SKILL.md", "scripts/alpha.sh"] }),
+    );
+
+    fireEvent.change(input, { target: { files: [readme, beta] } });
+
+    await waitFor(() => {
+      expect(generateChangelogPreview).toHaveBeenCalledTimes(2);
+    });
+    expect(generateChangelogPreview).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ filePaths: ["SKILL.md", "scripts/beta.sh"] }),
+    );
+  });
+
+  it("keeps a manually written changelog when the file set changes", async () => {
+    useSearchMock.mockReturnValue({ updateSlug: "changelog-manual-skill" });
+    useQueryMock.mockImplementation((fn: unknown, args: unknown) => {
+      if (args === "skip") return undefined;
+      const name = fn ? getFunctionName(fn as Parameters<typeof getFunctionName>[0]) : "";
+      if (name === "skills:getBySlug") {
+        return {
+          skill: { slug: "changelog-manual-skill", displayName: "Changelog Manual Skill" },
+          latestVersion: { version: "1.0.0" },
+          owner: { handle: "alice", displayName: "Alice" },
+        };
+      }
+      if (name === "publishers:listMine") return [];
+      return null;
+    });
+    generateChangelogPreview.mockResolvedValue({ changelog: "- Updated skill." });
+
+    render(<Upload />);
+
+    const readme = new File(
+      ["---\nname: changelog-manual-skill\n---\n# Changelog Manual Skill"],
+      "SKILL.md",
+      { type: "text/markdown", lastModified: 1_700_000_000_000 },
+    );
+    const alpha = new File(["echo alpha"], "scripts/alpha.sh", {
+      type: "text/plain",
+      lastModified: 1_700_000_000_000,
+    });
+    const beta = new File(["echo beta"], "scripts/beta.sh", {
+      type: "text/plain",
+      lastModified: 1_700_000_000_000,
+    });
+
+    const input = screen.getByTestId("upload-input") as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [readme, alpha] } });
+
+    const changelogField = (await screen.findByPlaceholderText(
+      "Describe what changed in this skill...",
+    )) as HTMLTextAreaElement;
+    fireEvent.change(changelogField, { target: { value: "Rotated the bundled helper script." } });
+
+    fireEvent.change(input, { target: { files: [readme, beta] } });
+    await screen.findByText("scripts/beta.sh");
+
+    expect(changelogField.value).toBe("Rotated the bundled helper script.");
+  });
 });

--- a/src/routes/skills/publish.tsx
+++ b/src/routes/skills/publish.tsx
@@ -392,6 +392,19 @@ export function Upload() {
     setConfirmMigrateOwner(false);
   }, [ownerHandle, publisherMemberships, existing?.owner?.handle, updateSlug]);
 
+  // A generated changelog only describes the bundle it was generated from. Once
+  // the selection changes it is stale, and because the effect below skips work
+  // while the field is non-empty it would otherwise stay on screen for the rest
+  // of the session. Text the user typed is never discarded.
+  useEffect(() => {
+    changelogRequestRef.current += 1;
+    changelogKeyRef.current = null;
+    if (changelogTouchedRef.current) return;
+    setChangelog("");
+    setChangelogSource(null);
+    setChangelogStatus("idle");
+  }, [normalizedPaths, trimmedSlug, trimmedVersion]);
+
   useEffect(() => {
     if (!showChangelogField) return;
     if (changelogTouchedRef.current) return;
@@ -407,7 +420,9 @@ export function Upload() {
     const requiredFile = files[requiredIndex];
     if (!requiredFile) return;
 
-    const key = `${trimmedSlug}:${trimmedVersion}:${requiredFile.size}:${requiredFile.lastModified}:${normalizedPaths.length}`;
+    // The paths are sent to the preview action, so the key has to track their
+    // identity. Keying on the count alone let a swapped file reuse the key.
+    const key = `${trimmedSlug}:${trimmedVersion}:${requiredFile.size}:${requiredFile.lastModified}:${normalizedPaths.join("\0")}`;
     if (changelogKeyRef.current === key) return;
     changelogKeyRef.current = key;
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where publishers updating an existing skill see a generated
changelog that describes a bundle they are no longer publishing. Changing the
selected files in a way that keeps the file count the same — swapping one
bundled script for another, or replacing a helper file — leaves the previously
generated text in the "What changed" field.

The affected surface is the skill publish form in update mode
(`/skills/publish?updateSlug=...`), where that field is prefilled from
`skills.generateChangelogPreview`.

## Why This Change Was Made

The form caches its last preview request in `changelogKeyRef` so ordinary
re-renders do not re-run generation. The key was built from the slug, version,
SKILL.md size and `lastModified`, and `normalizedPaths.length` — the path
*count*. The path list itself is what the form sends to the action as
`filePaths`, so two different bundles holding the same number of files produce
an identical key and the second request is skipped.

Nothing reset that key when the selection changed, and the generation effect
returns early while the field is non-empty. Together those two things mean that
once a preview has landed, no later change to the file set can replace it for
the rest of the session.

The plugin publish form already covers both halves of this in
`src/routes/plugins/publish.tsx`: it keys on `normalizedPaths.join("\0")` and
resets the cached key when the file set changes. The skill form now does the
same, so the two publish forms agree.

Manually written text is never discarded — the reset returns early when
`changelogTouchedRef` is set, and there is a regression test for that.

Of the two changes, the reset is what restores the behavior; keying on the joined
paths removes the underlying mismatch so the guard no longer depends on the reset
for correctness, and matches the sibling form.

Non-goals, kept out to hold the change to one concern:

- Sharing this logic between the two publish forms. They are now consistent;
  extracting a common hook is a separate refactor.
- The preview action's own file-diff behavior.

## User Impact

The generated changelog now describes the bundle that is actually about to be
published. Previously a publisher who swapped a file after the first preview
landed would either submit a changelog naming a file that is no longer in the
upload, or have to notice the problem and overwrite the field by hand.

## Evidence

Base commit: `79ef4af1`. The fix is not present on `main` — `changelogKeyRef` there
is still built from `normalizedPaths.length`, and the skill form has no effect that
resets it.

Behavior read out of the mounted `Upload` form. The same `SKILL.md` instance is
reused across both selections so its `size` and `lastModified` do not change; only
a sibling file is swapped, keeping the path count at two:

| step | before | after |
| --- | --- | --- |
| select `[SKILL.md, scripts/alpha.sh]` | 1 preview call, field shows `- Generated for [SKILL.md, scripts/alpha.sh]` | same |
| swap to `[SKILL.md, scripts/beta.sh]` | still 1 preview call, last `filePaths` `["SKILL.md","scripts/alpha.sh"]`, field unchanged | 2 preview calls, last `filePaths` `["SKILL.md","scripts/beta.sh"]`, field shows `- Generated for [SKILL.md, scripts/beta.sh]` |

The new regression test fails on the parent commit and passes with the fix:

```
$ VITE_CONVEX_URL=https://example.invalid bunx vitest run \
    src/__tests__/skills-publish-route.test.tsx        # parent commit 79ef4af1

 × regenerates the changelog preview when the bundle swaps one file for another
AssertionError: expected "vi.fn()" to be called 2 times, but got 1 times
    1173|     expect(generateChangelogPreview).toHaveBeenNthCalledWith(

 Test Files  1 failed (1)
      Tests  1 failed | 31 passed (32)
```

```
$ VITE_CONVEX_URL=https://example.invalid bunx vitest run \
    src/__tests__/skills-publish-route.test.tsx        # with the fix

 Test Files  1 passed (1)
      Tests  32 passed (32)
```

The second new test (`keeps a manually written changelog when the file set
changes`) passes on both sides — it guards the reset against discarding text the
publisher typed.

Both publish route suites together, to confirm the plugin form is unaffected:

```
$ bunx vitest run src/__tests__/skills-publish-route.test.tsx \
    src/__tests__/plugins-publish-route.test.tsx
 Test Files  2 passed (2)
      Tests  69 passed (69)
```

Gates run locally on Windows:

- `bunx tsc --noEmit` — clean
- `bun run lint` — clean
- `bun run deadcode:ci` — clean
- `bun run format:check` — the only two files it reports are `CLAUDE.md` and
  `.agents/skills/autoreview/CLAUDE.md`; both report identically on an unmodified
  checkout of `79ef4af1`, so they are pre-existing and untouched here.
- `bun run ci:unit` — 5541 passed. The 24 failures are pre-existing on this
  platform: `79ef4af1` fails the same 14 files with the same 24 tests (5539
  passed there, the difference being the two tests added by this PR). They are the
  `scripts/` worker, CLI and security-dataset suites that shell out to `bun`, plus
  `convex/lib/githubAccount.test.ts` and `src/routes/-management.test.tsx`. Linux
  CI is the authoritative signal.

The Vercel preview check will need OpenClaw Foundation team authorization, as with
other fork pull requests.
