### PR TITLE
feat: publish verified skills.sh catalog

### DIFF
--- a/.github/workflows/skills-sh-sync.yml
+++ b/.github/workflows/skills-sh-sync.yml
@@ -1,0 +1,55 @@
+name: skills.sh Production Sync
+
+on:
+  schedule:
+    - cron: "17 * * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: skills-sh-production-sync
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    permissions:
+      contents: read
+      id-token: write
+    environment:
+      name: Production
+    steps:
+      - name: Require main
+        run: |
+          set -euo pipefail
+          if [[ "$GITHUB_REF" != "refs/heads/main" ]]; then
+            echo "::error::skills.sh production sync must run from refs/heads/main"
+            exit 1
+          fi
+
+      - uses: actions/checkout@v7.0.1
+        with:
+          ref: ${{ github.sha }}
+
+      - uses: ./.github/actions/setup-bun
+
+      - name: Synchronize and automatically verify the production corpus
+        env:
+          CLAWHUB_SKILLS_SH_SYNC_OUTPUT: skills-sh-sync-proof.json
+          CLAWHUB_SKILLS_SH_SYNC_REASON: skills.sh production sync ${{ github.run_id }} attempt ${{ github.run_attempt }}
+          CLAWHUB_SKILLS_SH_SYNC_URL: https://clawhub.ai/ops/skills-sh/mirror
+        run: |
+          set -euo pipefail
+          bun scripts/skills-sh-catalog/sync.ts
+
+      - name: Upload skills.sh synchronization proof
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: skills-sh-sync-${{ github.run_id }}-${{ github.run_attempt }}
+          if-no-files-found: error
+          path: skills-sh-sync-proof.json

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -150,6 +150,7 @@ import type * as lib_skillsShCatalogEnvironment from "../lib/skillsShCatalogEnvi
 import type * as lib_skillsShCatalogFixtures from "../lib/skillsShCatalogFixtures.js";
 import type * as lib_skillsShCatalogPublication from "../lib/skillsShCatalogPublication.js";
 import type * as lib_skillsShMirrorPublic from "../lib/skillsShMirrorPublic.js";
+import type * as lib_skillsShPublicVisibility from "../lib/skillsShPublicVisibility.js";
 import type * as lib_staticPublishScan from "../lib/staticPublishScan.js";
 import type * as lib_testSeed from "../lib/testSeed.js";
 import type * as lib_tokens from "../lib/tokens.js";
@@ -192,8 +193,10 @@ import type * as skillStatEvents from "../skillStatEvents.js";
 import type * as skillTransfers from "../skillTransfers.js";
 import type * as skills from "../skills.js";
 import type * as skillsShCatalog from "../skillsShCatalog.js";
+import type * as skillsShClaims from "../skillsShClaims.js";
 import type * as skillsShMirror from "../skillsShMirror.js";
 import type * as skillsShMirrorPublic from "../skillsShMirrorPublic.js";
+import type * as skillsShMirrorVisibility from "../skillsShMirrorVisibility.js";
 import type * as skillsShPublicTestFixtures from "../skillsShPublicTestFixtures.js";
 import type * as stars from "../stars.js";
 import type * as statsMaintenance from "../statsMaintenance.js";
