### PR TITLE
fix: bundle plugin releases no longer stall in security scans

### DIFF
--- a/scripts/security/run-codex-scan-worker.test.ts
+++ b/scripts/security/run-codex-scan-worker.test.ts
@@ -1,4 +1,5 @@
 /* @vitest-environment node */
+import { createHash } from "node:crypto";
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -490,6 +491,43 @@ describe("run-codex-scan-worker diagnostics", () => {
       "echo ready\n",
     );
     expect(await readFile(join(workspace, "artifact", "EMPTY"))).toHaveLength(0);
+  });
+
+  it("does not extract legacy ZIP archives after materializing verified files", async () => {
+    const workspace = await tempDir();
+    const manifest = '{"id":"demo-plugin"}\n';
+
+    await writeArtifactWorkspace(
+      {
+        job: {
+          _id: "job-legacy-zip",
+          hasMaliciousSignal: false,
+          leaseToken: "lease-secret",
+          source: "pre-publication",
+          targetKind: "packageRelease",
+          waitForVtUntil: 0,
+        },
+        target: {
+          files: [
+            {
+              path: "openclaw.plugin.json",
+              sha256: createHash("sha256").update(manifest).digest("hex"),
+              size: Buffer.byteLength(manifest),
+              url: `data:text/plain,${encodeURIComponent(manifest)}`,
+            },
+          ],
+          clawpackUrl: "data:application/zip;base64,bm90LWFuLWFyY2hpdmU=",
+          release: {
+            artifactKind: "legacy-zip",
+          },
+        },
+      },
+      workspace,
+    );
+
+    expect(await readFile(join(workspace, "artifact", "openclaw.plugin.json"), "utf8")).toBe(
+      manifest,
+    );
   });
 
   it("omits signed artifact URLs from download failure errors", async () => {

--- a/scripts/security/run-codex-scan-worker.ts
+++ b/scripts/security/run-codex-scan-worker.ts
@@ -44,6 +44,9 @@ export type ClaimedJob = {
       contentType?: string;
     }>;
     clawpackUrl?: string | null;
+    release?: Record<string, unknown> & {
+      artifactKind?: "legacy-zip" | "npm-pack";
+    };
   };
 };
 
@@ -769,11 +772,15 @@ export async function writeArtifactWorkspace(job: ClaimedJob, workspace: string)
     await writeFile(out, bytes);
   }
 
-  if (job.target.clawpackUrl) {
+  // Legacy ZIP releases are already materialized above as individually verified files.
+  // Their archival copy is not an npm tarball and makes GNU tar fail before scanning.
+  const clawpackUrl =
+    job.target.release?.artifactKind === "legacy-zip" ? null : job.target.clawpackUrl;
+  if (clawpackUrl) {
     const tarballPath = join(workspace, "artifact.tgz");
     await writeFile(
       tarballPath,
-      await download(job.target.clawpackUrl, { kind: "clawpack", path: "artifact.tgz" }),
+      await download(clawpackUrl, { kind: "clawpack", path: "artifact.tgz" }),
     );
     const listing = await runCommand("tar", ["-tzf", tarballPath], {
       cwd: workspace,


### PR DESCRIPTION
Closes #3288

## What Problem This Solves

Fixes an issue where bundle-plugin releases could remain stuck in `pending` when the security scan worker tried to open their legacy ZIP artifact as a gzipped npm tarball. On the production Linux worker, GNU tar exits with status 2 before the release can be scanned.

## Why This Change Was Made

The worker now recognizes `legacy-zip` release metadata and scans the already materialized, size- and SHA-256-verified files without trying to extract the archival ZIP copy. Npm-pack releases keep the existing tar listing, path validation, and extraction flow unchanged.

This keeps the format decision in the shared scan worker, so both regular and pre-publication package scans get the same behavior without duplicating filtering logic in each job producer.

## User Impact

Bundle-plugin releases can complete security scanning instead of repeatedly failing before Clawscan/Codex runs. After this worker change is deployed, queued or retried releases affected by #3288 can proceed through the existing scan pipeline.

## Evidence

- Regression test before the fix: the new legacy-ZIP case failed with `CommandFailure: tar exited 1` on macOS because the worker attempted archive extraction.
- Regression test after the fix: the same worker test passed in an `oven/bun:1.3.11` Linux container using GNU tar 1.35, matching the production tar behavior.
- `bunx vitest run scripts/security/run-codex-scan-worker.test.ts scripts/security/run-codex-scan-worker-clawscan.test.ts` — 43 tests passed.
- `bun run ci:static` — passed.
- `bun run ci:unit` — 432 test files passed, 1 skipped; 5,636 tests passed, 2 skipped.
- `bun run ci:types-build` — passed, including TypeScript checks and the production build.
- `git diff --check` — passed.
