### PR TITLE
fix: guard kitchen sink latest repair

### DIFF
--- a/.github/workflows/repair-kitchen-sink-latest.yml
+++ b/.github/workflows/repair-kitchen-sink-latest.yml
@@ -1,0 +1,142 @@
+name: Repair Kitchen Sink Latest Pointer
+
+on:
+  workflow_dispatch:
+    inputs:
+      expected_sha:
+        description: "Exact main SHA containing the repair mutation"
+        required: true
+        type: string
+      apply:
+        description: "Apply the repair after the dry-run"
+        required: true
+        default: false
+        type: boolean
+      confirm:
+        description: "Required confirmation token when apply is true"
+        required: false
+        type: string
+
+concurrency:
+  group: repair-kitchen-sink-latest
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  repair:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment:
+      name: Production
+      url: https://clawhub.ai/packages/%40openclaw%2Fkitchen-sink
+    steps:
+      - name: Require exact main revision
+        env:
+          EXPECTED_SHA: ${{ inputs.expected_sha }}
+        run: |
+          set -euo pipefail
+          if [[ "$GITHUB_REF" != "refs/heads/main" ]]; then
+            echo "::error::The repair must run from main."
+            exit 1
+          fi
+          if [[ "$GITHUB_SHA" != "$EXPECTED_SHA" ]]; then
+            echo "::error::Main moved: expected $EXPECTED_SHA, got $GITHUB_SHA."
+            exit 1
+          fi
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+        with:
+          bun-version: 1.3.10
+
+      - name: Install
+        run: bun install --frozen-lockfile
+
+      - name: Dry-run repair
+        id: preflight
+        env:
+          CONVEX_DEPLOY_KEY: ${{ secrets.CONVEX_DEPLOY_KEY }}
+        run: |
+          set -euo pipefail
+          if [[ -z "$CONVEX_DEPLOY_KEY" ]]; then
+            echo "::error::Missing Production environment secret CONVEX_DEPLOY_KEY"
+            exit 1
+          fi
+          result="$(bunx convex run maintenance:repairPackageLatestPointer \
+            '{"name":"@openclaw/kitchen-sink"}' --prod)"
+          if jq -e '
+            .dryRun == true and
+            .previousLatestVersion == "0.2.11" and
+            .selectedVersion == "0.2.12" and
+            .eligibleReleaseCount >= 2
+          ' <<< "$result" >/dev/null; then
+            {
+              echo "already_repaired=false"
+              echo "plan_token=$(jq -r '.planToken' <<< "$result")"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if jq -e '
+            .dryRun == true and
+            .previousLatestVersion == "0.2.12" and
+            .selectedVersion == "0.2.12" and
+            (.releaseTagChanges | length) == 0
+          ' <<< "$result" >/dev/null; then
+            echo "already_repaired=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "::error::Production package state did not match the expected pre- or post-repair state."
+          exit 1
+
+      - name: Require apply confirmation
+        if: inputs.apply
+        env:
+          CONFIRM: ${{ inputs.confirm }}
+        run: |
+          set -euo pipefail
+          if [[ "$CONFIRM" != "repair-package-latest-pointer-2026-07-30" ]]; then
+            echo "::error::The exact repair confirmation token is required."
+            exit 1
+          fi
+
+      - name: Apply repair
+        if: inputs.apply && steps.preflight.outputs.already_repaired != 'true'
+        env:
+          CONVEX_DEPLOY_KEY: ${{ secrets.CONVEX_DEPLOY_KEY }}
+          EXPECTED_PLAN_TOKEN: ${{ steps.preflight.outputs.plan_token }}
+        run: |
+          set -euo pipefail
+          required_confirm="repair-package-latest-pointer-2026-07-30"
+          args="$(jq -nc \
+            --arg name "@openclaw/kitchen-sink" \
+            --arg confirm "$required_confirm" \
+            --arg planToken "$EXPECTED_PLAN_TOKEN" \
+            '{
+              name: $name,
+              dryRun: false,
+              confirm: $confirm,
+              expectedPlanToken: $planToken
+            }')"
+          result="$(bunx convex run maintenance:repairPackageLatestPointer "$args" --prod)"
+          jq -e '
+            .dryRun == false and
+            .selectedVersion == "0.2.12"
+          ' <<< "$result"
+
+      - name: Verify repaired state
+        if: inputs.apply
+        env:
+          CONVEX_DEPLOY_KEY: ${{ secrets.CONVEX_DEPLOY_KEY }}
+        run: |
+          set -euo pipefail
+          readback="$(bunx convex run maintenance:repairPackageLatestPointer \
+            '{"name":"@openclaw/kitchen-sink"}' --prod)"
+          jq -e '
+            .dryRun == true and
+            .previousLatestVersion == "0.2.12" and
+            .selectedVersion == "0.2.12" and
+            (.releaseTagChanges | length) == 0
+          ' <<< "$readback"