@@ -353,6 +356,7 @@ declare const fullApi: ApiFromModules<{
   "lib/skillsShCatalogFixtures": typeof lib_skillsShCatalogFixtures;
   "lib/skillsShCatalogPublication": typeof lib_skillsShCatalogPublication;
   "lib/skillsShMirrorPublic": typeof lib_skillsShMirrorPublic;
+  "lib/skillsShPublicVisibility": typeof lib_skillsShPublicVisibility;
   "lib/staticPublishScan": typeof lib_staticPublishScan;
   "lib/testSeed": typeof lib_testSeed;
   "lib/tokens": typeof lib_tokens;
@@ -395,8 +399,10 @@ declare const fullApi: ApiFromModules<{
   skillTransfers: typeof skillTransfers;
   skills: typeof skills;
   skillsShCatalog: typeof skillsShCatalog;
+  skillsShClaims: typeof skillsShClaims;
   skillsShMirror: typeof skillsShMirror;
   skillsShMirrorPublic: typeof skillsShMirrorPublic;
+  skillsShMirrorVisibility: typeof skillsShMirrorVisibility;
   skillsShPublicTestFixtures: typeof skillsShPublicTestFixtures;
   stars: typeof stars;
   statsMaintenance: typeof statsMaintenance;

--- a/convex/canonicalTrending.test.ts
+++ b/convex/canonicalTrending.test.ts
@@ -159,6 +159,8 @@ describe("canonical Trending snapshot storage", () => {
   });
 
   it("keeps pagination pinned to the snapshot encoded by the cursor", async () => {
+    vi.stubEnv("CLAWHUB_ENV", "test");
+    vi.stubEnv("CLAWHUB_SKILLS_SH_ROLLOUT_MODE", "test");
     const t = convexTest(schema, modules);
     const source = await insertEligibleNativeSource(t, "pagination-source");
     const now = Date.now();
@@ -181,7 +183,7 @@ describe("canonical Trending snapshot storage", () => {
         },
         {
           position: 1,
-          lane: "skills-sh-trending",
+          lane: "clawhub-trending",
           sourceRef: { kind: "clawhub", skillId: source.skillId },
           card: nativeCard("clawhub:two", 2),
         },
@@ -197,7 +199,7 @@ describe("canonical Trending snapshot storage", () => {
       snapshotId: "skills-1000",
       completedAt: now - 950,
       totalItems: 3,
-      sourceCounts: { clawhubTrending: 1, clawhubRising: 1, skillsShTrending: 1 },
+      sourceCounts: { clawhubTrending: 2, clawhubRising: 1, skillsShTrending: 0 },
       operations: { documentsRead: 12, documentsWritten: 4, functionCalls: 3 },
     });
 
@@ -216,10 +218,31 @@ describe("canonical Trending snapshot storage", () => {
       rankingVersion: "skills-trending-v2",
       items: [
         { id: "clawhub:one", rank: 1, lane: "clawhub-trending" },
-        { id: "clawhub:two", rank: 2, lane: "skills-sh-trending" },
+        { id: "clawhub:two", rank: 2, lane: "clawhub-trending" },
       ],
     });
     expect(firstPage?.nextCursor).toEqual(expect.any(String));
+
+    const beyondVisibleTotalCursor = btoa(
+      JSON.stringify({ v: 1, s: "skills-1000", o: 5, e: 4, p: false }),
+    ).replace(/=+$/g, "");
+    await expect(
+      t.query(internal.canonicalTrending.getPageInternal, {
+        cursor: beyondVisibleTotalCursor,
+        limit: 2,
+      }),
+    ).resolves.toEqual({ status: "invalid-cursor" });
+
+    const ambiguousLegacyCursor = btoa(JSON.stringify({ v: 1, s: "skills-1000", o: 2 })).replace(
+      /=+$/g,
+      "",
+    );
+    await expect(
+      t.query(internal.canonicalTrending.getPageInternal, {
+        cursor: ambiguousLegacyCursor,
+        limit: 2,
+      }),
+    ).resolves.toEqual({ status: "invalid-cursor" });
 
     await t.mutation(internal.canonicalTrending.startSnapshotInternal, {
       snapshotId: "skills-2000",
@@ -261,10 +284,54 @@ describe("canonical Trending snapshot storage", () => {
     expect(secondPage?.nextCursor).toBeNull();
 
     await t.run(async (ctx) => {
+      await ctx.db.insert("skillsShCatalogControls", {
+        key: "global",
+        mode: "off",
+        discoveryEnabled: false,
+        writesEnabled: false,
+        scanPlanningEnabled: false,
+        scanAdmissionEnabled: false,
+        publicVisibilityEnabled: true,
+        mirrorPublicVisibilityEnabled: true,
+        paused: true,
+        maxEntriesPerRun: 0,
+        maxEntriesPerBatch: 0,
+        maxWritesPerBatch: 0,
+        maxPlannedScans: 0,
+        maxScanAdmissionsPerBatch: 0,
+        maxScanAdmissionsPerRun: 0,
+        maxScanAdmissionsPerDay: 0,
+        maxCatalogQueued: 0,
+        maxCatalogInFlight: 0,
+        maxNativeQueued: 0,
+        maxNativeInFlight: 0,
+        realScanAllowlist: [],
+        updatedBy: "pagination-test",
+        reason: "visibility generation changed",
+        updatedAt: now,
+      });
+    });
+    await expect(
+      t.query(internal.canonicalTrending.getPageInternal, {
+        cursor: firstPage.nextCursor,
+        limit: 2,
+      }),
+    ).resolves.toEqual({ status: "invalid-cursor" });
+
+    const postActivationResult = await t.query(internal.canonicalTrending.getPageInternal, {
+      cursor: null,
+      limit: 2,
+    });
+    expect(postActivationResult.status).toBe("ok");
+    if (postActivationResult.status !== "ok") {
+      throw new Error("Expected a fresh cursor after the visibility generation changed");
+    }
+
+    await t.run(async (ctx) => {
       await ctx.db.patch(source.digestId, { softDeletedAt: Date.now() });
     });
     const revokedResult = await t.query(internal.canonicalTrending.getPageInternal, {
-      cursor: firstPage.snapshotCursor,
+      cursor: postActivationResult.page.snapshotCursor,
       limit: 2,
     });
     expect(revokedResult.status).toBe("ok");
@@ -505,7 +572,7 @@ describe("canonical Trending snapshot storage", () => {
     expect(rows).toEqual({ snapshots: [], items: [] });
   });
 
-  it("materializes hourly native metrics with a fresh enabled skills.sh contribution", async () => {
+  it("materializes hourly native metrics with verified skills.sh rows under the activation lock", async () => {
     vi.stubEnv("CLAWHUB_ENV", "test");
     vi.stubEnv("CLAWHUB_SKILLS_SH_ROLLOUT_MODE", "test");
     const t = convexTest(schema, modules);
@@ -513,6 +580,45 @@ describe("canonical Trending snapshot storage", () => {
     const window = getCompletedRolling24HourWindow(now);
 
     await t.run(async (ctx) => {
+      await ctx.db.insert("skillsShCatalogControls", {
+        key: "global",
+        mode: "staging-live",
+        discoveryEnabled: true,
+        writesEnabled: false,
+        scanPlanningEnabled: false,
+        scanAdmissionEnabled: false,
+        publicVisibilityEnabled: false,
+        mirrorPublicVisibilityEnabled: false,
+        paused: false,
+        maxEntriesPerRun: 0,
+        maxEntriesPerBatch: 0,
+        maxWritesPerBatch: 0,
+        maxPlannedScans: 0,
+        maxScanAdmissionsPerBatch: 0,
+        maxScanAdmissionsPerRun: 0,
+        maxScanAdmissionsPerDay: 0,
+        maxCatalogQueued: 0,
+        maxCatalogInFlight: 0,
+        maxNativeQueued: 0,
+        maxNativeInFlight: 0,
+        realScanAllowlist: [],
+        updatedBy: "runtime-test",
+        reason: "canonical Trending runtime test",
+        updatedAt: now,
+      });
+      await ctx.db.insert("skillsShMirrorControls", {
+        key: "global",
+        enabled: true,
+        paused: false,
+        maxRowsPerRun: 50_000,
+        maxRowsPerBatch: 50,
+        maxDetailBytes: 65_536,
+        activationLockToken: "activation-lock",
+        activationLockedAt: now,
+        updatedBy: "runtime-test",
+        reason: "canonical Trending hidden activation test",
+        updatedAt: now,
+      });
       const userId = await ctx.db.insert("users", {
         handle: "patrick",
         displayName: "Patrick",
@@ -659,7 +765,9 @@ describe("canonical Trending snapshot storage", () => {
       });
     });
 
-    const result = await t.action(internal.canonicalTrending.materializeInternal, {});
+    const result = await t.action(internal.canonicalTrending.materializeInternal, {
+      activationLockToken: "activation-lock",
+    });
     expect(result).toMatchObject({
       status: "ready",
       totalItems: 2,
@@ -681,7 +789,47 @@ describe("canonical Trending snapshot storage", () => {
         },
       ],
     });
+    if (!result.snapshotId) throw new Error("Expected a materialized Trending snapshot ID");
+    const snapshotId = result.snapshotId;
 
+    await t.run(async (ctx) => {
+      const items = await ctx.db
+        .query("canonicalTrendingItems")
+        .withIndex("by_snapshot_id_and_position", (q) => q.eq("snapshotId", snapshotId))
+        .collect();
+      const native = items.find((item) => item.sourceRef.kind === "clawhub");
+      const external = items.find((item) => item.sourceRef.kind === "skills-sh");
+      if (!native || !external) throw new Error("mixed Trending fixture missing");
+      await ctx.db.patch(native._id, { position: 99 });
+      await ctx.db.patch(external._id, { position: 0 });
+      await ctx.db.patch(native._id, { position: 1 });
+    });
+    const hiddenPageResult = await t.query(internal.canonicalTrending.getPageInternal, {
+      cursor: null,
+      limit: 1,
+    });
+    expect(hiddenPageResult.status).toBe("ok");
+    if (hiddenPageResult.status !== "ok") throw new Error("Expected a hidden Trending page");
+    expect(hiddenPageResult.page.items.map((item) => item.source)).toEqual(["clawhub"]);
+
+    await t.run(async (ctx) => {
+      const items = await ctx.db
+        .query("canonicalTrendingItems")
+        .withIndex("by_snapshot_id_and_position", (q) => q.eq("snapshotId", snapshotId))
+        .collect();
+      const native = items.find((item) => item.sourceRef.kind === "clawhub");
+      const external = items.find((item) => item.sourceRef.kind === "skills-sh");
+      if (!native || !external) throw new Error("mixed Trending fixture missing");
+      await ctx.db.patch(native._id, { position: 99 });
+      await ctx.db.patch(external._id, { position: 1 });
+      await ctx.db.patch(native._id, { position: 0 });
+      const control = await ctx.db
+        .query("skillsShCatalogControls")
+        .withIndex("by_key", (q) => q.eq("key", "global"))
+        .unique();
+      if (!control) throw new Error("catalog control missing");
+      await ctx.db.patch(control._id, { mirrorPublicVisibilityEnabled: true });
+    });
     const pageResult = await t.query(internal.canonicalTrending.getPageInternal, {
       cursor: null,
       limit: 20,

--- a/convex/canonicalTrending.ts
+++ b/convex/canonicalTrending.ts
@@ -21,6 +21,7 @@ import { getRuntimeRolloutCapabilities } from "./lib/rolloutCapabilities";
 import { getCompletedRolling24HourWindow, sumRollingHourlyStats } from "./lib/skillHourlyStats";
 import { isPublicSkillsShMirrorDigest } from "./lib/skillsShMirrorPublic";
 import { assertTestSeedAllowed } from "./lib/testSeed";
+import { getSkillsShPublicCatalogEnabledHandler } from "./rolloutCapabilities";
 
 const SOURCE_PAGE_SIZE = 250;
 const WRITE_BATCH_SIZE = 100;
@@ -37,6 +38,7 @@ const internalRefs = internal as unknown as {
     finalizeSnapshotInternal: unknown;
     getExternalSourcePageInternal: unknown;
     getHourlySourcePageInternal: unknown;
+    getMaterializationModeInternal: unknown;
     getNativeSourcePageInternal: unknown;
     getLatestCompletedTrendingRunInternal: unknown;
     pruneExpiredInternal: unknown;
@@ -164,8 +166,34 @@ export const getHourlySourcePageInternal = internalQuery({
 });
 
 export const getExternalSourcePageInternal = internalQuery({
-  args: { paginationOpts: paginationOptsValidator },
+  args: {
+    activationLockToken: v.optional(v.string()),
+    allowHiddenProof: v.optional(v.boolean()),
+    paginationOpts: paginationOptsValidator,
+  },
   handler: async (ctx, args) => {
+    if (args.allowHiddenProof) assertTestSeedAllowed();
+    const mirrorControl = args.activationLockToken
+      ? await ctx.db
+          .query("skillsShMirrorControls")
+          .withIndex("by_key", (q) => q.eq("key", "global"))
+          .unique()
+      : null;
+    const activationAuthorized = Boolean(
+      args.activationLockToken && mirrorControl?.activationLockToken === args.activationLockToken,
+    );
+    if (
+      !activationAuthorized &&
+      !args.allowHiddenProof &&
+      !(await getSkillsShPublicCatalogEnabledHandler(ctx))
+    ) {
+      return {
+        page: [],
+        isDone: true,
+        continueCursor: "",
+        documentsRead: 1,
+      };
+    }
     const result = await ctx.db
       .query("skillsShMirrorDigests")
       .withIndex("by_active_visible_installable_fresh_slug", (q) =>
@@ -183,6 +211,26 @@ export const getExternalSourcePageInternal = internalQuery({
       ),
       documentsRead: result.page.length,
     };
+  },
+});
+
+export const getMaterializationModeInternal = internalQuery({
+  args: { activationLockToken: v.optional(v.string()) },
+  handler: async (ctx, args) => {
+    const control = await ctx.db
+      .query("skillsShMirrorControls")
+      .withIndex("by_key", (q) => q.eq("key", "global"))
+      .unique();
+    if (args.activationLockToken) {
+      if (control?.activationLockToken !== args.activationLockToken) {
+        throw new Error("skills.sh activation lock is not current");
+      }
+      return { includeHiddenSkillsSh: true as const };
+    }
+    if (control?.activationLockToken) {
+      throw new Error("skills.sh public activation is in progress");
+    }
+    return { includeHiddenSkillsSh: false as const };
   },
 });
 
@@ -370,7 +418,10 @@ export const pruneExpiredActionInternal = internalAction({
 });
 
 export const materializeInternal = internalAction({
-  args: { proofSnapshotId: v.optional(v.string()) },
+  args: {
+    proofSnapshotId: v.optional(v.string()),
+    activationLockToken: v.optional(v.string()),
+  },
   handler: async (ctx, args) => {
     if (args.proofSnapshotId !== undefined) {
       assertTestSeedAllowed();
@@ -386,6 +437,11 @@ export const materializeInternal = internalAction({
     let documentsWritten = 0;
 
     try {
+      await ctx.runQuery(
+        internalRefs.canonicalTrending.getMaterializationModeInternal as never,
+        { activationLockToken: args.activationLockToken } as never,
+      );
+      functionCalls += 1;
       type HourlyWindow = {
         startHour: number;
         endHour: number;
@@ -449,6 +505,10 @@ export const materializeInternal = internalAction({
           externalSource = (await collectSourcePages(
             ctx,
             internalRefs.canonicalTrending.getExternalSourcePageInternal,
+            {
+              activationLockToken: args.activationLockToken,
+              allowHiddenProof: args.proofSnapshotId !== undefined,
+            },
           )) as CollectedSource<Doc<"skillsShMirrorDigests">>;
         }
       }
@@ -639,37 +699,75 @@ export const getPageInternal = internalQuery({
       return { status: "expired" as const };
     }
     const offset = decoded?.offset ?? 0;
-    const rows = await ctx.db
-      .query("canonicalTrendingItems")
-      .withIndex("by_snapshot_id_and_position", (q) =>
-        q
-          .eq("snapshotId", snapshot.snapshotId)
-          .gte("position", offset)
-          .lt("position", offset + args.limit),
-      )
-      .take(args.limit);
-    const eligibility = await Promise.all(
-      rows.map(async (row) => {
-        const sourceRef = row.sourceRef;
-        if (sourceRef.kind === "clawhub") {
+    const skillsShPublicCatalogEnabled = await getSkillsShPublicCatalogEnabledHandler(ctx);
+    if (
+      decoded &&
+      ((decoded.skillsShPublic ?? false) !== skillsShPublicCatalogEnabled ||
+        // Pre-CLAW-603 page cursors did not record emitted rows, so a nonzero
+        // offset cannot be ranked correctly once hidden rows are filtered.
+        (decoded.emitted === undefined && decoded.offset > 0))
+    ) {
+      return { status: "invalid-cursor" as const };
+    }
+    const visibleTotal = skillsShPublicCatalogEnabled
+      ? snapshot.totalItems
+      : Math.max(0, snapshot.totalItems - (snapshot.sourceCounts?.skillsShTrending ?? 0));
+    if (
+      decoded &&
+      (decoded.offset > snapshot.totalItems ||
+        (decoded.emitted !== undefined && decoded.emitted > visibleTotal))
+    ) {
+      return { status: "invalid-cursor" as const };
+    }
+    const emittedBefore = decoded?.emitted ?? 0;
+    const visibleRows: Array<Doc<"canonicalTrendingItems">> = [];
+    let nextOffset = offset;
+    while (
+      emittedBefore + visibleRows.length < visibleTotal &&
+      visibleRows.length < args.limit &&
+      nextOffset < snapshot.totalItems
+    ) {
+      const batchSize = Math.min(100, snapshot.totalItems - nextOffset);
+      const rows = await ctx.db
+        .query("canonicalTrendingItems")
+        .withIndex("by_snapshot_id_and_position", (q) =>
+          q
+            .eq("snapshotId", snapshot.snapshotId)
+            .gte("position", nextOffset)
+            .lt("position", nextOffset + batchSize),
+        )
+        .take(batchSize);
+      if (rows.length === 0) break;
+      const eligibility = await Promise.all(
+        rows.map(async (row) => {
+          const sourceRef = row.sourceRef;
+          if (sourceRef.kind === "clawhub") {
+            const digest = await ctx.db
+              .query("skillSearchDigest")
+              .withIndex("by_skill", (q) => q.eq("skillId", sourceRef.skillId))
+              .unique();
+            return Boolean(
+              digest &&
+              !shouldExcludeSkillFromPublicBrowse(digest) &&
+              digest.publicVersion?.status === "available",
+            );
+          }
+          if (!skillsShPublicCatalogEnabled) return false;
           const digest = await ctx.db
-            .query("skillSearchDigest")
-            .withIndex("by_skill", (q) => q.eq("skillId", sourceRef.skillId))
+            .query("skillsShMirrorDigests")
+            .withIndex("by_external_id", (q) => q.eq("externalId", sourceRef.externalId))
             .unique();
-          return Boolean(
-            digest &&
-            !shouldExcludeSkillFromPublicBrowse(digest) &&
-            digest.publicVersion?.status === "available",
-          );
-        }
-        const digest = await ctx.db
-          .query("skillsShMirrorDigests")
-          .withIndex("by_external_id", (q) => q.eq("externalId", sourceRef.externalId))
-          .unique();
-        return Boolean(digest && isPublicSkillsShMirrorDigest(digest));
-      }),
-    );
-    const nextOffset = offset + rows.length;
+          return Boolean(digest && isPublicSkillsShMirrorDigest(digest));
+        }),
+      );
+      for (let index = 0; index < rows.length; index += 1) {
+        const row = rows[index]!;
+        nextOffset = row.position + 1;
+        if (eligibility[index]) visibleRows.push(row);
+        if (visibleRows.length >= args.limit) break;
+      }
+    }
+    const emitted = emittedBefore + visibleRows.length;
     return {
       status: "ok" as const,
       page: {
@@ -678,17 +776,26 @@ export const getPageInternal = internalQuery({
         snapshotCursor: encodeCanonicalTrendingCursor({
           snapshotId: snapshot.snapshotId,
           offset: 0,
+          emitted: 0,
+          skillsShPublic: skillsShPublicCatalogEnabled,
         }),
         generatedAt: new Date(snapshot.generatedAt).toISOString(),
         windowHours: snapshot.windowHours,
         rankingVersion: snapshot.rankingVersion,
-        totalItems: snapshot.totalItems,
-        items: rows.flatMap((row, index) =>
-          eligibility[index] ? [{ ...row.card, rank: row.position + 1, lane: row.lane }] : [],
-        ),
+        totalItems: visibleTotal,
+        items: visibleRows.map((row, index) => ({
+          ...row.card,
+          rank: skillsShPublicCatalogEnabled ? row.position + 1 : emittedBefore + index + 1,
+          lane: row.lane,
+        })),
         nextCursor:
-          nextOffset < snapshot.totalItems
-            ? encodeCanonicalTrendingCursor({ snapshotId: snapshot.snapshotId, offset: nextOffset })
+          emitted < visibleTotal && nextOffset < snapshot.totalItems
+            ? encodeCanonicalTrendingCursor({
+                snapshotId: snapshot.snapshotId,
+                offset: nextOffset,
+                emitted,
+                skillsShPublic: skillsShPublicCatalogEnabled,
+              })
             : null,
       },
     };

--- a/convex/githubSkillSync.test.ts
+++ b/convex/githubSkillSync.test.ts
@@ -26,7 +26,9 @@ import { Events } from "./lib/observabilityEvents";
 
 beforeEach(() => {
   vi.stubEnv("CONVEX_DEPLOYMENT", "local:clawhub");
+  vi.stubEnv("CONVEX_CLOUD_URL", "http://127.0.0.1:3210");
   vi.stubEnv("CLAWHUB_GITHUB_SKILL_SYNC_ROLLOUT_MODE", "test");
+  vi.stubEnv("CLAWHUB_SKILLS_SH_ROLLOUT_MODE", "test");
 });
 
 afterEach(() => {
@@ -537,6 +539,39 @@ describe("configurePublicGitHubSkillSourceHandler", () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(4);
     expect(runMutation).not.toHaveBeenCalled();
+  });
+
+  it("keeps production skills.sh claiming disabled before repository reads or writes", async () => {
+    vi.stubEnv("CONVEX_DEPLOYMENT", "prod:wry-manatee-359");
+    vi.stubEnv("CLAWHUB_ENV", "production");
+    vi.stubEnv("CLAWHUB_DEPLOYMENT_NAME", "wry-manatee-359");
+    vi.stubEnv("CLAWHUB_SKILLS_SH_ROLLOUT_MODE", "production");
+    vi.stubEnv("CONVEX_CLOUD_URL", "https://wry-manatee-359.convex.cloud");
+    const runQuery = vi.fn();
+    const runMutation = vi.fn();
+    const fetchMock = vi.fn();
+
+    await expect(
+      configurePublicGitHubSkillSourceHandler(
+        { runQuery, runMutation, auth: { getUserIdentity: vi.fn() } } as never,
+        {
+          ownerPublisherId: "publishers:local" as never,
+          repo: "patrick-erichsen/skills",
+          expectedSkillsShSource: {
+            repo: "patrick-erichsen/skills",
+            externalId: "patrick-erichsen/skills/html",
+            path: "skills/html",
+            commit: "2".repeat(40),
+            contentHash: "3".repeat(64),
+          },
+        },
+        fetchMock as never,
+        { userId: "users:actor" as never },
+      ),
+    ).rejects.toThrow("skills.sh claiming is enabled only in local development and Test");
+    expect(runQuery).not.toHaveBeenCalled();
+    expect(runMutation).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("matches a skills.sh selection by exact slug, path, commit, and content hash", async () => {
@@ -4336,6 +4371,51 @@ description: Build HTML artifacts.
     expect(getFunctionName(scheduledFunction as Parameters<typeof getFunctionName>[0])).toBe(
       "githubSkillSyncNode:verifyGitHubSkillInternal",
     );
+  });
+
+  it("keeps the exact permanent-Test skills.sh claim pending without scheduling verification", async () => {
+    const snapshot = await buildGitHubSkillSourceSnapshot({
+      repo: "patrick-erichsen/skills",
+      defaultBranch: "main",
+      commit: "2".repeat(40),
+      entries: {
+        "skills/html/SKILL.md": new TextEncoder().encode("# HTML\n"),
+      },
+    });
+    const { db, tables } = createDb({
+      publishers: [
+        {
+          _id: "publishers:patrick",
+          kind: "org",
+          handle: "patrick",
+          displayName: "Patrick",
+          createdAt: 1,
+          updatedAt: 1,
+        },
+      ],
+    });
+    const scheduler = { runAfter: vi.fn(async () => undefined) };
+
+    await applyGitHubSkillSourceSyncHandler({ db, scheduler } as never, {
+      repo: "patrick-erichsen/skills",
+      ownerUserId: "users:patrick" as never,
+      ownerPublisherId: "publishers:patrick" as never,
+      githubRepositoryId: "100",
+      githubOwnerId: "200",
+      skillsShClaimPath: "skills/html",
+      snapshot,
+      now: 123,
+    });
+
+    expect(tables.skills).toEqual([
+      expect.objectContaining({
+        slug: "html",
+        githubPath: "skills/html",
+        githubScanStatus: "pending",
+      }),
+    ]);
+    expect(tables.githubSkillScans ?? []).toHaveLength(0);
+    expect(scheduler.runAfter).not.toHaveBeenCalled();
   });
 
   it("does not requeue heavy verification while the current content scan job is active", async () => {

--- a/convex/githubSkillSync.ts
+++ b/convex/githubSkillSync.ts
@@ -44,6 +44,7 @@ import {
 import { chunkSkillScanRequestFiles } from "./lib/skillScanRequestFiles";
 import { syncSkillSearchDigestForSkill } from "./lib/skillSearchDigest";
 import { assertValidSkillSlug } from "./lib/skillSlugValidator";
+import { getSkillsShFixtureEnvironmentPolicy } from "./lib/skillsShCatalogEnvironment";
 import {
   isDecodableSkillPresentationRaster,
   storeSkillPresentationAsset,
@@ -77,7 +78,7 @@ type SourceForSyncPage = {
   isDone: boolean;
 };
 
-type SyncOneResult = {
+export type SyncOneResult = {
   ok: true;
   skipped?: "stale-source-observation";
   repo: string;
@@ -100,6 +101,11 @@ type SyncOneResult = {
     conflicts: number;
     invalid: number;
     revived: number;
+  };
+  claim?: {
+    phase: "first-claim" | "native-followup";
+    attempt: number;
+    skillId: Id<"skills">;
   };
 };
 
@@ -249,7 +255,7 @@ const discoveredSkillContentValidator = v.object({
   contentHash: v.string(),
 });
 
-const sourceSnapshotValidator = v.object({
+export const sourceSnapshotValidator = v.object({
   repo: v.string(),
   defaultBranch: v.string(),
   commit: v.string(),
@@ -764,6 +770,7 @@ export type ApplyGitHubSkillSourceSyncArgs = {
   githubRepositoryId?: string;
   githubOwnerId?: string;
   expectedSourceUpdatedAt?: number | null;
+  skillsShClaimPath?: string;
   snapshot: GitHubSkillSourceMetadataSnapshot;
   now?: number;
 };
@@ -1192,6 +1199,7 @@ async function applyGenericGitHubSkillSourceSyncHandler(
   };
 
   for (const discovered of args.snapshot.skills) {
+    const scheduleVerification = discovered.path !== args.skillsShClaimPath;
     try {
       assertValidSkillSlug(discovered.slug);
     } catch (error) {
@@ -1277,12 +1285,14 @@ async function applyGenericGitHubSkillSourceSyncHandler(
         await syncSkillSearchDigestForSkill(ctx, insertedSkill);
         await adjustGlobalPublicCountForSkillChange(ctx, null, insertedSkill, args.now);
       }
-      await scheduleGitHubSkillVerification(ctx, {
-        skillId,
-        contentHash: discovered.contentHash,
-        scanStatus: "pending",
-        now: args.now,
-      });
+      if (scheduleVerification) {
+        await scheduleGitHubSkillVerification(ctx, {
+          skillId,
+          contentHash: discovered.contentHash,
+          scanStatus: "pending",
+          now: args.now,
+        });
+      }
       matchedSkillIds.add(skillId);
       stats.inserted += 1;
       continue;
@@ -1391,6 +1401,7 @@ async function applyGenericGitHubSkillSourceSyncHandler(
         discovered,
         commit: args.snapshot.commit,
         now: args.now,
+        scheduleVerification,
       });
       matchedCandidateIds.add(candidateId);
       if (canAutoReviveGitHubSkill(skill)) stats.revived += 1;
@@ -1436,12 +1447,14 @@ async function applyGenericGitHubSkillSourceSyncHandler(
     const nextSkill = { ...previousSkill, ...patch };
     await syncSkillSearchDigestForSkill(ctx, nextSkill);
     await adjustGlobalPublicCountForSkillChange(ctx, previousSkill, nextSkill, args.now);
-    await scheduleGitHubSkillVerification(ctx, {
-      skillId: skill._id,
-      contentHash: discovered.contentHash,
-      scanStatus: "pending",
-      now: args.now,
-    });
+    if (scheduleVerification) {
+      await scheduleGitHubSkillVerification(ctx, {
+        skillId: skill._id,
+        contentHash: discovered.contentHash,
+        scanStatus: "pending",
+        now: args.now,
+      });
+    }
     if (skill.softDeletedAt) stats.revived += 1;
     else stats.changed += 1;
   }
@@ -1520,6 +1533,7 @@ async function upsertGitHubSkillCandidate(
     discovered: GitHubSkillSourceMetadataSnapshot["skills"][number];
     commit: string;
     now: number;
+    scheduleVerification: boolean;
   },
 ) {
   const currentCandidateId = await ensureRetainedCurrentGitHubSkillCandidate(ctx, {
@@ -1553,13 +1567,15 @@ async function upsertGitHubSkillCandidate(
         githubPendingCandidateId: exactCandidate._id,
         updatedAt: args.now,
       });
-      const verdictSourceScanId = await scheduleGitHubSkillVerification(ctx, {
-        skillId: args.skill._id,
-        contentHash: exactCandidate.githubContentHash,
-        scanStatus: exactCandidate.scanStatus,
-        now: args.now,
-        candidateId: exactCandidate._id,
-      });
+      const verdictSourceScanId = args.scheduleVerification
+        ? await scheduleGitHubSkillVerification(ctx, {
+            skillId: args.skill._id,
+            contentHash: exactCandidate.githubContentHash,
+            scanStatus: exactCandidate.scanStatus,
+            now: args.now,
+            candidateId: exactCandidate._id,
+          })
+        : null;
       if (verdictSourceScanId && verdictSourceScanId !== exactCandidate.verdictSourceScanId) {
         await ctx.db.patch(exactCandidate._id, {
           verdictSourceScanId,
@@ -1651,13 +1667,15 @@ async function upsertGitHubSkillCandidate(
       : { githubPendingCandidateId: candidateId, updatedAt: args.now },
   );
   if (scanStatus === "pending" || scanStatus === "clean" || scanStatus === "suspicious") {
-    const verdictSourceScanId = await scheduleGitHubSkillVerification(ctx, {
-      skillId: args.skill._id,
-      contentHash: args.discovered.contentHash,
-      scanStatus,
-      now: args.now,
-      candidateId,
-    });
+    const verdictSourceScanId = args.scheduleVerification
+      ? await scheduleGitHubSkillVerification(ctx, {
+          skillId: args.skill._id,
+          contentHash: args.discovered.contentHash,
+          scanStatus,
+          now: args.now,
+          candidateId,
+        })
+      : null;
     if (verdictSourceScanId && verdictSourceScanId !== reusableScan?._id) {
       await ctx.db.patch(candidateId, {
         verdictSourceScanId,
@@ -2075,6 +2093,7 @@ export const applyGitHubSkillSourceSyncInternal = internalMutation({
     githubRepositoryId: v.optional(v.string()),
     githubOwnerId: v.optional(v.string()),
     expectedSourceUpdatedAt: v.optional(v.union(v.number(), v.null())),
+    skillsShClaimPath: v.optional(v.string()),
     snapshot: sourceSnapshotValidator,
     now: v.optional(v.number()),
   },
@@ -2541,6 +2560,12 @@ export async function configurePublicGitHubSkillSourceHandler(
   fetcher: typeof fetch = fetch,
   authOverride?: { userId: Id<"users"> },
 ): Promise<SyncOneResult> {
+  if (args.expectedSkillsShSource) {
+    const claimPolicy = getSkillsShFixtureEnvironmentPolicy();
+    if (!claimPolicy.allowed) {
+      throw new ConvexError("skills.sh claiming is enabled only in local development and Test");
+    }
+  }
   assertGitHubSkillSyncRuntimeEnabled();
   const actor = authOverride ?? (await requireUserFromAction(ctx));
   const metadata = await fetchPublicGitHubRepoMetadata(args.repo, fetcher);
@@ -2573,6 +2598,9 @@ export async function configurePublicGitHubSkillSourceHandler(
     throw new ConvexError("No skills were found in that public GitHub repo.");
   }
   const canonicalRepo = normalizeRepo(revalidatedMetadata.repo).toLowerCase();
+  const skillsShClaimPath = args.expectedSkillsShSource
+    ? normalizeRepoPath(args.expectedSkillsShSource.path)
+    : undefined;
   return await applyFetchedGitHubSkillSourceSnapshot(ctx, {
     sourceId: setup.existingSource?._id,
     repo: canonicalRepo,
@@ -2581,6 +2609,15 @@ export async function configurePublicGitHubSkillSourceHandler(
     githubRepositoryId: revalidatedMetadata.repositoryId,
     githubOwnerId: revalidatedMetadata.ownerId,
     expectedSourceUpdatedAt: setup.existingSource?.updatedAt ?? null,
+    ...(args.expectedSkillsShSource
+      ? {
+          skillsShClaim: {
+            ...args.expectedSkillsShSource,
+            path: normalizeRepoPath(args.expectedSkillsShSource.path),
+          },
+        }
+      : {}),
+    ...(skillsShClaimPath ? { skillsShClaimPath } : {}),
     snapshot,
   });
 }
@@ -2613,23 +2650,31 @@ async function applyFetchedGitHubSkillSourceSnapshot(
     githubRepositoryId?: string;
     githubOwnerId?: string;
     expectedSourceUpdatedAt?: number | null;
+    skillsShClaimPath?: string;
+    skillsShClaim?: ExpectedSkillsShSource;
     snapshot: GitHubSkillSourceSnapshot;
   },
 ) {
   await persistGitHubSkillPresentationAssets(ctx, args.snapshot);
-  const result = (await ctx.runMutation(
-    internal.githubSkillSync.applyGitHubSkillSourceSyncInternal,
-    {
-      sourceId: args.sourceId,
-      repo: args.repo,
-      ownerUserId: args.ownerUserId,
-      ownerPublisherId: args.ownerPublisherId,
-      githubRepositoryId: args.githubRepositoryId,
-      githubOwnerId: args.githubOwnerId,
-      expectedSourceUpdatedAt: args.expectedSourceUpdatedAt,
-      snapshot: toGitHubSkillSourceMetadataSnapshot(args.snapshot),
-    },
-  )) as SyncOneResult;
+  const syncFunction = args.skillsShClaim
+    ? (
+        internal as unknown as {
+          skillsShClaims: { applyClaimedGitHubSkillSourceSyncInternal: never };
+        }
+      ).skillsShClaims.applyClaimedGitHubSkillSourceSyncInternal
+    : internal.githubSkillSync.applyGitHubSkillSourceSyncInternal;
+  const result = (await ctx.runMutation(syncFunction, {
+    sourceId: args.sourceId,
+    repo: args.repo,
+    ownerUserId: args.ownerUserId,
+    ownerPublisherId: args.ownerPublisherId,
+    githubRepositoryId: args.githubRepositoryId,
+    githubOwnerId: args.githubOwnerId,
+    expectedSourceUpdatedAt: args.expectedSourceUpdatedAt,
+    ...(args.skillsShClaimPath ? { skillsShClaimPath: args.skillsShClaimPath } : {}),
+    ...(args.skillsShClaim ? { skillsShClaim: args.skillsShClaim } : {}),
+    snapshot: toGitHubSkillSourceMetadataSnapshot(args.snapshot),
+  })) as SyncOneResult;
   if (result.skipped === "stale-source-observation") return result;
   await persistGitHubSkillContentsForSnapshot(ctx, result, args.snapshot);
   return result;

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -374,6 +374,12 @@ http.route({
 });
 
 http.route({
+  path: "/api/v1/operator/skills-sh/mirror",
+  method: "POST",
+  handler: skillsShCatalogTestV1Http,
+});
+
+http.route({
   pathPrefix: `${ApiRoutes.contentRights}/`,
   method: "POST",
   handler: contentRightsV1Http,

--- a/convex/httpApiV1.handlers.test.ts
+++ b/convex/httpApiV1.handlers.test.ts
@@ -3060,6 +3060,9 @@ describe("httpApiV1 handlers", () => {
         expect(args).toEqual({ externalId: "patrick-erichsen/skills/html" });
         return makePublicSkillsShDigest();
       }
+      if (Object.keys(args).length === 0) {
+        return { skillsSh: { publicCatalogEnabled: true } };
+      }
       expect(args).toEqual({ repo: "patrick-erichsen/skills", path: "skills/html" });
       return null;
     });
@@ -3089,7 +3092,7 @@ describe("httpApiV1 handlers", () => {
       trust: { clawhubScan: "unscanned", label: "Not scanned by ClawHub" },
       canonicalRef: null,
     });
-    expect(runQuery).toHaveBeenCalledTimes(2);
+    expect(runQuery).toHaveBeenCalledTimes(3);
   });
 
   it("skill install resolver keeps a scanned skills.sh alias GitHub-backed", async () => {
@@ -3177,6 +3180,9 @@ describe("httpApiV1 handlers", () => {
     vi.stubEnv("CLAWHUB_SKILLS_SH_ROLLOUT_MODE", "test");
     const runQuery = vi.fn(async (_query: unknown, args: Record<string, unknown>) => {
       if ("externalId" in args) return makePublicSkillsShDigest();
+      if (Object.keys(args).length === 0) {
+        return { skillsSh: { publicCatalogEnabled: true } };
+      }
       expect(args).toEqual({ repo: "patrick-erichsen/skills", path: "skills/html" });
       return null;
     });
@@ -3209,7 +3215,7 @@ describe("httpApiV1 handlers", () => {
         label: "Not scanned by ClawHub",
       },
     });
-    expect(runQuery).toHaveBeenCalledTimes(2);
+    expect(runQuery).toHaveBeenCalledTimes(3);
   });
 
   it("skill verification preserves a scanned GitHub alias while failing suspicious trust", async () => {

--- a/convex/httpApiV1/skillsShCatalogV1.test.ts
+++ b/convex/httpApiV1/skillsShCatalogV1.test.ts
@@ -10,6 +10,14 @@ vi.mock("../lib/githubAuth", () => ({
   buildGitHubApiHeaders: vi.fn(async () => ({ Authorization: "Bearer placeholder" })),
 }));
 
+vi.mock("../lib/githubActionsOidc", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../lib/githubActionsOidc")>();
+  return {
+    ...original,
+    verifyGitHubActionsSkillsShSyncJwt: vi.fn(),
+  };
+});
+
 vi.mock("../lib/githubSkillSync", async (importOriginal) => {
   const original = await importOriginal<typeof import("../lib/githubSkillSync")>();
   return {
@@ -29,6 +37,7 @@ vi.mock("./shared", async (importOriginal) => {
 
 const { requireAdminOrResponse, requireApiTokenUserOrResponse } = await import("./shared");
 const { buildGitHubApiHeaders } = await import("../lib/githubAuth");
+const { verifyGitHubActionsSkillsShSyncJwt } = await import("../lib/githubActionsOidc");
 const { computeGitHubSkillFolderContentHash } = await import("../lib/githubSkillSync");
 const { applyRateLimit } = await import("../lib/httpRateLimit");
 const {
@@ -67,6 +76,77 @@ function artifact(externalId: string, content: string) {
 }
 
 describe("skills.sh catalog Test HTTP API", () => {
+  it("accepts only the exact GitHub Actions production sync identity", async () => {
+    const workflowSha = "a".repeat(40);
+    vi.stubEnv("CLAWHUB_ENV", "production");
+    vi.stubEnv("CLAWHUB_DEPLOYMENT_NAME", "wry-manatee-359");
+    vi.stubEnv("CLAWHUB_SKILLS_SH_ROLLOUT_MODE", "production");
+    vi.mocked(verifyGitHubActionsSkillsShSyncJwt).mockResolvedValue({
+      actor: "github-actions[bot]",
+      eventName: "schedule",
+      runId: "603",
+      runAttempt: "1",
+      sha: workflowSha,
+    } as never);
+    const runQuery = vi.fn(async () => ({ runs: [], control: null }));
+    const runAction = vi.fn(async () => ({ ok: true, activated: true }));
+    const runMutation = vi.fn(async () => ({ ok: true, enabled: false }));
+
+    const response = await skillsShCatalogTestV1Handler(
+      { runQuery, runAction, runMutation } as never,
+      new Request("https://wry-manatee-359.convex.site/api/v1/operator/skills-sh/mirror", {
+        method: "POST",
+        headers: { Authorization: "Bearer github-oidc-token" },
+        body: JSON.stringify({ operation: "mirror-status" }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(verifyGitHubActionsSkillsShSyncJwt).toHaveBeenCalledWith("github-oidc-token");
+    expect(requireApiTokenUserOrResponse).not.toHaveBeenCalled();
+    expect(requireAdminOrResponse).not.toHaveBeenCalled();
+
+    const activation = await skillsShCatalogTestV1Handler(
+      { runQuery, runAction, runMutation } as never,
+      new Request("https://wry-manatee-359.convex.site/api/v1/operator/skills-sh/mirror", {
+        method: "POST",
+        headers: { Authorization: "Bearer github-oidc-token" },
+        body: JSON.stringify({
+          operation: "mirror-verify-activate",
+          reason: "CLAW-603 production activation",
+          confirm: "activate-skills-sh-public-production",
+        }),
+      }),
+    );
+    expect(activation.status).toBe(200);
+    expect(runAction).toHaveBeenCalledWith(expect.anything(), {
+      actor: "github-actions:603:1",
+      reason: "CLAW-603 production activation",
+      confirm: "activate-skills-sh-public-production",
+    });
+
+    const rollback = await skillsShCatalogTestV1Handler(
+      { runQuery, runAction, runMutation } as never,
+      new Request("https://wry-manatee-359.convex.site/api/v1/operator/skills-sh/mirror", {
+        method: "POST",
+        headers: { Authorization: "Bearer github-oidc-token" },
+        body: JSON.stringify({
+          operation: "mirror-public-gate",
+          enabled: false,
+          reason: "systemic skills.sh rollback",
+          confirm: "deactivate-skills-sh-public-production",
+        }),
+      }),
+    );
+    expect(rollback.status).toBe(200);
+    expect(runMutation).toHaveBeenCalledWith(expect.anything(), {
+      enabled: false,
+      actor: "github-actions:603:1",
+      reason: "systemic skills.sh rollback",
+      confirm: "deactivate-skills-sh-public-production",
+    });
+  });
+
   it("returns 404 before rate limiting or authentication while rollout is off", async () => {
     vi.stubEnv("CLAWHUB_SKILLS_SH_ROLLOUT_MODE", "off");
 
@@ -1247,7 +1327,11 @@ describe("skills.sh public HTTP API", () => {
 
   it("serves stored mirror detail from an activated row", async () => {
     const digest = makePublicMirrorDigest();
-    const runQuery = vi.fn().mockResolvedValueOnce(digest).mockResolvedValueOnce(null);
+    const runQuery = vi
+      .fn()
+      .mockResolvedValueOnce(digest)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ skillsSh: { publicCatalogEnabled: true } });
     const ctx = { runQuery } as never;
     const response = await skillsShCatalogPublicV1Handler(
       ctx,
@@ -1267,7 +1351,8 @@ describe("skills.sh public HTTP API", () => {
     const runQuery = vi
       .fn()
       .mockResolvedValueOnce(makePublicMirrorDigest())
-      .mockResolvedValueOnce(null);
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ skillsSh: { publicCatalogEnabled: true } });
     const response = await skillsShCatalogPublicV1Handler(
       { runQuery } as never,
       new Request(
@@ -1317,6 +1402,22 @@ describe("skills.sh public HTTP API", () => {
 
     expect(response.status).toBe(404);
     expect(await response.text()).toBe("Skill not found");
+  });
+
+  it("returns 404 for an eligible row while the atomic public gate is off", async () => {
+    const runQuery = vi
+      .fn()
+      .mockResolvedValueOnce(makePublicMirrorDigest())
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ skillsSh: { publicCatalogEnabled: false } });
+    const response = await skillsShCatalogPublicV1Handler(
+      { runQuery } as never,
+      new Request(
+        "https://academic-chihuahua-392.convex.site/api/v1/skills-sh/patrick-erichsen/skills/html/install",
+      ),
+    );
+
+    expect(response.status).toBe(404);
   });
 });
 

--- a/convex/httpApiV1/skillsShCatalogV1.ts
+++ b/convex/httpApiV1/skillsShCatalogV1.ts
@@ -1,6 +1,7 @@
 import { internal } from "../_generated/api";
 import type { Id } from "../_generated/dataModel";
 import type { ActionCtx } from "../_generated/server";
+import { verifyGitHubActionsSkillsShSyncJwt } from "../lib/githubActionsOidc";
 import { buildGitHubApiHeaders } from "../lib/githubAuth";
 import { computeGitHubSkillFolderContentHash } from "../lib/githubSkillSync";
 import { applyRateLimit } from "../lib/httpRateLimit";
@@ -70,6 +71,11 @@ const internalRefs = internal as unknown as {
     startRunInternal: unknown;
     storeSourcePageInternal: unknown;
   };
+  skillsShMirrorVisibility: {
+    setPublicGateInternal: unknown;
+    verifyAndActivateInternal: unknown;
+  };
+  rolloutCapabilities: { getPublicCapabilitiesInternal: unknown };
 };
 const MAX_GITHUB_OWNER_RESOLUTIONS = 500;
 const GITHUB_OWNER_RESOLUTION_CONCURRENCY = 8;
@@ -124,6 +130,15 @@ async function getSkillsShResolutionState(
   return { externalId, digest, alias };
 }
 
+async function isSkillsShPublicationEnabled(ctx: ActionCtx) {
+  const capabilities = await runQueryRef<{ skillsSh: { publicCatalogEnabled: boolean } }>(
+    ctx,
+    internalRefs.rolloutCapabilities.getPublicCapabilitiesInternal,
+    {},
+  );
+  return capabilities.skillsSh.publicCatalogEnabled;
+}
+
 export async function resolveSkillsShInstall(
   ctx: ActionCtx,
   request: Request,
@@ -131,7 +146,10 @@ export async function resolveSkillsShInstall(
 ) {
   const { externalId, digest, alias } = await getSkillsShResolutionState(ctx, ref);
   const reference = `skills-sh:${externalId}`;
-  if (!alias) return digest ? buildUnclaimedSkillsShInstallResolution(digest) : null;
+  if (!alias) {
+    if (!digest || !(await isSkillsShPublicationEnabled(ctx))) return null;
+    return buildUnclaimedSkillsShInstallResolution(digest);
+  }
   const resolution = buildSkillInstallResolution({
     origin: new URL(request.url).origin,
     skill: alias.skill,
@@ -161,7 +179,7 @@ export async function resolveSkillsShVerify(
 ) {
   const { externalId, digest, alias } = await getSkillsShResolutionState(ctx, ref);
   if (!alias) {
-    return digest
+    return digest && (await isSkillsShPublicationEnabled(ctx))
       ? buildUnclaimedSkillsShVerifyResponse({ digest, origin: new URL(request.url).origin })
       : null;
   }
@@ -593,29 +611,58 @@ async function storeArtifactFiles(
 }
 
 export async function skillsShCatalogTestV1Handler(ctx: ActionCtx, request: Request) {
-  if (!getRuntimeRolloutCapabilities().skillsSh.runtimeEnabled) {
+  const runtime = getRuntimeRolloutCapabilities();
+  if (!runtime.skillsSh.runtimeEnabled) {
     return text("Not found", 404);
   }
   const rate = await applyRateLimit(ctx, request, request.method === "GET" ? "read" : "write");
   if (!rate.ok) return rate.response;
-  const auth = await requireApiTokenUserOrResponse(ctx, request, rate.headers);
-  if (!auth.ok) return auth.response;
-  const admin = requireAdminOrResponse(auth.user, rate.headers);
-  if (!admin.ok) return admin.response;
+  let actor: string;
+  let actorUserId: string | null = null;
+  if (runtime.environment === "production") {
+    if (new URL(request.url).pathname !== "/api/v1/operator/skills-sh/mirror") {
+      return text("Not found", 404, rate.headers);
+    }
+    const authorization = request.headers.get("authorization")?.trim() ?? "";
+    const match = /^Bearer\s+(.+)$/i.exec(authorization);
+    if (!match) return text("Unauthorized", 401, rate.headers);
+    try {
+      const identity = await verifyGitHubActionsSkillsShSyncJwt(match[1]!);
+      actor = `github-actions:${identity.runId}:${identity.runAttempt}`;
+    } catch {
+      return text("Unauthorized", 401, rate.headers);
+    }
+  } else {
+    const auth = await requireApiTokenUserOrResponse(ctx, request, rate.headers);
+    if (!auth.ok) return auth.response;
+    const admin = requireAdminOrResponse(auth.user, rate.headers);
+    if (!admin.ok) return admin.response;
+    actor = auth.user.handle ?? String(auth.userId);
+    actorUserId = String(auth.userId);
+  }
 
   try {
-    const staging = await runQueryRef<{
-      environment: "test";
-      deploymentName: string | null;
-      buildSha: string | null;
-      control: Record<string, unknown>;
-    }>(ctx, internalRefs.skillsShCatalog.getStagingLiveControlInternal, {});
-    if (request.method === "GET") return json(staging, 200, rate.headers);
+    const staging =
+      runtime.environment === "test"
+        ? await runQueryRef<{
+            environment: "test";
+            deploymentName: string | null;
+            buildSha: string | null;
+            control: Record<string, unknown>;
+          }>(ctx, internalRefs.skillsShCatalog.getStagingLiveControlInternal, {})
+        : null;
+    if (request.method === "GET") {
+      if (!staging) return text("Not found", 404, rate.headers);
+      return json(staging, 200, rate.headers);
+    }
     if (request.method !== "POST") return text("Not found", 404, rate.headers);
 
     const body = asRecord(await request.json());
     if (!body) return text("Invalid JSON", 400, rate.headers);
     const operation = requireString(body, "operation");
+    if (runtime.environment === "production" && !operation.startsWith("mirror-")) {
+      return text("Not found", 404, rate.headers);
+    }
     if (operation === "mirror-status") {
       return json(
         await runQueryRef(ctx, internalRefs.skillsShMirror.getStatusInternal, {}),
@@ -626,6 +673,29 @@ export async function skillsShCatalogTestV1Handler(ctx: ActionCtx, request: Requ
     if (operation === "mirror-isolation") {
       return json(
         await runQueryRef(ctx, internalRefs.skillsShMirror.getIsolationInternal, {}),
+        200,
+        rate.headers,
+      );
+    }
+    if (operation === "mirror-verify-activate") {
+      return json(
+        await runActionRef(ctx, internalRefs.skillsShMirrorVisibility.verifyAndActivateInternal, {
+          actor,
+          reason: requireString(body, "reason"),
+          confirm: requireString(body, "confirm"),
+        }),
+        200,
+        rate.headers,
+      );
+    }
+    if (operation === "mirror-public-gate") {
+      return json(
+        await runMutationRef(ctx, internalRefs.skillsShMirrorVisibility.setPublicGateInternal, {
+          enabled: requireBoolean(body, "enabled"),
+          actor,
+          reason: requireString(body, "reason"),
+          confirm: requireString(body, "confirm"),
+        }),
         200,
         rate.headers,
       );
@@ -745,7 +815,7 @@ export async function skillsShCatalogTestV1Handler(ctx: ActionCtx, request: Requ
     if (operation === "mirror-configure") {
       return json(
         await runMutationRef(ctx, internalRefs.skillsShMirror.configureInternal, {
-          actor: auth.user.handle,
+          actor,
           reason: requireString(body, "reason"),
           confirm: requireString(body, "confirm"),
           enabled: requireBoolean(body, "enabled"),
@@ -761,7 +831,7 @@ export async function skillsShCatalogTestV1Handler(ctx: ActionCtx, request: Requ
       const sourceView = optionalMirrorSourceView(body);
       return json(
         await runMutationRef(ctx, internalRefs.skillsShMirror.startRunInternal, {
-          actor: auth.user.handle,
+          actor,
           reason: requireString(body, "reason"),
           snapshotId: requireString(body, "snapshotId"),
           ...(sourceView ? { sourceView } : {}),
@@ -886,7 +956,7 @@ export async function skillsShCatalogTestV1Handler(ctx: ActionCtx, request: Requ
         await runMutationRef(ctx, internalRefs.skillsShMirror.setPausedInternal, {
           runId: requireString(body, "runId"),
           paused: requireBoolean(body, "paused"),
-          actor: auth.user.handle,
+          actor,
           reason: requireString(body, "reason"),
           confirm: requireString(body, "confirm"),
         }),
@@ -898,7 +968,7 @@ export async function skillsShCatalogTestV1Handler(ctx: ActionCtx, request: Requ
       return json(
         await runMutationRef(ctx, internalRefs.skillsShMirror.cancelRunInternal, {
           runId: requireString(body, "runId"),
-          actor: auth.user.handle,
+          actor,
           reason: requireString(body, "reason"),
           confirm: requireString(body, "confirm"),
         }),
@@ -933,7 +1003,7 @@ export async function skillsShCatalogTestV1Handler(ctx: ActionCtx, request: Requ
         internalRefs.skillsShCatalog.startFixtureRunInternal,
         {
           fixtureId: CONTROLLED_CANARY_FIXTURE_ID,
-          actor: auth.user.handle,
+          actor,
           reason: requireString(body, "reason"),
           sourceVerification,
         },
@@ -946,7 +1016,7 @@ export async function skillsShCatalogTestV1Handler(ctx: ActionCtx, request: Requ
           ctx,
           internalRefs.skillsShCatalog.startControlledCanaryScanRunInternal,
           {
-            actor: auth.user.handle,
+            actor,
             reason: requireString(body, "reason"),
           },
         ),
@@ -958,7 +1028,7 @@ export async function skillsShCatalogTestV1Handler(ctx: ActionCtx, request: Requ
       return json(
         await runMutationRef(ctx, internalRefs.skillsShCatalog.setPublicationEnabledInternal, {
           enabled: requireBoolean(body, "enabled"),
-          actor: auth.user.handle,
+          actor,
           reason: requireString(body, "reason"),
           confirm: requireString(body, "confirm"),
         }),
@@ -970,7 +1040,7 @@ export async function skillsShCatalogTestV1Handler(ctx: ActionCtx, request: Requ
       return json(
         await runMutationRef(ctx, internalRefs.skillsShCatalog.setCatalogPausedInternal, {
           paused: requireBoolean(body, "paused"),
-          actor: auth.user.handle,
+          actor,
           reason: requireString(body, "reason"),
           confirm: requireString(body, "confirm"),
         }),
@@ -983,7 +1053,7 @@ export async function skillsShCatalogTestV1Handler(ctx: ActionCtx, request: Requ
         await runMutationRef(ctx, internalRefs.skillsShCatalog.rollbackPublicationInternal, {
           externalId: requireString(body, "externalId"),
           attemptId: requireString(body, "attemptId"),
-          actor: auth.user.handle,
+          actor,
           reason: requireString(body, "reason"),
           confirm: requireString(body, "confirm"),
         }),
@@ -1013,7 +1083,7 @@ export async function skillsShCatalogTestV1Handler(ctx: ActionCtx, request: Requ
       return json(
         await runMutationRef(ctx, internalRefs.skillsShCatalog.rollbackFixtureRunInternal, {
           runId: requireString(body, "runId"),
-          actor: auth.user.handle,
+          actor,
           reason: requireString(body, "reason"),
           confirm: requireString(body, "confirm"),
         }),
@@ -1029,7 +1099,7 @@ export async function skillsShCatalogTestV1Handler(ctx: ActionCtx, request: Requ
         ctx,
         internalRefs.skillsShCatalog.startStagingLiveRunInternal,
         {
-          actor: auth.user.handle,
+          actor,
           reason: requireString(body, "reason"),
           snapshotId: requireString(body, "snapshotId"),
           sourceCapturedAt: requireString(body, "sourceCapturedAt"),
@@ -1053,6 +1123,7 @@ export async function skillsShCatalogTestV1Handler(ctx: ActionCtx, request: Requ
       return json(result, 200, rate.headers);
     }
     if (operation === "admit") {
+      if (!actorUserId) throw new Error("Test operator user is required");
       if (!Array.isArray(body.externalIds)) throw new Error("externalIds is required");
       const stored = await storeArtifactFiles(ctx, body.artifacts);
       let result: {
@@ -1063,7 +1134,7 @@ export async function skillsShCatalogTestV1Handler(ctx: ActionCtx, request: Requ
         result = await runActionRef(ctx, internalRefs.skillsShCatalog.admitRealScansInternal, {
           runId: requireString(body, "runId"),
           externalIds: body.externalIds,
-          actorUserId: auth.userId,
+          actorUserId,
           artifacts: stored.artifacts,
         });
       } catch (error) {
@@ -1137,6 +1208,9 @@ export async function skillsShCatalogPublicV1Handler(ctx: ActionCtx, request: Re
       { externalId },
     ),
   ]);
+  if (!digest || !(await isSkillsShPublicationEnabled(ctx))) {
+    return text("Skill not found", 404, rate.headers);
+  }
   const entry = digest ? buildSkillsShMirrorCatalogDetail({ digest, detail }) : null;
   return entry ? json(entry, 200, rate.headers) : text("Skill not found", 404, rate.headers);
 }

--- a/convex/lib/canonicalTrending.test.ts
+++ b/convex/lib/canonicalTrending.test.ts
@@ -186,6 +186,14 @@ describe("canonical Trending cursors", () => {
     });
     expect(() => decodeCanonicalTrendingCursor("not-a-cursor")).toThrow("Invalid cursor format");
   });
+
+  it("rejects emitted counts beyond their physical snapshot offset", () => {
+    expect(() =>
+      encodeCanonicalTrendingCursor({ snapshotId: "snapshot-123", offset: 3, emitted: 4 }),
+    ).toThrow("Invalid cursor emitted count");
+    const malformed = btoa(JSON.stringify({ v: 1, s: "snapshot-123", o: 3, e: 4 }));
+    expect(() => decodeCanonicalTrendingCursor(malformed)).toThrow("Invalid cursor format");
+  });
 });
 
 describe("canonical Trending cards", () => {

--- a/convex/lib/canonicalTrending.ts
+++ b/convex/lib/canonicalTrending.ts
@@ -416,6 +416,8 @@ export function blendCanonicalTrendingPools<T extends CanonicalTrendingCandidate
 export type CanonicalTrendingCursor = {
   snapshotId: string;
   offset: number;
+  emitted?: number;
+  skillsShPublic?: boolean;
 };
 
 export function encodeCanonicalTrendingCursor(cursor: CanonicalTrendingCursor) {
@@ -425,7 +427,21 @@ export function encodeCanonicalTrendingCursor(cursor: CanonicalTrendingCursor) {
   if (!Number.isSafeInteger(cursor.offset) || cursor.offset < 0) {
     throw new Error("Invalid cursor offset");
   }
-  return btoa(JSON.stringify({ v: 1, s: cursor.snapshotId, o: cursor.offset }))
+  if (
+    cursor.emitted !== undefined &&
+    (!Number.isSafeInteger(cursor.emitted) || cursor.emitted < 0 || cursor.emitted > cursor.offset)
+  ) {
+    throw new Error("Invalid cursor emitted count");
+  }
+  return btoa(
+    JSON.stringify({
+      v: 1,
+      s: cursor.snapshotId,
+      o: cursor.offset,
+      ...(cursor.emitted !== undefined ? { e: cursor.emitted } : {}),
+      ...(cursor.skillsShPublic !== undefined ? { p: cursor.skillsShPublic } : {}),
+    }),
+  )
     .replace(/\+/g, "-")
     .replace(/\//g, "_")
     .replace(/=+$/g, "");
@@ -437,17 +453,33 @@ export function decodeCanonicalTrendingCursor(value: string): CanonicalTrendingC
       .replace(/-/g, "+")
       .replace(/_/g, "/")
       .padEnd(Math.ceil(value.length / 4) * 4, "=");
-    const parsed = JSON.parse(atob(padded)) as { v?: unknown; s?: unknown; o?: unknown };
+    const parsed = JSON.parse(atob(padded)) as {
+      v?: unknown;
+      s?: unknown;
+      o?: unknown;
+      e?: unknown;
+      p?: unknown;
+    };
     if (
       parsed.v !== 1 ||
       typeof parsed.s !== "string" ||
       !/^[A-Za-z0-9:_-]+$/.test(parsed.s) ||
       !Number.isSafeInteger(parsed.o) ||
-      (parsed.o as number) < 0
+      (parsed.o as number) < 0 ||
+      (parsed.e !== undefined &&
+        (!Number.isSafeInteger(parsed.e) ||
+          (parsed.e as number) < 0 ||
+          (parsed.e as number) > (parsed.o as number))) ||
+      (parsed.p !== undefined && typeof parsed.p !== "boolean")
     ) {
       throw new Error("invalid");
     }
-    return { snapshotId: parsed.s, offset: parsed.o as number };
+    return {
+      snapshotId: parsed.s,
+      offset: parsed.o as number,
+      ...(parsed.e !== undefined ? { emitted: parsed.e as number } : {}),
+      ...(parsed.p !== undefined ? { skillsShPublic: parsed.p as boolean } : {}),
+    };
   } catch {
     throw new Error("Invalid cursor format");
   }

--- a/convex/lib/githubActionsOidc.test.ts
+++ b/convex/lib/githubActionsOidc.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   extractWorkflowFilenameFromWorkflowRef,
   fetchGitHubRepositoryIdentity,
+  verifyGitHubActionsSkillsShSyncJwt,
   verifyGitHubActionsTrustedPublishJwt,
   type TrustedGitHubActionsPublisher,
 } from "./githubActionsOidc";
@@ -549,6 +550,47 @@ describe("verifyGitHubActionsTrustedPublishJwt", () => {
       workflowFilename: trustedPublisher.workflowFilename,
     });
     expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("verifyGitHubActionsSkillsShSyncJwt", () => {
+  it("accepts the exact scheduled production sync identity across app deploys", async () => {
+    const workflowSha = "a".repeat(40);
+    const { token, jwks } = await createSignedToken({
+      repository: "openclaw/clawhub",
+      repository_id: "1127248221",
+      repository_owner: "openclaw",
+      repository_owner_id: "252820863",
+      workflow_ref: "openclaw/clawhub/.github/workflows/skills-sh-sync.yml@refs/heads/main",
+      runner_environment: "github-hosted",
+      environment: "Production",
+      event_name: "schedule",
+      workflow: "Skills.sh Sync",
+      sha: workflowSha,
+      ref: "refs/heads/main",
+      ref_type: "branch",
+      actor: "github-actions[bot]",
+      actor_id: "41898282",
+      run_id: "603",
+      run_attempt: "1",
+      iss: "https://token.actions.githubusercontent.com",
+      aud: "clawhub",
+      exp: Math.floor(Date.now() / 1000) + 300,
+      iat: Math.floor(Date.now() / 1000) - 5,
+    });
+
+    await expect(
+      verifyGitHubActionsSkillsShSyncJwt(token, {
+        fetchImpl: async () => Response.json({ keys: [jwks] }),
+      }),
+    ).resolves.toMatchObject({
+      repository: "openclaw/clawhub",
+      workflowFilename: "skills-sh-sync.yml",
+      environment: "Production",
+      eventName: "schedule",
+      sha: workflowSha,
+      ref: "refs/heads/main",
+    });
   });
 });
 

--- a/convex/lib/githubActionsOidc.ts
+++ b/convex/lib/githubActionsOidc.ts
@@ -47,6 +47,12 @@ type VerifyGitHubActionsOidcOptions = {
   now?: () => number;
 };
 
+type GitHubActionsWorkflowPolicy = {
+  allowedEvents: readonly string[];
+  expectedRef?: string;
+  reusableWorkflow: { repository: string; workflowFilename: string } | null;
+};
+
 type GitHubRepositoryIdentity = {
   repository: string;
   repositoryId: string;
@@ -66,6 +72,14 @@ const CLOCK_SKEW_MS = 60_000;
 const JWKS_CACHE_TTL_MS = 5 * 60_000;
 const OFFICIAL_REUSABLE_WORKFLOW_REPOSITORY = "openclaw/clawhub";
 const OFFICIAL_REUSABLE_WORKFLOW_FILENAME = "package-publish.yml";
+const SKILLS_SH_SYNC_WORKFLOW: TrustedGitHubActionsPublisher = {
+  repository: "openclaw/clawhub",
+  repositoryId: "1127248221",
+  repositoryOwner: "openclaw",
+  repositoryOwnerId: "252820863",
+  workflowFilename: "skills-sh-sync.yml",
+  environment: "Production",
+};
 
 let cachedJwks: { value: JwkSet; fetchedAt: number } | null = null;
 
@@ -73,6 +87,42 @@ export async function verifyGitHubActionsTrustedPublishJwt(
   jwt: string,
   trustedPublisher: TrustedGitHubActionsPublisher,
   options: VerifyGitHubActionsOidcOptions = {},
+): Promise<VerifiedGitHubActionsIdentity> {
+  return await verifyGitHubActionsWorkflowJwt(
+    jwt,
+    trustedPublisher,
+    {
+      allowedEvents: ["workflow_dispatch"],
+      reusableWorkflow: {
+        repository: OFFICIAL_REUSABLE_WORKFLOW_REPOSITORY,
+        workflowFilename: OFFICIAL_REUSABLE_WORKFLOW_FILENAME,
+      },
+    },
+    options,
+  );
+}
+
+export async function verifyGitHubActionsSkillsShSyncJwt(
+  jwt: string,
+  options: VerifyGitHubActionsOidcOptions = {},
+): Promise<VerifiedGitHubActionsIdentity> {
+  return await verifyGitHubActionsWorkflowJwt(
+    jwt,
+    SKILLS_SH_SYNC_WORKFLOW,
+    {
+      allowedEvents: ["schedule", "workflow_dispatch"],
+      expectedRef: "refs/heads/main",
+      reusableWorkflow: null,
+    },
+    options,
+  );
+}
+
+async function verifyGitHubActionsWorkflowJwt(
+  jwt: string,
+  trustedPublisher: TrustedGitHubActionsPublisher,
+  workflowPolicy: GitHubActionsWorkflowPolicy,
+  options: VerifyGitHubActionsOidcOptions,
 ): Promise<VerifiedGitHubActionsIdentity> {
   const fetchImpl = options.fetchImpl ?? fetch;
   const now = (options.now ?? Date.now)();
@@ -163,9 +213,12 @@ export async function verifyGitHubActionsTrustedPublishJwt(
   }
   if (jobWorkflowRef) {
     const reusableWorkflow = parseWorkflowRef(jobWorkflowRef);
+    if (!workflowPolicy.reusableWorkflow) {
+      throw new Error("Reusable workflows may not run the skills.sh production sync");
+    }
     const usesOfficialReusableWorkflow =
-      reusableWorkflow.repository === OFFICIAL_REUSABLE_WORKFLOW_REPOSITORY &&
-      reusableWorkflow.workflowFilename === OFFICIAL_REUSABLE_WORKFLOW_FILENAME;
+      reusableWorkflow.repository === workflowPolicy.reusableWorkflow.repository &&
+      reusableWorkflow.workflowFilename === workflowPolicy.reusableWorkflow.workflowFilename;
     if (!usesOfficialReusableWorkflow) {
       throw new Error(
         "Only the official ClawHub reusable workflow is supported for trusted publishing",
@@ -177,17 +230,18 @@ export async function verifyGitHubActionsTrustedPublishJwt(
       `Only GitHub-hosted runners may mint trusted publish tokens, got ${runnerEnvironment}`,
     );
   }
-  // v1 keeps secretless publishing behind a manual entry point. Environment
-  // pinning is optional, but if configured it must match exactly.
-  if (eventName !== "workflow_dispatch") {
-    throw new Error(`Trusted publishing requires workflow_dispatch, got ${eventName}`);
+  if (!workflowPolicy.allowedEvents.includes(eventName)) {
+    const expected = workflowPolicy.allowedEvents.join(" or ");
+    throw new Error(`GitHub OIDC workflow requires ${expected}, got ${eventName}`);
   }
   if (trustedPublisher.environment && environment !== trustedPublisher.environment) {
     throw new Error(
       `GitHub OIDC environment mismatch: expected ${trustedPublisher.environment}, got ${formatClaimValue(environment ?? "<missing>")}`,
     );
   }
-
+  if (workflowPolicy.expectedRef && ref !== workflowPolicy.expectedRef) {
+    throw new Error(`GitHub OIDC ref mismatch: expected ${workflowPolicy.expectedRef}, got ${ref}`);
+  }
   return {
     repository,
     repositoryId,

--- a/convex/lib/skillsShCatalogEnvironment.test.ts
+++ b/convex/lib/skillsShCatalogEnvironment.test.ts
@@ -1,6 +1,42 @@
 /* @vitest-environment node */
 import { describe, expect, it } from "vitest";
-import { getSkillsShFixtureEnvironmentPolicy } from "./skillsShCatalogEnvironment";
+import {
+  getSkillsShFixtureEnvironmentPolicy,
+  getSkillsShMirrorEnvironmentPolicy,
+} from "./skillsShCatalogEnvironment";
+
+describe("skills.sh mirror environment policy", () => {
+  it("allows the exact production deployment for the shared importer", () => {
+    expect(
+      getSkillsShMirrorEnvironmentPolicy({
+        CLAWHUB_DEPLOYMENT_NAME: "wry-manatee-359",
+        CLAWHUB_ENV: "production",
+        CLAWHUB_SKILLS_SH_ROLLOUT_MODE: "production",
+        CONVEX_CLOUD_URL: "https://wry-manatee-359.convex.cloud",
+        CONVEX_SITE_URL: "https://wry-manatee-359.convex.site",
+      }),
+    ).toEqual({ allowed: true, environment: "production" });
+  });
+
+  it("rejects production importer work with a mismatched deployment or rollout", () => {
+    expect(
+      getSkillsShMirrorEnvironmentPolicy({
+        CLAWHUB_DEPLOYMENT_NAME: "wry-manatee-359",
+        CLAWHUB_ENV: "production",
+        CLAWHUB_SKILLS_SH_ROLLOUT_MODE: "off",
+        CONVEX_CLOUD_URL: "https://wry-manatee-359.convex.cloud",
+      }),
+    ).toMatchObject({ allowed: false, environment: "production" });
+    expect(
+      getSkillsShMirrorEnvironmentPolicy({
+        CLAWHUB_DEPLOYMENT_NAME: "another-deployment",
+        CLAWHUB_ENV: "production",
+        CLAWHUB_SKILLS_SH_ROLLOUT_MODE: "production",
+        CONVEX_CLOUD_URL: "https://another-deployment.convex.cloud",
+      }),
+    ).toMatchObject({ allowed: false, environment: "production" });
+  });
+});
 
 describe("skills.sh fixture environment policy", () => {
   it("allows only local development or the exact cron-disabled Test deployment", () => {

--- a/convex/lib/skillsShCatalogEnvironment.ts
+++ b/convex/lib/skillsShCatalogEnvironment.ts
@@ -26,6 +26,9 @@ export type SkillsShFixtureEnvironmentPolicy =
 const TEST_DEPLOYMENT = "academic-chihuahua-392";
 const TEST_CLOUD_URL = `https://${TEST_DEPLOYMENT}.convex.cloud`;
 const TEST_SITE_URL = `https://${TEST_DEPLOYMENT}.convex.site`;
+const PRODUCTION_DEPLOYMENT = "wry-manatee-359";
+const PRODUCTION_CLOUD_URL = `https://${PRODUCTION_DEPLOYMENT}.convex.cloud`;
+const PRODUCTION_SITE_URL = `https://${PRODUCTION_DEPLOYMENT}.convex.site`;
 
 function populatedRuntimeUrls(env: SkillsShCatalogEnvironment) {
   return [
@@ -128,6 +131,55 @@ export function assertSkillsShFixtureEnvironmentAllowed(
   env: SkillsShCatalogEnvironment = process.env,
 ) {
   const policy = getSkillsShFixtureEnvironmentPolicy(env);
+  if (!policy.allowed) throw new Error(policy.reason);
+  return policy;
+}
+
+export function getSkillsShMirrorEnvironmentPolicy(
+  env: SkillsShCatalogEnvironment = process.env,
+): SkillsShFixtureEnvironmentPolicy | { allowed: true; environment: "production" } {
+  if (env.CLAWHUB_PREVIEW === "1") {
+    return {
+      allowed: false,
+      environment: "preview",
+      reason: "skills.sh mirror work is disabled in Preview",
+    };
+  }
+  const rollout = getClawHubRolloutCapabilities(env);
+  if (rollout.environment !== "production") return getSkillsShFixtureEnvironmentPolicy(env);
+  if (!rollout.skillsSh.runtimeEnabled) {
+    return {
+      allowed: false,
+      environment: "production",
+      reason: "skills.sh catalog rollout is disabled",
+    };
+  }
+  const configuredDeployment =
+    env.CLAWHUB_DEPLOYMENT_NAME?.trim() ||
+    env.CONVEX_DEPLOYMENT?.trim().replace(/^[^:]+:/, "") ||
+    "";
+  const urls = [
+    { actual: env.CONVEX_CLOUD_URL?.trim(), expected: PRODUCTION_CLOUD_URL },
+    { actual: env.CONVEX_SITE_URL?.trim(), expected: PRODUCTION_SITE_URL },
+  ].filter((entry): entry is { actual: string; expected: string } => Boolean(entry.actual));
+  if (
+    configuredDeployment !== PRODUCTION_DEPLOYMENT ||
+    urls.length === 0 ||
+    urls.some((entry) => entry.actual !== entry.expected)
+  ) {
+    return {
+      allowed: false,
+      environment: "production",
+      reason: `skills.sh production mirror work requires ${PRODUCTION_DEPLOYMENT}`,
+    };
+  }
+  return { allowed: true, environment: "production" };
+}
+
+export function assertSkillsShMirrorEnvironmentAllowed(
+  env: SkillsShCatalogEnvironment = process.env,
+) {
+  const policy = getSkillsShMirrorEnvironmentPolicy(env);
   if (!policy.allowed) throw new Error(policy.reason);
   return policy;
 }

--- a/convex/lib/skillsShMirrorPublic.ts
+++ b/convex/lib/skillsShMirrorPublic.ts
@@ -38,6 +38,8 @@ export type SkillsShMirrorDigest = {
   active: boolean;
   publicVisible: boolean;
   installable: boolean;
+  claimStatus?: "pending" | "failed" | "promoted";
+  claimAttempt?: number;
   tombstonedAt?: number;
   lastObservedAt: number;
 };

--- a/convex/lib/skillsShPublicVisibility.test.ts
+++ b/convex/lib/skillsShPublicVisibility.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from "vitest";
+import type { Doc } from "../_generated/dataModel";
+import {
+  ACTIVATE_SKILLS_SH_PUBLIC_PRODUCTION_CONFIRM,
+  ACTIVATE_SKILLS_SH_PUBLIC_TEST_CONFIRM,
+  assertSkillsShPublicVisibilityMutationAllowed,
+  isSkillsShMirrorDigestEligible,
+  skillsShMirrorFreshObservationFlags,
+  skillsShMirrorPublicationFlags,
+} from "./skillsShPublicVisibility";
+
+function testEnv(environment: "test" | "production") {
+  return {
+    CLAWHUB_DEPLOYMENT_NAME: environment === "test" ? "academic-chihuahua-392" : "wry-manatee-359",
+    CLAWHUB_ENV: environment,
+    CLAWHUB_SKILLS_SH_ROLLOUT_MODE: environment,
+  };
+}
+
+function digest(
+  overrides: Partial<Doc<"skillsShMirrorDigests">> = {},
+): Doc<"skillsShMirrorDigests"> {
+  return {
+    _id: "digest-id" as Doc<"skillsShMirrorDigests">["_id"],
+    _creationTime: 1,
+    externalId: "patrick-erichsen/skills/html",
+    sourceType: "github",
+    owner: "patrick-erichsen",
+    repo: "skills",
+    slug: "html",
+    normalizedSlug: "html",
+    normalizedSlugFirstToken: "html",
+    displayName: "HTML",
+    normalizedDisplayName: "html",
+    normalizedDisplayNameFirstToken: "html",
+    searchText: "html",
+    sourceUrl: "https://www.skills.sh/patrick-erichsen/skills/html",
+    canonicalRepoUrl: "https://github.com/patrick-erichsen/skills",
+    githubPath: "skills/html",
+    githubCommit: "050daba89f6b6636470add5cb300aac46a412cf8",
+    sourceContentHash: "a47adb2c1ac33c088f664b5187971b63d2b958a7b9f01516d26005ca941a108f",
+    upstreamInstalls: 1,
+    upstreamScanners: {
+      genAgentTrustHub: { status: "pass" },
+      socket: { status: "pass" },
+      snyk: { status: "pass" },
+    },
+    sourceFreshnessStatus: "observed-only",
+    detailStatus: "available",
+    observationFingerprint: "{}",
+    sourceSnapshotId: "snapshot",
+    lastObservedRunId: "run-id" as Doc<"skillsShMirrorRuns">["_id"],
+    active: true,
+    publicVisible: false,
+    installable: false,
+    firstObservedAt: 1,
+    lastObservedAt: 1,
+    createdAt: 1,
+    updatedAt: 1,
+    ...overrides,
+  };
+}
+
+describe("skills.sh public visibility policy", () => {
+  it("allows the same activation path in Test and production rollout modes", () => {
+    expect(
+      assertSkillsShPublicVisibilityMutationAllowed({
+        activate: true,
+        confirm: ACTIVATE_SKILLS_SH_PUBLIC_TEST_CONFIRM,
+        env: testEnv("test"),
+      }),
+    ).toBe("test");
+    expect(
+      assertSkillsShPublicVisibilityMutationAllowed({
+        activate: true,
+        confirm: ACTIVATE_SKILLS_SH_PUBLIC_PRODUCTION_CONFIRM,
+        env: testEnv("production"),
+      }),
+    ).toBe("production");
+  });
+
+  it("rejects production while the production rollout is off", () => {
+    expect(() =>
+      assertSkillsShPublicVisibilityMutationAllowed({
+        activate: true,
+        confirm: ACTIVATE_SKILLS_SH_PUBLIC_PRODUCTION_CONFIRM,
+        env: {
+          ...testEnv("production"),
+          CLAWHUB_SKILLS_SH_ROLLOUT_MODE: "off",
+        },
+      }),
+    ).toThrow("skills.sh catalog rollout is disabled");
+  });
+
+  it("requires the environment-specific confirmation phrase", () => {
+    expect(() =>
+      assertSkillsShPublicVisibilityMutationAllowed({
+        activate: true,
+        confirm: ACTIVATE_SKILLS_SH_PUBLIC_PRODUCTION_CONFIRM,
+        env: testEnv("test"),
+      }),
+    ).toThrow("confirmation is invalid");
+  });
+});
+
+describe("skills.sh public visibility eligibility", () => {
+  it("accepts an active exact pinned GitHub source", () => {
+    expect(isSkillsShMirrorDigestEligible(digest())).toBe(true);
+    expect(skillsShMirrorPublicationFlags(digest())).toEqual({
+      publicVisible: true,
+      installable: true,
+    });
+  });
+
+  it.each([
+    { active: false },
+    { sourceFreshnessStatus: "stale" as const },
+    { tombstonedAt: 1 },
+    { githubPath: undefined },
+    { githubCommit: undefined },
+    { sourceContentHash: undefined },
+  ])("rejects an unsafe or incomplete source: %o", (overrides) => {
+    expect(isSkillsShMirrorDigestEligible(digest(overrides))).toBe(false);
+  });
+
+  it("keeps only the first pending claim visible", () => {
+    expect(
+      skillsShMirrorPublicationFlags(digest({ claimStatus: "pending", claimAttempt: 1 } as never)),
+    ).toEqual({ publicVisible: true, installable: true });
+    expect(
+      skillsShMirrorPublicationFlags(digest({ claimStatus: "pending", claimAttempt: 2 } as never)),
+    ).toEqual({ publicVisible: false, installable: false });
+  });
+
+  it.each(["failed", "promoted"] as const)(
+    "keeps a %s claim out of the mirror catalog",
+    (claimStatus) => {
+      expect(
+        skillsShMirrorPublicationFlags(digest({ claimStatus, claimAttempt: 1 } as never)),
+      ).toEqual({ publicVisible: false, installable: false });
+    },
+  );
+
+  it("does not reactivate failed, retrying, or promoted mirrors during import refresh", () => {
+    expect(skillsShMirrorFreshObservationFlags(digest())).toEqual({
+      active: true,
+      publicVisible: true,
+      installable: true,
+    });
+    for (const claim of [
+      { claimStatus: "pending", claimAttempt: 2 },
+      { claimStatus: "failed", claimAttempt: 1 },
+      { claimStatus: "promoted", claimAttempt: 1 },
+    ] as const) {
+      expect(skillsShMirrorFreshObservationFlags(digest(claim as never))).toEqual({
+        active: false,
+        publicVisible: false,
+        installable: false,
+      });
+    }
+  });
+});

--- a/convex/lib/skillsShPublicVisibility.ts
+++ b/convex/lib/skillsShPublicVisibility.ts
@@ -1,0 +1,80 @@
+import { getClawHubRolloutCapabilities, type ClawHubRolloutEnvironment } from "clawhub-schema";
+import type { SkillsShMirrorDigest } from "./skillsShMirrorPublic";
+import { buildUnclaimedSkillsShInstallResolution } from "./skillsShMirrorPublic";
+
+export const ACTIVATE_SKILLS_SH_PUBLIC_TEST_CONFIRM = "activate-skills-sh-public-test";
+export const DEACTIVATE_SKILLS_SH_PUBLIC_TEST_CONFIRM = "deactivate-skills-sh-public-test";
+export const ACTIVATE_SKILLS_SH_PUBLIC_PRODUCTION_CONFIRM = "activate-skills-sh-public-production";
+export const DEACTIVATE_SKILLS_SH_PUBLIC_PRODUCTION_CONFIRM =
+  "deactivate-skills-sh-public-production";
+
+export function assertSkillsShPublicVisibilityMutationAllowed(args: {
+  activate: boolean;
+  confirm: string;
+  env?: ClawHubRolloutEnvironment;
+}) {
+  const capabilities = getClawHubRolloutCapabilities(args.env ?? process.env);
+  if (!capabilities.skillsSh.runtimeEnabled) {
+    throw new Error("skills.sh catalog rollout is disabled");
+  }
+
+  const expectedConfirm =
+    capabilities.environment === "production"
+      ? args.activate
+        ? ACTIVATE_SKILLS_SH_PUBLIC_PRODUCTION_CONFIRM
+        : DEACTIVATE_SKILLS_SH_PUBLIC_PRODUCTION_CONFIRM
+      : args.activate
+        ? ACTIVATE_SKILLS_SH_PUBLIC_TEST_CONFIRM
+        : DEACTIVATE_SKILLS_SH_PUBLIC_TEST_CONFIRM;
+
+  if (
+    !["local", "test", "production"].includes(capabilities.environment) ||
+    args.confirm !== expectedConfirm
+  ) {
+    throw new Error("skills.sh public visibility confirmation is invalid");
+  }
+  return capabilities.environment;
+}
+
+export function isSkillsShMirrorDigestEligible(digest: SkillsShMirrorDigest) {
+  return (
+    buildUnclaimedSkillsShInstallResolution({
+      ...digest,
+      publicVisible: true,
+      installable: true,
+    }) !== null
+  );
+}
+
+export function isSkillsShMirrorSourceEligible(digest: SkillsShMirrorDigest) {
+  return isSkillsShMirrorDigestEligible({
+    ...digest,
+    active: true,
+    publicVisible: true,
+    installable: true,
+  });
+}
+
+export function skillsShMirrorPublicationFlags(digest: SkillsShMirrorDigest) {
+  const claimAllowsPublication =
+    digest.claimStatus === undefined ||
+    (digest.claimStatus === "pending" && digest.claimAttempt === 1);
+  const eligible = claimAllowsPublication && isSkillsShMirrorDigestEligible(digest);
+  return {
+    publicVisible: eligible,
+    installable: eligible,
+  };
+}
+
+export function skillsShMirrorFreshObservationFlags(digest: SkillsShMirrorDigest) {
+  // Only the first production corpus is hidden behind the global gate. Once
+  // activated, exact eligible hourly observations publish row-by-row so
+  // healthy rows stay live while a bad source remains row-scoped.
+  const active =
+    digest.claimStatus === undefined ||
+    (digest.claimStatus === "pending" && digest.claimAttempt === 1);
+  return {
+    active,
+    ...skillsShMirrorPublicationFlags({ ...digest, active }),
+  };
+}

--- a/convex/rolloutCapabilities.test.ts
+++ b/convex/rolloutCapabilities.test.ts
@@ -89,4 +89,56 @@ describe("getPublicCapabilitiesHandler", () => {
       },
     });
   });
+
+  it("treats the mirror public gate independently from preserved legacy operator controls", async () => {
+    const { db } = createControlDb({
+      mode: "off",
+      paused: true,
+      discoveryEnabled: false,
+      writesEnabled: false,
+      publicVisibilityEnabled: true,
+      mirrorPublicVisibilityEnabled: true,
+      scanPlanningEnabled: false,
+      scanAdmissionEnabled: false,
+    });
+
+    await expect(
+      getPublicCapabilitiesHandler({ db } as never, {
+        CLAWHUB_ENV: "test",
+        CLAWHUB_SKILLS_SH_ROLLOUT_MODE: "test",
+      }),
+    ).resolves.toMatchObject({
+      skillsSh: {
+        discoveryEnabled: true,
+        publicCatalogEnabled: true,
+        writesEnabled: false,
+        scanPlanningEnabled: false,
+        scanAdmissionEnabled: false,
+      },
+    });
+  });
+
+  it("does not reinterpret the legacy visibility bit as verified mirror activation", async () => {
+    const { db } = createControlDb({
+      mode: "off",
+      paused: true,
+      discoveryEnabled: false,
+      writesEnabled: false,
+      publicVisibilityEnabled: true,
+      scanPlanningEnabled: false,
+      scanAdmissionEnabled: false,
+    });
+
+    await expect(
+      getPublicCapabilitiesHandler({ db } as never, {
+        CLAWHUB_ENV: "production",
+        CLAWHUB_SKILLS_SH_ROLLOUT_MODE: "production",
+      }),
+    ).resolves.toMatchObject({
+      skillsSh: {
+        discoveryEnabled: false,
+        publicCatalogEnabled: false,
+      },
+    });
+  });
 });

--- a/convex/rolloutCapabilities.ts
+++ b/convex/rolloutCapabilities.ts
@@ -1,6 +1,6 @@
 import { getClawHubRolloutCapabilities, type ClawHubRolloutEnvironment } from "clawhub-schema";
 import type { QueryCtx } from "./_generated/server";
-import { query } from "./functions";
+import { internalQuery, query } from "./functions";
 
 const CONTROL_KEY = "global";
 
@@ -18,6 +18,9 @@ export async function getPublicCapabilitiesHandler(
   const catalogActive = Boolean(
     runtime.skillsSh.runtimeEnabled && control && control.mode !== "off" && !control.paused,
   );
+  const mirrorPublicActive = Boolean(
+    runtime.skillsSh.runtimeEnabled && control?.mirrorPublicVisibilityEnabled,
+  );
   return {
     environment: runtime.environment,
     catalogDiscovery: {
@@ -30,12 +33,9 @@ export async function getPublicCapabilitiesHandler(
     skillsSh: {
       mode: runtime.skillsSh.mode,
       runtimeEnabled: runtime.skillsSh.runtimeEnabled,
-      discoveryEnabled: catalogActive && Boolean(control?.discoveryEnabled),
+      discoveryEnabled: mirrorPublicActive || (catalogActive && Boolean(control?.discoveryEnabled)),
       writesEnabled: catalogActive && Boolean(control?.writesEnabled),
-      publicCatalogEnabled:
-        catalogActive &&
-        Boolean(control?.discoveryEnabled) &&
-        Boolean(control?.publicVisibilityEnabled),
+      publicCatalogEnabled: mirrorPublicActive,
       scanPlanningEnabled: catalogActive && Boolean(control?.scanPlanningEnabled),
       scanAdmissionEnabled: catalogActive && Boolean(control?.scanAdmissionEnabled),
     },
@@ -45,6 +45,18 @@ export async function getPublicCapabilitiesHandler(
     },
   };
 }
+
+export async function getSkillsShPublicCatalogEnabledHandler(
+  ctx: Pick<QueryCtx, "db">,
+  env: ClawHubRolloutEnvironment = process.env,
+) {
+  return (await getPublicCapabilitiesHandler(ctx, env)).skillsSh.publicCatalogEnabled;
+}
+
+export const getPublicCapabilitiesInternal = internalQuery({
+  args: {},
+  handler: async (ctx) => await getPublicCapabilitiesHandler(ctx),
+});
 
 export const getPublicCapabilities = query({
   args: {},

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -3023,6 +3023,7 @@ const skillsShCatalogControls = defineTable({
   scanPlanningEnabled: v.boolean(),
   scanAdmissionEnabled: v.boolean(),
   publicVisibilityEnabled: v.boolean(),
+  mirrorPublicVisibilityEnabled: v.optional(v.boolean()),
   paused: v.boolean(),
   maxEntriesPerRun: v.number(),
   maxEntriesPerBatch: v.number(),
@@ -3236,6 +3237,10 @@ const skillsShMirrorControls = defineTable({
   maxRowsPerBatch: v.number(),
   maxDetailBytes: v.number(),
   latestCompletedLeaderboardRunId: v.optional(v.id("skillsShMirrorRuns")),
+  activationLockToken: v.optional(v.string()),
+  activationLockedAt: v.optional(v.number()),
+  activationLeaderboardRunId: v.optional(v.id("skillsShMirrorRuns")),
+  activationTrendingRunId: v.optional(v.id("skillsShMirrorRuns")),
   updatedBy: v.string(),
   reason: v.string(),
   updatedAt: v.number(),
@@ -3355,6 +3360,12 @@ const skillsShMirrorClassificationConfidenceValidator = v.union(
   v.literal("low"),
 );
 
+const skillsShMirrorClaimStatusValidator = v.union(
+  v.literal("pending"),
+  v.literal("failed"),
+  v.literal("promoted"),
+);
+
 const skillsShMirrorDigests = defineTable({
   externalId: v.string(),
   sourceType: v.union(v.literal("github"), v.literal("well-known")),
@@ -3402,10 +3413,21 @@ const skillsShMirrorDigests = defineTable({
   sourceSnapshotId: v.string(),
   lastObservedRunId: v.id("skillsShMirrorRuns"),
   active: v.boolean(),
-  // Mirror ingestion always writes both flags false. Separately accepted
-  // activation work may opt an exact row into public search/install surfaces.
+  // Importer-owned row eligibility. The catalog-wide publication control is the
+  // atomic exposure/rollback gate; invalid rows keep both fields false.
   publicVisible: v.boolean(),
   installable: v.boolean(),
+  claimStatus: v.optional(skillsShMirrorClaimStatusValidator),
+  claimSkillId: v.optional(v.id("skills")),
+  claimPublisherId: v.optional(v.id("publishers")),
+  claimGithubSourceId: v.optional(v.id("githubSkillSources")),
+  claimGithubPath: v.optional(v.string()),
+  claimGithubCommit: v.optional(v.string()),
+  claimGithubContentHash: v.optional(v.string()),
+  claimAttempt: v.optional(v.number()),
+  claimStartedAt: v.optional(v.number()),
+  claimFailedAt: v.optional(v.number()),
+  claimedAt: v.optional(v.number()),
   tombstonedAt: v.optional(v.number()),
   firstObservedAt: v.number(),
   lastObservedAt: v.number(),

--- a/convex/search.test.ts
+++ b/convex/search.test.ts
@@ -1,7 +1,7 @@
 /* @vitest-environment node */
 
 import { getFunctionName } from "convex/server";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { tokenize } from "./lib/searchText";
 import {
   __test,
@@ -19,6 +19,8 @@ import {
 const { generateEmbeddingMock } = vi.hoisted(() => ({
   generateEmbeddingMock: vi.fn(),
 }));
+
+afterEach(() => vi.unstubAllEnvs());
 
 vi.mock("./lib/embeddings", () => ({
   generateEmbedding: generateEmbeddingMock,
@@ -1158,6 +1160,8 @@ describe("search helpers", () => {
   });
 
   it("filters external candidates by visibility and installability and bounds every recall index", async () => {
+    vi.stubEnv("CLAWHUB_ENV", "test");
+    vi.stubEnv("CLAWHUB_SKILLS_SH_ROLLOUT_MODE", "test");
     const visible = makeExternalSearchDigest({ externalId: "acme/skills/calendar" });
     const hidden = makeExternalSearchDigest({
       externalId: "acme/skills/hidden",
@@ -1187,10 +1191,21 @@ describe("search helpers", () => {
     };
     const ctx = {
       db: {
-        query: vi.fn(() => ({
+        query: vi.fn((table: string) => ({
           withIndex: (index: string, build: (q: typeof queryBuilder) => unknown) => {
             usedIndexes.push(index);
             build(queryBuilder);
+            if (table === "skillsShCatalogControls") {
+              return {
+                unique: vi.fn(async () => ({
+                  mode: "staging-live",
+                  paused: false,
+                  discoveryEnabled: true,
+                  publicVisibilityEnabled: true,
+                  mirrorPublicVisibilityEnabled: true,
+                })),
+              };
+            }
             if (index === "by_external_id") {
               return { unique: vi.fn(async () => visible) };
             }
@@ -1213,6 +1228,7 @@ describe("search helpers", () => {
     expect(result.map((row) => row.externalId)).toEqual([visible.externalId]);
     expect(takeLimits).toEqual([50, 50, 50, 50, 50]);
     expect(usedIndexes).toEqual([
+      "by_key",
       "by_external_id",
       "by_active_visible_installable_fresh_slug",
       "by_active_visible_installable_fresh_display",
@@ -1223,6 +1239,29 @@ describe("search helpers", () => {
     expect(equalityFields).toEqual(
       expect.arrayContaining(["active", "publicVisible", "installable", "sourceFreshnessStatus"]),
     );
+  });
+
+  it("returns no external candidates while the atomic public catalog gate is off", async () => {
+    vi.stubEnv("CLAWHUB_ENV", "test");
+    vi.stubEnv("CLAWHUB_SKILLS_SH_ROLLOUT_MODE", "test");
+    const unique = vi.fn(async () => ({
+      mode: "staging-live",
+      paused: false,
+      discoveryEnabled: true,
+      publicVisibilityEnabled: false,
+      mirrorPublicVisibilityEnabled: false,
+    }));
+    const withIndex = vi.fn((_index: string, build: (q: { eq: () => unknown }) => unknown) => {
+      build({ eq: () => undefined });
+      return { unique };
+    });
+
+    await expect(
+      getExternalSkillSearchCandidatesHandler(
+        { db: { query: vi.fn(() => ({ withIndex })) } },
+        { query: "calendar" },
+      ),
+    ).resolves.toEqual([]);
   });
 
   it("aggregates only the bounded 60-day install and bookmark window", async () => {

--- a/convex/search.ts
+++ b/convex/search.ts
@@ -46,6 +46,7 @@ import {
   normalizeSkillSearchText,
 } from "./lib/skillSearchDigest";
 import { isSearchableSkillSlugShape, normalizeSkillSlug } from "./lib/skillSlugValidator";
+import { getSkillsShPublicCatalogEnabledHandler } from "./rolloutCapabilities";
 
 type OwnerInfo = { ownerHandle: string | null; owner: PublicPublisher | null };
 
@@ -1024,6 +1025,7 @@ export const getExternalSkillSearchCandidates = internalQuery({
     topic: v.optional(v.string()),
   },
   handler: async (ctx, args): Promise<Doc<"skillsShMirrorDigests">[]> => {
+    if (!(await getSkillsShPublicCatalogEnabledHandler(ctx))) return [];
     if (args.highlightedOnly) return [];
     const categorySlug = normalizeSkillCategoryFilter(args.categorySlug);
     if (categorySlug === null) return [];

--- a/convex/skillsShClaims.test.ts
+++ b/convex/skillsShClaims.test.ts
@@ -1,0 +1,433 @@
+/// <reference types="vite/client" />
+/* @vitest-environment edge-runtime */
+import { convexTest } from "convex-test";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { internal } from "./_generated/api";
+import schema from "./schema";
+import { applySkillsShTestClaimVerdictHandler, beginSkillsShClaimHandler } from "./skillsShClaims";
+
+const modules = import.meta.glob("./**/*.ts");
+const COMMIT_A = "a".repeat(40);
+const COMMIT_B = "b".repeat(40);
+const HASH_A = "1".repeat(64);
+const HASH_B = "2".repeat(64);
+const EXTERNAL_ID = "patrick-erichsen/skills/html";
+const TEST_ENV = {
+  CLAWHUB_SKILLS_SH_ROLLOUT_MODE: "test",
+  CONVEX_CLOUD_URL: "http://127.0.0.1:3210",
+} as const;
+
+beforeEach(() => {
+  vi.stubEnv("CLAWHUB_SKILLS_SH_ROLLOUT_MODE", "test");
+  vi.stubEnv("CONVEX_CLOUD_URL", "http://127.0.0.1:3210");
+});
+
+afterEach(() => vi.unstubAllEnvs());
+
+async function seedPendingFirstClaim(t: ReturnType<typeof convexTest>) {
+  return await t.run(async (ctx) => {
+    const ownerUserId = await ctx.db.insert("users", {
+      handle: "patrick",
+      createdAt: 1,
+      updatedAt: 1,
+    });
+    const publisherId = await ctx.db.insert("publishers", {
+      kind: "org",
+      handle: "openclaw",
+      displayName: "OpenClaw",
+      createdAt: 1,
+      updatedAt: 1,
+    });
+    const sourceId = await ctx.db.insert("githubSkillSources", {
+      repo: "patrick-erichsen/skills",
+      ownerPublisherId: publisherId,
+      githubRepositoryId: "100",
+      githubOwnerId: "200",
+      authorizationStatus: "active",
+      createdAt: 1,
+      updatedAt: 1,
+    });
+    const runId = await ctx.db.insert("skillsShMirrorRuns", {
+      snapshotId: "snapshot-a",
+      sourceView: "leaderboard",
+      status: "completed",
+      sourceTotal: 1,
+      sourcePageSize: 1,
+      sourceMeasuredAt: "2026-07-30T00:00:00.000Z",
+      page: 2,
+      offset: 0,
+      counts: {
+        observed: 1,
+        inserted: 1,
+        updated: 0,
+        unchanged: 0,
+        rejected: 0,
+        conflicts: 0,
+        detailsInserted: 1,
+        detailsUpdated: 0,
+        detailsUnchanged: 0,
+        detailsMissing: 0,
+        detailsTruncated: 0,
+        tombstoned: 0,
+        reactivated: 0,
+        scansPlanned: 0,
+        scansAdmitted: 0,
+      },
+      operations: {
+        functionCalls: 1,
+        dbReads: 1,
+        dbWrites: 1,
+        sourceRequests: 1,
+        sourceBytes: 1,
+      },
+      actor: "test",
+      reason: "claim lifecycle fixture",
+      startedAt: 1,
+      completedAt: 2,
+      updatedAt: 2,
+    });
+    const mirrorId = await ctx.db.insert("skillsShMirrorDigests", {
+      externalId: EXTERNAL_ID,
+      sourceType: "github",
+      owner: "patrick-erichsen",
+      repo: "skills",
+      slug: "html",
+      normalizedSlug: "html",
+      normalizedSlugFirstToken: "html",
+      displayName: "HTML",
+      normalizedDisplayName: "html",
+      normalizedDisplayNameFirstToken: "html",
+      searchText: "html",
+      sourceUrl: `https://skills.sh/${EXTERNAL_ID}`,
+      canonicalRepoUrl: "https://github.com/patrick-erichsen/skills",
+      githubPath: "skills/html",
+      githubCommit: COMMIT_A,
+      sourceContentHash: HASH_A,
+      upstreamInstalls: 77,
+      upstreamScanners: {
+        genAgentTrustHub: { status: "pass" },
+        socket: { status: "warn" },
+        snyk: { status: "unknown" },
+      },
+      sourceFreshnessStatus: "observed-only",
+      detailStatus: "available",
+      observationFingerprint: "a",
+      sourceSnapshotId: "snapshot-a",
+      lastObservedRunId: runId,
+      active: true,
+      publicVisible: true,
+      installable: true,
+      firstObservedAt: 1,
+      lastObservedAt: 2,
+      createdAt: 1,
+      updatedAt: 2,
+    });
+    const skillId = await ctx.db.insert("skills", {
+      slug: "html",
+      displayName: "HTML",
+      ownerUserId,
+      ownerPublisherId: publisherId,
+      installKind: "github",
+      githubSourceId: sourceId,
+      githubCurrentRepo: "patrick-erichsen/skills",
+      githubPath: "skills/html",
+      githubHasSkillCard: false,
+      githubCurrentCommit: COMMIT_A,
+      githubCurrentContentHash: HASH_A,
+      githubCurrentStatus: "present",
+      githubCurrentCheckedAt: 2,
+      githubScanStatus: "pending",
+      tags: {},
+      statsDownloads: 9,
+      statsStars: 5,
+      statsInstallsCurrent: 3,
+      statsInstallsAllTime: 4,
+      stats: {
+        downloads: 9,
+        stars: 5,
+        installsCurrent: 3,
+        installsAllTime: 4,
+        versions: 0,
+        comments: 0,
+      },
+      moderationStatus: "active",
+      moderationReason: "pending.scan",
+      moderationFlags: [],
+      isSuspicious: false,
+      createdAt: 2,
+      updatedAt: 2,
+    });
+    return { mirrorId, ownerUserId, publisherId, sourceId, skillId };
+  });
+}
+
+describe("skills.sh first-claim lifecycle", () => {
+  it("rolls back an unbound claimed sync instead of suppressing normal verification", async () => {
+    const t = convexTest(schema, modules);
+    const { ownerUserId, publisherId } = await t.run(async (ctx) => ({
+      ownerUserId: await ctx.db.insert("users", {
+        handle: "patrick",
+        createdAt: 1,
+        updatedAt: 1,
+      }),
+      publisherId: await ctx.db.insert("publishers", {
+        kind: "org",
+        handle: "openclaw",
+        displayName: "OpenClaw",
+        createdAt: 1,
+        updatedAt: 1,
+      }),
+    }));
+
+    await expect(
+      t.mutation(internal.skillsShClaims.applyClaimedGitHubSkillSourceSyncInternal, {
+        repo: "patrick-erichsen/skills",
+        ownerUserId,
+        ownerPublisherId: publisherId,
+        githubRepositoryId: "100",
+        githubOwnerId: "200",
+        skillsShClaimPath: "skills/html",
+        skillsShClaim: {
+          externalId: EXTERNAL_ID,
+          path: "skills/html",
+          commit: COMMIT_A,
+          contentHash: HASH_A,
+        },
+        snapshot: {
+          repo: "patrick-erichsen/skills",
+          defaultBranch: "main",
+          commit: COMMIT_A,
+          manifestStatus: "missing",
+          skills: [
+            {
+              slug: "html",
+              displayName: "HTML",
+              path: "skills/html",
+              skillMarkdownPath: "skills/html/SKILL.md",
+              contentHash: HASH_A,
+            },
+          ],
+        },
+        now: 10,
+      }),
+    ).rejects.toThrow("Exact skills.sh claim source no longer matches");
+
+    const residue = await t.run(async (ctx) => ({
+      sources: await ctx.db.query("githubSkillSources").collect(),
+      skills: await ctx.db.query("skills").collect(),
+      scans: await ctx.db.query("githubSkillScans").collect(),
+      requests: await ctx.db.query("skillScanRequests").collect(),
+      jobs: await ctx.db.query("securityScanJobs").collect(),
+    }));
+    expect(residue).toEqual({ sources: [], skills: [], scans: [], requests: [], jobs: [] });
+  });
+
+  it("keeps attempt one visible, hides a failure, and promotes a corrected retry without paid scans", async () => {
+    const t = convexTest(schema, modules);
+    const ids = await seedPendingFirstClaim(t);
+
+    await t.run(async (ctx) =>
+      beginSkillsShClaimHandler(ctx as never, {
+        externalId: EXTERNAL_ID,
+        ownerPublisherId: ids.publisherId,
+        githubSourceId: ids.sourceId,
+        githubPath: "skills/html",
+        githubCommit: COMMIT_A,
+        githubContentHash: HASH_A,
+        now: 10,
+      }),
+    );
+    expect(await t.run(async (ctx) => ctx.db.get(ids.mirrorId))).toMatchObject({
+      claimStatus: "pending",
+      claimAttempt: 1,
+      claimSkillId: ids.skillId,
+      publicVisible: true,
+      installable: true,
+    });
+
+    await t.run(async (ctx) =>
+      applySkillsShTestClaimVerdictHandler(
+        ctx as never,
+        {
+          externalId: EXTERNAL_ID,
+          phase: "first-claim",
+          verdict: "fail",
+          confirm: "fail-skills-sh-test-claim",
+          now: 20,
+        },
+        TEST_ENV,
+      ),
+    );
+    expect(await t.run(async (ctx) => ctx.db.get(ids.mirrorId))).toMatchObject({
+      claimStatus: "failed",
+      claimFailedAt: 20,
+      active: false,
+      publicVisible: false,
+      installable: false,
+    });
+
+    await t.run(async (ctx) => {
+      await ctx.db.patch(ids.mirrorId, {
+        githubCommit: COMMIT_B,
+        sourceContentHash: HASH_B,
+        observationFingerprint: "b",
+        updatedAt: 30,
+      });
+      await ctx.db.patch(ids.skillId, {
+        githubCurrentCommit: COMMIT_B,
+        githubCurrentContentHash: HASH_B,
+        githubScanStatus: "pending",
+        moderationStatus: "active",
+        moderationReason: "pending.scan",
+        updatedAt: 30,
+      });
+    });
+    await t.run(async (ctx) =>
+      beginSkillsShClaimHandler(ctx as never, {
+        externalId: EXTERNAL_ID,
+        ownerPublisherId: ids.publisherId,
+        githubSourceId: ids.sourceId,
+        githubPath: "skills/html",
+        githubCommit: COMMIT_B,
+        githubContentHash: HASH_B,
+        now: 31,
+      }),
+    );
+    expect(await t.run(async (ctx) => ctx.db.get(ids.mirrorId))).toMatchObject({
+      claimStatus: "pending",
+      claimAttempt: 2,
+      active: false,
+      publicVisible: false,
+      installable: false,
+    });
+
+    await t.run(async (ctx) =>
+      applySkillsShTestClaimVerdictHandler(
+        ctx as never,
+        {
+          externalId: EXTERNAL_ID,
+          phase: "first-claim",
+          verdict: "pass",
+          confirm: "pass-skills-sh-test-claim",
+          now: 40,
+        },
+        TEST_ENV,
+      ),
+    );
+    const [mirror, native, scans, requests, jobs] = await t.run(async (ctx) =>
+      Promise.all([
+        ctx.db.get(ids.mirrorId),
+        ctx.db.get(ids.skillId),
+        ctx.db.query("githubSkillScans").collect(),
+        ctx.db.query("skillScanRequests").collect(),
+        ctx.db.query("securityScanJobs").collect(),
+      ]),
+    );
+    expect(mirror).toMatchObject({
+      claimStatus: "promoted",
+      claimedAt: 40,
+      active: false,
+      publicVisible: false,
+      installable: false,
+    });
+    expect(native).toMatchObject({
+      githubCurrentCommit: COMMIT_B,
+      githubCurrentContentHash: HASH_B,
+      githubScanStatus: "clean",
+      moderationStatus: "active",
+      statsDownloads: 9,
+      statsStars: 5,
+      statsSkillsShInstalls: 77,
+    });
+    expect(scans).toEqual([
+      expect.objectContaining({
+        status: "clean",
+        runId: `skills-sh-test-claim:${EXTERNAL_ID}:2`,
+      }),
+    ]);
+    expect(requests).toHaveLength(0);
+    expect(jobs).toHaveLength(0);
+  });
+
+  it("keeps the last passing native candidate live when a scan-free Test follow-up fails", async () => {
+    const t = convexTest(schema, modules);
+    const ids = await seedPendingFirstClaim(t);
+    await t.run(async (ctx) => {
+      await ctx.db.patch(ids.mirrorId, {
+        claimStatus: "promoted",
+        claimSkillId: ids.skillId,
+        claimPublisherId: ids.publisherId,
+        claimGithubSourceId: ids.sourceId,
+        claimGithubPath: "skills/html",
+        claimGithubCommit: COMMIT_A,
+        claimGithubContentHash: HASH_A,
+        claimAttempt: 1,
+        claimedAt: 10,
+        active: false,
+        publicVisible: false,
+        installable: false,
+      });
+      await ctx.db.patch(ids.skillId, {
+        githubScanStatus: "clean",
+        moderationStatus: "active",
+        moderationReason: undefined,
+      });
+      const candidateId = await ctx.db.insert("githubSkillCandidates", {
+        skillId: ids.skillId,
+        githubSourceId: ids.sourceId,
+        githubRepo: "patrick-erichsen/skills",
+        githubPath: "skills/html",
+        githubHasSkillCard: false,
+        githubCommit: COMMIT_B,
+        githubContentHash: HASH_B,
+        displayName: "HTML v2",
+        skillMarkdownPath: "skills/html/SKILL.md",
+        skillMarkdown: "# HTML v2\n",
+        scanStatus: "pending",
+        lifecycleStatus: "pending",
+        createdAt: 20,
+        updatedAt: 20,
+      });
+      await ctx.db.patch(ids.skillId, { githubPendingCandidateId: candidateId });
+    });
+
+    await t.run(async (ctx) =>
+      applySkillsShTestClaimVerdictHandler(
+        ctx as never,
+        {
+          externalId: EXTERNAL_ID,
+          phase: "native-followup",
+          verdict: "fail",
+          confirm: "fail-skills-sh-test-native-followup",
+          now: 30,
+        },
+        TEST_ENV,
+      ),
+    );
+    const { skill, candidate, requests, jobs } = await t.run(async (ctx) => {
+      const persistedSkill = await ctx.db.get(ids.skillId);
+      return {
+        skill: persistedSkill,
+        candidate: persistedSkill?.githubPendingCandidateId
+          ? await ctx.db.get(persistedSkill.githubPendingCandidateId)
+          : null,
+        requests: await ctx.db.query("skillScanRequests").collect(),
+        jobs: await ctx.db.query("securityScanJobs").collect(),
+      };
+    });
+    expect(skill).toMatchObject({
+      githubCurrentCommit: COMMIT_A,
+      githubCurrentContentHash: HASH_A,
+      githubScanStatus: "clean",
+      moderationStatus: "active",
+    });
+    expect(candidate).toMatchObject({
+      githubCommit: COMMIT_B,
+      githubContentHash: HASH_B,
+      scanStatus: "failed",
+      lifecycleStatus: "failed",
+    });
+    expect(requests).toHaveLength(0);
+    expect(jobs).toHaveLength(0);
+  });
+});

--- a/convex/skillsShClaims.ts
+++ b/convex/skillsShClaims.ts
@@ -1,0 +1,439 @@
+import { ConvexError, v } from "convex/values";
+import type { Doc, Id } from "./_generated/dataModel";
+import type { MutationCtx } from "./_generated/server";
+import { internalMutation } from "./functions";
+import {
+  applyGitHubSkillSourceSyncHandler,
+  applyGitHubSkillVerificationResultHandler,
+  sourceSnapshotValidator,
+} from "./githubSkillSync";
+import { syncSkillSearchDigestForSkill } from "./lib/skillSearchDigest";
+import { assertSkillsShFixtureEnvironmentAllowed } from "./lib/skillsShCatalogEnvironment";
+import { skillsShMirrorPublicationFlags } from "./lib/skillsShPublicVisibility";
+
+const FIRST_CLAIM_CONFIRM = {
+  pass: "pass-skills-sh-test-claim",
+  fail: "fail-skills-sh-test-claim",
+} as const;
+
+const NATIVE_FOLLOWUP_CONFIRM = {
+  pass: "pass-skills-sh-test-native-followup",
+  fail: "fail-skills-sh-test-native-followup",
+} as const;
+
+type BeginSkillsShClaimArgs = {
+  externalId: string;
+  ownerPublisherId: Id<"publishers">;
+  githubSourceId: Id<"githubSkillSources">;
+  githubPath: string;
+  githubCommit: string;
+  githubContentHash: string;
+  now?: number;
+};
+
+type TestClaimVerdictArgs = {
+  externalId: string;
+  phase: "first-claim" | "native-followup";
+  verdict: "pass" | "fail";
+  confirm: string;
+  now?: number;
+};
+
+function normalizeExternalId(value: string) {
+  return value.trim().toLowerCase();
+}
+
+function normalizePath(value: string) {
+  return value.trim().replace(/^\/+|\/+$/g, "");
+}
+
+function sameExactSource(
+  value: {
+    path?: string;
+    commit?: string;
+    contentHash?: string;
+  },
+  expected: { path: string; commit: string; contentHash: string },
+) {
+  return (
+    value.path === expected.path &&
+    value.commit?.toLowerCase() === expected.commit &&
+    value.contentHash?.toLowerCase() === expected.contentHash
+  );
+}
+
+async function findExactClaimSkill(
+  ctx: MutationCtx,
+  args: {
+    ownerPublisherId: Id<"publishers">;
+    githubSourceId: Id<"githubSkillSources">;
+    path: string;
+    commit: string;
+    contentHash: string;
+  },
+) {
+  const currentSkills = await ctx.db
+    .query("skills")
+    .withIndex("by_github_source", (q) => q.eq("githubSourceId", args.githubSourceId))
+    .filter((q) => q.eq(q.field("githubPath"), args.path))
+    .take(2);
+  const currentMatches = currentSkills.filter(
+    (skill) =>
+      skill.ownerPublisherId === args.ownerPublisherId &&
+      skill.githubCurrentStatus === "present" &&
+      sameExactSource(
+        {
+          path: skill.githubPath,
+          commit: skill.githubCurrentCommit,
+          contentHash: skill.githubCurrentContentHash,
+        },
+        args,
+      ),
+  );
+  const pendingCandidates = await ctx.db
+    .query("githubSkillCandidates")
+    .withIndex("by_github_source_and_lifecycle_status", (q) =>
+      q.eq("githubSourceId", args.githubSourceId).eq("lifecycleStatus", "pending"),
+    )
+    .take(501);
+  if (pendingCandidates.length > 500) {
+    throw new ConvexError("skills.sh claim source has too many pending candidates");
+  }
+  const candidateMatches: Array<{
+    skill: Doc<"skills">;
+    candidate: Doc<"githubSkillCandidates">;
+  }> = [];
+  for (const candidate of pendingCandidates) {
+    if (
+      !sameExactSource(
+        {
+          path: candidate.githubPath,
+          commit: candidate.githubCommit,
+          contentHash: candidate.githubContentHash,
+        },
+        args,
+      )
+    ) {
+      continue;
+    }
+    const skill = await ctx.db.get(candidate.skillId);
+    if (
+      skill?.ownerPublisherId === args.ownerPublisherId &&
+      skill.githubPendingCandidateId === candidate._id
+    ) {
+      candidateMatches.push({ skill, candidate });
+    }
+  }
+  const matches = [
+    ...currentMatches.map((skill) => ({ skill, candidate: null })),
+    ...candidateMatches,
+  ];
+  const bySkill = new Map(matches.map((match) => [match.skill._id, match]));
+  if (bySkill.size !== 1) {
+    throw new ConvexError("Exact skills.sh claim target was not found");
+  }
+  return [...bySkill.values()][0]!;
+}
+
+export async function beginSkillsShClaimHandler(ctx: MutationCtx, args: BeginSkillsShClaimArgs) {
+  const externalId = normalizeExternalId(args.externalId);
+  const path = normalizePath(args.githubPath);
+  const commit = args.githubCommit.trim().toLowerCase();
+  const contentHash = args.githubContentHash.trim().toLowerCase();
+  const digest = await ctx.db
+    .query("skillsShMirrorDigests")
+    .withIndex("by_external_id", (q) => q.eq("externalId", externalId))
+    .unique();
+  const source = await ctx.db.get(args.githubSourceId);
+  if (
+    !digest ||
+    digest.sourceType !== "github" ||
+    digest.externalId !== externalId ||
+    digest.githubPath !== path ||
+    digest.githubCommit?.toLowerCase() !== commit ||
+    digest.sourceContentHash?.toLowerCase() !== contentHash ||
+    !source ||
+    source.ownerPublisherId !== args.ownerPublisherId
+  ) {
+    throw new ConvexError("Exact skills.sh claim source no longer matches");
+  }
+  const target = await findExactClaimSkill(ctx, {
+    ownerPublisherId: args.ownerPublisherId,
+    githubSourceId: args.githubSourceId,
+    path,
+    commit,
+    contentHash,
+  });
+  if (digest.claimStatus === "promoted") {
+    if (
+      digest.claimSkillId !== target.skill._id ||
+      digest.claimPublisherId !== args.ownerPublisherId
+    ) {
+      throw new ConvexError("skills.sh claim is already promoted to another owner");
+    }
+    return {
+      ok: true as const,
+      phase: "native-followup" as const,
+      attempt: digest.claimAttempt ?? 1,
+      skillId: target.skill._id,
+    };
+  }
+  if (
+    digest.claimStatus === "pending" &&
+    digest.claimSkillId === target.skill._id &&
+    digest.claimPublisherId === args.ownerPublisherId &&
+    digest.claimGithubSourceId === args.githubSourceId &&
+    digest.claimGithubPath === path &&
+    digest.claimGithubCommit === commit &&
+    digest.claimGithubContentHash === contentHash
+  ) {
+    return {
+      ok: true as const,
+      phase: "first-claim" as const,
+      attempt: digest.claimAttempt ?? 1,
+      skillId: target.skill._id,
+    };
+  }
+  if (
+    digest.claimStatus === "failed" &&
+    digest.claimGithubCommit === commit &&
+    digest.claimGithubContentHash === contentHash
+  ) {
+    throw new ConvexError("A failed skills.sh claim requires a corrected exact candidate");
+  }
+  if (digest.claimPublisherId && digest.claimPublisherId !== args.ownerPublisherId) {
+    throw new ConvexError("skills.sh claim is already bound to another publisher");
+  }
+  const now = args.now ?? Date.now();
+  const attempt = (digest.claimAttempt ?? 0) + 1;
+  const claimPatch = {
+    claimStatus: "pending" as const,
+    claimSkillId: target.skill._id,
+    claimPublisherId: args.ownerPublisherId,
+    claimGithubSourceId: args.githubSourceId,
+    claimGithubPath: path,
+    claimGithubCommit: commit,
+    claimGithubContentHash: contentHash,
+    claimAttempt: attempt,
+    claimStartedAt: now,
+    claimFailedAt: undefined,
+    active: attempt === 1,
+    updatedAt: now,
+  };
+  await ctx.db.patch(digest._id, {
+    ...claimPatch,
+    ...skillsShMirrorPublicationFlags({ ...digest, ...claimPatch }),
+  });
+  return {
+    ok: true as const,
+    phase: "first-claim" as const,
+    attempt,
+    skillId: target.skill._id,
+  };
+}
+
+async function insertDeterministicTestScan(
+  ctx: MutationCtx,
+  args: {
+    digest: Doc<"skillsShMirrorDigests">;
+    skill: Doc<"skills">;
+    candidate: Doc<"githubSkillCandidates"> | null;
+    now: number;
+  },
+) {
+  const target = args.candidate
+    ? {
+        githubSourceId: args.candidate.githubSourceId,
+        path: args.candidate.githubPath,
+        commit: args.candidate.githubCommit,
+        contentHash: args.candidate.githubContentHash,
+      }
+    : {
+        githubSourceId: args.skill.githubSourceId,
+        path: args.skill.githubPath,
+        commit: args.skill.githubCurrentCommit,
+        contentHash: args.skill.githubCurrentContentHash,
+      };
+  if (!target.githubSourceId || !target.path || !target.commit || !target.contentHash) {
+    throw new ConvexError("Exact Test claim candidate is incomplete");
+  }
+  const existing = await ctx.db
+    .query("githubSkillScans")
+    .withIndex("by_skill_and_content_hash", (q) =>
+      q.eq("skillId", args.skill._id).eq("contentHash", target.contentHash!),
+    )
+    .unique();
+  const runId = `skills-sh-test-claim:${args.digest.externalId}:${args.digest.claimAttempt ?? 1}`;
+  if (existing) {
+    await ctx.db.patch(existing._id, {
+      githubSourceId: target.githubSourceId,
+      path: target.path,
+      commit: target.commit,
+      status: "clean",
+      skillScanRequestId: undefined,
+      runId,
+      completedAt: args.now,
+      updatedAt: args.now,
+    });
+    return existing._id;
+  }
+  return await ctx.db.insert("githubSkillScans", {
+    skillId: args.skill._id,
+    githubSourceId: target.githubSourceId,
+    path: target.path,
+    commit: target.commit,
+    contentHash: target.contentHash,
+    status: "clean",
+    runId,
+    completedAt: args.now,
+    createdAt: args.now,
+    updatedAt: args.now,
+  });
+}
+
+export async function applySkillsShTestClaimVerdictHandler(
+  ctx: MutationCtx,
+  args: TestClaimVerdictArgs,
+  environment: Parameters<typeof assertSkillsShFixtureEnvironmentAllowed>[0] = process.env,
+) {
+  assertSkillsShFixtureEnvironmentAllowed(environment);
+  const expectedConfirm =
+    args.phase === "first-claim"
+      ? FIRST_CLAIM_CONFIRM[args.verdict]
+      : NATIVE_FOLLOWUP_CONFIRM[args.verdict];
+  if (args.confirm !== expectedConfirm) {
+    throw new ConvexError("skills.sh Test claim verdict confirmation is invalid");
+  }
+  const digest = await ctx.db
+    .query("skillsShMirrorDigests")
+    .withIndex("by_external_id", (q) => q.eq("externalId", normalizeExternalId(args.externalId)))
+    .unique();
+  if (!digest?.claimSkillId) throw new ConvexError("skills.sh claim binding was not found");
+  const skill = await ctx.db.get(digest.claimSkillId);
+  if (!skill) throw new ConvexError("skills.sh claimed skill was not found");
+  const candidate = skill.githubPendingCandidateId
+    ? await ctx.db.get(skill.githubPendingCandidateId)
+    : null;
+  if (args.phase === "first-claim" && digest.claimStatus !== "pending") {
+    if (args.verdict === "pass" && digest.claimStatus === "promoted") {
+      return { ok: true as const, promoted: true as const, idempotent: true as const };
+    }
+    throw new ConvexError("skills.sh first claim is not pending");
+  }
+  if (args.phase === "native-followup") {
+    if (digest.claimStatus !== "promoted" || !candidate) {
+      throw new ConvexError("skills.sh native follow-up candidate was not found");
+    }
+  }
+  const now = args.now ?? Date.now();
+  const contentHash = candidate?.githubContentHash ?? skill.githubCurrentContentHash;
+  if (!contentHash) throw new ConvexError("skills.sh claim content hash was not found");
+  const scanId =
+    args.verdict === "pass"
+      ? await insertDeterministicTestScan(ctx, { digest, skill, candidate, now })
+      : undefined;
+  const result = await applyGitHubSkillVerificationResultHandler(ctx, {
+    skillId: skill._id,
+    contentHash,
+    ...(scanId ? { githubSkillScanId: scanId } : {}),
+    scanStatus: args.verdict === "pass" ? "clean" : "failed",
+    now,
+  });
+  if (args.phase === "native-followup") {
+    return { ...result, phase: "native-followup" as const };
+  }
+  if (args.verdict === "fail") {
+    await ctx.db.patch(digest._id, {
+      claimStatus: "failed",
+      claimFailedAt: now,
+      active: false,
+      publicVisible: false,
+      installable: false,
+      updatedAt: now,
+    });
+    return { ...result, phase: "first-claim" as const };
+  }
+  if (!("promoted" in result) || result.promoted !== true) {
+    throw new ConvexError("Deterministic skills.sh Test claim did not promote the exact candidate");
+  }
+  const promotedSkill = await ctx.db.get(skill._id);
+  if (!promotedSkill) throw new ConvexError("Promoted skills.sh skill was not found");
+  const metricPatch = {
+    statsSkillsShInstalls: digest.upstreamInstalls,
+    updatedAt: now,
+  };
+  await ctx.db.patch(promotedSkill._id, metricPatch);
+  await syncSkillSearchDigestForSkill(ctx, { ...promotedSkill, ...metricPatch });
+  await ctx.db.patch(digest._id, {
+    claimStatus: "promoted",
+    claimedAt: now,
+    claimFailedAt: undefined,
+    active: false,
+    publicVisible: false,
+    installable: false,
+    updatedAt: now,
+  });
+  return { ...result, phase: "first-claim" as const };
+}
+
+export const applyClaimedGitHubSkillSourceSyncInternal = internalMutation({
+  args: {
+    sourceId: v.optional(v.id("githubSkillSources")),
+    repo: v.string(),
+    ownerUserId: v.id("users"),
+    ownerPublisherId: v.id("publishers"),
+    githubRepositoryId: v.optional(v.string()),
+    githubOwnerId: v.optional(v.string()),
+    expectedSourceUpdatedAt: v.optional(v.union(v.number(), v.null())),
+    skillsShClaimPath: v.optional(v.string()),
+    skillsShClaim: v.object({
+      externalId: v.string(),
+      path: v.string(),
+      commit: v.string(),
+      contentHash: v.string(),
+    }),
+    snapshot: sourceSnapshotValidator,
+    now: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const claimPath = normalizePath(args.skillsShClaim.path);
+    if (args.skillsShClaimPath && normalizePath(args.skillsShClaimPath) !== claimPath) {
+      throw new ConvexError("skills.sh claim verification suppression must match the claim path");
+    }
+    const result = await applyGitHubSkillSourceSyncHandler(ctx, {
+      sourceId: args.sourceId,
+      repo: args.repo,
+      ownerUserId: args.ownerUserId,
+      ownerPublisherId: args.ownerPublisherId,
+      githubRepositoryId: args.githubRepositoryId,
+      githubOwnerId: args.githubOwnerId,
+      expectedSourceUpdatedAt: args.expectedSourceUpdatedAt,
+      ...(args.skillsShClaimPath ? { skillsShClaimPath: claimPath } : {}),
+      snapshot: args.snapshot,
+      now: args.now,
+    });
+    if (result.skipped === "stale-source-observation") return result;
+    if (!result.sourceId) throw new ConvexError("skills.sh claim source was not created");
+    const claim = await beginSkillsShClaimHandler(ctx, {
+      externalId: args.skillsShClaim.externalId,
+      ownerPublisherId: args.ownerPublisherId,
+      githubSourceId: result.sourceId,
+      githubPath: claimPath,
+      githubCommit: args.skillsShClaim.commit,
+      githubContentHash: args.skillsShClaim.contentHash,
+      now: args.now,
+    });
+    return { ...result, claim };
+  },
+});
+
+export const applyTestVerdictInternal = internalMutation({
+  args: {
+    externalId: v.string(),
+    phase: v.union(v.literal("first-claim"), v.literal("native-followup")),
+    verdict: v.union(v.literal("pass"), v.literal("fail")),
+    confirm: v.string(),
+    now: v.optional(v.number()),
+  },
+  handler: applySkillsShTestClaimVerdictHandler,
+});

--- a/convex/skillsShMirror.test.ts
+++ b/convex/skillsShMirror.test.ts
@@ -20,6 +20,14 @@ function useTestEnvironment() {
   for (const [name, value] of Object.entries(TEST_ENV)) vi.stubEnv(name, value);
 }
 
+function useProductionEnvironment() {
+  vi.stubEnv("CLAWHUB_DEPLOYMENT_NAME", "wry-manatee-359");
+  vi.stubEnv("CLAWHUB_ENV", "production");
+  vi.stubEnv("CLAWHUB_SKILLS_SH_ROLLOUT_MODE", "production");
+  vi.stubEnv("CONVEX_CLOUD_URL", "https://wry-manatee-359.convex.cloud");
+  vi.stubEnv("CONVEX_SITE_URL", "https://wry-manatee-359.convex.site");
+}
+
 async function sha256Hex(value: string) {
   const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(value));
   return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, "0")).join("");
@@ -69,6 +77,12 @@ const githubRow = {
     sourceFileCount: 1,
     truncated: false,
   },
+};
+
+const exactGithubRow = {
+  ...githubRow,
+  githubPath: "skills/find-skills",
+  githubCommit: "c".repeat(40),
 };
 
 const wellKnownRow = {
@@ -230,6 +244,221 @@ describe("skills.sh external mirror", () => {
     vi.unstubAllEnvs();
   });
 
+  it("does not start a mirror run while atomic public activation holds the corpus lock", async () => {
+    useTestEnvironment();
+    const t = convexTest(schema, modules);
+    await configure(t);
+    await t.run(async (ctx) => {
+      const control = await ctx.db
+        .query("skillsShMirrorControls")
+        .withIndex("by_key", (q) => q.eq("key", "global"))
+        .unique();
+      if (!control) throw new Error("mirror control missing");
+      await ctx.db.patch(control._id, {
+        activationLockToken: "activation-lock",
+        activationLockedAt: Date.now(),
+      });
+    });
+
+    await expect(startRun(t, "blocked-by-activation", 1)).rejects.toThrow(
+      "public activation is in progress",
+    );
+  });
+
+  it("reports the live public gate instead of a hard-coded hidden invariant", async () => {
+    useTestEnvironment();
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("skillsShCatalogControls", {
+        key: "global",
+        mode: "off",
+        discoveryEnabled: false,
+        writesEnabled: false,
+        scanPlanningEnabled: false,
+        scanAdmissionEnabled: false,
+        publicVisibilityEnabled: true,
+        mirrorPublicVisibilityEnabled: true,
+        paused: true,
+        maxEntriesPerRun: 0,
+        maxEntriesPerBatch: 0,
+        maxWritesPerBatch: 0,
+        maxPlannedScans: 0,
+        maxScanAdmissionsPerBatch: 0,
+        maxScanAdmissionsPerRun: 0,
+        maxScanAdmissionsPerDay: 0,
+        maxCatalogQueued: 0,
+        maxCatalogInFlight: 0,
+        maxNativeQueued: 0,
+        maxNativeInFlight: 0,
+        realScanAllowlist: [],
+        updatedBy: "codex-test",
+        reason: "live status test",
+        updatedAt: 1,
+      });
+    });
+
+    await expect(t.query(internal.skillsShMirror.getStatusInternal, {})).resolves.toMatchObject({
+      invariants: {
+        publicVisible: true,
+        installable: true,
+        scanPlanningEnabled: false,
+        scanAdmissionEnabled: false,
+      },
+    });
+  });
+
+  it("requires a production-specific confirmation before configuring the shared importer", async () => {
+    useProductionEnvironment();
+    const t = convexTest(schema, modules);
+    const args = {
+      actor: "codex-test",
+      reason: "CLAW-603 production guard test",
+      enabled: true,
+      maxRowsPerRun: 10_000,
+      maxRowsPerBatch: 50,
+      maxDetailBytes: 64 * 1024,
+    };
+    await expect(
+      t.mutation(internal.skillsShMirror.configureInternal, {
+        ...args,
+        confirm: "enable-skills-sh-mirror-test",
+      }),
+    ).rejects.toThrow('Pass confirm="enable-skills-sh-mirror-production"');
+    await expect(
+      t.mutation(internal.skillsShMirror.configureInternal, {
+        ...args,
+        confirm: "enable-skills-sh-mirror-production",
+      }),
+    ).resolves.toMatchObject({
+      environment: "production",
+      publicGateEnabled: false,
+      scanPlanningEnabled: false,
+      scanAdmissionEnabled: false,
+    });
+  });
+
+  it("publishes every exact Test import without scheduling a ClawHub scan", async () => {
+    useTestEnvironment();
+    const t = convexTest(schema, modules);
+    await configure(t);
+    const run = await startRun(t, "snapshot:exact-public", 1);
+
+    const result = await processBatch(t, {
+      runId: run.runId,
+      page: 0,
+      offset: 0,
+      pageLength: 1,
+      hasMore: false,
+      sourceTotal: 1,
+      sourceRequests: 3,
+      sourceBytes: 1_024,
+      rows: [exactGithubRow],
+    });
+
+    expect(result).toMatchObject({
+      counts: { scansPlanned: 0, scansAdmitted: 0 },
+    });
+    await expect(
+      t.query(internal.skillsShMirror.getByExternalIdInternal, {
+        externalId: exactGithubRow.externalId,
+      }),
+    ).resolves.toMatchObject({
+      active: true,
+      publicVisible: true,
+      installable: true,
+      githubPath: exactGithubRow.githubPath,
+      githubCommit: exactGithubRow.githubCommit,
+      sourceContentHash: exactGithubRow.sourceContentHash,
+      upstreamScanners: {
+        snyk: { status: "warn" },
+      },
+    });
+    await expect(
+      t.run(async (ctx) => await ctx.db.query("skillsShCatalogScanAttempts").collect()),
+    ).resolves.toEqual([]);
+    await expect(
+      t.run(async (ctx) => await ctx.db.query("securityScanJobs").collect()),
+    ).resolves.toEqual([]);
+  });
+
+  it("hides an imported mirror when an exact source becomes incomplete", async () => {
+    useTestEnvironment();
+    const t = convexTest(schema, modules);
+    await configure(t);
+    const first = await startRun(t, "snapshot:exact-before-invalid", 1);
+    await processBatch(t, {
+      runId: first.runId,
+      page: 0,
+      offset: 0,
+      pageLength: 1,
+      hasMore: false,
+      sourceTotal: 1,
+      sourceRequests: 3,
+      sourceBytes: 1_024,
+      rows: [exactGithubRow],
+    });
+    await t.mutation(internal.skillsShMirror.reconcileBatchInternal, {
+      runId: first.runId,
+      limit: 10,
+    });
+    const second = await startRun(t, "snapshot:invalid-after-exact", 1);
+    await processBatch(t, {
+      runId: second.runId,
+      page: 0,
+      offset: 0,
+      pageLength: 1,
+      hasMore: false,
+      sourceTotal: 1,
+      sourceRequests: 2,
+      sourceBytes: 512,
+      rows: [{ ...exactGithubRow, githubCommit: undefined }],
+    });
+
+    await expect(
+      t.query(internal.skillsShMirror.getByExternalIdInternal, {
+        externalId: exactGithubRow.externalId,
+      }),
+    ).resolves.toMatchObject({
+      active: true,
+      publicVisible: false,
+      installable: false,
+    });
+  });
+
+  it("contains a duplicate identity conflict to the affected mirror row", async () => {
+    useTestEnvironment();
+    const t = convexTest(schema, modules);
+    await configure(t);
+    const run = await startRun(t, "snapshot:duplicate-conflict", 3);
+    const result = await processBatch(t, {
+      runId: run.runId,
+      page: 0,
+      offset: 0,
+      pageLength: 3,
+      hasMore: false,
+      sourceTotal: 3,
+      sourceRequests: 3,
+      sourceBytes: 1_024,
+      rows: [
+        exactGithubRow,
+        { ...exactGithubRow, displayName: "Conflicting Name" },
+        exactGithubRow,
+      ],
+    });
+
+    expect(result).toMatchObject({ counts: { rejected: 2, conflicts: 2 } });
+    await expect(
+      t.query(internal.skillsShMirror.getByExternalIdInternal, {
+        externalId: exactGithubRow.externalId,
+      }),
+    ).resolves.toMatchObject({
+      active: true,
+      sourceFreshnessStatus: "stale",
+      publicVisible: false,
+      installable: false,
+    });
+  });
+
   it("joins trending rank onto one mirror identity without scan work", async () => {
     useTestEnvironment();
     const t = convexTest(schema, modules);
@@ -388,6 +617,38 @@ describe("skills.sh external mirror", () => {
     expect(
       await t.run(async (ctx) => await ctx.db.query("skillsShMirrorDigests").collect()),
     ).toHaveLength(1);
+  });
+
+  it("keeps hydrated same-run drift quarantined when the first observation repeats", async () => {
+    useTestEnvironment();
+    const t = convexTest(schema, modules);
+    await configure(t);
+    const trending = await startRun(t, "skills-sh:trending:a-b-a", 1, undefined, "trending");
+    const leaseToken = await claimLease(t, trending.runId, 0, 0);
+    const hydrate = async (row: typeof githubRow) =>
+      await t.mutation(trendingRefs.hydrateTrendingBatchInternal, {
+        runId: trending.runId,
+        page: 0,
+        offset: 0,
+        leaseToken,
+        rows: [row],
+      });
+
+    await hydrate(githubRow);
+    await hydrate({ ...githubRow, displayName: "Conflicting Name" });
+    await expect(hydrate(githubRow)).resolves.toMatchObject({
+      counts: { rejected: 2, conflicts: 2, trendingHydrationFailed: 2 },
+    });
+    await expect(
+      t.query(internal.skillsShMirror.getByExternalIdInternal, {
+        externalId: githubRow.externalId,
+      }),
+    ).resolves.toMatchObject({
+      sourceFreshnessStatus: "stale",
+      staleQuarantineReason: "same-run-drift",
+      publicVisible: false,
+      installable: false,
+    });
   });
 
   it("fails closed when exceptional trending hydration exceeds the run bound", async () => {

--- a/convex/skillsShMirror.ts
+++ b/convex/skillsShMirror.ts
@@ -9,12 +9,15 @@ import type { Doc, Id } from "./_generated/dataModel";
 import type { MutationCtx, QueryCtx } from "./_generated/server";
 import { internalMutation, internalQuery } from "./functions";
 import { tokenize } from "./lib/searchText";
-import { assertSkillsShFixtureEnvironmentAllowed } from "./lib/skillsShCatalogEnvironment";
+import { assertSkillsShMirrorEnvironmentAllowed } from "./lib/skillsShCatalogEnvironment";
+import { skillsShMirrorFreshObservationFlags } from "./lib/skillsShPublicVisibility";
 
 const CONTROL_KEY = "global";
-const ENABLE_CONFIRM = "enable-skills-sh-mirror-test";
+const TEST_ENABLE_CONFIRM = "enable-skills-sh-mirror-test";
+const PRODUCTION_ENABLE_CONFIRM = "enable-skills-sh-mirror-production";
 const PAUSE_CONFIRM = "set-skills-sh-mirror-pause";
-const CANCEL_CONFIRM = "cancel-skills-sh-mirror-test-run";
+const TEST_CANCEL_CONFIRM = "cancel-skills-sh-mirror-test-run";
+const PRODUCTION_CANCEL_CONFIRM = "cancel-skills-sh-mirror-production-run";
 const MAX_ROWS_PER_RUN = 50_000;
 const MAX_ROWS_PER_BATCH = 50;
 const MAX_DETAIL_BYTES = 64 * 1024;
@@ -132,6 +135,14 @@ function assertIntegerInRange(name: string, value: number, min: number, max: num
   if (!Number.isInteger(value) || value < min || value > max) {
     throw new ConvexError(`${name} must be an integer between ${min} and ${max}`);
   }
+}
+
+function environmentConfirm(
+  environment: "local" | "test" | "production",
+  testValue: string,
+  productionValue: string,
+) {
+  return environment === "production" ? productionValue : testValue;
 }
 
 function normalizedSourceSnapshotHash(value: string) {
@@ -448,7 +459,7 @@ function newMirrorDigest(
   fingerprint: string,
   now: number,
 ) {
-  return {
+  const digest = {
     externalId: row.externalId,
     sourceType: row.sourceType,
     upstreamSourceType: row.upstreamSourceType,
@@ -479,24 +490,32 @@ function newMirrorDigest(
     observationFingerprint: fingerprint,
     sourceSnapshotId,
     lastObservedRunId: runId,
-    active: true,
-    publicVisible: false as const,
-    installable: false as const,
     firstObservedAt: now,
     lastObservedAt: now,
     createdAt: now,
     updatedAt: now,
   };
+  return {
+    ...digest,
+    ...skillsShMirrorFreshObservationFlags({
+      ...digest,
+      active: true,
+      publicVisible: false,
+      installable: false,
+    }),
+  };
 }
 
 function mirrorDigestPatch(
   row: MirrorRow,
+  existing: Doc<"skillsShMirrorDigests">,
   runId: Id<"skillsShMirrorRuns">,
   sourceSnapshotId: string,
   fingerprint: string,
   now: number,
 ) {
-  return {
+  const digest = {
+    externalId: row.externalId,
     sourceType: row.sourceType,
     upstreamSourceType: row.upstreamSourceType,
     owner: row.owner,
@@ -527,12 +546,19 @@ function mirrorDigestPatch(
     observationFingerprint: fingerprint,
     sourceSnapshotId,
     lastObservedRunId: runId,
-    active: true,
-    publicVisible: false as const,
-    installable: false as const,
     tombstonedAt: undefined,
     lastObservedAt: now,
     updatedAt: now,
+  };
+  return {
+    ...digest,
+    ...skillsShMirrorFreshObservationFlags({
+      ...existing,
+      ...digest,
+      active: true,
+      publicVisible: false,
+      installable: false,
+    }),
   };
 }
 
@@ -844,6 +870,26 @@ async function upsertHydratedMirrorRow(
   let writes = 0;
   if (
     existing?.lastObservedRunId === args.run._id &&
+    existing.sourceFreshnessStatus === "stale" &&
+    existing.staleQuarantineReason === "same-run-drift"
+  ) {
+    await ctx.db.insert("skillsShMirrorConflicts", {
+      runId: args.run._id,
+      externalId: args.row.externalId,
+      kind: "same-run-drift",
+      previousFingerprint: existing.observationFingerprint,
+      observedFingerprint: fingerprint,
+      page: args.page,
+      offset: args.offset,
+      createdAt: args.now,
+    });
+    args.counts.rejected += 1;
+    args.counts.quarantined += 1;
+    args.counts.conflicts += 1;
+    return { hydrated: false, reads, writes: writes + 1 };
+  }
+  if (
+    existing?.lastObservedRunId === args.run._id &&
     existing.sourceFreshnessStatus !== "stale" &&
     existing.observationFingerprint !== fingerprint
   ) {
@@ -857,9 +903,17 @@ async function upsertHydratedMirrorRow(
       offset: args.offset,
       createdAt: args.now,
     });
+    await ctx.db.patch(existing._id, {
+      sourceFreshnessStatus: "stale",
+      staleQuarantineReason: "same-run-drift",
+      publicVisible: false,
+      installable: false,
+      updatedAt: args.now,
+    });
     args.counts.rejected += 1;
+    args.counts.quarantined += 1;
     args.counts.conflicts += 1;
-    return { hydrated: false, reads, writes: writes + 1 };
+    return { hydrated: false, reads, writes: writes + 2 };
   }
 
   let digestId: Id<"skillsShMirrorDigests">;
@@ -877,7 +931,7 @@ async function upsertHydratedMirrorRow(
     if (!existing.active) args.counts.reactivated += 1;
     await ctx.db.patch(
       existing._id,
-      mirrorDigestPatch(args.row, args.run._id, sourceSnapshotId, fingerprint, args.now),
+      mirrorDigestPatch(args.row, existing, args.run._id, sourceSnapshotId, fingerprint, args.now),
     );
     writes += 1;
   }
@@ -951,9 +1005,14 @@ export const configureInternal = internalMutation({
     maxDetailBytes: v.number(),
   },
   handler: async (ctx, args) => {
-    assertSkillsShFixtureEnvironmentAllowed();
-    if (args.confirm !== ENABLE_CONFIRM) {
-      throw new ConvexError(`Pass confirm="${ENABLE_CONFIRM}" to configure the mirror.`);
+    const policy = assertSkillsShMirrorEnvironmentAllowed();
+    const expectedConfirm = environmentConfirm(
+      policy.environment,
+      TEST_ENABLE_CONFIRM,
+      PRODUCTION_ENABLE_CONFIRM,
+    );
+    if (args.confirm !== expectedConfirm) {
+      throw new ConvexError(`Pass confirm="${expectedConfirm}" to configure the mirror.`);
     }
     assertIntegerInRange("maxRowsPerRun", args.maxRowsPerRun, 1, MAX_ROWS_PER_RUN);
     assertIntegerInRange("maxRowsPerBatch", args.maxRowsPerBatch, 1, MAX_ROWS_PER_BATCH);
@@ -989,9 +1048,8 @@ export const configureInternal = internalMutation({
     else await ctx.db.insert("skillsShMirrorControls", { key: CONTROL_KEY, ...next });
     return {
       ...next,
-      environment: assertSkillsShFixtureEnvironmentAllowed().environment,
-      publicVisible: false as const,
-      installable: false as const,
+      environment: policy.environment,
+      publicGateEnabled: false as const,
       scanPlanningEnabled: false as const,
       scanAdmissionEnabled: false as const,
     };
@@ -1013,8 +1071,11 @@ export const startRunInternal = internalMutation({
     sourceDurationMs: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
-    assertSkillsShFixtureEnvironmentAllowed();
+    assertSkillsShMirrorEnvironmentAllowed();
     const control = requireActiveControl(await getControl(ctx));
+    if (control.activationLockToken) {
+      throw new ConvexError("skills.sh public activation is in progress");
+    }
     assertIntegerInRange("sourceTotal", args.sourceTotal, 1, control.maxRowsPerRun);
     assertIntegerInRange("sourcePageSize", args.sourcePageSize, 1, 500);
     if (Number.isNaN(Date.parse(args.sourceMeasuredAt))) {
@@ -1084,7 +1145,7 @@ export const storeSourcePageInternal = internalMutation({
     rows: v.array(sourceListRowValidator),
   },
   handler: async (ctx, args) => {
-    assertSkillsShFixtureEnvironmentAllowed();
+    assertSkillsShMirrorEnvironmentAllowed();
     const control = requireActiveControl(await getControl(ctx));
     const snapshotHash = normalizedSourceSnapshotHash(args.snapshotHash);
     const identityHash = normalizedSourceSnapshotHash(args.identityHash);
@@ -1157,7 +1218,7 @@ export const storeSourcePageInternal = internalMutation({
 export const getSourceCaptureSummaryInternal = internalQuery({
   args: { snapshotHash: v.string() },
   handler: async (ctx, args) => {
-    assertSkillsShFixtureEnvironmentAllowed();
+    assertSkillsShMirrorEnvironmentAllowed();
     const snapshotHash = normalizedSourceSnapshotHash(args.snapshotHash);
     const pages = await ctx.db
       .query("skillsShMirrorSourcePages")
@@ -1190,7 +1251,7 @@ export const setPausedInternal = internalMutation({
     confirm: v.string(),
   },
   handler: async (ctx, args) => {
-    assertSkillsShFixtureEnvironmentAllowed();
+    assertSkillsShMirrorEnvironmentAllowed();
     if (args.confirm !== PAUSE_CONFIRM) {
       throw new ConvexError(`Pass confirm="${PAUSE_CONFIRM}" to change mirror pause state.`);
     }
@@ -1232,9 +1293,14 @@ export const cancelRunInternal = internalMutation({
     confirm: v.string(),
   },
   handler: async (ctx, args) => {
-    assertSkillsShFixtureEnvironmentAllowed();
-    if (args.confirm !== CANCEL_CONFIRM) {
-      throw new ConvexError(`Pass confirm="${CANCEL_CONFIRM}" to cancel a mirror run.`);
+    const policy = assertSkillsShMirrorEnvironmentAllowed();
+    const expectedConfirm = environmentConfirm(
+      policy.environment,
+      TEST_CANCEL_CONFIRM,
+      PRODUCTION_CANCEL_CONFIRM,
+    );
+    if (args.confirm !== expectedConfirm) {
+      throw new ConvexError(`Pass confirm="${expectedConfirm}" to cancel a mirror run.`);
     }
     const run = await ctx.db.get(args.runId);
     if (!run) throw new ConvexError("skills.sh mirror run not found");
@@ -1269,7 +1335,7 @@ export const claimBatchLeaseInternal = internalMutation({
     leaseToken: v.string(),
   },
   handler: async (ctx, args) => {
-    assertSkillsShFixtureEnvironmentAllowed();
+    assertSkillsShMirrorEnvironmentAllowed();
     requireActiveControl(await getControl(ctx));
     const run = await ctx.db.get(args.runId);
     if (!run) throw new ConvexError("skills.sh mirror run not found");
@@ -1336,7 +1402,7 @@ export const releaseBatchLeaseInternal = internalMutation({
     leaseToken: v.string(),
   },
   handler: async (ctx, args) => {
-    assertSkillsShFixtureEnvironmentAllowed();
+    assertSkillsShMirrorEnvironmentAllowed();
     const run = await ctx.db.get(args.runId);
     if (!run) throw new ConvexError("skills.sh mirror run not found");
     requireExactRunCursor(run, args.page, args.offset);
@@ -1374,7 +1440,7 @@ export const processBatchInternal = internalMutation({
     rows: v.array(v.union(rowValidator, quarantinedRowValidator)),
   },
   handler: async (ctx, args) => {
-    assertSkillsShFixtureEnvironmentAllowed();
+    assertSkillsShMirrorEnvironmentAllowed();
     const [controlDoc, run] = await Promise.all([getControl(ctx), ctx.db.get(args.runId)]);
     const control = requireActiveControl(controlDoc);
     if (!run) throw new ConvexError("skills.sh mirror run not found");
@@ -1452,6 +1518,8 @@ export const processBatchInternal = internalMutation({
               lastObservedRunId: run._id,
               sourceFreshnessStatus: "stale",
               staleQuarantineReason: row.reason,
+              publicVisible: false,
+              installable: false,
               updatedAt: now,
             });
             writes += 1;
@@ -1472,6 +1540,7 @@ export const processBatchInternal = internalMutation({
           createdAt: now,
         });
         counts.rejected += 1;
+        counts.quarantined += 1;
         counts.conflicts += 1;
         writes += 1;
         continue;
@@ -1482,6 +1551,27 @@ export const processBatchInternal = internalMutation({
         .withIndex("by_external_id", (q) => q.eq("externalId", row.externalId))
         .unique();
       reads += 1;
+      if (
+        existing?.lastObservedRunId === run._id &&
+        existing.sourceFreshnessStatus === "stale" &&
+        existing.staleQuarantineReason === "same-run-drift"
+      ) {
+        await ctx.db.insert("skillsShMirrorConflicts", {
+          runId: run._id,
+          externalId: row.externalId,
+          kind: "same-run-drift",
+          previousFingerprint: existing.observationFingerprint,
+          observedFingerprint: fingerprint,
+          page: args.page,
+          offset: args.offset + index,
+          createdAt: now,
+        });
+        counts.rejected += 1;
+        counts.quarantined += 1;
+        counts.conflicts += 1;
+        writes += 1;
+        continue;
+      }
       if (existing?.lastObservedRunId === run._id && existing.sourceFreshnessStatus === "stale") {
         counts.quarantinedPreserved = Math.max(0, counts.quarantinedPreserved - 1);
       }
@@ -1500,9 +1590,17 @@ export const processBatchInternal = internalMutation({
           offset: args.offset + index,
           createdAt: now,
         });
+        await ctx.db.patch(existing._id, {
+          sourceFreshnessStatus: "stale",
+          staleQuarantineReason: "same-run-drift",
+          publicVisible: false,
+          installable: false,
+          updatedAt: now,
+        });
         counts.rejected += 1;
+        counts.quarantined += 1;
         counts.conflicts += 1;
-        writes += 1;
+        writes += 2;
         continue;
       }
 
@@ -1528,7 +1626,7 @@ export const processBatchInternal = internalMutation({
         if (!existing.active) counts.reactivated += 1;
         await ctx.db.patch(
           existing._id,
-          mirrorDigestPatch(row, run._id, sourceSnapshotId, fingerprint, now),
+          mirrorDigestPatch(row, existing, run._id, sourceSnapshotId, fingerprint, now),
         );
         writes += 1;
       }
@@ -1651,7 +1749,7 @@ export const hydrateTrendingBatchInternal = internalMutation({
     rows: v.array(v.union(rowValidator, quarantinedRowValidator)),
   },
   handler: async (ctx, args) => {
-    assertSkillsShFixtureEnvironmentAllowed();
+    assertSkillsShMirrorEnvironmentAllowed();
     const [controlDoc, run] = await Promise.all([getControl(ctx), ctx.db.get(args.runId)]);
     const control = requireActiveControl(controlDoc);
     if (!run) throw new ConvexError("skills.sh mirror run not found");
@@ -1767,7 +1865,7 @@ export const processTrendingBatchInternal = internalMutation({
     rows: v.array(trendingRowValidator),
   },
   handler: async (ctx, args) => {
-    assertSkillsShFixtureEnvironmentAllowed();
+    assertSkillsShMirrorEnvironmentAllowed();
     const [controlDoc, run] = await Promise.all([getControl(ctx), ctx.db.get(args.runId)]);
     const control = requireActiveControl(controlDoc);
     if (!run) throw new ConvexError("skills.sh mirror run not found");
@@ -1906,7 +2004,7 @@ export const reconcileBatchInternal = internalMutation({
     limit: v.number(),
   },
   handler: async (ctx, args) => {
-    assertSkillsShFixtureEnvironmentAllowed();
+    assertSkillsShMirrorEnvironmentAllowed();
     const run = await ctx.db.get(args.runId);
     if (!run) throw new ConvexError("skills.sh mirror run not found");
     if (run.status !== "reconciling") return summarizeRun(run);
@@ -2385,8 +2483,12 @@ export const listConflictsByRunInternal = internalQuery({
 export const getStatusInternal = internalQuery({
   args: {},
   handler: async (ctx) => {
-    const [control, runs, sampleDigests] = await Promise.all([
+    const [control, catalogControl, runs, sampleDigests] = await Promise.all([
       getControl(ctx),
+      ctx.db
+        .query("skillsShCatalogControls")
+        .withIndex("by_key", (q) => q.eq("key", "global"))
+        .unique(),
       ctx.db.query("skillsShMirrorRuns").withIndex("by_started_at").order("desc").take(20),
       ctx.db.query("skillsShMirrorDigests").withIndex("by_external_id").take(50),
     ]);
@@ -2396,18 +2498,19 @@ export const getStatusInternal = internalQuery({
           .withIndex("by_run_id", (q) => q.eq("runId", runs[0]!._id))
           .take(50)
       : [];
+    const publicCatalogEnabled = Boolean(catalogControl?.mirrorPublicVisibilityEnabled);
     return {
-      environment: assertSkillsShFixtureEnvironmentAllowed(),
+      environment: assertSkillsShMirrorEnvironmentAllowed(),
       control,
       runs: runs.map(summarizeRun),
       sampleDigests,
       sampleConflicts: latestRunConflicts,
       latestRunConflicts,
       invariants: {
-        publicVisible: false,
-        installable: false,
-        scanPlanningEnabled: false,
-        scanAdmissionEnabled: false,
+        publicVisible: publicCatalogEnabled,
+        installable: publicCatalogEnabled,
+        scanPlanningEnabled: Boolean(catalogControl?.scanPlanningEnabled),
+        scanAdmissionEnabled: Boolean(catalogControl?.scanAdmissionEnabled),
         publisherAttachmentEnabled: false,
       },
     };

--- a/convex/skillsShMirrorPublic.test.ts
+++ b/convex/skillsShMirrorPublic.test.ts
@@ -45,4 +45,39 @@ describe("skillsShMirrorPublic.getSkillsShMirrorByRoute", () => {
     await expect(getSkillsShMirrorByRoute({ runQuery } as never, route)).resolves.toBeNull();
     expect(runQuery).not.toHaveBeenCalled();
   });
+
+  it("keeps an eligible mirror hidden while the atomic public catalog gate is off", async () => {
+    const runQuery = vi
+      .fn()
+      .mockResolvedValueOnce({
+        externalId: "patrick-erichsen/skills/html",
+        sourceType: "github",
+        owner: "patrick-erichsen",
+        repo: "skills",
+        slug: "html",
+        displayName: "HTML",
+        sourceUrl: "https://skills.sh/patrick-erichsen/skills/html",
+        canonicalRepoUrl: "https://github.com/patrick-erichsen/skills",
+        githubPath: "skills/html",
+        githubCommit: "c".repeat(40),
+        sourceContentHash: "a".repeat(64),
+        upstreamInstalls: 1,
+        upstreamScanners: {
+          genAgentTrustHub: { status: "pass" },
+          socket: { status: "pass" },
+          snyk: { status: "warn" },
+        },
+        sourceFreshnessStatus: "observed-only",
+        detailStatus: "available",
+        active: true,
+        publicVisible: true,
+        installable: true,
+        lastObservedAt: 1,
+      })
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ skillsSh: { publicCatalogEnabled: false } });
+
+    await expect(getSkillsShMirrorByRoute({ runQuery } as never, route)).resolves.toBeNull();
+  });
 });

--- a/convex/skillsShMirrorPublic.ts
+++ b/convex/skillsShMirrorPublic.ts
@@ -16,6 +16,7 @@ const internalRefs = internal as unknown as {
     getByExternalIdInternal: unknown;
     getDetailByExternalIdInternal: unknown;
   };
+  rolloutCapabilities: { getPublicCapabilitiesInternal: unknown };
 };
 
 function normalizeRouteSegment(value: string) {
@@ -73,6 +74,11 @@ export async function getSkillsShMirrorByRoute(
       : null;
   if (alias) return { kind: "redirect" as const, ...alias };
   if (!digest) return null;
+  const capabilities = (await ctx.runQuery(
+    internalRefs.rolloutCapabilities.getPublicCapabilitiesInternal as never,
+    {} as never,
+  )) as { skillsSh: { publicCatalogEnabled: boolean } };
+  if (!capabilities.skillsSh.publicCatalogEnabled) return null;
   const entry = buildSkillsShMirrorCatalogDetail({ digest, detail });
   return entry ? { kind: "external" as const, entry } : null;
 }

--- a/convex/skillsShMirrorVisibility.test.ts
+++ b/convex/skillsShMirrorVisibility.test.ts
@@ -1,0 +1,812 @@
+/// <reference types="vite/client" />
+/* @vitest-environment edge-runtime */
+import { convexTest } from "convex-test";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { internal } from "./_generated/api";
+import type { Doc } from "./_generated/dataModel";
+import { getCompletedRolling24HourWindow } from "./lib/skillHourlyStats";
+import schema from "./schema";
+
+const modules = import.meta.glob("./**/*.ts");
+
+beforeEach(() => {
+  vi.stubEnv("CLAWHUB_ENV", "test");
+  vi.stubEnv("CLAWHUB_DEPLOYMENT_NAME", "academic-chihuahua-392");
+  vi.stubEnv("CLAWHUB_SKILLS_SH_ROLLOUT_MODE", "test");
+});
+
+afterEach(() => vi.unstubAllEnvs());
+
+describe("skills.sh mirror visibility operations", () => {
+  it("keeps the global lane closed when stored rejection evidence is incomplete", async () => {
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) => {
+      const leaderboardRunId = await ctx.db.insert("skillsShMirrorRuns", {
+        snapshotId: "skills-sh:leaderboard:missing-conflict",
+        sourceView: "leaderboard",
+        status: "completed",
+        sourceTotal: 1,
+        sourcePageSize: 500,
+        sourceMeasuredAt: new Date(1).toISOString(),
+        page: 1,
+        offset: 0,
+        counts: {
+          observed: 1,
+          inserted: 0,
+          updated: 0,
+          unchanged: 0,
+          rejected: 1,
+          quarantined: 1,
+          conflicts: 1,
+          detailsInserted: 0,
+          detailsUpdated: 0,
+          detailsUnchanged: 0,
+          detailsMissing: 0,
+          detailsTruncated: 0,
+          tombstoned: 0,
+          reactivated: 0,
+          scansPlanned: 0,
+          scansAdmitted: 0,
+        },
+        operations: {
+          functionCalls: 1,
+          dbReads: 1,
+          dbWrites: 1,
+          sourceRequests: 1,
+          sourceBytes: 1,
+        },
+        actor: "codex-test",
+        reason: "CLAW-603 missing conflict proof",
+        startedAt: 1,
+        completedAt: 2,
+        updatedAt: 2,
+      });
+      await ctx.db.insert("skillsShMirrorRuns", {
+        snapshotId: "skills-sh:trending:empty",
+        sourceView: "trending",
+        status: "completed",
+        sourceTotal: 0,
+        sourcePageSize: 500,
+        sourceMeasuredAt: new Date(3).toISOString(),
+        page: 1,
+        offset: 0,
+        counts: {
+          observed: 0,
+          inserted: 0,
+          updated: 0,
+          unchanged: 0,
+          rejected: 0,
+          conflicts: 0,
+          detailsInserted: 0,
+          detailsUpdated: 0,
+          detailsUnchanged: 0,
+          detailsMissing: 0,
+          detailsTruncated: 0,
+          tombstoned: 0,
+          reactivated: 0,
+          trendingJoined: 0,
+          trendingMissing: 0,
+          scansPlanned: 0,
+          scansAdmitted: 0,
+        },
+        operations: {
+          functionCalls: 1,
+          dbReads: 0,
+          dbWrites: 0,
+          sourceRequests: 0,
+          sourceBytes: 0,
+        },
+        actor: "codex-test",
+        reason: "CLAW-603 empty trending proof",
+        startedAt: 3,
+        completedAt: 4,
+        updatedAt: 4,
+      });
+      await ctx.db.insert("skillsShMirrorControls", {
+        key: "global",
+        enabled: true,
+        paused: false,
+        maxRowsPerRun: 50_000,
+        maxRowsPerBatch: 50,
+        maxDetailBytes: 65_536,
+        latestCompletedLeaderboardRunId: leaderboardRunId,
+        updatedBy: "codex-test",
+        reason: "CLAW-603 missing conflict proof",
+        updatedAt: 2,
+      });
+    });
+
+    await expect(
+      t.action(internal.skillsShMirrorVisibility.verifyAndActivateInternal, {
+        actor: "codex-test",
+        reason: "CLAW-603 must remain hidden",
+        confirm: "activate-skills-sh-public-test",
+      }),
+    ).rejects.toThrow("stored conflict accounting differs");
+    const catalogControl = await t.run(async (ctx) =>
+      ctx.db
+        .query("skillsShCatalogControls")
+        .withIndex("by_key", (q) => q.eq("key", "global"))
+        .unique(),
+    );
+    expect(catalogControl).toBeNull();
+  });
+
+  it("keeps the global lane closed when the eligible corpus does not match accepted rows", async () => {
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) => {
+      const leaderboardRunId = await ctx.db.insert(
+        "skillsShMirrorRuns",
+        mirrorRun({
+          sourceView: "leaderboard",
+          sourceTotal: 1,
+          counts: mirrorRunCounts({ observed: 1, inserted: 1, detailsInserted: 1 }),
+          startedAt: 1,
+          completedAt: 2,
+          updatedAt: 2,
+        }),
+      );
+      await ctx.db.insert(
+        "skillsShMirrorRuns",
+        mirrorRun({
+          sourceView: "trending",
+          startedAt: 3,
+          completedAt: 4,
+          updatedAt: 4,
+        }),
+      );
+      await ctx.db.insert("skillsShMirrorControls", {
+        key: "global",
+        enabled: true,
+        paused: false,
+        maxRowsPerRun: 50_000,
+        maxRowsPerBatch: 50,
+        maxDetailBytes: 65_536,
+        latestCompletedLeaderboardRunId: leaderboardRunId,
+        updatedBy: "codex-test",
+        reason: "CLAW-603 missing accepted digest proof",
+        updatedAt: 2,
+      });
+    });
+
+    await expect(
+      t.action(internal.skillsShMirrorVisibility.verifyAndActivateInternal, {
+        actor: "codex-test",
+        reason: "CLAW-603 must remain hidden",
+        confirm: "activate-skills-sh-public-test",
+      }),
+    ).rejects.toThrow("eligible corpus count differs from accepted rows");
+  });
+
+  it("verifies the complete imported corpus before opening the global lane", async () => {
+    const t = convexTest(schema, modules);
+    const now = Date.now();
+    const window = getCompletedRolling24HourWindow(now);
+    await t.run(async (ctx) => {
+      const leaderboardRunId = await ctx.db.insert("skillsShMirrorRuns", {
+        snapshotId: "skills-sh:leaderboard:verified",
+        sourceView: "leaderboard",
+        sourceSnapshotHash: "a".repeat(64),
+        status: "completed",
+        sourceTotal: 3,
+        sourcePageSize: 500,
+        sourceMeasuredAt: new Date(now - 2_000).toISOString(),
+        page: 1,
+        offset: 0,
+        counts: {
+          observed: 3,
+          inserted: 2,
+          updated: 0,
+          unchanged: 0,
+          rejected: 1,
+          quarantined: 1,
+          conflicts: 1,
+          detailsInserted: 2,
+          detailsUpdated: 0,
+          detailsUnchanged: 0,
+          detailsMissing: 0,
+          detailsTruncated: 0,
+          tombstoned: 0,
+          reactivated: 0,
+          scansPlanned: 0,
+          scansAdmitted: 0,
+        },
+        operations: {
+          functionCalls: 1,
+          dbReads: 2,
+          dbWrites: 2,
+          sourceRequests: 2,
+          sourceBytes: 100,
+        },
+        actor: "codex-test",
+        reason: "CLAW-603 verification test",
+        startedAt: now - 3_000,
+        completedAt: now - 2_000,
+        updatedAt: now - 2_000,
+      });
+      const trendingRunId = await ctx.db.insert("skillsShMirrorRuns", {
+        snapshotId: "skills-sh:trending:verified",
+        sourceView: "trending",
+        sourceSnapshotHash: "b".repeat(64),
+        status: "completed",
+        sourceTotal: 1,
+        sourcePageSize: 500,
+        sourceMeasuredAt: new Date(now - 1_000).toISOString(),
+        page: 1,
+        offset: 0,
+        counts: {
+          observed: 1,
+          inserted: 0,
+          updated: 0,
+          unchanged: 0,
+          rejected: 0,
+          conflicts: 0,
+          detailsInserted: 0,
+          detailsUpdated: 0,
+          detailsUnchanged: 0,
+          detailsMissing: 0,
+          detailsTruncated: 0,
+          tombstoned: 0,
+          reactivated: 0,
+          trendingJoined: 1,
+          trendingUpdated: 0,
+          trendingUnchanged: 1,
+          trendingMissing: 0,
+          trendingStaleRejected: 0,
+          trendingHydrationAttempts: 0,
+          trendingHydrated: 0,
+          trendingHydrationFailed: 0,
+          scansPlanned: 0,
+          scansAdmitted: 0,
+        },
+        operations: {
+          functionCalls: 1,
+          dbReads: 1,
+          dbWrites: 1,
+          sourceRequests: 1,
+          sourceBytes: 50,
+        },
+        actor: "codex-test",
+        reason: "CLAW-603 trending verification test",
+        startedAt: now - 1_500,
+        completedAt: now - 1_000,
+        updatedAt: now - 1_000,
+      });
+      await ctx.db.insert(
+        "skillsShMirrorDigests",
+        digest({
+          lastObservedRunId: leaderboardRunId,
+          trendingObservedRunId: trendingRunId,
+          trendingRank: 1,
+          trendingLifetimeInstalls: 12,
+          trendingObservedAt: now - 1_000,
+        }),
+      );
+      await ctx.db.insert(
+        "skillsShMirrorDigests",
+        digest({
+          externalId: "patrick/skills/failed-claim",
+          slug: "failed-claim",
+          normalizedSlug: "failed-claim",
+          normalizedSlugFirstToken: "failed",
+          displayName: "Failed claim",
+          normalizedDisplayName: "failed claim",
+          normalizedDisplayNameFirstToken: "failed",
+          searchText: "failed claim",
+          sourceUrl: "https://skills.sh/patrick/skills/failed-claim",
+          githubPath: "skills/failed-claim",
+          lastObservedRunId: leaderboardRunId,
+          claimStatus: "failed",
+          claimAttempt: 1,
+          active: false,
+          publicVisible: false,
+          installable: false,
+        }),
+      );
+      await ctx.db.insert("skillsShMirrorConflicts", {
+        runId: leaderboardRunId,
+        externalId: "invalid/source/row",
+        kind: "source-quarantine",
+        reason: "invalid source",
+        observedFingerprint: "invalid",
+        page: 0,
+        offset: 1,
+        createdAt: now - 2_000,
+      });
+      await ctx.db.insert("skillsShMirrorControls", {
+        key: "global",
+        enabled: true,
+        paused: false,
+        maxRowsPerRun: 50_000,
+        maxRowsPerBatch: 50,
+        maxDetailBytes: 65_536,
+        latestCompletedLeaderboardRunId: leaderboardRunId,
+        updatedBy: "codex-test",
+        reason: "CLAW-603 verification test",
+        updatedAt: now - 2_000,
+      });
+      await ctx.db.insert("skillHourlyStatStates", {
+        key: "canonical_trending",
+        liveStartedAt: now - 3_600_000,
+        eventBackfillThroughCreationTime: 100,
+        activeGeneration: 1,
+        backfillCompletedAt: now - 1_000,
+        lastAggregationCompletedAt: window.endAt + 1,
+        lastProcessedEventCreationTime: 100,
+        updatedAt: now,
+      });
+    });
+
+    await expect(
+      t.action(internal.skillsShMirrorVisibility.verifyAndActivateInternal, {
+        actor: "codex-test",
+        reason: "CLAW-603 verified atomic publication",
+        confirm: "activate-skills-sh-public-test",
+      }),
+    ).resolves.toMatchObject({
+      ok: true,
+      environment: "test",
+      activated: true,
+      leaderboard: { sourceTotal: 3, accepted: 2, rejected: 1 },
+      trending: { sourceTotal: 1, joined: 1, missing: 0 },
+      corpus: {
+        total: 2,
+        eligible: 1,
+        claimExcluded: 1,
+        eligiblePublished: 1,
+        unsafePublished: 0,
+      },
+      trendingSnapshot: {
+        status: "ready",
+        sourceCounts: { skillsShTrending: 1 },
+      },
+      scansPlanned: 0,
+      scansAdmitted: 0,
+    });
+    const activationState = await t.run(async (ctx) => ({
+      mirrorControl: await ctx.db
+        .query("skillsShMirrorControls")
+        .withIndex("by_key", (q) => q.eq("key", "global"))
+        .unique(),
+      snapshots: await ctx.db
+        .query("canonicalTrendingSnapshots")
+        .withIndex("by_kind_and_status_and_expires_at", (q) =>
+          q.eq("kind", "skills").eq("status", "ready").gt("expiresAt", 0),
+        )
+        .collect(),
+    }));
+    expect(activationState.mirrorControl?.activationLockToken).toBeUndefined();
+    expect(activationState.snapshots).toHaveLength(1);
+  });
+
+  it("reclaims an abandoned activation lock after its bounded lease", async () => {
+    const t = convexTest(schema, modules);
+    const now = Date.now();
+    await t.run(async (ctx) => {
+      const leaderboardRunId = await ctx.db.insert(
+        "skillsShMirrorRuns",
+        mirrorRun({
+          sourceView: "leaderboard",
+          startedAt: now - 20 * 60_000,
+          completedAt: now - 19 * 60_000,
+          updatedAt: now - 19 * 60_000,
+        }),
+      );
+      const trendingRunId = await ctx.db.insert(
+        "skillsShMirrorRuns",
+        mirrorRun({
+          sourceView: "trending",
+          startedAt: now - 18 * 60_000,
+          completedAt: now - 17 * 60_000,
+          updatedAt: now - 17 * 60_000,
+        }),
+      );
+      await ctx.db.insert("skillsShMirrorControls", {
+        key: "global",
+        enabled: true,
+        paused: false,
+        maxRowsPerRun: 50_000,
+        maxRowsPerBatch: 50,
+        maxDetailBytes: 65_536,
+        latestCompletedLeaderboardRunId: leaderboardRunId,
+        activationLockToken: "abandoned-lock",
+        activationLockedAt: now - 16 * 60_000,
+        activationLeaderboardRunId: leaderboardRunId,
+        activationTrendingRunId: trendingRunId,
+        updatedBy: "interrupted-action",
+        reason: "abandoned activation test",
+        updatedAt: now - 16 * 60_000,
+      });
+    });
+
+    await expect(
+      t.mutation(internal.skillsShMirrorVisibility.beginActivationInternal, {
+        actor: "retrying-action",
+        reason: "recover abandoned activation",
+        confirm: "activate-skills-sh-public-test",
+        lockToken: "replacement-lock",
+      }),
+    ).resolves.toMatchObject({ environment: "test" });
+    await expect(
+      t.run(async (ctx) =>
+        ctx.db
+          .query("skillsShMirrorControls")
+          .withIndex("by_key", (q) => q.eq("key", "global"))
+          .unique(),
+      ),
+    ).resolves.toMatchObject({
+      activationLockToken: "replacement-lock",
+      updatedBy: "retrying-action",
+    });
+  });
+
+  it("rejects a completed Trending run older than the selected leaderboard import", async () => {
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) => {
+      const leaderboardRunId = await ctx.db.insert(
+        "skillsShMirrorRuns",
+        mirrorRun({ sourceView: "leaderboard", startedAt: 10, completedAt: 20, updatedAt: 20 }),
+      );
+      await ctx.db.insert(
+        "skillsShMirrorRuns",
+        mirrorRun({ sourceView: "trending", startedAt: 1, completedAt: 2, updatedAt: 2 }),
+      );
+      await ctx.db.insert("skillsShMirrorControls", {
+        key: "global",
+        enabled: true,
+        paused: false,
+        maxRowsPerRun: 50_000,
+        maxRowsPerBatch: 50,
+        maxDetailBytes: 65_536,
+        latestCompletedLeaderboardRunId: leaderboardRunId,
+        updatedBy: "codex-test",
+        reason: "current leaderboard without current trending",
+        updatedAt: 20,
+      });
+    });
+
+    await expect(
+      t.mutation(internal.skillsShMirrorVisibility.beginActivationInternal, {
+        actor: "codex-test",
+        reason: "must not reuse stale trending",
+        confirm: "activate-skills-sh-public-test",
+        lockToken: "new-lock",
+      }),
+    ).rejects.toThrow("skills.sh trending run is older than the leaderboard run");
+  });
+
+  it("invalidates an in-flight activation when the public lane is deactivated", async () => {
+    const t = convexTest(schema, modules);
+    const { leaderboardRunId, trendingRunId } = await t.run(async (ctx) => {
+      const createdLeaderboardRunId = await ctx.db.insert(
+        "skillsShMirrorRuns",
+        mirrorRun({ sourceView: "leaderboard", startedAt: 1, completedAt: 2, updatedAt: 2 }),
+      );
+      const createdTrendingRunId = await ctx.db.insert(
+        "skillsShMirrorRuns",
+        mirrorRun({ sourceView: "trending", startedAt: 3, completedAt: 4, updatedAt: 4 }),
+      );
+      await ctx.db.insert("skillsShMirrorControls", {
+        key: "global",
+        enabled: true,
+        paused: false,
+        maxRowsPerRun: 50_000,
+        maxRowsPerBatch: 50,
+        maxDetailBytes: 65_536,
+        latestCompletedLeaderboardRunId: createdLeaderboardRunId,
+        activationLockToken: "in-flight-lock",
+        activationLockedAt: Date.now(),
+        activationLeaderboardRunId: createdLeaderboardRunId,
+        activationTrendingRunId: createdTrendingRunId,
+        updatedBy: "activating-action",
+        reason: "activation in progress",
+        updatedAt: Date.now(),
+      });
+      return {
+        leaderboardRunId: createdLeaderboardRunId,
+        trendingRunId: createdTrendingRunId,
+      };
+    });
+
+    await t.mutation(internal.skillsShMirrorVisibility.setPublicGateInternal, {
+      enabled: false,
+      actor: "codex-test",
+      reason: "systemic rollback",
+      confirm: "deactivate-skills-sh-public-test",
+    });
+    const control = await t.run(async (ctx) =>
+      ctx.db
+        .query("skillsShMirrorControls")
+        .withIndex("by_key", (q) => q.eq("key", "global"))
+        .unique(),
+    );
+    expect(control?.activationLockToken).toBeUndefined();
+    expect(control?.activationLockedAt).toBeUndefined();
+    expect(control?.activationLeaderboardRunId).toBeUndefined();
+    expect(control?.activationTrendingRunId).toBeUndefined();
+    await expect(
+      t.mutation(internal.skillsShMirrorVisibility.finalizeActivationInternal, {
+        actor: "activating-action",
+        reason: "stale activation",
+        confirm: "activate-skills-sh-public-test",
+        lockToken: "in-flight-lock",
+        leaderboardRunId,
+        trendingRunId,
+        snapshotId: "stale-snapshot",
+        expectedSkillsShTrending: 0,
+      }),
+    ).rejects.toThrow("activation lock or source run changed before publication");
+  });
+
+  it("reconciles all row eligibility before atomically opening the scanless lane", async () => {
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) => {
+      const runId = await ctx.db.insert("skillsShMirrorRuns", {
+        snapshotId: "snapshot",
+        sourceView: "leaderboard",
+        status: "completed",
+        sourceTotal: 2,
+        sourcePageSize: 100,
+        sourceMeasuredAt: new Date(1).toISOString(),
+        page: 1,
+        offset: 0,
+        counts: {
+          observed: 2,
+          inserted: 2,
+          updated: 0,
+          unchanged: 0,
+          rejected: 0,
+          conflicts: 0,
+          detailsInserted: 0,
+          detailsUpdated: 0,
+          detailsUnchanged: 0,
+          detailsMissing: 0,
+          detailsTruncated: 0,
+          tombstoned: 0,
+          reactivated: 0,
+          scansPlanned: 0,
+          scansAdmitted: 0,
+        },
+        operations: {
+          functionCalls: 1,
+          dbReads: 0,
+          dbWrites: 2,
+          sourceRequests: 0,
+          sourceBytes: 0,
+        },
+        actor: "codex-test",
+        reason: "CLAW-603 visibility test",
+        startedAt: 1,
+        completedAt: 2,
+        updatedAt: 2,
+      });
+      await ctx.db.insert(
+        "skillsShMirrorDigests",
+        digest({
+          lastObservedRunId: runId,
+          externalId: "patrick/skills/eligible",
+          slug: "eligible",
+          normalizedSlug: "eligible",
+          normalizedSlugFirstToken: "eligible",
+          displayName: "Eligible",
+          normalizedDisplayName: "eligible",
+          normalizedDisplayNameFirstToken: "eligible",
+          searchText: "eligible",
+          sourceUrl: "https://skills.sh/patrick/skills/eligible",
+          githubPath: "skills/eligible",
+          publicVisible: false,
+          installable: false,
+        }),
+      );
+      await ctx.db.insert(
+        "skillsShMirrorDigests",
+        digest({
+          lastObservedRunId: runId,
+          externalId: "patrick/skills/incomplete",
+          slug: "incomplete",
+          normalizedSlug: "incomplete",
+          normalizedSlugFirstToken: "incomplete",
+          displayName: "Incomplete",
+          normalizedDisplayName: "incomplete",
+          normalizedDisplayNameFirstToken: "incomplete",
+          searchText: "incomplete",
+          sourceUrl: "https://skills.sh/patrick/skills/incomplete",
+          githubPath: undefined,
+          publicVisible: true,
+          installable: true,
+        }),
+      );
+    });
+
+    await expect(
+      t.action(internal.skillsShMirrorVisibility.reconcileEligibilityInternal, {
+        confirm: "activate-skills-sh-public-test",
+      }),
+    ).resolves.toMatchObject({
+      scanned: 2,
+      changed: 2,
+      eligible: 1,
+      hiddenEligible: 1,
+      unsafePublished: 1,
+      scansPlanned: 0,
+      scansAdmitted: 0,
+    });
+    await expect(
+      t.action(internal.skillsShMirrorVisibility.auditInternal, {}),
+    ).resolves.toMatchObject({
+      counts: {
+        total: 2,
+        eligible: 1,
+        eligiblePublished: 1,
+        hiddenEligible: 0,
+        unsafePublished: 0,
+      },
+    });
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert("skillsShCatalogControls", {
+        key: "global",
+        mode: "off",
+        discoveryEnabled: false,
+        writesEnabled: false,
+        scanPlanningEnabled: false,
+        scanAdmissionEnabled: false,
+        publicVisibilityEnabled: false,
+        mirrorPublicVisibilityEnabled: false,
+        paused: true,
+        maxEntriesPerRun: 17,
+        maxEntriesPerBatch: 11,
+        maxWritesPerBatch: 7,
+        maxPlannedScans: 0,
+        maxScanAdmissionsPerBatch: 0,
+        maxScanAdmissionsPerRun: 0,
+        maxScanAdmissionsPerDay: 0,
+        maxCatalogQueued: 3,
+        maxCatalogInFlight: 2,
+        maxNativeQueued: 5,
+        maxNativeInFlight: 4,
+        realScanAllowlist: [],
+        updatedBy: "existing-operator",
+        reason: "preserve this control",
+        updatedAt: 1,
+      });
+    });
+
+    await expect(
+      t.mutation(internal.skillsShMirrorVisibility.setPublicGateInternal, {
+        enabled: true,
+        actor: "codex-test",
+        reason: "CLAW-603 direct activation must be rejected",
+        confirm: "activate-skills-sh-public-test",
+      }),
+    ).rejects.toThrow("only the verified activation action can enable the skills.sh public gate");
+
+    await t.mutation(internal.skillsShMirrorVisibility.setPublicGateInternal, {
+      enabled: false,
+      actor: "codex-test",
+      reason: "CLAW-603 rollback test",
+      confirm: "deactivate-skills-sh-public-test",
+    });
+    const state = await t.run(async (ctx) => ({
+      control: await ctx.db
+        .query("skillsShCatalogControls")
+        .withIndex("by_key", (q) => q.eq("key", "global"))
+        .unique(),
+      digests: await ctx.db.query("skillsShMirrorDigests").collect(),
+    }));
+    expect(state.control?.publicVisibilityEnabled).toBe(false);
+    expect(state.control?.mirrorPublicVisibilityEnabled).toBe(false);
+    expect(state.control).toMatchObject({
+      mode: "off",
+      paused: true,
+      maxEntriesPerRun: 17,
+      maxCatalogQueued: 3,
+      maxNativeInFlight: 4,
+    });
+    expect(state.digests.find((row) => row.slug === "eligible")).toMatchObject({
+      publicVisible: true,
+      installable: true,
+    });
+  });
+});
+
+function mirrorRunCounts(
+  overrides: Partial<Doc<"skillsShMirrorRuns">["counts"]> = {},
+): Doc<"skillsShMirrorRuns">["counts"] {
+  return {
+    observed: 0,
+    inserted: 0,
+    updated: 0,
+    unchanged: 0,
+    rejected: 0,
+    quarantined: 0,
+    conflicts: 0,
+    detailsInserted: 0,
+    detailsUpdated: 0,
+    detailsUnchanged: 0,
+    detailsMissing: 0,
+    detailsTruncated: 0,
+    tombstoned: 0,
+    reactivated: 0,
+    trendingJoined: 0,
+    trendingMissing: 0,
+    scansPlanned: 0,
+    scansAdmitted: 0,
+    ...overrides,
+  };
+}
+
+function mirrorRun(
+  overrides: Partial<Doc<"skillsShMirrorRuns">> = {},
+): Omit<Doc<"skillsShMirrorRuns">, "_id" | "_creationTime"> {
+  return {
+    snapshotId: "skills-sh:test-run",
+    sourceView: "leaderboard",
+    status: "completed",
+    sourceTotal: 0,
+    sourcePageSize: 500,
+    sourceMeasuredAt: new Date(1).toISOString(),
+    page: 1,
+    offset: 0,
+    counts: mirrorRunCounts(),
+    operations: {
+      functionCalls: 1,
+      dbReads: 0,
+      dbWrites: 0,
+      sourceRequests: 0,
+      sourceBytes: 0,
+    },
+    actor: "codex-test",
+    reason: "CLAW-603 verification test",
+    startedAt: 1,
+    completedAt: 2,
+    updatedAt: 2,
+    ...overrides,
+  };
+}
+
+function digest(
+  overrides: Partial<Doc<"skillsShMirrorDigests">>,
+): Omit<Doc<"skillsShMirrorDigests">, "_id" | "_creationTime"> {
+  return {
+    externalId: "patrick/skills/demo",
+    sourceType: "github",
+    upstreamSourceType: "github",
+    owner: "patrick",
+    repo: "skills",
+    slug: "demo",
+    normalizedSlug: "demo",
+    normalizedSlugFirstToken: "demo",
+    displayName: "Demo",
+    normalizedDisplayName: "demo",
+    normalizedDisplayNameFirstToken: "demo",
+    searchText: "demo",
+    sourceUrl: "https://skills.sh/patrick/skills/demo",
+    canonicalRepoUrl: "https://github.com/patrick/skills",
+    githubPath: "skills/demo",
+    githubCommit: "c".repeat(40),
+    sourceContentHash: "a".repeat(64),
+    upstreamInstalls: 1,
+    upstreamScanners: {
+      genAgentTrustHub: { status: "pass" },
+      socket: { status: "pass" },
+      snyk: { status: "warn" },
+    },
+    inferredCategories: ["development"],
+    inferredTopics: ["skills"],
+    sourceFreshnessStatus: "observed-only",
+    detailStatus: "available",
+    observationFingerprint: "fingerprint",
+    sourceSnapshotId: "snapshot",
+    lastObservedRunId:
+      "skillsShMirrorRuns:run" as Doc<"skillsShMirrorDigests">["lastObservedRunId"],
+    active: true,
+    publicVisible: false,
+    installable: false,
+    firstObservedAt: 1,
+    lastObservedAt: 1,
+    createdAt: 1,
+    updatedAt: 1,
+    ...overrides,
+  };
+}

--- a/convex/skillsShMirrorVisibility.ts
+++ b/convex/skillsShMirrorVisibility.ts
@@ -1,0 +1,749 @@
+import { paginationOptsValidator } from "convex/server";
+import { v } from "convex/values";
+import { internal } from "./_generated/api";
+import type { Doc } from "./_generated/dataModel";
+import type { ActionCtx, MutationCtx } from "./_generated/server";
+import { internalAction, internalMutation, internalQuery } from "./functions";
+import {
+  assertSkillsShPublicVisibilityMutationAllowed,
+  isSkillsShMirrorSourceEligible,
+  skillsShMirrorPublicationFlags,
+} from "./lib/skillsShPublicVisibility";
+
+const CONTROL_KEY = "global";
+const MAX_BATCH_SIZE = 100;
+const MAX_ROWS = 50_000;
+// Convex actions time out before this lease. A later action may safely replace
+// an abandoned token, while the old action can no longer finalize or release it.
+const ACTIVATION_LOCK_LEASE_MS = 15 * 60_000;
+
+const internalRefs = internal as unknown as {
+  canonicalTrending: { materializeInternal: unknown };
+  skillsShMirrorVisibility: {
+    beginActivationInternal: unknown;
+    finalizeActivationInternal: unknown;
+    releaseActivationInternal: unknown;
+  };
+};
+
+type EligibilityBatchResult = {
+  continueCursor: string;
+  isDone: boolean;
+  scanned: number;
+  changed: number;
+  eligible: number;
+  hiddenEligible: number;
+  unsafePublished: number;
+};
+
+type MirrorRun = Doc<"skillsShMirrorRuns">;
+
+function requireCompletedRun(run: MirrorRun | null, sourceView: "leaderboard" | "trending") {
+  if (!run || run.status !== "completed" || (run.sourceView ?? "leaderboard") !== sourceView) {
+    throw new Error(`latest skills.sh ${sourceView} run is not complete`);
+  }
+  if (run.counts.observed !== run.sourceTotal) {
+    throw new Error(`skills.sh ${sourceView} source accounting is incomplete`);
+  }
+  if (run.counts.scansPlanned !== 0 || run.counts.scansAdmitted !== 0) {
+    throw new Error(`skills.sh ${sourceView} run scheduled a ClawHub scan`);
+  }
+  return run;
+}
+
+function verifyLeaderboardRun(run: MirrorRun) {
+  const accepted = run.counts.inserted + run.counts.updated + run.counts.unchanged;
+  const rejected = run.counts.rejected;
+  const quarantined = run.counts.quarantined ?? 0;
+  const detailsAccounted =
+    run.counts.detailsInserted +
+    run.counts.detailsUpdated +
+    run.counts.detailsUnchanged +
+    run.counts.detailsMissing;
+  if (accepted + rejected !== run.counts.observed) {
+    throw new Error("skills.sh leaderboard accepted and rejected counts do not cover the source");
+  }
+  if (run.counts.conflicts !== rejected || quarantined !== rejected) {
+    throw new Error("skills.sh leaderboard rejection and quarantine accounting differs");
+  }
+  if (detailsAccounted !== accepted) {
+    throw new Error("skills.sh leaderboard detail accounting differs from accepted rows");
+  }
+  return { sourceTotal: run.sourceTotal, accepted, rejected };
+}
+
+function verifyTrendingRun(run: MirrorRun) {
+  const joined = run.counts.trendingJoined ?? 0;
+  const missing = run.counts.trendingMissing ?? 0;
+  if (joined + missing !== run.counts.observed) {
+    throw new Error("skills.sh Trending joined and missing counts do not cover the source");
+  }
+  return {
+    sourceTotal: run.sourceTotal,
+    joined,
+    missing,
+    updated: run.counts.trendingUpdated ?? 0,
+    hydrated: run.counts.trendingHydrated ?? 0,
+  };
+}
+
+export const getActivationPreflightInternal = internalQuery({
+  args: {},
+  handler: async (ctx) => {
+    const [control, running, paused, reconciling, recentRuns] = await Promise.all([
+      ctx.db
+        .query("skillsShMirrorControls")
+        .withIndex("by_key", (q) => q.eq("key", CONTROL_KEY))
+        .unique(),
+      ctx.db
+        .query("skillsShMirrorRuns")
+        .withIndex("by_status_and_updated_at", (q) => q.eq("status", "running"))
+        .order("desc")
+        .first(),
+      ctx.db
+        .query("skillsShMirrorRuns")
+        .withIndex("by_status_and_updated_at", (q) => q.eq("status", "paused"))
+        .order("desc")
+        .first(),
+      ctx.db
+        .query("skillsShMirrorRuns")
+        .withIndex("by_status_and_updated_at", (q) => q.eq("status", "reconciling"))
+        .order("desc")
+        .first(),
+      ctx.db.query("skillsShMirrorRuns").withIndex("by_started_at").order("desc").take(50),
+    ]);
+    const leaderboard = control?.latestCompletedLeaderboardRunId
+      ? await ctx.db.get(control.latestCompletedLeaderboardRunId)
+      : null;
+    const trending = recentRuns.find(
+      (run) => run.status === "completed" && run.sourceView === "trending",
+    );
+    return {
+      activeRun: running ?? paused ?? reconciling,
+      leaderboard,
+      trending: trending ?? null,
+    };
+  },
+});
+
+export const getConflictCountPageInternal = internalQuery({
+  args: {
+    runId: v.id("skillsShMirrorRuns"),
+    paginationOpts: paginationOptsValidator,
+  },
+  handler: async (ctx, args) => {
+    const page = await ctx.db
+      .query("skillsShMirrorConflicts")
+      .withIndex("by_run_id", (q) => q.eq("runId", args.runId))
+      .paginate(args.paginationOpts);
+    return {
+      continueCursor: page.continueCursor,
+      isDone: page.isDone,
+      count: page.page.length,
+    };
+  },
+});
+
+async function countRunConflicts(ctx: Pick<ActionCtx, "runQuery">, runId: MirrorRun["_id"]) {
+  let cursor: string | null = null;
+  let count = 0;
+  while (true) {
+    const page = (await ctx.runQuery(
+      internal.skillsShMirrorVisibility.getConflictCountPageInternal,
+      {
+        runId,
+        paginationOpts: { cursor, numItems: MAX_BATCH_SIZE },
+      },
+    )) as { continueCursor: string; isDone: boolean; count: number };
+    count += page.count;
+    if (count > MAX_ROWS) {
+      throw new Error(`skills.sh conflict audit exceeded ${MAX_ROWS} rows`);
+    }
+    if (page.isDone) return count;
+    cursor = page.continueCursor;
+  }
+}
+
+export const reconcileEligibilityBatchInternal = internalMutation({
+  args: {
+    confirm: v.string(),
+    paginationOpts: paginationOptsValidator,
+  },
+  handler: async (ctx, args): Promise<EligibilityBatchResult> => {
+    assertSkillsShPublicVisibilityMutationAllowed({
+      activate: true,
+      confirm: args.confirm,
+    });
+    if (args.paginationOpts.numItems < 1 || args.paginationOpts.numItems > MAX_BATCH_SIZE) {
+      throw new Error(`eligibility batch size must be between 1 and ${MAX_BATCH_SIZE}`);
+    }
+
+    const page = await ctx.db
+      .query("skillsShMirrorDigests")
+      .order("asc")
+      .paginate(args.paginationOpts);
+    let changed = 0;
+    let eligible = 0;
+    let hiddenEligible = 0;
+    let unsafePublished = 0;
+    for (const digest of page.page) {
+      const expected = skillsShMirrorPublicationFlags(digest);
+      if (expected.publicVisible) eligible += 1;
+      if (expected.publicVisible && (!digest.publicVisible || !digest.installable)) {
+        hiddenEligible += 1;
+      }
+      if (!expected.publicVisible && (digest.publicVisible || digest.installable)) {
+        unsafePublished += 1;
+      }
+      if (
+        digest.publicVisible === expected.publicVisible &&
+        digest.installable === expected.installable
+      ) {
+        continue;
+      }
+      await ctx.db.patch(digest._id, expected);
+      changed += 1;
+    }
+
+    return {
+      continueCursor: page.continueCursor,
+      isDone: page.isDone,
+      scanned: page.page.length,
+      changed,
+      eligible,
+      hiddenEligible,
+      unsafePublished,
+    };
+  },
+});
+
+async function reconcileEligibility(ctx: Pick<ActionCtx, "runMutation">, confirm: string) {
+  const environment = assertSkillsShPublicVisibilityMutationAllowed({
+    activate: true,
+    confirm,
+  });
+  let cursor: string | null = null;
+  let scanned = 0;
+  let changed = 0;
+  let eligible = 0;
+  let hiddenEligible = 0;
+  let unsafePublished = 0;
+  let batches = 0;
+
+  while (true) {
+    const result: EligibilityBatchResult = await ctx.runMutation(
+      internal.skillsShMirrorVisibility.reconcileEligibilityBatchInternal,
+      {
+        confirm,
+        paginationOpts: { cursor, numItems: MAX_BATCH_SIZE },
+      },
+    );
+    scanned += result.scanned;
+    changed += result.changed;
+    eligible += result.eligible;
+    hiddenEligible += result.hiddenEligible;
+    unsafePublished += result.unsafePublished;
+    batches += 1;
+    if (scanned > MAX_ROWS) {
+      throw new Error(`skills.sh eligibility reconciliation exceeded ${MAX_ROWS} rows`);
+    }
+    if (result.isDone) break;
+    cursor = result.continueCursor;
+  }
+
+  return {
+    ok: true as const,
+    environment,
+    batches,
+    scanned,
+    changed,
+    eligible,
+    hiddenEligible,
+    unsafePublished,
+    scansPlanned: 0 as const,
+    scansAdmitted: 0 as const,
+  };
+}
+
+export const reconcileEligibilityInternal = internalAction({
+  args: { confirm: v.string() },
+  handler: async (ctx, args) => await reconcileEligibility(ctx, args.confirm),
+});
+
+function publicGateValue(args: { enabled: boolean; actor: string; reason: string; now: number }) {
+  return {
+    mode: "staging-live" as const,
+    discoveryEnabled: true,
+    writesEnabled: false,
+    scanPlanningEnabled: false,
+    scanAdmissionEnabled: false,
+    publicVisibilityEnabled: false,
+    mirrorPublicVisibilityEnabled: args.enabled,
+    paused: false,
+    maxEntriesPerRun: 0,
+    maxEntriesPerBatch: 0,
+    maxWritesPerBatch: 0,
+    maxPlannedScans: 0,
+    maxScanAdmissionsPerBatch: 0,
+    maxScanAdmissionsPerRun: 0,
+    maxScanAdmissionsPerDay: 0,
+    maxCatalogQueued: 0,
+    maxCatalogInFlight: 0,
+    maxNativeQueued: 0,
+    maxNativeInFlight: 0,
+    realScanAllowlist: [],
+    updatedBy: args.actor,
+    reason: args.reason,
+    updatedAt: args.now,
+  };
+}
+
+async function writePublicGate(
+  ctx: Pick<MutationCtx, "db">,
+  args: { enabled: boolean; actor: string; reason: string; now: number },
+) {
+  const existing = await ctx.db
+    .query("skillsShCatalogControls")
+    .withIndex("by_key", (q) => q.eq("key", CONTROL_KEY))
+    .unique();
+  const next = publicGateValue(args);
+  if (existing) {
+    await ctx.db.patch(existing._id, {
+      mirrorPublicVisibilityEnabled: args.enabled,
+      updatedBy: args.actor,
+      reason: args.reason,
+      updatedAt: args.now,
+    });
+  } else {
+    await ctx.db.insert("skillsShCatalogControls", { key: CONTROL_KEY, ...next });
+  }
+}
+
+export const setPublicGateInternal = internalMutation({
+  args: {
+    enabled: v.boolean(),
+    actor: v.string(),
+    reason: v.string(),
+    confirm: v.string(),
+  },
+  handler: async (ctx, args) => {
+    if (args.enabled) {
+      throw new Error("only the verified activation action can enable the skills.sh public gate");
+    }
+    const environment = assertSkillsShPublicVisibilityMutationAllowed({
+      activate: false,
+      confirm: args.confirm,
+    });
+    const actor = args.actor.trim();
+    const reason = args.reason.trim();
+    if (!actor || !reason) throw new Error("skills.sh public gate actor and reason are required");
+    const now = Date.now();
+    const mirrorControl = await ctx.db
+      .query("skillsShMirrorControls")
+      .withIndex("by_key", (q) => q.eq("key", CONTROL_KEY))
+      .unique();
+    if (mirrorControl) {
+      await ctx.db.patch(mirrorControl._id, {
+        activationLockToken: undefined,
+        activationLockedAt: undefined,
+        activationLeaderboardRunId: undefined,
+        activationTrendingRunId: undefined,
+        updatedBy: actor,
+        reason,
+        updatedAt: now,
+      });
+    }
+    await writePublicGate(ctx, { enabled: false, actor, reason, now });
+    return {
+      ok: true as const,
+      environment,
+      enabled: false,
+      updatedAt: now,
+      scansPlanned: 0 as const,
+      scansAdmitted: 0 as const,
+    };
+  },
+});
+
+export const beginActivationInternal = internalMutation({
+  args: {
+    actor: v.string(),
+    reason: v.string(),
+    confirm: v.string(),
+    lockToken: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const environment = assertSkillsShPublicVisibilityMutationAllowed({
+      activate: true,
+      confirm: args.confirm,
+    });
+    const actor = args.actor.trim();
+    const reason = args.reason.trim();
+    const lockToken = args.lockToken.trim();
+    if (!actor || !reason || !lockToken) {
+      throw new Error("skills.sh activation actor, reason, and lock token are required");
+    }
+    const now = Date.now();
+    const control = await ctx.db
+      .query("skillsShMirrorControls")
+      .withIndex("by_key", (q) => q.eq("key", CONTROL_KEY))
+      .unique();
+    if (!control || !control.enabled || control.paused) {
+      throw new Error("skills.sh mirror control is not active");
+    }
+    if (control.activationLockToken) {
+      if (
+        control.activationLockToken !== lockToken &&
+        control.activationLockedAt !== undefined &&
+        control.activationLockedAt > now - ACTIVATION_LOCK_LEASE_MS
+      ) {
+        throw new Error("another skills.sh public activation is in progress");
+      }
+      if (control.activationLockToken === lockToken) {
+        const [leaderboard, trending] = await Promise.all([
+          control.activationLeaderboardRunId
+            ? ctx.db.get(control.activationLeaderboardRunId)
+            : null,
+          control.activationTrendingRunId ? ctx.db.get(control.activationTrendingRunId) : null,
+        ]);
+        return { environment, leaderboard, trending };
+      }
+    }
+    for (const status of ["running", "paused", "reconciling"] as const) {
+      const active = await ctx.db
+        .query("skillsShMirrorRuns")
+        .withIndex("by_status_and_updated_at", (q) => q.eq("status", status))
+        .first();
+      if (active) throw new Error(`skills.sh mirror run ${active._id} is still active`);
+    }
+    const leaderboard = control.latestCompletedLeaderboardRunId
+      ? await ctx.db.get(control.latestCompletedLeaderboardRunId)
+      : null;
+    const trending = await ctx.db
+      .query("skillsShMirrorRuns")
+      .withIndex("by_started_at")
+      .order("desc")
+      .filter((q) =>
+        q.and(q.eq(q.field("sourceView"), "trending"), q.eq(q.field("status"), "completed")),
+      )
+      .first();
+    requireCompletedRun(leaderboard, "leaderboard");
+    requireCompletedRun(trending, "trending");
+    if (trending!.startedAt < (leaderboard!.completedAt ?? leaderboard!.updatedAt)) {
+      throw new Error("skills.sh trending run is older than the leaderboard run");
+    }
+    await ctx.db.patch(control._id, {
+      activationLockToken: lockToken,
+      activationLockedAt: now,
+      activationLeaderboardRunId: leaderboard!._id,
+      activationTrendingRunId: trending!._id,
+      updatedBy: actor,
+      reason,
+      updatedAt: now,
+    });
+    return { environment, leaderboard, trending };
+  },
+});
+
+export const releaseActivationInternal = internalMutation({
+  args: { lockToken: v.string() },
+  handler: async (ctx, args) => {
+    const control = await ctx.db
+      .query("skillsShMirrorControls")
+      .withIndex("by_key", (q) => q.eq("key", CONTROL_KEY))
+      .unique();
+    if (!control || control.activationLockToken !== args.lockToken) return { released: false };
+    await ctx.db.patch(control._id, {
+      activationLockToken: undefined,
+      activationLockedAt: undefined,
+      activationLeaderboardRunId: undefined,
+      activationTrendingRunId: undefined,
+    });
+    return { released: true };
+  },
+});
+
+export const finalizeActivationInternal = internalMutation({
+  args: {
+    actor: v.string(),
+    reason: v.string(),
+    confirm: v.string(),
+    lockToken: v.string(),
+    leaderboardRunId: v.id("skillsShMirrorRuns"),
+    trendingRunId: v.id("skillsShMirrorRuns"),
+    snapshotId: v.string(),
+    expectedSkillsShTrending: v.number(),
+  },
+  handler: async (ctx, args) => {
+    const environment = assertSkillsShPublicVisibilityMutationAllowed({
+      activate: true,
+      confirm: args.confirm,
+    });
+    const control = await ctx.db
+      .query("skillsShMirrorControls")
+      .withIndex("by_key", (q) => q.eq("key", CONTROL_KEY))
+      .unique();
+    if (
+      !control ||
+      control.activationLockToken !== args.lockToken ||
+      control.activationLeaderboardRunId !== args.leaderboardRunId ||
+      control.activationTrendingRunId !== args.trendingRunId ||
+      control.latestCompletedLeaderboardRunId !== args.leaderboardRunId ||
+      !control.enabled ||
+      control.paused
+    ) {
+      throw new Error("skills.sh activation lock or source run changed before publication");
+    }
+    const snapshot = await ctx.db
+      .query("canonicalTrendingSnapshots")
+      .withIndex("by_snapshot_id", (q) => q.eq("snapshotId", args.snapshotId))
+      .unique();
+    const latestReady = await ctx.db
+      .query("canonicalTrendingSnapshots")
+      .withIndex("by_kind_and_status_and_expires_at", (q) =>
+        q.eq("kind", "skills").eq("status", "ready").gt("expiresAt", Date.now()),
+      )
+      .order("desc")
+      .first();
+    if (
+      !snapshot ||
+      snapshot.status !== "ready" ||
+      snapshot.snapshotId !== latestReady?.snapshotId ||
+      snapshot.sourceCounts?.skillsShTrending !== args.expectedSkillsShTrending
+    ) {
+      throw new Error("verified skills.sh Trending snapshot is not the current ready snapshot");
+    }
+    const actor = args.actor.trim();
+    const reason = args.reason.trim();
+    if (!actor || !reason) throw new Error("skills.sh public gate actor and reason are required");
+    const now = Date.now();
+    await writePublicGate(ctx, { enabled: true, actor, reason, now });
+    await ctx.db.patch(control._id, {
+      activationLockToken: undefined,
+      activationLockedAt: undefined,
+      activationLeaderboardRunId: undefined,
+      activationTrendingRunId: undefined,
+      updatedBy: actor,
+      reason,
+      updatedAt: now,
+    });
+    return { ok: true as const, environment, enabled: true as const, updatedAt: now };
+  },
+});
+
+export const getAuditPageInternal = internalQuery({
+  args: { paginationOpts: paginationOptsValidator },
+  handler: async (ctx, args) => {
+    if (args.paginationOpts.numItems < 1 || args.paginationOpts.numItems > MAX_BATCH_SIZE) {
+      throw new Error(`audit batch size must be between 1 and ${MAX_BATCH_SIZE}`);
+    }
+    const page = await ctx.db
+      .query("skillsShMirrorDigests")
+      .order("asc")
+      .paginate(args.paginationOpts);
+    const counts = {
+      total: page.page.length,
+      active: 0,
+      sourceEligible: 0,
+      eligible: 0,
+      claimExcluded: 0,
+      claimFailed: 0,
+      claimPromoted: 0,
+      claimRetrying: 0,
+      eligiblePublished: 0,
+      hiddenEligible: 0,
+      unsafePublished: 0,
+      stale: 0,
+      tombstoned: 0,
+    };
+    for (const digest of page.page) {
+      const sourceEligible = isSkillsShMirrorSourceEligible(digest);
+      const publicationFlags = skillsShMirrorPublicationFlags(digest);
+      const eligible = publicationFlags.publicVisible && publicationFlags.installable;
+      const claimExcluded = sourceEligible && !eligible && digest.claimStatus !== undefined;
+      const published = digest.publicVisible && digest.installable;
+      if (digest.active) counts.active += 1;
+      if (sourceEligible) counts.sourceEligible += 1;
+      if (eligible) counts.eligible += 1;
+      if (claimExcluded) counts.claimExcluded += 1;
+      if (claimExcluded && digest.claimStatus === "failed") counts.claimFailed += 1;
+      if (claimExcluded && digest.claimStatus === "promoted") counts.claimPromoted += 1;
+      if (claimExcluded && digest.claimStatus === "pending") counts.claimRetrying += 1;
+      if (eligible && published) counts.eligiblePublished += 1;
+      if (eligible && !published) counts.hiddenEligible += 1;
+      if (!eligible && (digest.publicVisible || digest.installable)) counts.unsafePublished += 1;
+      if (digest.sourceFreshnessStatus === "stale") counts.stale += 1;
+      if (digest.tombstonedAt !== undefined) counts.tombstoned += 1;
+    }
+    return { ...page, page: counts };
+  },
+});
+
+async function audit(ctx: Pick<ActionCtx, "runQuery">) {
+  let cursor: string | null = null;
+  let batches = 0;
+  const counts = {
+    total: 0,
+    active: 0,
+    sourceEligible: 0,
+    eligible: 0,
+    claimExcluded: 0,
+    claimFailed: 0,
+    claimPromoted: 0,
+    claimRetrying: 0,
+    eligiblePublished: 0,
+    hiddenEligible: 0,
+    unsafePublished: 0,
+    stale: 0,
+    tombstoned: 0,
+  };
+  while (true) {
+    const result = (await ctx.runQuery(internal.skillsShMirrorVisibility.getAuditPageInternal, {
+      paginationOpts: { cursor, numItems: MAX_BATCH_SIZE },
+    })) as {
+      continueCursor: string;
+      isDone: boolean;
+      page: typeof counts;
+    };
+    for (const key of Object.keys(counts) as Array<keyof typeof counts>) {
+      counts[key] += result.page[key];
+    }
+    batches += 1;
+    if (counts.total > MAX_ROWS) {
+      throw new Error(`skills.sh visibility audit exceeded ${MAX_ROWS} rows`);
+    }
+    if (result.isDone) break;
+    cursor = result.continueCursor;
+  }
+  return {
+    ok: true as const,
+    batches,
+    counts,
+    scansPlanned: 0 as const,
+    scansAdmitted: 0 as const,
+  };
+}
+
+export const auditInternal = internalAction({
+  args: {},
+  handler: async (ctx) => await audit(ctx),
+});
+
+export const verifyAndActivateInternal = internalAction({
+  args: {
+    actor: v.string(),
+    reason: v.string(),
+    confirm: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const environment = assertSkillsShPublicVisibilityMutationAllowed({
+      activate: true,
+      confirm: args.confirm,
+    });
+    const lockToken = `skills-sh-activation:${crypto.randomUUID()}`;
+    let locked = false;
+    try {
+      const preflight = (await ctx.runMutation(
+        internalRefs.skillsShMirrorVisibility.beginActivationInternal as never,
+        { ...args, lockToken } as never,
+      )) as { leaderboard: MirrorRun; trending: MirrorRun };
+      locked = true;
+      const leaderboardRun = requireCompletedRun(preflight.leaderboard, "leaderboard");
+      const trendingRun = requireCompletedRun(preflight.trending, "trending");
+      const leaderboard = verifyLeaderboardRun(leaderboardRun);
+      const trending = verifyTrendingRun(trendingRun);
+      const storedConflicts = await countRunConflicts(ctx, leaderboardRun._id);
+      if (storedConflicts !== leaderboard.rejected) {
+        throw new Error("skills.sh stored conflict accounting differs from rejected rows");
+      }
+      await reconcileEligibility(ctx, args.confirm);
+      const corpusAudit = await audit(ctx);
+      if (
+        corpusAudit.counts.eligible + corpusAudit.counts.claimExcluded !==
+        leaderboard.accepted + trending.hydrated
+      ) {
+        throw new Error("skills.sh eligible corpus count differs from accepted rows");
+      }
+      if (
+        corpusAudit.counts.hiddenEligible !== 0 ||
+        corpusAudit.counts.unsafePublished !== 0 ||
+        corpusAudit.counts.eligiblePublished !== corpusAudit.counts.eligible
+      ) {
+        throw new Error("skills.sh corpus eligibility reconciliation did not converge");
+      }
+      const trendingSnapshot = (await ctx.runAction(
+        internalRefs.canonicalTrending.materializeInternal as never,
+        { activationLockToken: lockToken } as never,
+      )) as {
+        status: "ready";
+        snapshotId: string;
+        sourceCounts: { skillsShTrending: number };
+      };
+      if (
+        trendingSnapshot.status !== "ready" ||
+        trendingSnapshot.sourceCounts.skillsShTrending !== trending.joined
+      ) {
+        throw new Error("skills.sh Trending activation snapshot failed source verification");
+      }
+      await ctx.runMutation(
+        internalRefs.skillsShMirrorVisibility.finalizeActivationInternal as never,
+        {
+          ...args,
+          lockToken,
+          leaderboardRunId: leaderboardRun._id,
+          trendingRunId: trendingRun._id,
+          snapshotId: trendingSnapshot.snapshotId,
+          expectedSkillsShTrending: trendingSnapshot.sourceCounts.skillsShTrending,
+        } as never,
+      );
+      locked = false;
+      return {
+        ok: true as const,
+        environment,
+        activated: true as const,
+        leaderboard,
+        trending,
+        corpus: corpusAudit.counts,
+        trendingSnapshot,
+        scansPlanned: 0 as const,
+        scansAdmitted: 0 as const,
+      };
+    } finally {
+      if (locked) {
+        await ctx.runMutation(
+          internalRefs.skillsShMirrorVisibility.releaseActivationInternal as never,
+          { lockToken } as never,
+        );
+      }
+    }
+  },
+});
+
+export const getVisibilityPageInternal = internalQuery({
+  args: { paginationOpts: paginationOptsValidator },
+  handler: async (ctx, args) => {
+    const page = await ctx.db
+      .query("skillsShMirrorDigests")
+      .withIndex("by_active_visible_installable_fresh_slug", (q) =>
+        q
+          .eq("active", true)
+          .eq("publicVisible", true)
+          .eq("installable", true)
+          .eq("sourceFreshnessStatus", "observed-only"),
+      )
+      .paginate(args.paginationOpts);
+    return {
+      ...page,
+      page: page.page.map((digest) => ({
+        externalId: digest.externalId,
+        displayName: digest.displayName,
+        sourceUrl: digest.sourceUrl,
+        githubPath: digest.githubPath,
+        githubCommit: digest.githubCommit,
+        sourceContentHash: digest.sourceContentHash,
+        publicVisible: digest.publicVisible,
+        installable: digest.installable,
+      })),
+    };
+  },
+});

--- a/scripts/skills-sh-catalog/sync.test.ts
+++ b/scripts/skills-sh-catalog/sync.test.ts
@@ -1,0 +1,293 @@
+/* @vitest-environment node */
+
+import { describe, expect, it, vi } from "vitest";
+import { createGitHubActionsOidcAuthorization, runSkillsShSync } from "./sync";
+
+function response(payload: Record<string, unknown>, status = 200) {
+  return new Response(JSON.stringify(payload), { status });
+}
+
+function completedRun(sourceView: "leaderboard" | "trending", scansPlanned = 0) {
+  return {
+    runId: `run-${sourceView}`,
+    snapshotId: `snapshot-${sourceView}`,
+    sourceView,
+    sourceTotal: 1,
+    sourcePageSize: 500,
+    sourceMeasuredAt: "2026-07-30T06:00:00.000Z",
+    page: 1,
+    offset: 0,
+    status: "completed",
+    counts:
+      sourceView === "leaderboard"
+        ? {
+            observed: 1,
+            inserted: 1,
+            updated: 0,
+            unchanged: 0,
+            rejected: 0,
+            conflicts: 0,
+            quarantined: 0,
+            detailsInserted: 1,
+            detailsUpdated: 0,
+            detailsUnchanged: 0,
+            detailsMissing: 0,
+            scansPlanned,
+            scansAdmitted: 0,
+          }
+        : {
+            observed: 1,
+            trendingJoined: 1,
+            trendingMissing: 0,
+            scansPlanned,
+            scansAdmitted: 0,
+          },
+  };
+}
+
+describe("skills.sh synchronization runner", () => {
+  it("refreshes GitHub OIDC authorization before the cached token expires", async () => {
+    let now = 1_000_000;
+    const token = (value: string, expiresAt: number) => {
+      const payload = Buffer.from(JSON.stringify({ exp: Math.floor(expiresAt / 1_000) })).toString(
+        "base64url",
+      );
+      return `header.${payload}.${value}`;
+    };
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(response({ value: token("first", now + 5 * 60_000) }))
+      .mockResolvedValueOnce(response({ value: token("second", now + 10 * 60_000) }));
+    const authorization = createGitHubActionsOidcAuthorization({
+      requestUrl: "https://token.actions.example/id-token?job=sync",
+      requestToken: "request-token",
+      fetchImpl,
+      now: () => now,
+    });
+
+    await expect(authorization()).resolves.toContain(".first");
+    now += 2 * 60_000;
+    await expect(authorization()).resolves.toContain(".first");
+    now += 2 * 60_000;
+    await expect(authorization()).resolves.toContain(".second");
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("completes leaderboard and Trending before automatic activation", async () => {
+    const operations: string[] = [];
+    const fetchImpl = vi.fn(async (_url: string, init: RequestInit) => {
+      const body = JSON.parse(String(init.body)) as Record<string, unknown>;
+      operations.push(String(body.operation));
+      switch (body.operation) {
+        case "status":
+          return response({ runs: [] });
+        case "configure":
+          return response({ ok: true, enabled: body.enabled });
+        case "start":
+          return response({
+            runId: "run-leaderboard",
+            sourceView: "leaderboard",
+            sourceTotal: 1,
+            page: 0,
+            offset: 0,
+            status: "running",
+          });
+        case "step":
+          return response(completedRun("leaderboard"));
+        case "start-trending":
+          return response({
+            runId: "run-trending",
+            sourceView: "trending",
+            sourceTotal: 1,
+            page: 0,
+            offset: 0,
+            status: "running",
+          });
+        case "step-trending":
+          return response(completedRun("trending"));
+        case "verify-activate":
+          return response({ ok: true, activated: true });
+        default:
+          throw new Error(`unexpected operation ${String(body.operation)}`);
+      }
+    });
+
+    await expect(
+      runSkillsShSync({
+        targetUrl: "https://clawhub.ai/ops/skills-sh/mirror",
+        authorization: "github-oidc",
+        reason: "scheduled proof",
+        fetchImpl,
+      }),
+    ).resolves.toMatchObject({
+      ok: true,
+      leaderboard: { status: "completed" },
+      trending: { status: "completed" },
+      activation: { activated: true },
+      scansPlanned: 0,
+      scansAdmitted: 0,
+    });
+    expect(operations).toEqual([
+      "status",
+      "configure",
+      "start",
+      "step",
+      "start-trending",
+      "step-trending",
+      "verify-activate",
+      "configure",
+      "status",
+    ]);
+  });
+
+  it("resumes an interrupted durable run before starting the next source view", async () => {
+    const operations: string[] = [];
+    const fetchImpl = vi.fn(async (_url: string, init: RequestInit) => {
+      const body = JSON.parse(String(init.body)) as Record<string, unknown>;
+      operations.push(String(body.operation));
+      switch (body.operation) {
+        case "status":
+          return operations.length === 1
+            ? response({
+                runs: [
+                  {
+                    runId: "run-leaderboard",
+                    snapshotId: "skills-sh:leaderboard:interrupted",
+                    sourceView: "leaderboard",
+                    sourceTotal: 1,
+                    sourcePageSize: 500,
+                    sourceMeasuredAt: "2026-07-30T06:00:00.000Z",
+                    page: 0,
+                    offset: 0,
+                    status: "running",
+                    startedAt: 1,
+                  },
+                ],
+              })
+            : response({ runs: [] });
+        case "configure":
+          return response({ ok: true, enabled: body.enabled });
+        case "step":
+          return response(completedRun("leaderboard"));
+        case "start-trending":
+          return response(completedRun("trending"));
+        case "verify-activate":
+          return response({ ok: true, activated: true });
+        default:
+          throw new Error(`unexpected operation ${String(body.operation)}`);
+      }
+    });
+
+    await expect(
+      runSkillsShSync({
+        targetUrl: "https://clawhub.ai/ops/skills-sh/mirror",
+        authorization: "github-oidc",
+        reason: "scheduled recovery",
+        fetchImpl,
+      }),
+    ).resolves.toMatchObject({
+      ok: true,
+      leaderboard: { status: "completed" },
+      trending: { status: "completed" },
+    });
+    expect(operations).toEqual([
+      "status",
+      "configure",
+      "step",
+      "start-trending",
+      "verify-activate",
+      "configure",
+      "status",
+    ]);
+  });
+
+  it("closes only the skills.sh lane when a systemic invariant fails", async () => {
+    const operations: string[] = [];
+    const fetchImpl = vi.fn(async (_url: string, init: RequestInit) => {
+      const body = JSON.parse(String(init.body)) as Record<string, unknown>;
+      operations.push(String(body.operation));
+      if (body.operation === "status") return response({ runs: [] });
+      if (body.operation === "configure") return response({ ok: true });
+      if (body.operation === "start") {
+        return response({
+          runId: "run-leaderboard",
+          sourceView: "leaderboard",
+          sourceTotal: 1,
+          page: 0,
+          offset: 0,
+          status: "running",
+        });
+      }
+      if (body.operation === "step") return response(completedRun("leaderboard", 1));
+      if (body.operation === "deactivate") return response({ ok: true, enabled: false });
+      throw new Error(`unexpected operation ${String(body.operation)}`);
+    });
+
+    await expect(
+      runSkillsShSync({
+        targetUrl: "https://clawhub.ai/ops/skills-sh/mirror",
+        authorization: "github-oidc",
+        reason: "scheduled proof",
+        fetchImpl,
+      }),
+    ).rejects.toThrow("scheduled a ClawHub scan");
+    expect(operations).toEqual(["status", "configure", "start", "step", "deactivate", "configure"]);
+  });
+
+  it("closes the skills.sh lane when server-side activation verification fails", async () => {
+    const operations: string[] = [];
+    const fetchImpl = vi.fn(async (_url: string, init: RequestInit) => {
+      const body = JSON.parse(String(init.body)) as Record<string, unknown>;
+      operations.push(String(body.operation));
+      if (body.operation === "status") return response({ runs: [] });
+      if (body.operation === "configure") return response({ ok: true });
+      if (body.operation === "start") return response(completedRun("leaderboard"));
+      if (body.operation === "start-trending") return response(completedRun("trending"));
+      if (body.operation === "verify-activate") {
+        return response({ error: "corpus reconciliation failed" }, 409);
+      }
+      if (body.operation === "deactivate") return response({ ok: true, enabled: false });
+      throw new Error(`unexpected operation ${String(body.operation)}`);
+    });
+
+    await expect(
+      runSkillsShSync({
+        targetUrl: "https://clawhub.ai/ops/skills-sh/mirror",
+        authorization: "github-oidc",
+        reason: "scheduled proof",
+        fetchImpl,
+      }),
+    ).rejects.toThrow("verify-activate returned HTTP 409");
+    expect(operations).toEqual([
+      "status",
+      "configure",
+      "start",
+      "start-trending",
+      "verify-activate",
+      "deactivate",
+      "configure",
+    ]);
+  });
+
+  it("preserves the last verified public lane on a transient sync failure", async () => {
+    const operations: string[] = [];
+    const fetchImpl = vi.fn(async (_url: string, init: RequestInit) => {
+      const body = JSON.parse(String(init.body)) as Record<string, unknown>;
+      operations.push(String(body.operation));
+      if (body.operation === "status") return response({ runs: [] });
+      if (body.operation === "configure") return response({ ok: true });
+      if (body.operation === "start") return response({ error: "upstream unavailable" }, 503);
+      throw new Error(`unexpected operation ${String(body.operation)}`);
+    });
+
+    await expect(
+      runSkillsShSync({
+        targetUrl: "https://clawhub.ai/ops/skills-sh/mirror",
+        authorization: "github-oidc",
+        reason: "scheduled proof",
+        fetchImpl,
+      }),
+    ).rejects.toThrow("start returned HTTP 503");
+    expect(operations).toEqual(["status", "configure", "start", "configure"]);
+  });
+});

--- a/scripts/skills-sh-catalog/sync.ts
+++ b/scripts/skills-sh-catalog/sync.ts
@@ -1,0 +1,312 @@
+#!/usr/bin/env bun
+
+import { writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import {
+  findRecoverableMirrorRun,
+  mirrorRateLimitRetryDelayMs,
+  mirrorRunAccounting,
+  mirrorRunFromPayload,
+  reconcileMirrorRunToCompletion,
+} from "./prove-mirror-request";
+
+const MAX_STEPS = 2_000;
+const MAX_RATE_LIMIT_RETRIES = 30;
+const MAX_RATE_LIMIT_WAIT_MS = 30 * 60 * 1_000;
+
+type MirrorRun = Record<string, unknown>;
+type SyncFetch = (input: string, init: RequestInit) => Promise<Response>;
+type SyncAuthorization = string | (() => Promise<string>);
+
+const OIDC_REFRESH_SKEW_MS = 2 * 60_000;
+
+class UnsafeSkillsShCorpusError extends Error {}
+
+function requireEnv(name: string) {
+  const value = process.env[name]?.trim();
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+function requiredString(value: unknown, name: string) {
+  if (typeof value !== "string" || !value.trim()) throw new Error(`${name} is required`);
+  return value;
+}
+
+function requiredInteger(value: unknown, name: string) {
+  if (!Number.isSafeInteger(value) || Number(value) < 0) {
+    throw new Error(`${name} must be a nonnegative integer`);
+  }
+  return Number(value);
+}
+
+function jwtExpiresAt(jwt: string) {
+  const payload = jwt.split(".")[1];
+  if (!payload) throw new Error("GitHub OIDC returned a malformed token");
+  let decoded: unknown;
+  try {
+    decoded = JSON.parse(Buffer.from(payload, "base64url").toString("utf8"));
+  } catch {
+    throw new Error("GitHub OIDC returned a malformed token");
+  }
+  const exp = (decoded as { exp?: unknown } | null)?.exp;
+  if (typeof exp !== "number" || !Number.isSafeInteger(exp) || exp <= 0) {
+    throw new Error("GitHub OIDC token is missing a valid expiration");
+  }
+  return exp * 1_000;
+}
+
+export function createGitHubActionsOidcAuthorization(options: {
+  requestUrl: string;
+  requestToken: string;
+  fetchImpl?: SyncFetch;
+  now?: () => number;
+}) {
+  const requestUrl = requiredString(options.requestUrl, "ACTIONS_ID_TOKEN_REQUEST_URL");
+  const requestToken = requiredString(options.requestToken, "ACTIONS_ID_TOKEN_REQUEST_TOKEN");
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const now = options.now ?? Date.now;
+  let cached: { token: string; expiresAt: number } | null = null;
+  return async () => {
+    const currentTime = now();
+    if (cached && currentTime < cached.expiresAt - OIDC_REFRESH_SKEW_MS) return cached.token;
+    const separator = requestUrl.includes("?") ? "&" : "?";
+    const response = await fetchImpl(`${requestUrl}${separator}audience=clawhub`, {
+      headers: { Authorization: `Bearer ${requestToken}` },
+    });
+    if (!response.ok) {
+      throw new Error(`GitHub OIDC token request returned HTTP ${response.status}`);
+    }
+    const payload = (await response.json()) as { value?: unknown };
+    const token = requiredString(payload.value, "GitHub OIDC token");
+    cached = { token, expiresAt: jwtExpiresAt(token) };
+    return token;
+  };
+}
+
+export function assertCompletedMirrorRun(run: MirrorRun, sourceView: "leaderboard" | "trending") {
+  try {
+    if (run.status !== "completed" || (run.sourceView ?? "leaderboard") !== sourceView) {
+      throw new Error(`skills.sh ${sourceView} run did not complete`);
+    }
+    const sourceTotal = requiredInteger(run.sourceTotal, "sourceTotal");
+    const counts = run.counts as Record<string, number> | undefined;
+    if (!counts) throw new Error(`skills.sh ${sourceView} run lacks counts`);
+    if (requiredInteger(counts.observed, "counts.observed") !== sourceTotal) {
+      throw new Error(`skills.sh ${sourceView} run did not account for the full source`);
+    }
+    if (counts.scansPlanned !== 0 || counts.scansAdmitted !== 0) {
+      throw new Error(`skills.sh ${sourceView} run scheduled a ClawHub scan`);
+    }
+    if (sourceView === "leaderboard") {
+      const { accepted } = mirrorRunAccounting(sourceTotal, counts);
+      if ((counts.inserted ?? 0) + (counts.updated ?? 0) + (counts.unchanged ?? 0) !== accepted) {
+        throw new Error("skills.sh leaderboard accepted-row accounting differs");
+      }
+      if (
+        (counts.detailsInserted ?? 0) +
+          (counts.detailsUpdated ?? 0) +
+          (counts.detailsUnchanged ?? 0) +
+          (counts.detailsMissing ?? 0) !==
+        accepted
+      ) {
+        throw new Error("skills.sh leaderboard detail accounting differs");
+      }
+    } else if ((counts.trendingJoined ?? 0) + (counts.trendingMissing ?? 0) !== sourceTotal) {
+      throw new Error("skills.sh Trending accounting differs");
+    }
+    return run;
+  } catch (error) {
+    throw new UnsafeSkillsShCorpusError(error instanceof Error ? error.message : String(error));
+  }
+}
+
+export async function runSkillsShSync(options: {
+  targetUrl: string;
+  authorization: SyncAuthorization;
+  reason: string;
+  fetchImpl?: SyncFetch;
+  sleep?: (ms: number) => Promise<void>;
+}) {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const sleep =
+    options.sleep ?? ((ms: number) => new Promise((resolve) => setTimeout(resolve, ms)));
+  const callRaw = async (body: Record<string, unknown>) => {
+    const authorization =
+      typeof options.authorization === "string"
+        ? options.authorization
+        : await options.authorization();
+    const response = await fetchImpl(options.targetUrl, {
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        Authorization: `Bearer ${authorization}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    });
+    const text = await response.text();
+    let payload: Record<string, unknown>;
+    try {
+      payload = JSON.parse(text) as Record<string, unknown>;
+    } catch {
+      payload = { text };
+    }
+    return { response, payload };
+  };
+  const call = async (body: Record<string, unknown>) => {
+    const result = await callRaw(body);
+    if (!result.response.ok) {
+      throw new Error(
+        `${String(body.operation)} returned HTTP ${result.response.status}: ${JSON.stringify(result.payload)}`,
+      );
+    }
+    return result.payload;
+  };
+  const completeRun = async (initial: MirrorRun, sourceView: "leaderboard" | "trending") => {
+    let run = mirrorRunFromPayload(initial, `start-${sourceView}`);
+    let steps = 0;
+    let rateLimitRetries = 0;
+    let rateLimitWaitMs = 0;
+    if (run.status === "paused") {
+      run = mirrorRunFromPayload(
+        await call({
+          operation: "resume",
+          runId: requiredString(run.runId, "runId"),
+          reason: `${options.reason} interrupted-run recovery`,
+        }),
+        "resume",
+      );
+    }
+    while (run.status === "running") {
+      if (steps >= MAX_STEPS)
+        throw new Error(`skills.sh ${sourceView} exceeded ${MAX_STEPS} steps`);
+      const request = {
+        operation: sourceView === "leaderboard" ? "step" : "step-trending",
+        runId: requiredString(run.runId, "runId"),
+        page: requiredInteger(run.page, "page"),
+        offset: requiredInteger(run.offset, "offset"),
+      };
+      const result = await callRaw(request);
+      if (!result.response.ok) {
+        const delayMs = mirrorRateLimitRetryDelayMs(
+          result.response.status,
+          result.response.headers.get("retry-after"),
+          rateLimitRetries,
+        );
+        if (
+          delayMs === null ||
+          rateLimitRetries >= MAX_RATE_LIMIT_RETRIES ||
+          rateLimitWaitMs + delayMs > MAX_RATE_LIMIT_WAIT_MS
+        ) {
+          throw new Error(
+            `${request.operation} returned HTTP ${result.response.status}: ${JSON.stringify(result.payload)}`,
+          );
+        }
+        rateLimitRetries += 1;
+        rateLimitWaitMs += delayMs;
+        await sleep(delayMs);
+        continue;
+      }
+      run = mirrorRunFromPayload(result.payload, request.operation);
+      steps += 1;
+    }
+    const reconciled = await reconcileMirrorRunToCompletion(run, async () =>
+      call({ operation: "reconcile", runId: requiredString(run.runId, "runId"), limit: 250 }),
+    );
+    run = reconciled.run;
+    return {
+      ...assertCompletedMirrorRun(run, sourceView),
+      syncProof: {
+        steps,
+        reconciliationBatches: reconciled.reconciliationBatches,
+        rateLimitRetries,
+        rateLimitWaitMs,
+      },
+    };
+  };
+
+  const startedAt = Date.now();
+  const before = await call({ operation: "status" });
+  const recoverable = findRecoverableMirrorRun(before) as
+    | (MirrorRun & { sourceView?: "leaderboard" | "trending" })
+    | null;
+  await call({ operation: "configure", enabled: true, reason: options.reason });
+  try {
+    const recoveredSourceView = recoverable?.sourceView ?? "leaderboard";
+    const recovered = recoverable ? await completeRun(recoverable, recoveredSourceView) : null;
+    const leaderboard =
+      recovered && recoveredSourceView === "leaderboard"
+        ? recovered
+        : await completeRun(
+            await call({ operation: "start", reason: options.reason }),
+            "leaderboard",
+          );
+    const trending = await completeRun(
+      await call({ operation: "start-trending", reason: options.reason }),
+      "trending",
+    );
+    let activation: MirrorRun;
+    try {
+      activation = await call({ operation: "verify-activate", reason: options.reason });
+    } catch (error) {
+      throw new UnsafeSkillsShCorpusError(error instanceof Error ? error.message : String(error));
+    }
+    await call({ operation: "configure", enabled: false, reason: `${options.reason} complete` });
+    const after = await call({ operation: "status" });
+    return {
+      ok: true as const,
+      startedAt: new Date(startedAt).toISOString(),
+      completedAt: new Date().toISOString(),
+      durationMs: Date.now() - startedAt,
+      before,
+      ...(recovered ? { recovered } : {}),
+      leaderboard,
+      trending,
+      activation,
+      after,
+      scansPlanned: 0 as const,
+      scansAdmitted: 0 as const,
+    };
+  } catch (error) {
+    const rollbackErrors: string[] = [];
+    for (const body of [
+      ...(error instanceof UnsafeSkillsShCorpusError
+        ? [{ operation: "deactivate", reason: `${options.reason} systemic failure` }]
+        : []),
+      { operation: "configure", enabled: false, reason: `${options.reason} failed` },
+    ]) {
+      try {
+        await call(body);
+      } catch (rollbackError) {
+        rollbackErrors.push(
+          rollbackError instanceof Error ? rollbackError.message : String(rollbackError),
+        );
+      }
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      rollbackErrors.length > 0
+        ? `${message}; rollback errors: ${rollbackErrors.join("; ")}`
+        : message,
+    );
+  }
+}
+
+if (import.meta.main) {
+  const targetUrl = requireEnv("CLAWHUB_SKILLS_SH_SYNC_URL");
+  const staticAuthorization = process.env.CLAWHUB_SKILLS_SH_SYNC_TOKEN?.trim();
+  const authorization =
+    staticAuthorization ||
+    createGitHubActionsOidcAuthorization({
+      requestUrl: requireEnv("ACTIONS_ID_TOKEN_REQUEST_URL"),
+      requestToken: requireEnv("ACTIONS_ID_TOKEN_REQUEST_TOKEN"),
+    });
+  const reason = process.env.CLAWHUB_SKILLS_SH_SYNC_REASON?.trim() || "hourly skills.sh sync";
+  const outputPath = resolve(
+    process.env.CLAWHUB_SKILLS_SH_SYNC_OUTPUT?.trim() || "skills-sh-sync-proof.json",
+  );
+  const proof = await runSkillsShSync({ targetUrl, authorization, reason });
+  await writeFile(outputPath, `${JSON.stringify(proof, null, 2)}\n`, "utf8");
+  process.stdout.write(`${JSON.stringify(proof)}\n`);
+}

--- a/scripts/skills-sh-sync-workflow.test.ts
+++ b/scripts/skills-sh-sync-workflow.test.ts
@@ -1,0 +1,49 @@
+/* @vitest-environment node */
+
+import { readFile } from "node:fs/promises";
+import { describe, expect, it } from "vitest";
+import { parse as parseYaml } from "yaml";
+
+describe("skills.sh production synchronization workflow", () => {
+  it("runs hourly without overlap from main using Production OIDC", async () => {
+    const workflow = parseYaml(await readFile(".github/workflows/skills-sh-sync.yml", "utf8")) as {
+      concurrency?: { group?: string; "cancel-in-progress"?: boolean };
+      jobs: Record<
+        string,
+        {
+          environment?: { name?: string } | string;
+          permissions?: Record<string, string>;
+          steps?: Array<{
+            env?: Record<string, unknown>;
+            name?: string;
+            run?: string;
+            uses?: string;
+          }>;
+        }
+      >;
+      on?: {
+        schedule?: Array<{ cron?: string }>;
+        workflow_dispatch?: unknown;
+      };
+      permissions?: Record<string, string>;
+    };
+
+    expect(workflow.on?.schedule).toEqual([{ cron: "17 * * * *" }]);
+    expect(workflow.on?.workflow_dispatch).toBeDefined();
+    expect(workflow.concurrency).toEqual({
+      group: "skills-sh-production-sync",
+      "cancel-in-progress": false,
+    });
+    expect(workflow.permissions).toEqual({ contents: "read", "id-token": "write" });
+
+    const job = workflow.jobs.sync;
+    expect(job?.environment).toEqual({ name: "Production" });
+    expect(job?.permissions).toEqual({ contents: "read", "id-token": "write" });
+    const run = job?.steps?.map((step) => step.run ?? "").join("\n") ?? "";
+    const serializedSteps = JSON.stringify(job?.steps ?? []);
+    expect(run).toContain("refs/heads/main");
+    expect(serializedSteps).toContain("https://clawhub.ai/ops/skills-sh/mirror");
+    expect(run).toContain("bun scripts/skills-sh-catalog/sync.ts");
+    expect(run).not.toContain("CLAWHUB_SKILLS_SH_SYNC_TOKEN");
+  });
+});

--- a/server/routes/ops/skills-sh/mirror-test.post.ts
+++ b/server/routes/ops/skills-sh/mirror-test.post.ts
@@ -4,6 +4,7 @@ import {
   buildSkillsShMirrorProofSnapshotId,
   fetchSkillsShMirrorBatch,
   fetchSkillsShMirrorControlledBatch,
+  getSkillsShCatalogProductionSourcePolicy,
   getSkillsShCatalogTestSourcePolicy,
   measureSkillsShMirrorProofSource,
   measureSkillsShTrendingSource,
@@ -16,8 +17,26 @@ import {
   type SkillsShMirrorClassificationState,
 } from "../../../skillsShMirrorClassification";
 
-const TEST_CONVEX_SITE_URL = "https://academic-chihuahua-392.convex.site";
-const OPERATOR_PATH = "/api/v1/operator/skills-sh/catalog-test";
+const ROUTE_CONFIG = {
+  test: {
+    convexSiteUrl: "https://academic-chihuahua-392.convex.site",
+    operatorPath: "/api/v1/operator/skills-sh/catalog-test",
+    enableConfirm: "enable-skills-sh-mirror-test",
+    cancelConfirm: "cancel-skills-sh-mirror-test-run",
+    activateConfirm: "activate-skills-sh-public-test",
+    deactivateConfirm: "deactivate-skills-sh-public-test",
+    controlledTestSource: true,
+  },
+  production: {
+    convexSiteUrl: "https://wry-manatee-359.convex.site",
+    operatorPath: "/api/v1/operator/skills-sh/mirror",
+    enableConfirm: "enable-skills-sh-mirror-production",
+    cancelConfirm: "cancel-skills-sh-mirror-production-run",
+    activateConfirm: "activate-skills-sh-public-production",
+    deactivateConfirm: "deactivate-skills-sh-public-production",
+    controlledTestSource: false,
+  },
+} as const;
 const SOURCE_PAGE_SIZE = 500;
 const MIRROR_BATCH_SIZE = 50;
 const MAX_TEST_SOURCE_ROWS = 50_000;
@@ -29,6 +48,8 @@ const BATCH_LEASE_HEARTBEAT_INTERVAL_MS = 60_000;
 type MirrorRequest = {
   operation?:
     | "configure"
+    | "verify-activate"
+    | "deactivate"
     | "start"
     | "start-trending"
     | "start-trending-replay"
@@ -110,8 +131,12 @@ function assertNoActiveMirrorRun(status: Record<string, unknown>) {
   throw new Error(`skills.sh mirror already has an active run${runId}`);
 }
 
-async function callConvexOperator(authorization: string, body: Record<string, unknown>) {
-  const response = await fetch(`${TEST_CONVEX_SITE_URL}${OPERATOR_PATH}`, {
+async function callConfiguredConvexOperator(
+  config: (typeof ROUTE_CONFIG)[keyof typeof ROUTE_CONFIG],
+  authorization: string,
+  body: Record<string, unknown>,
+) {
+  const response = await fetch(`${config.convexSiteUrl}${config.operatorPath}`, {
     method: "POST",
     headers: {
       Accept: "application/json",
@@ -129,6 +154,10 @@ async function callConvexOperator(authorization: string, body: Record<string, un
 
 function createBatchLeaseHeartbeat(args: {
   authorization: string;
+  callOperator: (
+    authorization: string,
+    body: Record<string, unknown>,
+  ) => Promise<Record<string, unknown>>;
   runId: string;
   page: number;
   offset: number;
@@ -139,13 +168,14 @@ function createBatchLeaseHeartbeat(args: {
   return async () => {
     if (Date.now() < nextHeartbeatAt) return;
     if (pending) return await pending;
-    pending = callConvexOperator(args.authorization, {
-      operation: "mirror-batch-claim",
-      runId: args.runId,
-      page: args.page,
-      offset: args.offset,
-      leaseToken: args.leaseToken,
-    })
+    pending = args
+      .callOperator(args.authorization, {
+        operation: "mirror-batch-claim",
+        runId: args.runId,
+        page: args.page,
+        offset: args.offset,
+        leaseToken: args.leaseToken,
+      })
       .then(() => undefined)
       .finally(() => {
         nextHeartbeatAt = Date.now() + BATCH_LEASE_HEARTBEAT_INTERVAL_MS;
@@ -155,768 +185,828 @@ function createBatchLeaseHeartbeat(args: {
   };
 }
 
-export default defineEventHandler(async (event) => {
-  const policy = getSkillsShCatalogTestSourcePolicy(process.env);
-  if (!policy.allowed) return jsonResponse({ error: "not_found" }, 404);
-  const authorization = getHeader(event, "authorization")?.trim() ?? "";
-  if (!authorization.toLowerCase().startsWith("bearer ")) {
-    return jsonResponse({ error: "unauthorized" }, 401);
-  }
+export function createSkillsShMirrorRoute(target: keyof typeof ROUTE_CONFIG) {
+  const config = ROUTE_CONFIG[target];
+  return defineEventHandler(async (event) => {
+    const policy =
+      target === "production"
+        ? getSkillsShCatalogProductionSourcePolicy(process.env)
+        : getSkillsShCatalogTestSourcePolicy(process.env);
+    if (!policy.allowed) return jsonResponse({ error: "not_found" }, 404);
+    const authorization = getHeader(event, "authorization")?.trim() ?? "";
+    if (!authorization.toLowerCase().startsWith("bearer ")) {
+      return jsonResponse({ error: "unauthorized" }, 401);
+    }
+    const callConvexOperator = (authorizationValue: string, body: Record<string, unknown>) =>
+      callConfiguredConvexOperator(config, authorizationValue, body);
 
-  try {
-    const body = (await readBody(event)) as MirrorRequest;
-    const operation = body.operation;
-    if (operation === "status") {
-      return jsonResponse(await callConvexOperator(authorization, { operation: "mirror-status" }));
-    }
-    if (operation === "run") {
-      return jsonResponse(
-        await callConvexOperator(authorization, {
-          operation: "mirror-run",
-          runId: requireString(body.runId, "runId"),
-        }),
-      );
-    }
-    if (operation === "isolation") {
-      return jsonResponse(
-        await callConvexOperator(authorization, { operation: "mirror-isolation" }),
-      );
-    }
-    if (operation === "read") {
-      return jsonResponse(
-        await callConvexOperator(authorization, {
-          operation: "mirror-read",
-          externalId: requireString(body.externalId, "externalId"),
-        }),
-      );
-    }
-    if (operation === "source-summary") {
-      return jsonResponse(
-        await callConvexOperator(authorization, {
+    try {
+      const body = (await readBody(event)) as MirrorRequest;
+      const operation = body.operation;
+      if (operation === "status") {
+        return jsonResponse(
+          await callConvexOperator(authorization, { operation: "mirror-status" }),
+        );
+      }
+      if (operation === "run") {
+        return jsonResponse(
+          await callConvexOperator(authorization, {
+            operation: "mirror-run",
+            runId: requireString(body.runId, "runId"),
+          }),
+        );
+      }
+      if (operation === "isolation") {
+        return jsonResponse(
+          await callConvexOperator(authorization, { operation: "mirror-isolation" }),
+        );
+      }
+      if (operation === "read") {
+        return jsonResponse(
+          await callConvexOperator(authorization, {
+            operation: "mirror-read",
+            externalId: requireString(body.externalId, "externalId"),
+          }),
+        );
+      }
+      if (operation === "source-summary") {
+        return jsonResponse(
+          await callConvexOperator(authorization, {
+            operation: "mirror-source-summary",
+            snapshotHash: requireString(body.snapshotHash, "snapshotHash"),
+          }),
+        );
+      }
+      if (operation === "conflicts") {
+        return jsonResponse(
+          await callConvexOperator(authorization, {
+            operation: "mirror-conflicts",
+            runId: requireString(body.runId, "runId"),
+            limit: requireInteger(body.limit, "limit", 1, 50),
+          }),
+        );
+      }
+      if (operation === "page") {
+        return jsonResponse(
+          await callConvexOperator(authorization, {
+            operation: "mirror-page",
+            cursor: body.cursor ?? null,
+            limit: requireInteger(body.limit, "limit", 1, 500),
+          }),
+        );
+      }
+      if (operation === "detail-page") {
+        return jsonResponse(
+          await callConvexOperator(authorization, {
+            operation: "mirror-detail-page",
+            cursor: body.cursor ?? null,
+            limit: requireInteger(body.limit, "limit", 1, MAX_DETAIL_PAGE_ROWS),
+          }),
+        );
+      }
+      if (operation === "facet-page") {
+        return jsonResponse(
+          await callConvexOperator(authorization, {
+            operation: "mirror-facet-page",
+            cursor: body.cursor ?? null,
+            limit: requireInteger(body.limit, "limit", 1, 500),
+          }),
+        );
+      }
+      if (operation === "configure") {
+        return jsonResponse(
+          await callConvexOperator(authorization, {
+            operation: "mirror-configure",
+            enabled: body.enabled === true,
+            reason: requireString(body.reason, "reason"),
+            confirm: config.enableConfirm,
+            maxRowsPerRun: MAX_TEST_SOURCE_ROWS,
+            maxRowsPerBatch: MIRROR_BATCH_SIZE,
+            maxDetailBytes: MAX_DETAIL_BYTES,
+          }),
+        );
+      }
+      if (operation === "verify-activate") {
+        return jsonResponse(
+          await callConvexOperator(authorization, {
+            operation: "mirror-verify-activate",
+            reason: requireString(body.reason, "reason"),
+            confirm: config.activateConfirm,
+          }),
+        );
+      }
+      if (operation === "deactivate") {
+        return jsonResponse(
+          await callConvexOperator(authorization, {
+            operation: "mirror-public-gate",
+            enabled: false,
+            reason: requireString(body.reason, "reason"),
+            confirm: config.deactivateConfirm,
+          }),
+        );
+      }
+      if (operation === "start") {
+        assertNoActiveMirrorRun(
+          await callConvexOperator(authorization, { operation: "mirror-status" }),
+        );
+        const oidcToken = await getVercelOidcToken();
+        const sourceMeasuredAt = new Date().toISOString();
+        const source = await measureSkillsShMirrorProofSource({ oidcToken });
+        if (source.catalogTotal < 1 || source.catalogTotal > MAX_TEST_SOURCE_ROWS) {
+          throw new Error(
+            `skills.sh source total ${source.catalogTotal} exceeds the Test mirror capacity`,
+          );
+        }
+        const controlledExternalIds = config.controlledTestSource
+          ? source.controlledExternalIds
+          : [];
+        const controlledOverlayExternalIds = config.controlledTestSource
+          ? source.controlledOverlayExternalIds
+          : [];
+        const controlledSupplementExternalIds = config.controlledTestSource
+          ? source.controlledSupplementExternalIds
+          : [];
+        const sourceTotal = source.catalogTotal + controlledSupplementExternalIds.length;
+        if (sourceTotal > MAX_TEST_SOURCE_ROWS) {
+          throw new Error(`skills.sh proof source total ${sourceTotal} exceeds the Test capacity`);
+        }
+        const snapshotId = buildSkillsShMirrorProofSnapshotId({
+          catalogTotal: source.catalogTotal,
+          controlledExternalIds,
+          controlledOverlayExternalIds,
+          controlledSupplementExternalIds,
+          evidence: source.evidence,
+        });
+        const snapshot = parseSkillsShMirrorProofSnapshotId(snapshotId);
+        const sourceSnapshotHash = requireString(snapshot.sourceSnapshotHash, "sourceSnapshotHash");
+        let sourceCaptureWrites = 0;
+        for (const page of source.sourcePages) {
+          const stored = await callConvexOperator(authorization, {
+            operation: "mirror-source-page-store",
+            snapshotHash: sourceSnapshotHash,
+            ...page,
+          });
+          if (stored.stored === true) sourceCaptureWrites += 1;
+        }
+        const sourceCapture = await callConvexOperator(authorization, {
           operation: "mirror-source-summary",
-          snapshotHash: requireString(body.snapshotHash, "snapshotHash"),
-        }),
-      );
-    }
-    if (operation === "conflicts") {
-      return jsonResponse(
-        await callConvexOperator(authorization, {
-          operation: "mirror-conflicts",
-          runId: requireString(body.runId, "runId"),
-          limit: requireInteger(body.limit, "limit", 1, 50),
-        }),
-      );
-    }
-    if (operation === "page") {
-      return jsonResponse(
-        await callConvexOperator(authorization, {
-          operation: "mirror-page",
-          cursor: body.cursor ?? null,
-          limit: requireInteger(body.limit, "limit", 1, 500),
-        }),
-      );
-    }
-    if (operation === "detail-page") {
-      return jsonResponse(
-        await callConvexOperator(authorization, {
-          operation: "mirror-detail-page",
-          cursor: body.cursor ?? null,
-          limit: requireInteger(body.limit, "limit", 1, MAX_DETAIL_PAGE_ROWS),
-        }),
-      );
-    }
-    if (operation === "facet-page") {
-      return jsonResponse(
-        await callConvexOperator(authorization, {
-          operation: "mirror-facet-page",
-          cursor: body.cursor ?? null,
-          limit: requireInteger(body.limit, "limit", 1, 500),
-        }),
-      );
-    }
-    if (operation === "configure") {
-      return jsonResponse(
-        await callConvexOperator(authorization, {
-          operation: "mirror-configure",
-          enabled: body.enabled === true,
-          reason: requireString(body.reason, "reason"),
-          confirm: "enable-skills-sh-mirror-test",
-          maxRowsPerRun: MAX_TEST_SOURCE_ROWS,
-          maxRowsPerBatch: MIRROR_BATCH_SIZE,
-          maxDetailBytes: MAX_DETAIL_BYTES,
-        }),
-      );
-    }
-    if (operation === "start") {
-      assertNoActiveMirrorRun(
-        await callConvexOperator(authorization, { operation: "mirror-status" }),
-      );
-      const oidcToken = await getVercelOidcToken();
-      const sourceMeasuredAt = new Date().toISOString();
-      const source = await measureSkillsShMirrorProofSource({ oidcToken });
-      if (source.catalogTotal < 1 || source.catalogTotal > MAX_TEST_SOURCE_ROWS) {
-        throw new Error(
-          `skills.sh source total ${source.catalogTotal} exceeds the Test mirror capacity`,
-        );
-      }
-      const sourceTotal = source.catalogTotal + source.controlledSupplementExternalIds.length;
-      if (sourceTotal > MAX_TEST_SOURCE_ROWS) {
-        throw new Error(`skills.sh proof source total ${sourceTotal} exceeds the Test capacity`);
-      }
-      const snapshotId = buildSkillsShMirrorProofSnapshotId(source);
-      const snapshot = parseSkillsShMirrorProofSnapshotId(snapshotId);
-      const sourceSnapshotHash = requireString(snapshot.sourceSnapshotHash, "sourceSnapshotHash");
-      let sourceCaptureWrites = 0;
-      for (const page of source.sourcePages) {
-        const stored = await callConvexOperator(authorization, {
-          operation: "mirror-source-page-store",
           snapshotHash: sourceSnapshotHash,
-          ...page,
         });
-        if (stored.stored === true) sourceCaptureWrites += 1;
-      }
-      const sourceCapture = await callConvexOperator(authorization, {
-        operation: "mirror-source-summary",
-        snapshotHash: sourceSnapshotHash,
-      });
-      const result = await callConvexOperator(authorization, {
-        operation: "mirror-start",
-        sourceView: "leaderboard",
-        reason: requireString(body.reason, "reason"),
-        snapshotId,
-        sourceSnapshotHash,
-        sourceCaptureWrites,
-        sourceTotal,
-        sourcePageSize: SOURCE_PAGE_SIZE,
-        sourceMeasuredAt,
-      });
-      return jsonResponse({
-        ...result,
-        sourceTotal,
-        sourceCatalogTotal: source.catalogTotal,
-        controlledOverlayTotal: source.controlledOverlayExternalIds.length,
-        controlledSupplementTotal: source.controlledSupplementExternalIds.length,
-        sourceMeasurementRequests: source.sourceRequests,
-        sourceCapture: {
-          ...sourceCapture,
-          requestDbWrites: sourceCaptureWrites,
-        },
-        sourceMeasuredAt,
-        sourcePageSize: SOURCE_PAGE_SIZE,
-      });
-    }
-    if (operation === "start-replay") {
-      const sourceMeasuredAt = requireString(body.sourceMeasuredAt, "sourceMeasuredAt");
-      if (Number.isNaN(Date.parse(sourceMeasuredAt))) {
-        throw new Error("sourceMeasuredAt must be an ISO timestamp");
-      }
-      const sourceTotal = requireInteger(body.sourceTotal, "sourceTotal", 1, MAX_TEST_SOURCE_ROWS);
-      const sourcePageSize = requireInteger(
-        body.sourcePageSize,
-        "sourcePageSize",
-        1,
-        SOURCE_PAGE_SIZE,
-      );
-      const result = await callConvexOperator(authorization, {
-        operation: "mirror-start",
-        reason: requireString(body.reason, "reason"),
-        snapshotId: `skills-sh-captured:${requireString(body.capturedRunId, "capturedRunId")}`,
-        sourceTotal,
-        sourcePageSize,
-        sourceMeasuredAt,
-      });
-      return jsonResponse({
-        ...result,
-        sourceTotal,
-        sourceMeasuredAt,
-        sourcePageSize,
-        captured: true,
-      });
-    }
-    if (operation === "start-trending") {
-      assertNoActiveMirrorRun(
-        await callConvexOperator(authorization, { operation: "mirror-status" }),
-      );
-      const oidcToken = await getVercelOidcToken();
-      const source = await measureSkillsShTrendingSource({ oidcToken });
-      if (source.catalogTotal < 1 || source.catalogTotal > MAX_TEST_SOURCE_ROWS) {
-        throw new Error(
-          `skills.sh trending source total ${source.catalogTotal} exceeds the Test capacity`,
-        );
-      }
-      let sourceCaptureWrites = 0;
-      for (const page of source.sourcePages) {
-        const stored = await callConvexOperator(authorization, {
-          operation: "mirror-source-page-store",
-          sourceView: "trending",
-          snapshotHash: source.snapshotHash,
-          ...page,
+        const result = await callConvexOperator(authorization, {
+          operation: "mirror-start",
+          sourceView: "leaderboard",
+          reason: requireString(body.reason, "reason"),
+          snapshotId,
+          sourceSnapshotHash,
+          sourceCaptureWrites,
+          sourceTotal,
+          sourcePageSize: SOURCE_PAGE_SIZE,
+          sourceMeasuredAt,
         });
-        if (stored.stored === true) sourceCaptureWrites += 1;
+        return jsonResponse({
+          ...result,
+          sourceTotal,
+          sourceCatalogTotal: source.catalogTotal,
+          controlledOverlayTotal: controlledOverlayExternalIds.length,
+          controlledSupplementTotal: controlledSupplementExternalIds.length,
+          sourceMeasurementRequests: source.sourceRequests,
+          sourceCapture: {
+            ...sourceCapture,
+            requestDbWrites: sourceCaptureWrites,
+          },
+          sourceMeasuredAt,
+          sourcePageSize: SOURCE_PAGE_SIZE,
+        });
       }
-      const sourceCapture = await callConvexOperator(authorization, {
-        operation: "mirror-source-summary",
-        snapshotHash: source.snapshotHash,
-      });
-      const result = await callConvexOperator(authorization, {
-        operation: "mirror-start",
-        sourceView: "trending",
-        reason: requireString(body.reason, "reason"),
-        snapshotId: `skills-sh:trending:${source.snapshotHash}`,
-        sourceSnapshotHash: source.snapshotHash,
-        sourceCaptureWrites,
-        sourceTotal: source.catalogTotal,
-        sourcePageSize: source.pageSize,
-        sourceMeasuredAt: source.observedAt,
-        sourceRequests: source.sourceRequests,
-        sourceDurationMs: source.sourceDurationMs,
-      });
-      return jsonResponse({
-        ...result,
-        sourceTotal: source.catalogTotal,
-        sourceMeasuredAt: source.observedAt,
-        sourcePageSize: source.pageSize,
-        sourceMeasurementRequests: source.sourceRequests,
-        sourceMeasurementDurationMs: source.sourceDurationMs,
-        sourceCapture: {
-          ...sourceCapture,
-          requestDbWrites: sourceCaptureWrites,
-        },
-        sourceEvidence: source.evidence,
-        sampleExternalIds: source.sourcePages[0]?.rows.slice(0, 3).map((row) => row.id) ?? [],
-      });
-    }
-    if (operation === "start-trending-replay") {
-      assertNoActiveMirrorRun(
-        await callConvexOperator(authorization, { operation: "mirror-status" }),
-      );
-      const capturedRunId = requireString(body.capturedRunId, "capturedRunId");
-      const captured = await callConvexOperator(authorization, {
-        operation: "mirror-run",
-        runId: capturedRunId,
-      });
-      if (
-        captured.sourceView !== "trending" ||
-        typeof captured.sourceSnapshotHash !== "string" ||
-        typeof captured.sourceTotal !== "number" ||
-        typeof captured.sourcePageSize !== "number"
-      ) {
-        throw new Error("captured skills.sh trending run is invalid");
-      }
-      const sourceMeasuredAt = requireString(body.sourceMeasuredAt, "sourceMeasuredAt");
-      if (Number.isNaN(Date.parse(sourceMeasuredAt))) {
-        throw new Error("sourceMeasuredAt must be an ISO timestamp");
-      }
-      const result = await callConvexOperator(authorization, {
-        operation: "mirror-start",
-        sourceView: "trending",
-        reason: requireString(body.reason, "reason"),
-        snapshotId: `skills-sh:trending-replay:${capturedRunId}:${sourceMeasuredAt}`,
-        sourceSnapshotHash: captured.sourceSnapshotHash,
-        sourceTotal: captured.sourceTotal,
-        sourcePageSize: captured.sourcePageSize,
-        sourceMeasuredAt,
-        sourceRequests: 0,
-        sourceDurationMs: 0,
-      });
-      return jsonResponse({ ...result, capturedRunId, captured: true });
-    }
-    if (operation === "step") {
-      const runId = requireString(body.runId, "runId");
-      const page = requireInteger(body.page, "page", 0, 100_000);
-      const offset = requireInteger(body.offset, "offset", 0, SOURCE_PAGE_SIZE - 1);
-      const leaseToken = crypto.randomUUID();
-      const lease = await callConvexOperator(authorization, {
-        operation: "mirror-batch-claim",
-        runId,
-        page,
-        offset,
-        leaseToken,
-      });
-      try {
+      if (operation === "start-replay") {
+        const sourceMeasuredAt = requireString(body.sourceMeasuredAt, "sourceMeasuredAt");
+        if (Number.isNaN(Date.parse(sourceMeasuredAt))) {
+          throw new Error("sourceMeasuredAt must be an ISO timestamp");
+        }
         const sourceTotal = requireInteger(
-          typeof lease.sourceTotal === "number" ? lease.sourceTotal : undefined,
-          "lease.sourceTotal",
+          body.sourceTotal,
+          "sourceTotal",
           1,
           MAX_TEST_SOURCE_ROWS,
         );
-        const snapshot = parseSkillsShMirrorProofSnapshotId(
-          requireString(
-            typeof lease.snapshotId === "string" ? lease.snapshotId : undefined,
-            "lease.snapshotId",
-          ),
+        const sourcePageSize = requireInteger(
+          body.sourcePageSize,
+          "sourcePageSize",
+          1,
+          SOURCE_PAGE_SIZE,
         );
-        if (
-          sourceTotal !==
-          snapshot.catalogTotal + snapshot.controlledSupplementExternalIds.length
-        ) {
-          throw new Error("skills.sh mirror run proof source metadata is inconsistent");
+        const result = await callConvexOperator(authorization, {
+          operation: "mirror-start",
+          reason: requireString(body.reason, "reason"),
+          snapshotId: `skills-sh-captured:${requireString(body.capturedRunId, "capturedRunId")}`,
+          sourceTotal,
+          sourcePageSize,
+          sourceMeasuredAt,
+        });
+        return jsonResponse({
+          ...result,
+          sourceTotal,
+          sourceMeasuredAt,
+          sourcePageSize,
+          captured: true,
+        });
+      }
+      if (operation === "start-trending") {
+        assertNoActiveMirrorRun(
+          await callConvexOperator(authorization, { operation: "mirror-status" }),
+        );
+        const oidcToken = await getVercelOidcToken();
+        const source = await measureSkillsShTrendingSource({ oidcToken });
+        if (source.catalogTotal < 1 || source.catalogTotal > MAX_TEST_SOURCE_ROWS) {
+          throw new Error(
+            `skills.sh trending source total ${source.catalogTotal} exceeds the Test capacity`,
+          );
         }
-        const controlledPage = Math.ceil(snapshot.catalogTotal / SOURCE_PAGE_SIZE);
-        const beforeRequest = createBatchLeaseHeartbeat({
-          authorization,
+        let sourceCaptureWrites = 0;
+        for (const page of source.sourcePages) {
+          const stored = await callConvexOperator(authorization, {
+            operation: "mirror-source-page-store",
+            sourceView: "trending",
+            snapshotHash: source.snapshotHash,
+            ...page,
+          });
+          if (stored.stored === true) sourceCaptureWrites += 1;
+        }
+        const sourceCapture = await callConvexOperator(authorization, {
+          operation: "mirror-source-summary",
+          snapshotHash: source.snapshotHash,
+        });
+        const result = await callConvexOperator(authorization, {
+          operation: "mirror-start",
+          sourceView: "trending",
+          reason: requireString(body.reason, "reason"),
+          snapshotId: `skills-sh:trending:${source.snapshotHash}`,
+          sourceSnapshotHash: source.snapshotHash,
+          sourceCaptureWrites,
+          sourceTotal: source.catalogTotal,
+          sourcePageSize: source.pageSize,
+          sourceMeasuredAt: source.observedAt,
+          sourceRequests: source.sourceRequests,
+          sourceDurationMs: source.sourceDurationMs,
+        });
+        return jsonResponse({
+          ...result,
+          sourceTotal: source.catalogTotal,
+          sourceMeasuredAt: source.observedAt,
+          sourcePageSize: source.pageSize,
+          sourceMeasurementRequests: source.sourceRequests,
+          sourceMeasurementDurationMs: source.sourceDurationMs,
+          sourceCapture: {
+            ...sourceCapture,
+            requestDbWrites: sourceCaptureWrites,
+          },
+          sourceEvidence: source.evidence,
+          sampleExternalIds: source.sourcePages[0]?.rows.slice(0, 3).map((row) => row.id) ?? [],
+        });
+      }
+      if (operation === "start-trending-replay") {
+        assertNoActiveMirrorRun(
+          await callConvexOperator(authorization, { operation: "mirror-status" }),
+        );
+        const capturedRunId = requireString(body.capturedRunId, "capturedRunId");
+        const captured = await callConvexOperator(authorization, {
+          operation: "mirror-run",
+          runId: capturedRunId,
+        });
+        if (
+          captured.sourceView !== "trending" ||
+          typeof captured.sourceSnapshotHash !== "string" ||
+          typeof captured.sourceTotal !== "number" ||
+          typeof captured.sourcePageSize !== "number"
+        ) {
+          throw new Error("captured skills.sh trending run is invalid");
+        }
+        const sourceMeasuredAt = requireString(body.sourceMeasuredAt, "sourceMeasuredAt");
+        if (Number.isNaN(Date.parse(sourceMeasuredAt))) {
+          throw new Error("sourceMeasuredAt must be an ISO timestamp");
+        }
+        const result = await callConvexOperator(authorization, {
+          operation: "mirror-start",
+          sourceView: "trending",
+          reason: requireString(body.reason, "reason"),
+          snapshotId: `skills-sh:trending-replay:${capturedRunId}:${sourceMeasuredAt}`,
+          sourceSnapshotHash: captured.sourceSnapshotHash,
+          sourceTotal: captured.sourceTotal,
+          sourcePageSize: captured.sourcePageSize,
+          sourceMeasuredAt,
+          sourceRequests: 0,
+          sourceDurationMs: 0,
+        });
+        return jsonResponse({ ...result, capturedRunId, captured: true });
+      }
+      if (operation === "step") {
+        const runId = requireString(body.runId, "runId");
+        const page = requireInteger(body.page, "page", 0, 100_000);
+        const offset = requireInteger(body.offset, "offset", 0, SOURCE_PAGE_SIZE - 1);
+        const leaseToken = crypto.randomUUID();
+        const lease = await callConvexOperator(authorization, {
+          operation: "mirror-batch-claim",
           runId,
           page,
           offset,
           leaseToken,
         });
-        const batch =
-          page === controlledPage && snapshot.controlledSupplementExternalIds.length > 0
-            ? await fetchSkillsShMirrorControlledBatch(
-                {
-                  page,
-                  offset,
-                  limit: MIRROR_BATCH_SIZE,
-                  maxDetailBytes: MAX_DETAIL_BYTES,
-                  sourceTotal,
-                  externalIds: snapshot.controlledSupplementExternalIds,
-                },
-                { beforeRequest },
-              )
-            : page < controlledPage
-              ? await (async () => {
-                  const capturedPage =
-                    lease.sourcePage &&
-                    typeof lease.sourcePage === "object" &&
-                    !Array.isArray(lease.sourcePage)
-                      ? (lease.sourcePage as Record<string, unknown>)
-                      : null;
-                  const expectedPage = snapshot.evidence?.pagination.requestedPages.find(
-                    (entry) => entry.page === page,
-                  );
-                  if (
-                    !capturedPage ||
-                    !expectedPage ||
-                    capturedPage.page !== page ||
-                    capturedPage.sourceTotal !== snapshot.catalogTotal ||
-                    capturedPage.pageLength !== expectedPage.count ||
-                    capturedPage.hasMore !== expectedPage.hasMore ||
-                    capturedPage.identityHash !== expectedPage.identityHash ||
-                    capturedPage.contentHash !== expectedPage.contentHash ||
-                    !Array.isArray(capturedPage.rows)
-                  ) {
-                    throw new Error(
-                      `captured skills.sh leaderboard page does not match the proof: ${page}`,
-                    );
-                  }
-                  const oidcToken = await getVercelOidcToken();
-                  const catalogBatch = await fetchSkillsShMirrorBatch(
-                    { page, offset, limit: MIRROR_BATCH_SIZE, maxDetailBytes: MAX_DETAIL_BYTES },
-                    {
-                      oidcToken,
-                      beforeRequest,
-                      sourcePage: {
-                        data: capturedPage.rows as never,
-                        pagination: {
-                          page,
-                          perPage: SOURCE_PAGE_SIZE,
-                          total: snapshot.catalogTotal,
-                          hasMore: expectedPage.hasMore,
-                        },
-                      },
-                    },
-                  );
-                  if (catalogBatch.sourceTotal !== snapshot.catalogTotal) {
-                    throw new Error("skills.sh catalog source total changed during the run");
-                  }
-                  if (
-                    expectedPage.count !== catalogBatch.pageLength ||
-                    expectedPage.hasMore !== catalogBatch.hasMore ||
-                    expectedPage.identityHash !== catalogBatch.sourcePageIdentityHash
-                  ) {
-                    throw new Error(
-                      `skills.sh ordered leaderboard page changed during the run: ${page}`,
-                    );
-                  }
-                  const controlledOverlayExternalIds = new Set<string>(
-                    snapshot.controlledOverlayExternalIds,
-                  );
-                  const overlayExternalIds = catalogBatch.rows.flatMap((row) =>
-                    controlledOverlayExternalIds.has(row.externalId) ? [row.externalId] : [],
-                  );
-                  const overlay =
-                    overlayExternalIds.length > 0
-                      ? await fetchSkillsShMirrorControlledBatch(
-                          {
-                            page,
-                            offset: 0,
-                            limit: overlayExternalIds.length,
-                            maxDetailBytes: MAX_DETAIL_BYTES,
-                            sourceTotal,
-                            externalIds: overlayExternalIds,
-                          },
-                          { beforeRequest },
-                        )
-                      : null;
-                  const overlayByExternalId = new Map(
-                    overlay?.rows.map((row) => [row.externalId, row]),
-                  );
-                  return {
-                    ...catalogBatch,
-                    sourceTotal,
-                    hasMore:
-                      catalogBatch.hasMore || snapshot.controlledSupplementExternalIds.length > 0,
-                    sourceRequests: catalogBatch.sourceRequests + (overlay?.sourceRequests ?? 0),
-                    sourceBytes: catalogBatch.sourceBytes + (overlay?.sourceBytes ?? 0),
-                    rows: catalogBatch.rows.map((row) => {
-                      const controlled = overlayByExternalId.get(row.externalId);
-                      if (!controlled) return row;
-                      if ("quarantined" in row) return controlled;
-                      return {
-                        ...controlled,
-                        upstreamSourceType: row.upstreamSourceType,
-                        upstreamInstalls: row.upstreamInstalls,
-                        upstreamScanners: row.upstreamScanners,
-                      };
-                    }),
-                  };
-                })()
-              : (() => {
-                  throw new Error("skills.sh mirror cursor is beyond the proof source");
-                })();
-        const externalIds = batch.rows.flatMap((row) =>
-          "quarantined" in row ? [] : [row.externalId],
-        );
-        const classificationState =
-          externalIds.length === 0
-            ? { states: [] }
-            : await callConvexOperator(authorization, {
-                operation: "mirror-classification-states",
-                externalIds,
-              });
-        if (!Array.isArray(classificationState.states)) {
-          throw new Error("Convex Test mirror classification state is invalid");
-        }
-        const rows = enrichSkillsShMirrorClassifications(
-          batch.rows as Parameters<typeof enrichSkillsShMirrorClassifications>[0],
-          classificationState.states as SkillsShMirrorClassificationState[],
-        );
-        return jsonResponse(
-          await callConvexOperator(authorization, {
-            operation: "mirror-batch",
-            runId,
-            leaseToken,
-            ...batch,
-            rows,
-          }),
-        );
-      } catch (error) {
         try {
-          await callConvexOperator(authorization, {
-            operation: "mirror-batch-release",
-            runId,
-            page,
-            offset,
-            leaseToken,
-          });
-        } catch {
-          // The five-minute durable lease remains the crash/outage recovery path.
-        }
-        throw error;
-      }
-    }
-    if (operation === "step-replay") {
-      const runId = requireString(body.runId, "runId");
-      const page = requireInteger(body.page, "page", 0, 100_000);
-      const offset = requireInteger(body.offset, "offset", 0, SOURCE_PAGE_SIZE - 1);
-      const pageLength = requireInteger(body.pageLength, "pageLength", 1, SOURCE_PAGE_SIZE);
-      const sourceTotal = requireInteger(body.sourceTotal, "sourceTotal", 1, MAX_TEST_SOURCE_ROWS);
-      if (typeof body.hasMore !== "boolean") throw new Error("hasMore is required");
-      if (
-        !Array.isArray(body.externalIds) ||
-        body.externalIds.length < 1 ||
-        body.externalIds.length > MIRROR_BATCH_SIZE ||
-        body.externalIds.some((externalId) => typeof externalId !== "string" || !externalId.trim())
-      ) {
-        throw new Error(`externalIds must contain between 1 and ${MIRROR_BATCH_SIZE} strings`);
-      }
-      const leaseToken = crypto.randomUUID();
-      await callConvexOperator(authorization, {
-        operation: "mirror-batch-claim",
-        runId,
-        page,
-        offset,
-        leaseToken,
-      });
-      try {
-        const captured = await callConvexOperator(authorization, {
-          operation: "mirror-replay-rows",
-          externalIds: body.externalIds,
-        });
-        if (!Array.isArray(captured.rows)) {
-          throw new Error("Convex Test mirror replay rows are invalid");
-        }
-        const rows = buildSkillsShMirrorReplayRows(captured.rows as never);
-        return jsonResponse(
-          await callConvexOperator(authorization, {
-            operation: "mirror-batch",
-            runId,
-            page,
-            offset,
-            leaseToken,
-            pageLength,
-            hasMore: body.hasMore,
-            sourceTotal,
-            sourceRequests: 0,
-            sourceBytes: 0,
-            rows,
-          }),
-        );
-      } catch (error) {
-        try {
-          await callConvexOperator(authorization, {
-            operation: "mirror-batch-release",
-            runId,
-            page,
-            offset,
-            leaseToken,
-          });
-        } catch {
-          // The five-minute durable lease remains the crash/outage recovery path.
-        }
-        throw error;
-      }
-    }
-    if (operation === "step-trending") {
-      const runId = requireString(body.runId, "runId");
-      const page = requireInteger(body.page, "page", 0, 100_000);
-      const offset = requireInteger(body.offset, "offset", 0, SOURCE_PAGE_SIZE - 1);
-      const leaseToken = crypto.randomUUID();
-      const lease = await callConvexOperator(authorization, {
-        operation: "mirror-batch-claim",
-        runId,
-        page,
-        offset,
-        leaseToken,
-      });
-      try {
-        if (lease.sourceView !== "trending") {
-          throw new Error("skills.sh mirror run is not a trending observation");
-        }
-        const sourceTotal = requireInteger(
-          typeof lease.sourceTotal === "number" ? lease.sourceTotal : undefined,
-          "lease.sourceTotal",
-          1,
-          MAX_TEST_SOURCE_ROWS,
-        );
-        const snapshotId = requireString(
-          typeof lease.snapshotId === "string" ? lease.snapshotId : undefined,
-          "lease.snapshotId",
-        );
-        const allowsExceptionalHydration = snapshotId.startsWith("skills-sh:trending:");
-        if (!allowsExceptionalHydration && !snapshotId.startsWith("skills-sh:trending-replay:")) {
-          throw new Error("skills.sh trending snapshot ID is invalid");
-        }
-        const trendingHydrationAttempts = requireInteger(
-          typeof lease.trendingHydrationAttempts === "number"
-            ? lease.trendingHydrationAttempts
-            : undefined,
-          "lease.trendingHydrationAttempts",
-          0,
-          MAX_TRENDING_HYDRATIONS_PER_RUN,
-        );
-        const remainingHydrationBudget = allowsExceptionalHydration
-          ? MAX_TRENDING_HYDRATIONS_PER_RUN - trendingHydrationAttempts
-          : 0;
-        const sourcePage =
-          lease.sourcePage &&
-          typeof lease.sourcePage === "object" &&
-          !Array.isArray(lease.sourcePage)
-            ? (lease.sourcePage as Record<string, unknown>)
-            : null;
-        if (
-          !sourcePage ||
-          sourcePage.sourceView !== "trending" ||
-          sourcePage.page !== page ||
-          sourcePage.sourceTotal !== sourceTotal ||
-          !Array.isArray(sourcePage.rows) ||
-          typeof sourcePage.pageLength !== "number" ||
-          typeof sourcePage.hasMore !== "boolean"
-        ) {
-          throw new Error(`captured skills.sh trending page is invalid: ${page}`);
-        }
-        const pageLength = requireInteger(
-          sourcePage.pageLength,
-          "sourcePage.pageLength",
-          1,
-          SOURCE_PAGE_SIZE,
-        );
-        const listRows = (sourcePage.rows as Array<Record<string, unknown>>).slice(
-          offset,
-          offset + MIRROR_BATCH_SIZE,
-        );
-        if (listRows.length < 1) {
-          throw new Error("skills.sh trending cursor is outside the captured source page");
-        }
-        const externalIds = listRows.map((row) => requireString(row.id as string, "externalId"));
-        const joinState = await callConvexOperator(authorization, {
-          operation: "mirror-trending-join-state",
-          externalIds,
-        });
-        if (!Array.isArray(joinState.missingExternalIds)) {
-          throw new Error("skills.sh trending join state is invalid");
-        }
-        const hydratableExternalIds = Array.isArray(joinState.hydratableExternalIds)
-          ? joinState.hydratableExternalIds
-          : joinState.missingExternalIds;
-        const hydratable = new Set(
-          hydratableExternalIds.map((value) =>
-            requireString(value as string, "externalId").toLowerCase(),
-          ),
-        );
-        const selectedExternalIds = new Set<string>();
-        const missingRows = listRows.filter((row) => {
-          const externalId = requireString(row.id as string, "externalId").toLowerCase();
+          const sourceTotal = requireInteger(
+            typeof lease.sourceTotal === "number" ? lease.sourceTotal : undefined,
+            "lease.sourceTotal",
+            1,
+            MAX_TEST_SOURCE_ROWS,
+          );
+          const snapshot = parseSkillsShMirrorProofSnapshotId(
+            requireString(
+              typeof lease.snapshotId === "string" ? lease.snapshotId : undefined,
+              "lease.snapshotId",
+            ),
+          );
           if (
-            selectedExternalIds.size >= remainingHydrationBudget ||
-            selectedExternalIds.has(externalId) ||
-            !hydratable.has(externalId)
+            sourceTotal !==
+            snapshot.catalogTotal + snapshot.controlledSupplementExternalIds.length
           ) {
-            return false;
+            throw new Error("skills.sh mirror run proof source metadata is inconsistent");
           }
-          selectedExternalIds.add(externalId);
-          return true;
-        });
-        if (missingRows.length > 0) {
+          const controlledPage = Math.ceil(snapshot.catalogTotal / SOURCE_PAGE_SIZE);
           const beforeRequest = createBatchLeaseHeartbeat({
             authorization,
+            callOperator: callConvexOperator,
             runId,
             page,
             offset,
             leaseToken,
           });
-          const oidcToken = await getVercelOidcToken();
-          const hydrated = await fetchSkillsShMirrorBatch(
-            { page: 0, offset: 0, limit: missingRows.length, maxDetailBytes: MAX_DETAIL_BYTES },
-            {
-              oidcToken,
-              beforeRequest,
-              sourcePage: {
-                data: missingRows as never,
-                pagination: {
-                  page: 0,
-                  perPage: SOURCE_PAGE_SIZE,
-                  total: missingRows.length,
-                  hasMore: false,
-                },
-              },
-            },
-          );
-          const hydratedExternalIds = hydrated.rows.flatMap((row) =>
+          const batch =
+            page === controlledPage && snapshot.controlledSupplementExternalIds.length > 0
+              ? await fetchSkillsShMirrorControlledBatch(
+                  {
+                    page,
+                    offset,
+                    limit: MIRROR_BATCH_SIZE,
+                    maxDetailBytes: MAX_DETAIL_BYTES,
+                    sourceTotal,
+                    externalIds: snapshot.controlledSupplementExternalIds,
+                  },
+                  { beforeRequest },
+                )
+              : page < controlledPage
+                ? await (async () => {
+                    const capturedPage =
+                      lease.sourcePage &&
+                      typeof lease.sourcePage === "object" &&
+                      !Array.isArray(lease.sourcePage)
+                        ? (lease.sourcePage as Record<string, unknown>)
+                        : null;
+                    const expectedPage = snapshot.evidence?.pagination.requestedPages.find(
+                      (entry) => entry.page === page,
+                    );
+                    if (
+                      !capturedPage ||
+                      !expectedPage ||
+                      capturedPage.page !== page ||
+                      capturedPage.sourceTotal !== snapshot.catalogTotal ||
+                      capturedPage.pageLength !== expectedPage.count ||
+                      capturedPage.hasMore !== expectedPage.hasMore ||
+                      capturedPage.identityHash !== expectedPage.identityHash ||
+                      capturedPage.contentHash !== expectedPage.contentHash ||
+                      !Array.isArray(capturedPage.rows)
+                    ) {
+                      throw new Error(
+                        `captured skills.sh leaderboard page does not match the proof: ${page}`,
+                      );
+                    }
+                    const oidcToken = await getVercelOidcToken();
+                    const catalogBatch = await fetchSkillsShMirrorBatch(
+                      { page, offset, limit: MIRROR_BATCH_SIZE, maxDetailBytes: MAX_DETAIL_BYTES },
+                      {
+                        oidcToken,
+                        beforeRequest,
+                        sourcePage: {
+                          data: capturedPage.rows as never,
+                          pagination: {
+                            page,
+                            perPage: SOURCE_PAGE_SIZE,
+                            total: snapshot.catalogTotal,
+                            hasMore: expectedPage.hasMore,
+                          },
+                        },
+                      },
+                    );
+                    if (catalogBatch.sourceTotal !== snapshot.catalogTotal) {
+                      throw new Error("skills.sh catalog source total changed during the run");
+                    }
+                    if (
+                      expectedPage.count !== catalogBatch.pageLength ||
+                      expectedPage.hasMore !== catalogBatch.hasMore ||
+                      expectedPage.identityHash !== catalogBatch.sourcePageIdentityHash
+                    ) {
+                      throw new Error(
+                        `skills.sh ordered leaderboard page changed during the run: ${page}`,
+                      );
+                    }
+                    const controlledOverlayExternalIds = new Set<string>(
+                      snapshot.controlledOverlayExternalIds,
+                    );
+                    const overlayExternalIds = catalogBatch.rows.flatMap((row) =>
+                      controlledOverlayExternalIds.has(row.externalId) ? [row.externalId] : [],
+                    );
+                    const overlay =
+                      overlayExternalIds.length > 0
+                        ? await fetchSkillsShMirrorControlledBatch(
+                            {
+                              page,
+                              offset: 0,
+                              limit: overlayExternalIds.length,
+                              maxDetailBytes: MAX_DETAIL_BYTES,
+                              sourceTotal,
+                              externalIds: overlayExternalIds,
+                            },
+                            { beforeRequest },
+                          )
+                        : null;
+                    const overlayByExternalId = new Map(
+                      overlay?.rows.map((row) => [row.externalId, row]),
+                    );
+                    return {
+                      ...catalogBatch,
+                      sourceTotal,
+                      hasMore:
+                        catalogBatch.hasMore || snapshot.controlledSupplementExternalIds.length > 0,
+                      sourceRequests: catalogBatch.sourceRequests + (overlay?.sourceRequests ?? 0),
+                      sourceBytes: catalogBatch.sourceBytes + (overlay?.sourceBytes ?? 0),
+                      rows: catalogBatch.rows.map((row) => {
+                        const controlled = overlayByExternalId.get(row.externalId);
+                        if (!controlled) return row;
+                        if ("quarantined" in row) return controlled;
+                        return {
+                          ...controlled,
+                          upstreamSourceType: row.upstreamSourceType,
+                          upstreamInstalls: row.upstreamInstalls,
+                          upstreamScanners: row.upstreamScanners,
+                        };
+                      }),
+                    };
+                  })()
+                : (() => {
+                    throw new Error("skills.sh mirror cursor is beyond the proof source");
+                  })();
+          const externalIds = batch.rows.flatMap((row) =>
             "quarantined" in row ? [] : [row.externalId],
           );
           const classificationState =
-            hydratedExternalIds.length === 0
+            externalIds.length === 0
               ? { states: [] }
               : await callConvexOperator(authorization, {
                   operation: "mirror-classification-states",
-                  externalIds: hydratedExternalIds,
+                  externalIds,
                 });
           if (!Array.isArray(classificationState.states)) {
             throw new Error("Convex Test mirror classification state is invalid");
           }
           const rows = enrichSkillsShMirrorClassifications(
-            hydrated.rows as Parameters<typeof enrichSkillsShMirrorClassifications>[0],
+            batch.rows as Parameters<typeof enrichSkillsShMirrorClassifications>[0],
             classificationState.states as SkillsShMirrorClassificationState[],
           );
-          await callConvexOperator(authorization, {
-            operation: "mirror-trending-hydrate",
-            runId,
-            page,
-            offset,
-            leaseToken,
-            sourceRequests: hydrated.sourceRequests,
-            sourceBytes: hydrated.sourceBytes,
-            rows,
-          });
+          return jsonResponse(
+            await callConvexOperator(authorization, {
+              operation: "mirror-batch",
+              runId,
+              leaseToken,
+              ...batch,
+              rows,
+            }),
+          );
+        } catch (error) {
+          try {
+            await callConvexOperator(authorization, {
+              operation: "mirror-batch-release",
+              runId,
+              page,
+              offset,
+              leaseToken,
+            });
+          } catch {
+            // The five-minute durable lease remains the crash/outage recovery path.
+          }
+          throw error;
         }
+      }
+      if (operation === "step-replay") {
+        const runId = requireString(body.runId, "runId");
+        const page = requireInteger(body.page, "page", 0, 100_000);
+        const offset = requireInteger(body.offset, "offset", 0, SOURCE_PAGE_SIZE - 1);
+        const pageLength = requireInteger(body.pageLength, "pageLength", 1, SOURCE_PAGE_SIZE);
+        const sourceTotal = requireInteger(
+          body.sourceTotal,
+          "sourceTotal",
+          1,
+          MAX_TEST_SOURCE_ROWS,
+        );
+        if (typeof body.hasMore !== "boolean") throw new Error("hasMore is required");
+        if (
+          !Array.isArray(body.externalIds) ||
+          body.externalIds.length < 1 ||
+          body.externalIds.length > MIRROR_BATCH_SIZE ||
+          body.externalIds.some(
+            (externalId) => typeof externalId !== "string" || !externalId.trim(),
+          )
+        ) {
+          throw new Error(`externalIds must contain between 1 and ${MIRROR_BATCH_SIZE} strings`);
+        }
+        const leaseToken = crypto.randomUUID();
+        await callConvexOperator(authorization, {
+          operation: "mirror-batch-claim",
+          runId,
+          page,
+          offset,
+          leaseToken,
+        });
+        try {
+          const captured = await callConvexOperator(authorization, {
+            operation: "mirror-replay-rows",
+            externalIds: body.externalIds,
+          });
+          if (!Array.isArray(captured.rows)) {
+            throw new Error("Convex Test mirror replay rows are invalid");
+          }
+          const rows = buildSkillsShMirrorReplayRows(captured.rows as never);
+          return jsonResponse(
+            await callConvexOperator(authorization, {
+              operation: "mirror-batch",
+              runId,
+              page,
+              offset,
+              leaseToken,
+              pageLength,
+              hasMore: body.hasMore,
+              sourceTotal,
+              sourceRequests: 0,
+              sourceBytes: 0,
+              rows,
+            }),
+          );
+        } catch (error) {
+          try {
+            await callConvexOperator(authorization, {
+              operation: "mirror-batch-release",
+              runId,
+              page,
+              offset,
+              leaseToken,
+            });
+          } catch {
+            // The five-minute durable lease remains the crash/outage recovery path.
+          }
+          throw error;
+        }
+      }
+      if (operation === "step-trending") {
+        const runId = requireString(body.runId, "runId");
+        const page = requireInteger(body.page, "page", 0, 100_000);
+        const offset = requireInteger(body.offset, "offset", 0, SOURCE_PAGE_SIZE - 1);
+        const leaseToken = crypto.randomUUID();
+        const lease = await callConvexOperator(authorization, {
+          operation: "mirror-batch-claim",
+          runId,
+          page,
+          offset,
+          leaseToken,
+        });
+        try {
+          if (lease.sourceView !== "trending") {
+            throw new Error("skills.sh mirror run is not a trending observation");
+          }
+          const sourceTotal = requireInteger(
+            typeof lease.sourceTotal === "number" ? lease.sourceTotal : undefined,
+            "lease.sourceTotal",
+            1,
+            MAX_TEST_SOURCE_ROWS,
+          );
+          const snapshotId = requireString(
+            typeof lease.snapshotId === "string" ? lease.snapshotId : undefined,
+            "lease.snapshotId",
+          );
+          const allowsExceptionalHydration = snapshotId.startsWith("skills-sh:trending:");
+          if (!allowsExceptionalHydration && !snapshotId.startsWith("skills-sh:trending-replay:")) {
+            throw new Error("skills.sh trending snapshot ID is invalid");
+          }
+          const trendingHydrationAttempts = requireInteger(
+            typeof lease.trendingHydrationAttempts === "number"
+              ? lease.trendingHydrationAttempts
+              : undefined,
+            "lease.trendingHydrationAttempts",
+            0,
+            MAX_TRENDING_HYDRATIONS_PER_RUN,
+          );
+          const remainingHydrationBudget = allowsExceptionalHydration
+            ? MAX_TRENDING_HYDRATIONS_PER_RUN - trendingHydrationAttempts
+            : 0;
+          const sourcePage =
+            lease.sourcePage &&
+            typeof lease.sourcePage === "object" &&
+            !Array.isArray(lease.sourcePage)
+              ? (lease.sourcePage as Record<string, unknown>)
+              : null;
+          if (
+            !sourcePage ||
+            sourcePage.sourceView !== "trending" ||
+            sourcePage.page !== page ||
+            sourcePage.sourceTotal !== sourceTotal ||
+            !Array.isArray(sourcePage.rows) ||
+            typeof sourcePage.pageLength !== "number" ||
+            typeof sourcePage.hasMore !== "boolean"
+          ) {
+            throw new Error(`captured skills.sh trending page is invalid: ${page}`);
+          }
+          const pageLength = requireInteger(
+            sourcePage.pageLength,
+            "sourcePage.pageLength",
+            1,
+            SOURCE_PAGE_SIZE,
+          );
+          const listRows = (sourcePage.rows as Array<Record<string, unknown>>).slice(
+            offset,
+            offset + MIRROR_BATCH_SIZE,
+          );
+          if (listRows.length < 1) {
+            throw new Error("skills.sh trending cursor is outside the captured source page");
+          }
+          const externalIds = listRows.map((row) => requireString(row.id as string, "externalId"));
+          const joinState = await callConvexOperator(authorization, {
+            operation: "mirror-trending-join-state",
+            externalIds,
+          });
+          if (!Array.isArray(joinState.missingExternalIds)) {
+            throw new Error("skills.sh trending join state is invalid");
+          }
+          const hydratableExternalIds = Array.isArray(joinState.hydratableExternalIds)
+            ? joinState.hydratableExternalIds
+            : joinState.missingExternalIds;
+          const hydratable = new Set(
+            hydratableExternalIds.map((value) =>
+              requireString(value as string, "externalId").toLowerCase(),
+            ),
+          );
+          const selectedExternalIds = new Set<string>();
+          const missingRows = listRows.filter((row) => {
+            const externalId = requireString(row.id as string, "externalId").toLowerCase();
+            if (
+              selectedExternalIds.size >= remainingHydrationBudget ||
+              selectedExternalIds.has(externalId) ||
+              !hydratable.has(externalId)
+            ) {
+              return false;
+            }
+            selectedExternalIds.add(externalId);
+            return true;
+          });
+          if (missingRows.length > 0) {
+            const beforeRequest = createBatchLeaseHeartbeat({
+              authorization,
+              callOperator: callConvexOperator,
+              runId,
+              page,
+              offset,
+              leaseToken,
+            });
+            const oidcToken = await getVercelOidcToken();
+            const hydrated = await fetchSkillsShMirrorBatch(
+              { page: 0, offset: 0, limit: missingRows.length, maxDetailBytes: MAX_DETAIL_BYTES },
+              {
+                oidcToken,
+                beforeRequest,
+                sourcePage: {
+                  data: missingRows as never,
+                  pagination: {
+                    page: 0,
+                    perPage: SOURCE_PAGE_SIZE,
+                    total: missingRows.length,
+                    hasMore: false,
+                  },
+                },
+              },
+            );
+            const hydratedExternalIds = hydrated.rows.flatMap((row) =>
+              "quarantined" in row ? [] : [row.externalId],
+            );
+            const classificationState =
+              hydratedExternalIds.length === 0
+                ? { states: [] }
+                : await callConvexOperator(authorization, {
+                    operation: "mirror-classification-states",
+                    externalIds: hydratedExternalIds,
+                  });
+            if (!Array.isArray(classificationState.states)) {
+              throw new Error("Convex Test mirror classification state is invalid");
+            }
+            const rows = enrichSkillsShMirrorClassifications(
+              hydrated.rows as Parameters<typeof enrichSkillsShMirrorClassifications>[0],
+              classificationState.states as SkillsShMirrorClassificationState[],
+            );
+            await callConvexOperator(authorization, {
+              operation: "mirror-trending-hydrate",
+              runId,
+              page,
+              offset,
+              leaseToken,
+              sourceRequests: hydrated.sourceRequests,
+              sourceBytes: hydrated.sourceBytes,
+              rows,
+            });
+          }
+          return jsonResponse(
+            await callConvexOperator(authorization, {
+              operation: "mirror-trending-batch",
+              runId,
+              page,
+              offset,
+              leaseToken,
+              pageLength,
+              hasMore: sourcePage.hasMore,
+              sourceTotal,
+              rows: listRows.map((row, index) => ({
+                externalId: requireString(row.id as string, "externalId"),
+                lifetimeInstalls: requireInteger(
+                  typeof row.installs === "number" ? row.installs : undefined,
+                  "lifetimeInstalls",
+                  0,
+                  Number.MAX_SAFE_INTEGER,
+                ),
+                rank: page * SOURCE_PAGE_SIZE + offset + index + 1,
+              })),
+            }),
+          );
+        } catch (error) {
+          try {
+            await callConvexOperator(authorization, {
+              operation: "mirror-batch-release",
+              runId,
+              page,
+              offset,
+              leaseToken,
+            });
+          } catch {
+            // The five-minute durable lease remains the crash/outage recovery path.
+          }
+          throw error;
+        }
+      }
+      if (operation === "pause" || operation === "resume") {
         return jsonResponse(
           await callConvexOperator(authorization, {
-            operation: "mirror-trending-batch",
-            runId,
-            page,
-            offset,
-            leaseToken,
-            pageLength,
-            hasMore: sourcePage.hasMore,
-            sourceTotal,
-            rows: listRows.map((row, index) => ({
-              externalId: requireString(row.id as string, "externalId"),
-              lifetimeInstalls: requireInteger(
-                typeof row.installs === "number" ? row.installs : undefined,
-                "lifetimeInstalls",
-                0,
-                Number.MAX_SAFE_INTEGER,
-              ),
-              rank: page * SOURCE_PAGE_SIZE + offset + index + 1,
-            })),
+            operation: "mirror-pause",
+            runId: requireString(body.runId, "runId"),
+            paused: operation === "pause",
+            reason: requireString(body.reason, "reason"),
+            confirm: "set-skills-sh-mirror-pause",
           }),
         );
-      } catch (error) {
-        try {
-          await callConvexOperator(authorization, {
-            operation: "mirror-batch-release",
-            runId,
-            page,
-            offset,
-            leaseToken,
-          });
-        } catch {
-          // The five-minute durable lease remains the crash/outage recovery path.
-        }
-        throw error;
       }
-    }
-    if (operation === "pause" || operation === "resume") {
-      return jsonResponse(
-        await callConvexOperator(authorization, {
-          operation: "mirror-pause",
-          runId: requireString(body.runId, "runId"),
-          paused: operation === "pause",
-          reason: requireString(body.reason, "reason"),
-          confirm: "set-skills-sh-mirror-pause",
-        }),
-      );
-    }
-    if (operation === "discard") {
-      return jsonResponse(
-        await callConvexOperator(authorization, {
-          operation: "mirror-cancel",
-          runId: requireString(body.runId, "runId"),
-          reason: requireString(body.reason, "reason"),
-          confirm: "cancel-skills-sh-mirror-test-run",
-        }),
-      );
-    }
-    if (operation === "reconcile") {
-      return jsonResponse(
-        await callConvexOperator(authorization, {
-          operation: "mirror-reconcile",
-          runId: requireString(body.runId, "runId"),
-          limit: requireInteger(body.limit ?? 250, "limit", 1, 250),
-        }),
-      );
-    }
-    return jsonResponse({ error: "unknown_operation" }, 400);
-  } catch (error) {
-    const retryAfterSeconds = skillsShSourceRetryAfterSeconds(error);
-    if (retryAfterSeconds !== null) {
+      if (operation === "discard") {
+        return jsonResponse(
+          await callConvexOperator(authorization, {
+            operation: "mirror-cancel",
+            runId: requireString(body.runId, "runId"),
+            reason: requireString(body.reason, "reason"),
+            confirm: config.cancelConfirm,
+          }),
+        );
+      }
+      if (operation === "reconcile") {
+        return jsonResponse(
+          await callConvexOperator(authorization, {
+            operation: "mirror-reconcile",
+            runId: requireString(body.runId, "runId"),
+            limit: requireInteger(body.limit ?? 250, "limit", 1, 250),
+          }),
+        );
+      }
+      return jsonResponse({ error: "unknown_operation" }, 400);
+    } catch (error) {
+      const retryAfterSeconds = skillsShSourceRetryAfterSeconds(error);
+      if (retryAfterSeconds !== null) {
+        return jsonResponse(
+          {
+            error: "skills_sh_source_rate_limited",
+            message: error instanceof Error ? error.message : "skills.sh source rate limited",
+            retryAfterSeconds,
+          },
+          429,
+          { "Retry-After": String(retryAfterSeconds) },
+        );
+      }
       return jsonResponse(
         {
-          error: "skills_sh_source_rate_limited",
-          message: error instanceof Error ? error.message : "skills.sh source rate limited",
-          retryAfterSeconds,
+          error: "skills_sh_mirror_test_failed",
+          message: error instanceof Error ? error.message : "Unknown Test mirror failure",
         },
-        429,
-        { "Retry-After": String(retryAfterSeconds) },
+        502,
       );
     }
-    return jsonResponse(
-      {
-        error: "skills_sh_mirror_test_failed",
-        message: error instanceof Error ? error.message : "Unknown Test mirror failure",
-      },
-      502,
-    );
-  }
-});
+  });
+}
+
+export default createSkillsShMirrorRoute("test");

--- a/server/routes/ops/skills-sh/mirror.post.ts
+++ b/server/routes/ops/skills-sh/mirror.post.ts
@@ -1,0 +1,3 @@
+import { createSkillsShMirrorRoute } from "./mirror-test.post";
+
+export default createSkillsShMirrorRoute("production");

--- a/server/skillsShCatalogSource.ts
+++ b/server/skillsShCatalogSource.ts
@@ -26,6 +26,7 @@ const MAX_INLINE_RETRY_AFTER_MS = 30_000;
 const CLAWHUB_VERCEL_OWNER_ID = "team_pLdjXbfy0XvPRiNmAygTjTSH";
 const CLAWHUB_VERCEL_PROJECT_ID = "prj_UVAJPNPYrBwTEkPJwkpEySsge8Mc";
 const CLAWHUB_TEST_CONVEX_URL = "https://academic-chihuahua-392.convex.cloud";
+const CLAWHUB_PRODUCTION_CONVEX_URL = "https://wry-manatee-359.convex.cloud";
 
 const SKILLS_SH_MIRROR_CONTROLLED_SUPPLEMENTS = [
   {
@@ -2458,6 +2459,23 @@ export function getSkillsShCatalogTestSourcePolicy(env: SkillsShCatalogSourceEnv
     maxDiscoveryRows: MAX_SOURCE_PAGE_SIZE,
     maxRealScanAdmissions: MAX_TEST_SCAN_ADMISSIONS,
   };
+}
+
+export function getSkillsShCatalogProductionSourcePolicy(
+  env: SkillsShCatalogSourceEnv = process.env,
+) {
+  if (
+    env.VITE_CLAWHUB_DEPLOY_ENV !== "production" ||
+    env.VERCEL_ENV?.trim().toLowerCase() !== "production" ||
+    env.VITE_CONVEX_URL !== CLAWHUB_PRODUCTION_CONVEX_URL
+  ) {
+    return {
+      allowed: false as const,
+      environment: "production",
+      reason: "skills.sh production discovery requires the exact ClawHub production runtime",
+    };
+  }
+  return { allowed: true as const, environment: "production" };
 }
 
 type VerifyVercelOidc = (

--- a/server/skillsShMirrorProductionRoute.test.ts
+++ b/server/skillsShMirrorProductionRoute.test.ts
@@ -1,0 +1,226 @@
+/* @vitest-environment node */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getHeaderMock = vi.fn();
+const getVercelOidcTokenMock = vi.fn();
+const readBodyMock = vi.fn();
+const buildProofSnapshotIdMock = vi.fn();
+const measureProofSourceMock = vi.fn();
+const parseProofSnapshotIdMock = vi.fn();
+const productionPolicyMock = vi.fn();
+
+vi.mock("h3", () => ({
+  defineEventHandler: (handler: unknown) => handler,
+  getHeader: (...args: unknown[]) => getHeaderMock(...args),
+  readBody: (...args: unknown[]) => readBodyMock(...args),
+}));
+
+vi.mock("@vercel/oidc", () => ({
+  getVercelOidcToken: (...args: unknown[]) => getVercelOidcTokenMock(...args),
+}));
+
+vi.mock("./skillsShCatalogSource", () => ({
+  buildSkillsShMirrorProofSnapshotId: (...args: unknown[]) => buildProofSnapshotIdMock(...args),
+  fetchSkillsShMirrorBatch: vi.fn(),
+  fetchSkillsShMirrorControlledBatch: vi.fn(),
+  getSkillsShCatalogProductionSourcePolicy: (...args: unknown[]) => productionPolicyMock(...args),
+  getSkillsShCatalogTestSourcePolicy: vi.fn(),
+  measureSkillsShMirrorProofSource: (...args: unknown[]) => measureProofSourceMock(...args),
+  measureSkillsShTrendingSource: vi.fn(),
+  parseSkillsShMirrorProofSnapshotId: (...args: unknown[]) => parseProofSnapshotIdMock(...args),
+  skillsShSourceRetryAfterSeconds: vi.fn(() => null),
+}));
+
+vi.mock("./skillsShMirrorClassification", () => ({
+  buildSkillsShMirrorReplayRows: vi.fn(),
+  enrichSkillsShMirrorClassifications: vi.fn(),
+}));
+
+describe("skills.sh production mirror route", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    getHeaderMock.mockReset();
+    getVercelOidcTokenMock.mockReset();
+    readBodyMock.mockReset();
+    buildProofSnapshotIdMock.mockReset();
+    measureProofSourceMock.mockReset();
+    parseProofSnapshotIdMock.mockReset();
+    productionPolicyMock.mockReset();
+    productionPolicyMock.mockReturnValue({ allowed: true, environment: "production" });
+    getHeaderMock.mockReturnValue("Bearer github-actions-oidc");
+    getVercelOidcTokenMock.mockResolvedValue("vercel-production-oidc");
+    buildProofSnapshotIdMock.mockReturnValue("skills-sh:proof:production");
+    parseProofSnapshotIdMock.mockReturnValue({
+      catalogTotal: 9_575,
+      controlledExternalIds: [],
+      controlledOverlayExternalIds: [],
+      controlledSupplementExternalIds: [],
+      sourceSnapshotHash: "a".repeat(64),
+    });
+  });
+
+  it("forwards the GitHub Actions OIDC token only to the exact production operator", async () => {
+    readBodyMock.mockResolvedValue({ operation: "status" });
+    const convexFetch = vi.fn(async (url: string, init: RequestInit) => {
+      expect(url).toBe("https://wry-manatee-359.convex.site/api/v1/operator/skills-sh/mirror");
+      expect(init.headers).toMatchObject({
+        Authorization: "Bearer github-actions-oidc",
+      });
+      expect(JSON.parse(String(init.body))).toEqual({ operation: "mirror-status" });
+      return new Response(JSON.stringify({ control: null, runs: [] }));
+    });
+    vi.stubGlobal("fetch", convexFetch);
+
+    const handler = (await import("./routes/ops/skills-sh/mirror.post")).default;
+    const response = (await handler({} as never)) as Response;
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ control: null, runs: [] });
+    expect(productionPolicyMock).toHaveBeenCalledOnce();
+    expect(convexFetch).toHaveBeenCalledOnce();
+  });
+
+  it("fails closed before the operator call when the production source policy is not exact", async () => {
+    productionPolicyMock.mockReturnValue({
+      allowed: false,
+      environment: "production",
+      reason: "wrong production backend",
+    });
+    readBodyMock.mockResolvedValue({ operation: "status" });
+    const convexFetch = vi.fn();
+    vi.stubGlobal("fetch", convexFetch);
+
+    const handler = (await import("./routes/ops/skills-sh/mirror.post")).default;
+    const response = (await handler({} as never)) as Response;
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({ error: "not_found" });
+    expect(convexFetch).not.toHaveBeenCalled();
+  });
+
+  it("configures production with the production-only confirmation", async () => {
+    readBodyMock.mockResolvedValue({
+      operation: "configure",
+      enabled: true,
+      reason: "hourly production sync",
+    });
+    const convexFetch = vi.fn(async (_url: string, init: RequestInit) => {
+      expect(JSON.parse(String(init.body))).toMatchObject({
+        operation: "mirror-configure",
+        confirm: "enable-skills-sh-mirror-production",
+        enabled: true,
+        reason: "hourly production sync",
+      });
+      return new Response(JSON.stringify({ enabled: true }));
+    });
+    vi.stubGlobal("fetch", convexFetch);
+
+    const handler = (await import("./routes/ops/skills-sh/mirror.post")).default;
+    const response = (await handler({} as never)) as Response;
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ enabled: true });
+  });
+
+  it("measures the raw production corpus without controlled Test supplements", async () => {
+    readBodyMock.mockResolvedValue({ operation: "start", reason: "initial hidden import" });
+    measureProofSourceMock.mockResolvedValue({
+      catalogTotal: 9_575,
+      controlledExternalIds: ["patrick-erichsen/skills/html"],
+      controlledOverlayExternalIds: [],
+      controlledSupplementExternalIds: ["patrick-erichsen/skills/html"],
+      sourceRequests: 21,
+      sourcePages: [
+        {
+          page: 0,
+          sourceTotal: 9_575,
+          pageLength: 500,
+          hasMore: true,
+          identityHash: "identity",
+          contentHash: "content",
+          sourceBytes: 100,
+          serializedBytes: 120,
+          rows: [],
+        },
+      ],
+      evidence: { pagination: { requestedPages: [] } },
+    });
+    const convexFetch = vi.fn(async (_url: string, init: RequestInit) => {
+      const body = JSON.parse(String(init.body));
+      if (body.operation === "mirror-status") {
+        return new Response(JSON.stringify({ runs: [] }));
+      }
+      if (body.operation === "mirror-source-page-store") {
+        return new Response(JSON.stringify({ stored: true }));
+      }
+      if (body.operation === "mirror-source-summary") {
+        return new Response(JSON.stringify({ rows: 500 }));
+      }
+      expect(body).toMatchObject({
+        operation: "mirror-start",
+        sourceView: "leaderboard",
+        sourceTotal: 9_575,
+        snapshotId: "skills-sh:proof:production",
+      });
+      return new Response(
+        JSON.stringify({ runId: "skillsShMirrorRuns:production", status: "running" }),
+      );
+    });
+    vi.stubGlobal("fetch", convexFetch);
+
+    const handler = (await import("./routes/ops/skills-sh/mirror.post")).default;
+    const response = (await handler({} as never)) as Response;
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      sourceTotal: 9_575,
+      sourceCatalogTotal: 9_575,
+      controlledOverlayTotal: 0,
+      controlledSupplementTotal: 0,
+    });
+    expect(buildProofSnapshotIdMock).toHaveBeenCalledWith({
+      catalogTotal: 9_575,
+      controlledExternalIds: [],
+      controlledOverlayExternalIds: [],
+      controlledSupplementExternalIds: [],
+      evidence: { pagination: { requestedPages: [] } },
+    });
+  });
+
+  it("uses distinct production confirmations for activation and rollback", async () => {
+    const forwarded: Array<Record<string, unknown>> = [];
+    const convexFetch = vi.fn(async (_url: string, init: RequestInit) => {
+      forwarded.push(JSON.parse(String(init.body)));
+      return new Response(JSON.stringify({ ok: true }));
+    });
+    vi.stubGlobal("fetch", convexFetch);
+    const handler = (await import("./routes/ops/skills-sh/mirror.post")).default;
+
+    readBodyMock.mockResolvedValueOnce({
+      operation: "verify-activate",
+      reason: "verified initial production import",
+    });
+    expect(((await handler({} as never)) as Response).status).toBe(200);
+
+    readBodyMock.mockResolvedValueOnce({
+      operation: "deactivate",
+      reason: "systemic production rollback",
+    });
+    expect(((await handler({} as never)) as Response).status).toBe(200);
+
+    expect(forwarded).toEqual([
+      {
+        operation: "mirror-verify-activate",
+        reason: "verified initial production import",
+        confirm: "activate-skills-sh-public-production",
+      },
+      {
+        operation: "mirror-public-gate",
+        enabled: false,
+        reason: "systemic production rollback",
+        confirm: "deactivate-skills-sh-public-production",
+      },
+    ]);
+  });
+});

--- a/server/skillsShMirrorTestRoute.test.ts
+++ b/server/skillsShMirrorTestRoute.test.ts
@@ -778,7 +778,8 @@ describe("skills.sh permanent Test mirror route", () => {
     const handler = (await import("./routes/ops/skills-sh/mirror-test.post")).default;
     const response = (await handler({} as never)) as Response;
 
-    expect(response.status).toBe(200);
+    const responsePayload = await response.clone().json();
+    expect(response.status, JSON.stringify(responsePayload)).toBe(200);
     const claims = convexFetch.mock.calls
       .map(([, init]) => JSON.parse(String(init?.body)))
       .filter((body) => body.operation === "mirror-batch-claim");


### PR DESCRIPTION
## Summary

- publish the complete eligible skills.sh mirror corpus behind an activation-owned global gate
- preserve exact-source identity, scan-free refreshes, separate metrics, canonical Trending, and deterministic Test claim outcomes
- add verified atomic activation, rollback, interrupted-run recovery, stable GitHub Actions OIDC, and hourly overlap prevention

## Verification

- `bunx vitest run` on the 19 touched suites: 816 tests passed
- `.agents/skills/autoreview/scripts/autoreview --mode local`: clean
- `bun run ci:static`
- `bun run ci:unit`: 5,737 tests passed, coverage gate passed
- `bun run ci:types-build`
- `bun run ci:packages`
- `bun run ci:e2e-http`
- `bunx tsc -p packages/schema/tsconfig.json --noEmit`
- `bunx tsc -p packages/clawhub/tsconfig.json --noEmit`
- `bunx convex codegen`

Permanent Test and production were not deployed or mutated in this PR preparation pass.
