### PR TITLE
fix: resume skills.sh sync after transport timeouts

### DIFF
--- a/scripts/skills-sh-catalog/sync.test.ts
+++ b/scripts/skills-sh-catalog/sync.test.ts
@@ -201,6 +201,146 @@ describe("skills.sh synchronization runner", () => {
     ]);
   });
 
+  it("retries the exact durable cursor after a rate-limit backoff and ambiguous timeout", async () => {
+    const requests: string[] = [];
+    const sleep = vi.fn(async () => undefined);
+    let stepAttempts = 0;
+    const running = {
+      runId: "run-leaderboard",
+      snapshotId: "skills-sh:leaderboard:durable",
+      sourceView: "leaderboard",
+      sourceTotal: 1,
+      sourcePageSize: 500,
+      sourceMeasuredAt: "2026-07-30T06:00:00.000Z",
+      page: 9,
+      offset: 50,
+      status: "running",
+      startedAt: 1,
+    };
+    const fetchImpl = vi.fn(async (_url: string, init: RequestInit) => {
+      const body = JSON.parse(String(init.body)) as Record<string, unknown>;
+      requests.push(
+        `${String(body.operation)}${body.page === undefined ? "" : `:${body.page}:${body.offset}`}`,
+      );
+      switch (body.operation) {
+        case "status":
+          return response({ runs: [] });
+        case "configure":
+          return response({ ok: true, enabled: body.enabled });
+        case "start":
+          return response(running);
+        case "step":
+          stepAttempts += 1;
+          if (stepAttempts === 1) {
+            return new Response(JSON.stringify({ error: "rate_limited" }), {
+              status: 429,
+              headers: { "retry-after": "1" },
+            });
+          }
+          if (stepAttempts === 2) {
+            throw new DOMException("The operation timed out.", "TimeoutError");
+          }
+          return response(completedRun("leaderboard"));
+        case "run":
+          return response(running);
+        case "start-trending":
+          return response(completedRun("trending"));
+        case "verify-activate":
+          return response({ ok: true, activated: true });
+        default:
+          throw new Error(`unexpected operation ${String(body.operation)}`);
+      }
+    });
+
+    await expect(
+      runSkillsShSync({
+        targetUrl: "https://clawhub.ai/ops/skills-sh/mirror",
+        authorization: "github-oidc",
+        reason: "scheduled recovery",
+        fetchImpl,
+        sleep,
+      }),
+    ).resolves.toMatchObject({
+      ok: true,
+      leaderboard: {
+        runId: "run-leaderboard",
+        syncProof: { rateLimitRetries: 1, transportTimeouts: 1 },
+      },
+      scansPlanned: 0,
+      scansAdmitted: 0,
+    });
+    expect(sleep).toHaveBeenCalledExactlyOnceWith(1_000);
+    expect(requests).toEqual([
+      "status",
+      "configure",
+      "start",
+      "step:9:50",
+      "step:9:50",
+      "run",
+      "step:9:50",
+      "start-trending",
+      "verify-activate",
+      "configure",
+      "status",
+    ]);
+  });
+
+  it("continues from the authoritative cursor when a timed-out step already committed", async () => {
+    const stepCursors: string[] = [];
+    const running = {
+      runId: "run-leaderboard",
+      snapshotId: "skills-sh:leaderboard:durable",
+      sourceView: "leaderboard",
+      sourceTotal: 1,
+      sourcePageSize: 500,
+      sourceMeasuredAt: "2026-07-30T06:00:00.000Z",
+      page: 9,
+      offset: 50,
+      status: "running",
+      startedAt: 1,
+    };
+    const fetchImpl = vi.fn(async (_url: string, init: RequestInit) => {
+      const body = JSON.parse(String(init.body)) as Record<string, unknown>;
+      switch (body.operation) {
+        case "status":
+          return response({ runs: [] });
+        case "configure":
+          return response({ ok: true, enabled: body.enabled });
+        case "start":
+          return response(running);
+        case "step":
+          stepCursors.push(`${body.page}:${body.offset}`);
+          if (body.offset === 50) {
+            throw new DOMException("The operation timed out.", "TimeoutError");
+          }
+          return response(completedRun("leaderboard"));
+        case "run":
+          return response({ ...running, offset: 100 });
+        case "start-trending":
+          return response(completedRun("trending"));
+        case "verify-activate":
+          return response({ ok: true, activated: true });
+        default:
+          throw new Error(`unexpected operation ${String(body.operation)}`);
+      }
+    });
+
+    await expect(
+      runSkillsShSync({
+        targetUrl: "https://clawhub.ai/ops/skills-sh/mirror",
+        authorization: "github-oidc",
+        reason: "scheduled recovery",
+        fetchImpl,
+      }),
+    ).resolves.toMatchObject({
+      ok: true,
+      leaderboard: { syncProof: { steps: 2, transportTimeouts: 1 } },
+      scansPlanned: 0,
+      scansAdmitted: 0,
+    });
+    expect(stepCursors).toEqual(["9:50", "9:100"]);
+  });
+
   it("closes only the skills.sh lane when a systemic invariant fails", async () => {
     const operations: string[] = [];
     const fetchImpl = vi.fn(async (_url: string, init: RequestInit) => {

--- a/scripts/skills-sh-catalog/sync.ts
+++ b/scripts/skills-sh-catalog/sync.ts
@@ -13,6 +13,7 @@ import {
 const MAX_STEPS = 2_000;
 const MAX_RATE_LIMIT_RETRIES = 30;
 const MAX_RATE_LIMIT_WAIT_MS = 30 * 60 * 1_000;
+const MAX_TRANSPORT_TIMEOUTS = 3;
 
 type MirrorRun = Record<string, unknown>;
 type SyncFetch = (input: string, init: RequestInit) => Promise<Response>;
@@ -21,6 +22,12 @@ type SyncAuthorization = string | (() => Promise<string>);
 const OIDC_REFRESH_SKEW_MS = 2 * 60_000;
 
 class UnsafeSkillsShCorpusError extends Error {}
+
+function isTransportTimeout(error: unknown) {
+  return (
+    typeof error === "object" && error !== null && "name" in error && error.name === "TimeoutError"
+  );
+}
 
 function requireEnv(name: string) {
   const value = process.env[name]?.trim();
@@ -168,6 +175,7 @@ export async function runSkillsShSync(options: {
     let steps = 0;
     let rateLimitRetries = 0;
     let rateLimitWaitMs = 0;
+    let transportTimeouts = 0;
     if (run.status === "paused") {
       run = mirrorRunFromPayload(
         await call({
@@ -187,7 +195,36 @@ export async function runSkillsShSync(options: {
         page: requiredInteger(run.page, "page"),
         offset: requiredInteger(run.offset, "offset"),
       };
-      const result = await callRaw(request);
+      let result: Awaited<ReturnType<typeof callRaw>>;
+      try {
+        result = await callRaw(request);
+      } catch (error) {
+        if (!isTransportTimeout(error)) throw error;
+        transportTimeouts += 1;
+        const authoritativeRun = mirrorRunFromPayload(
+          await call({ operation: "run", runId: request.runId }),
+          "run",
+        );
+        if (
+          requiredString(authoritativeRun.runId, "runId") !== request.runId ||
+          (authoritativeRun.sourceView ?? "leaderboard") !== sourceView
+        ) {
+          throw new Error(`timed-out ${request.operation} reconciled to a different durable run`);
+        }
+        run = authoritativeRun;
+        const cursorAdvanced = run.page !== request.page || run.offset !== request.offset;
+        if (cursorAdvanced) steps += 1;
+        if (
+          transportTimeouts >= MAX_TRANSPORT_TIMEOUTS &&
+          run.status === "running" &&
+          !cursorAdvanced
+        ) {
+          throw new Error(
+            `${request.operation} timed out ${transportTimeouts} times at durable cursor ${request.page}:${request.offset}`,
+          );
+        }
+        continue;
+      }
       if (!result.response.ok) {
         const delayMs = mirrorRateLimitRetryDelayMs(
           result.response.status,
@@ -222,6 +259,7 @@ export async function runSkillsShSync(options: {
         reconciliationBatches: reconciled.reconciliationBatches,
         rateLimitRetries,
         rateLimitWaitMs,
+        transportTimeouts,
       },
     };
   };


### PR DESCRIPTION
## Summary

- reconcile ambiguous sync `TimeoutError` outcomes against the exact durable mirror run
- retry an unchanged `(page, offset)` cursor without replacing the run, or continue from an already-committed cursor
- bound unchanged transport retries and count committed timeout recoveries toward the existing step limit

## Validation

- `bunx vitest run scripts/skills-sh-catalog/sync.test.ts scripts/skills-sh-catalog/prove-mirror-request.test.ts server/skillsShMirrorTestRoute.test.ts`
- `bun run ci:static`
- `VITE_CONVEX_URL=https://example.invalid bun run ci:unit`
- `bun run ci:types-build`
- `bun run ci:packages`
- `bun run ci:e2e-http`
- autoreview clean after one accepted step-budget finding

Production and permanent-Test data were not mutated by this fix.