--- a/convex/maintenance.test.ts
+++ b/convex/maintenance.test.ts
@@ -2104,6 +2104,7 @@ describe("maintenance package latest pointer repair", () => {
       previousLatestVersion: "0.2.11",
       selectedVersion: "0.2.12",
       eligibleReleaseCount: 2,
+      planToken: expect.stringMatching(/^[a-f\d]{64}$/),
       releaseTagChanges: [
         {
           releaseId: "packageReleases:old",
@@ -2134,13 +2135,34 @@ describe("maintenance package latest pointer repair", () => {
     expect(fixture.patch).not.toHaveBeenCalled();
   });
 
+  it("requires the applied repair to match the dry-run plan", async () => {
+    const fixture = makePackageLatestPointerRepairDb();
+
+    await expect(
+      repairPackageLatestPointerHandler(fixture as never, {
+        name: "@openclaw/kitchen-sink",
+        dryRun: false,
+        confirm: "repair-package-latest-pointer-2026-07-30",
+        expectedPlanToken: "wrong",
+      }),
+    ).rejects.toThrow(
+      "Package latest repair plan changed after dry-run; rerun the dry-run before applying.",
+    );
+    expect(fixture.patch).not.toHaveBeenCalled();
+    expect(fixture.insert).not.toHaveBeenCalled();
+  });
+
   it("repoints the package, normalizes release tags, and audits the repair", async () => {
     const fixture = makePackageLatestPointerRepairDb();
+    const preflight = await repairPackageLatestPointerHandler(fixture as never, {
+      name: "@openclaw/kitchen-sink",
+    });
 
     const result = await repairPackageLatestPointerHandler(fixture as never, {
       name: "@openclaw/kitchen-sink",
       dryRun: false,
       confirm: "repair-package-latest-pointer-2026-07-30",
+      expectedPlanToken: preflight.planToken,
     });
 
     expect(result.selectedVersion).toBe("0.2.12");

--- a/convex/maintenance.ts
+++ b/convex/maintenance.ts
@@ -11,6 +11,7 @@ import {
   syncPackageSearchDigestForPackageId,
 } from "./functions";
 import { assertRole, requireUserFromAction } from "./lib/access";
+import { sha256Hex } from "./lib/clawpack";
 import { summarizePackageReleaseArtifact } from "./lib/packageArtifacts";
 import { normalizePackageName } from "./lib/packageRegistry";
 import { extractPackageDigestFields } from "./lib/packageSearchDigest";
@@ -3304,12 +3305,35 @@ function comparePackageLatestCandidates(
   return a._id.localeCompare(b._id);
 }
 
+async function buildPackageLatestPointerPlanToken(params: {
+  pkg: Doc<"packages">;
+  releases: Doc<"packageReleases">[];
+  selectedRelease: Doc<"packageReleases">;
+  releaseTagChanges: Array<{
+    releaseId: Id<"packageReleases">;
+    version: string;
+    action: "add" | "remove";
+  }>;
+}) {
+  const payload = JSON.stringify({
+    packageLatestReleaseId: params.pkg.latestReleaseId ?? null,
+    packageTags: params.pkg.tags,
+    selectedRelease: params.selectedRelease,
+    releaseTags: params.releases
+      .map((release) => ({ releaseId: release._id, distTags: release.distTags }))
+      .sort((a, b) => a.releaseId.localeCompare(b.releaseId)),
+    releaseTagChanges: params.releaseTagChanges,
+  });
+  return await sha256Hex(new TextEncoder().encode(payload));
+}
+
 export async function repairPackageLatestPointerHandler(
   ctx: Pick<MutationCtx, "db">,
   args: {
     name: string;
     dryRun?: boolean;
     confirm?: string;
+    expectedPlanToken?: string;
   },
 ) {
   const dryRun = args.dryRun !== false;
@@ -3356,6 +3380,12 @@ export async function repairPackageLatestPointerHandler(
   const previousLatestRelease = pkg.latestReleaseId
     ? (releases.find((release) => release._id === pkg.latestReleaseId) ?? null)
     : null;
+  const planToken = await buildPackageLatestPointerPlanToken({
+    pkg,
+    releases,
+    selectedRelease,
+    releaseTagChanges,
+  });
 
   const result = {
     dryRun,
@@ -3371,8 +3401,14 @@ export async function repairPackageLatestPointerHandler(
     selectedReleaseId: selectedRelease._id,
     selectedVersion: selectedRelease.version,
     releaseTagChanges,
+    planToken,
   };
   if (dryRun) return result;
+  if (!args.expectedPlanToken || args.expectedPlanToken !== planToken) {
+    throw new ConvexError(
+      "Package latest repair plan changed after dry-run; rerun the dry-run before applying.",
+    );
+  }
 
   for (const change of releaseTagChanges) {
     const release = releases.find((candidate) => candidate._id === change.releaseId);
@@ -3435,6 +3471,7 @@ export const repairPackageLatestPointer = internalMutation({
     name: v.string(),
     dryRun: v.optional(v.boolean()),
     confirm: v.optional(v.string()),
+    expectedPlanToken: v.optional(v.string()),
   },
   handler: repairPackageLatestPointerHandler,
 });


### PR DESCRIPTION
## What Problem This Solves

Resolves the production closeout gap for `@openclaw/kitchen-sink`: the repair mutation is deployed, but local operator credentials are unavailable and the existing production workflows intentionally do not accept arbitrary maintenance commands.

## Why This Change Was Made

Adds a temporary fixed-purpose workflow for this package only and binds apply to the exact dry-run plan inside the Convex transaction. The workflow requires an exact `main` SHA, defaults to dry-run, requires the explicit repair confirmation token, supports safe retry after an ambiguous success, and verifies the repaired state.

## User Impact

Operators can repair the stale `latest` pointer without exposing a production deploy key or adding arbitrary production command execution. The workflow and one-off mutation will be removed immediately after live verification.

## Evidence

- `PATH=/opt/homebrew/opt/node@24/bin:$PATH bunx vitest run convex/maintenance.test.ts` - 38 passed
- `bunx tsc --noEmit --pretty false`
- `bun run ci:static`
- `actionlint .github/workflows/repair-kitchen-sink-latest.yml`
- autoreview clean after retry and concurrency findings were fixed

AI-assisted implementation; I reviewed the code and can maintain it.
