### PR TITLE
fix: stop rejecting skills whose SKILL.md uses thematic breaks

### DIFF
--- a/convex/lib/skillQuality.test.ts
+++ b/convex/lib/skillQuality.test.ts
@@ -36,6 +36,18 @@ const THEMATIC_BREAK_README = [
   "Rate limits apply.",
 ].join("\n");
 
+const LEADING_THEMATIC_BREAK_README = [
+  "---",
+  "",
+  "# Weather Report Skill",
+  "",
+  ...BODY_LINES,
+  "",
+  "---",
+  "",
+  "Rate limits apply.",
+].join("\n");
+
 const FRONTMATTER_README = [
   "---",
   "name: weather-report",
@@ -76,12 +88,45 @@ describe("computeQualitySignals", () => {
     expect(withFrontmatter.bodyWords).toBe(withoutFrontmatter.bodyWords);
     expect(withFrontmatter.bodyChars).toBe(withoutFrontmatter.bodyChars);
   });
+
+  it("strips real frontmatter with CR line endings", () => {
+    const withFrontmatter = computeQualitySignals({
+      readmeText: FRONTMATTER_README.replaceAll("\n", "\r"),
+      summary: SUMMARY,
+    });
+    const withoutFrontmatter = computeQualitySignals({
+      readmeText: NO_FRONTMATTER_README,
+      summary: SUMMARY,
+    });
+
+    expect(withFrontmatter).toMatchObject({
+      bodyWords: withoutFrontmatter.bodyWords,
+      bodyChars: withoutFrontmatter.bodyChars,
+      headingCount: withoutFrontmatter.headingCount,
+      bulletCount: withoutFrontmatter.bulletCount,
+    });
+  });
 });
 
 describe("evaluateQuality", () => {
   it("does not reject a documented frontmatter-less skill from a new account", () => {
     const signals = computeQualitySignals({
       readmeText: THEMATIC_BREAK_README,
+      summary: SUMMARY,
+    });
+
+    const assessment = evaluateQuality({
+      signals,
+      trustTier: "low",
+      similarRecentCount: 0,
+    });
+
+    expect(assessment.decision).toBe("pass");
+  });
+
+  it("does not reject a frontmatter-less skill that begins with a thematic break", () => {
+    const signals = computeQualitySignals({
+      readmeText: LEADING_THEMATIC_BREAK_README,
       summary: SUMMARY,
     });
 

--- a/convex/lib/skillQuality.test.ts
+++ b/convex/lib/skillQuality.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import { computeQualitySignals, evaluateQuality } from "./skillQuality";
+
+// Frontmatter is optional when publishing a skill: `publishSkillVersion` takes
+// the display name from its arguments and `parseFrontmatter` simply returns an
+// empty record when the document has none. A SKILL.md may therefore open with a
+// heading and use `---` purely as a Markdown thematic break.
+const BODY_LINES = [
+  "## How it works",
+  "",
+  "The skill resolves a location from the incoming request and queries the",
+  "national weather service for the current forecast window. Responses are",
+  "normalized into a single unit system before rendering, so a caller never",
+  "has to reconcile mixed metric and imperial values inside one table.",
+  "",
+  "- Resolves the location from the request payload",
+  "- Calls the upstream forecast endpoint with a bounded timeout",
+  "- Normalizes temperature, wind speed and precipitation units",
+  "- Renders the result as a compact table for the agent to read",
+  "",
+  "## Configuration",
+  "",
+  "Set the upstream endpoint and the request timeout through environment",
+  "variables. Both carry defaults that work for local development.",
+];
+
+const THEMATIC_BREAK_README = [
+  "# Weather Report Skill",
+  "",
+  "---",
+  "",
+  ...BODY_LINES,
+  "",
+  "---",
+  "",
+  "Rate limits apply.",
+].join("\n");
+
+const FRONTMATTER_README = [
+  "---",
+  "name: weather-report",
+  "description: Fetches forecasts from the national weather service.",
+  "---",
+  "",
+  "# Weather Report Skill",
+  "",
+  ...BODY_LINES,
+].join("\n");
+
+const NO_FRONTMATTER_README = ["# Weather Report Skill", "", ...BODY_LINES].join("\n");
+
+const SUMMARY = "Fetches forecasts and renders them as a normalized table.";
+
+describe("computeQualitySignals", () => {
+  it("keeps the body of a frontmatter-less SKILL.md that uses thematic breaks", () => {
+    const signals = computeQualitySignals({
+      readmeText: THEMATIC_BREAK_README,
+      summary: SUMMARY,
+    });
+
+    expect(signals.headingCount).toBe(3);
+    expect(signals.bulletCount).toBe(4);
+    expect(signals.bodyWords).toBeGreaterThanOrEqual(80);
+  });
+
+  it("still strips real frontmatter", () => {
+    const withFrontmatter = computeQualitySignals({
+      readmeText: FRONTMATTER_README,
+      summary: SUMMARY,
+    });
+    const withoutFrontmatter = computeQualitySignals({
+      readmeText: NO_FRONTMATTER_README,
+      summary: SUMMARY,
+    });
+
+    expect(withFrontmatter.bodyWords).toBe(withoutFrontmatter.bodyWords);
+    expect(withFrontmatter.bodyChars).toBe(withoutFrontmatter.bodyChars);
+  });
+});
+
+describe("evaluateQuality", () => {
+  it("does not reject a documented frontmatter-less skill from a new account", () => {
+    const signals = computeQualitySignals({
+      readmeText: THEMATIC_BREAK_README,
+      summary: SUMMARY,
+    });
+
+    const assessment = evaluateQuality({
+      signals,
+      trustTier: "low",
+      similarRecentCount: 0,
+    });
+
+    expect(assessment.decision).toBe("pass");
+  });
+});

--- a/convex/lib/skillQuality.ts
+++ b/convex/lib/skillQuality.ts
@@ -1,3 +1,5 @@
+import { parseSkillMarkdown } from "./skills";
+
 const TRUST_TIER_ACCOUNT_AGE_LOW_MS = 30 * 24 * 60 * 60 * 1000;
 const TRUST_TIER_ACCOUNT_AGE_MEDIUM_MS = 90 * 24 * 60 * 60 * 1000;
 const TRUST_TIER_SKILLS_LOW = 10;
@@ -41,7 +43,7 @@ export type QualityAssessment = {
 // with no frontmatter that used `---` as a Markdown thematic break lost
 // everything between its first two rules.
 function stripFrontmatter(raw: string) {
-  return raw.replace(/^---\s*\n[\s\S]*?\n---\s*\n?/, "");
+  return parseSkillMarkdown(raw).body;
 }
 
 function tokenizeWords(text: string) {

--- a/convex/lib/skillQuality.ts
+++ b/convex/lib/skillQuality.ts
@@ -36,8 +36,12 @@ export type QualityAssessment = {
   signals: Omit<QualitySignals, "structuralFingerprint">;
 };
 
+// Anchored to the start of the document on purpose. Frontmatter is optional,
+// and with the `m` flag `^` also matched at every line start, so a document
+// with no frontmatter that used `---` as a Markdown thematic break lost
+// everything between its first two rules.
 function stripFrontmatter(raw: string) {
-  return raw.replace(/^---\s*\n[\s\S]*?\n---\s*\n?/m, "");
+  return raw.replace(/^---\s*\n[\s\S]*?\n---\s*\n?/, "");
 }
 
 function tokenizeWords(text: string) {

--- a/convex/lib/skills.test.ts
+++ b/convex/lib/skills.test.ts
@@ -7,6 +7,7 @@ import {
   isMacJunkPath,
   parseClawdisMetadata,
   parseFrontmatter,
+  parseSkillMarkdown,
   sanitizePath,
 } from "./skills";
 
@@ -21,6 +22,34 @@ describe("skills utils", () => {
     expect(parseFrontmatter("nope")).toEqual({});
     expect(parseFrontmatter("---\nname: demo\nBody without end")).toEqual({});
   });
+
+  it.each(["\n", "\r\n", "\r"])("splits real frontmatter with %j line endings", (lineEnding) => {
+    const markdown = ["---", "name: demo", "---", "# Body"].join(lineEnding);
+
+    expect(parseSkillMarkdown(markdown)).toEqual({
+      frontmatter: { name: "demo" },
+      body: "# Body",
+    });
+  });
+
+  it("keeps a leading thematic break when its contents are not YAML frontmatter", () => {
+    const markdown = "---\n\n# Body\n\n---\n\nMore documentation.";
+
+    expect(parseSkillMarkdown(markdown)).toEqual({
+      frontmatter: {},
+      body: markdown,
+    });
+  });
+
+  it.each(["---\nname: [\n---\n# Body", "---\nname: demo\n# Body without a closing delimiter"])(
+    "keeps malformed or unterminated frontmatter as body",
+    (markdown) => {
+      expect(parseSkillMarkdown(markdown)).toEqual({
+        frontmatter: {},
+        body: markdown,
+      });
+    },
+  );
 
   it("strips quotes in frontmatter values", () => {
     const frontmatter = parseFrontmatter(`---\nname: "demo"\ndescription: 'Hello'\n---\nBody`);

--- a/convex/lib/skills/index.ts
+++ b/convex/lib/skills/index.ts
@@ -9,9 +9,12 @@ import {
 import { parse as parseYaml } from "yaml";
 
 export type ParsedSkillFrontmatter = Record<string, unknown>;
+export type ParsedSkillMarkdown = {
+  frontmatter: ParsedSkillFrontmatter;
+  body: string;
+};
 export type { ClawdisSkillMetadata, SkillInstallSpec };
 
-const FRONTMATTER_START = "---";
 const DEFAULT_EMBEDDING_MAX_CHARS = 12_000;
 // Each OpenAI token maps to at least one UTF-8 byte; keep publish embeddings
 // below the 8192-token model limit with conservative headroom.
@@ -19,27 +22,42 @@ const DEFAULT_EMBEDDING_MAX_BYTES = 7_500;
 
 const encoder = new TextEncoder();
 
-export function parseFrontmatter(content: string): ParsedSkillFrontmatter {
+export function parseSkillMarkdown(content: string): ParsedSkillMarkdown {
   const frontmatter: ParsedSkillFrontmatter = {};
   const normalized = content.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
-  if (!normalized.startsWith(FRONTMATTER_START)) return frontmatter;
-  const endIndex = normalized.indexOf(`\n${FRONTMATTER_START}`, 3);
-  if (endIndex === -1) return frontmatter;
-  const block = normalized.slice(4, endIndex);
+  const withoutFrontmatter = { frontmatter, body: normalized };
+  const lines = normalized.split("\n");
+  if (!isFrontmatterDelimiter(lines[0])) return withoutFrontmatter;
+  const closingLineIndex = lines.findIndex(
+    (line, index) => index > 0 && isFrontmatterDelimiter(line),
+  );
+  if (closingLineIndex === -1) return withoutFrontmatter;
+  const block = lines.slice(1, closingLineIndex).join("\n");
 
   try {
     const parsed = parseYaml(block) as unknown;
-    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return frontmatter;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return withoutFrontmatter;
     for (const [key, value] of Object.entries(parsed as Record<string, unknown>)) {
       if (!/^[\w-]+$/.test(key)) continue;
       const jsonValue = toJsonValue(value);
       if (jsonValue !== undefined) frontmatter[key] = jsonValue;
     }
   } catch {
-    return frontmatter;
+    return withoutFrontmatter;
   }
 
-  return frontmatter;
+  return {
+    frontmatter,
+    body: lines.slice(closingLineIndex + 1).join("\n"),
+  };
+}
+
+function isFrontmatterDelimiter(line: string | undefined) {
+  return line !== undefined && /^---[\t ]*$/.test(line);
+}
+
+export function parseFrontmatter(content: string): ParsedSkillFrontmatter {
+  return parseSkillMarkdown(content).frontmatter;
 }
 
 export function getFrontmatterValue(frontmatter: ParsedSkillFrontmatter, key: string) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where publishing a skill fails with

> Skill content is too thin or templated. Add meaningful, specific documentation.

even though the SKILL.md is fully documented. The trigger is a SKILL.md that has
no YAML frontmatter and uses `---` as an ordinary Markdown thematic break. The
publish is rejected outright, so the skill never reaches the catalog.

Newly created accounts are hit hardest: the reject floors are highest for the
`low` trust tier, which covers every account under 30 days old or with fewer
than 10 published skills.

## Why This Change Was Made

The quality gate removes frontmatter before measuring the body:

```ts
raw.replace(/^---\s*\n[\s\S]*?\n---\s*\n?/m, "")
```

The `m` flag makes `^` match at every line start rather than only at the start of
the document. Frontmatter is optional on publish — `publishSkillVersion` takes the
display name from its own arguments, and `parseFrontmatter` returns an empty
record for a document that has none — so a SKILL.md may legitimately open with a
heading and use `---` as a horizontal rule. When it does, the pattern latches onto
the first rule and deletes everything up to the second one.

Dropping the flag anchors the pattern to the start of the document, which is what
the rest of the repository already does. The canonical parser
`parseFrontmatter` in `convex/lib/skills/index.ts` guards with
`normalized.startsWith("---")`, and the three other frontmatter patterns
(`convex/skillsShMirror.ts`, `packages/schema/src/clawPackage.ts`,
`packages/clawhub/src/schema/clawPackage.ts`) carry no `m` flag. `skillQuality`
was the only one reading the same document differently from the publish path that
calls it.

The truncated body also fed `toStructuralFingerprint`, so template-spam
similarity was being compared over a fragment rather than the real document. That
is corrected by the same change.

Non-goals, kept out to hold the change to one concern:

- Tuning the reject or quarantine thresholds. They are unchanged.
- Sharing a single frontmatter helper across the four call sites.

## User Impact

A skill whose SKILL.md uses `---` as a thematic break now publishes normally
instead of being rejected as thin content. Spam detection also compares whole
documents rather than truncated fragments, so the fingerprint is no longer
skewed toward whatever a skill happens to place above its first horizontal rule.

## Evidence

Base commit: `79ef4af1`. The fix is not on `main` — `stripFrontmatter` there still
carries the `m` flag.

Signals and the gate decision read from `computeQualitySignals` and
`evaluateQuality`, for a 109-word SKILL.md with two headings, four bullets and two
`---` thematic breaks, evaluated at the `low` trust tier with no similar recent
publishes:

| | before | after |
| --- | --- | --- |
| `bodyChars` | 35 | 618 |
| `bodyWords` | 6 | 109 |
| `headingCount` | 1 | 3 |
| `bulletCount` | 0 | 4 |
| `score` | 30 | 100 |
| `decision` | `reject` | `pass` |
| `reason` | Skill content is too thin or templated. Add meaningful, specific documentation. | Quality checks passed. |

94% of the body was being discarded before measurement.

This module had no unit test. `convex/lib/skillQuality.test.ts` adds three cases;
two of them fail on the parent commit and pass with the fix:

```
$ VITE_CONVEX_URL=https://example.invalid bunx vitest run \
    convex/lib/skillQuality.test.ts        # parent commit 79ef4af1

 × computeQualitySignals > keeps the body of a frontmatter-less SKILL.md that uses thematic breaks
AssertionError: expected 1 to be 3 // Object.is equality

 × evaluateQuality > does not reject a documented frontmatter-less skill from a new account
AssertionError: expected 'reject' to be 'pass' // Object.is equality

 Test Files  1 failed (1)
      Tests  2 failed | 1 passed (3)
```

```
$ VITE_CONVEX_URL=https://example.invalid bunx vitest run \
    convex/lib/skillQuality.test.ts        # with the fix

 Test Files  1 passed (1)
      Tests  3 passed (3)
```

The third case (`still strips real frontmatter`) passes on both sides: it compares
a document carrying frontmatter against the same body without it and asserts the
measured `bodyWords` and `bodyChars` match, so the intended stripping is still
happening.

Consumers of the module, run together:

```
$ bunx vitest run convex/lib/skillPublish.test.ts convex/lib/skillQuality.test.ts \
    convex/lib/skills.test.ts
 Test Files  3 passed (3)
      Tests  61 passed (61)
```

Gates run locally on Windows:

- `bunx tsc --noEmit` — clean
- `bun run lint` — clean
- `bun run deadcode:ci` — clean
- `bun run format:check` — the only two files it reports are `CLAUDE.md` and
  `.agents/skills/autoreview/CLAUDE.md`; both report identically on an unmodified
  checkout of `79ef4af1`, so they are pre-existing and untouched here.
- `bun run ci:unit` — 5542 passed. The 24 failures are pre-existing on this
  platform: an unmodified checkout of `79ef4af1` fails the same 14 files with the
  same 24 tests (5539 passed there; the difference is the three tests added by
  this PR). They are the `scripts/` worker, CLI and security-dataset suites that
  shell out to `bun`, plus `convex/lib/githubAccount.test.ts` and
  `src/routes/-management.test.tsx`. Linux CI is the authoritative signal.

The Vercel preview check will need OpenClaw Foundation team authorization, as with
other fork pull requests.
