### PR TITLE
fix: quarantine stale skills.sh detail rows

### DIFF
--- a/server/skillsShCatalogSource.test.ts
+++ b/server/skillsShCatalogSource.test.ts
@@ -2039,6 +2039,83 @@ describe("skills.sh Vercel source boundary", () => {
     );
   });
 
+  it("quarantines a missing captured detail and continues the source batch", async () => {
+    const fetchImpl = vi.fn(async (urlInput: string | URL | Request) => {
+      const url = String(urlInput);
+      if (url.includes("?page=0&per_page=500")) {
+        return new Response(
+          JSON.stringify({
+            data: [
+              {
+                id: "owner/repo/removed-skill",
+                installUrl: "https://github.com/owner/repo",
+                installs: 7,
+                name: "Removed Skill",
+                slug: "removed-skill",
+                source: "owner/repo",
+                sourceType: "github",
+                url: "https://skills.sh/owner/repo/removed-skill",
+              },
+              {
+                id: "vercel-labs/skills/find-skills",
+                installUrl: "https://github.com/vercel-labs/skills",
+                installs: 42,
+                name: "Find Skills",
+                slug: "find-skills",
+                source: "vercel-labs/skills",
+                sourceType: "github",
+                url: "https://skills.sh/vercel-labs/skills/find-skills",
+              },
+            ],
+            pagination: { page: 0, perPage: 500, total: 2, hasMore: false },
+          }),
+        );
+      }
+      if (url.includes("/api/v1/skills/audit/")) {
+        return new Response(JSON.stringify({ error: "not_found" }), { status: 404 });
+      }
+      if (url.includes("/api/v1/skills/owner/repo/removed-skill")) {
+        return new Response(JSON.stringify({ error: "not_found" }), { status: 404 });
+      }
+      if (url.includes("/api/v1/skills/vercel-labs/skills/find-skills")) {
+        return new Response(
+          JSON.stringify({
+            id: "vercel-labs/skills/find-skills",
+            source: "vercel-labs/skills",
+            slug: "find-skills",
+            installs: 42,
+            hash: "a".repeat(64),
+            files: [{ path: "SKILL.md", contents: "# Find Skills" }],
+          }),
+        );
+      }
+      return new Response("unexpected request", { status: 500 });
+    });
+
+    const batch = await fetchSkillsShMirrorBatch(
+      { page: 0, offset: 0, limit: 2, maxDetailBytes: 64 },
+      {
+        oidcToken: "request-bound-oidc",
+        fetchImpl: fetchImpl as typeof fetch,
+        githubLocatorResolver: null,
+      },
+    );
+
+    expect(batch.rows).toEqual([
+      {
+        quarantined: true,
+        externalId: "owner/repo/removed-skill",
+        upstreamSourceType: "github",
+        reason: "detail-http-404",
+      },
+      expect.objectContaining({
+        externalId: "vercel-labs/skills/find-skills",
+        sourceType: "github",
+        sourceContentHash: "a".repeat(64),
+      }),
+    ]);
+  });
+
   it("cancels an oversized chunked identity page before buffering the full body", async () => {
     let canceled = false;
     let chunkIndex = 0;

--- a/server/skillsShCatalogSource.ts
+++ b/server/skillsShCatalogSource.ts
@@ -362,6 +362,7 @@ type HashQualifiedSkillsShCatalogDetail = SkillsShCatalogDetail & {
 };
 
 type SkillsShMirrorQuarantineReason =
+  | "detail-http-404"
   | "identity-page-content-type"
   | "identity-page-fetch-failed"
   | "identity-page-http-404"
@@ -799,15 +800,20 @@ export function buildSkillsShMirrorObservation(
 }
 
 function safeMirrorIdentityError(row: SkillsShCatalogListRow, error: unknown) {
-  const externalId = row.id.trim().toLowerCase().slice(0, 512) || "missing";
-  const upstreamSourceType = normalizeUpstreamSourceType(row.sourceType);
   const reason =
     error instanceof SkillsShMirrorIdentityError ? error.reason : "unsupported-identity";
+  return quarantinedMirrorRow(row, reason);
+}
+
+function quarantinedMirrorRow(row: SkillsShCatalogListRow, reason: SkillsShMirrorQuarantineReason) {
+  const externalId = row.id.trim().toLowerCase().slice(0, 512) || "missing";
+  const upstreamSourceType = normalizeUpstreamSourceType(row.sourceType);
   const source = row.source.trim().toLowerCase().slice(0, 256) || "missing";
   const installUrl = row.installUrl?.trim() || null;
   console.warn(
-    `Unsupported skills.sh mirror identity: ${externalId} ` +
-      `(sourceType=${upstreamSourceType}, source=${source}, ` +
+    `Quarantined skills.sh mirror row: ${externalId} ` +
+      `(reason=${reason}, ` +
+      `sourceType=${upstreamSourceType}, source=${source}, ` +
       `installUrlPresent=${installUrl !== null})`,
   );
   return {
@@ -2192,10 +2198,20 @@ export async function fetchSkillsShMirrorBatch(
           rows[index] = safeMirrorIdentityError(listRow, error);
           continue;
         }
-        const [detailResponse, auditResponse] = await Promise.all([
-          fetchSkillsShMirrorDetail(identity.row.externalId, fetchOptions),
-          fetchSkillsShMirrorAudit(identity.row.externalId, fetchOptions),
-        ]);
+        let detailResponse: Awaited<ReturnType<typeof fetchSkillsShMirrorDetail>>;
+        let auditResponse: Awaited<ReturnType<typeof fetchSkillsShMirrorAudit>>;
+        try {
+          [detailResponse, auditResponse] = await Promise.all([
+            fetchSkillsShMirrorDetail(identity.row.externalId, fetchOptions),
+            fetchSkillsShMirrorAudit(identity.row.externalId, fetchOptions),
+          ]);
+        } catch (error) {
+          if (error instanceof SkillsShSourceHttpError && error.status === 404) {
+            rows[index] = quarantinedMirrorRow(listRow, "detail-http-404");
+            continue;
+          }
+          throw error;
+        }
         rowSourceBytes += detailResponse.sourceBytes + (auditResponse?.sourceBytes ?? 0);
         const detailPayload = detailResponse.value;
         const auditPayload = auditResponse?.value ?? null;


### PR DESCRIPTION
## Summary

- quarantine a captured skills.sh row when its detail endpoint now returns 404
- continue processing healthy rows in the same mirror batch
- preserve systemic handling for auth, rate-limit, and upstream availability failures

## Tests

- `bunx vitest run server/skillsShCatalogSource.test.ts server/skillsShMirrorTestRoute.test.ts scripts/skills-sh-catalog/sync.test.ts`
- `bun run ci:static`
- `bun run ci:unit`
- `bun run ci:types-build`
- `bun run ci:packages`
- `bun run ci:e2e-http`
- `.agents/skills/autoreview/scripts/autoreview --mode local --stream-engine-output`
