### PR TITLE
fix: verify skills.sh activation corpus safely

### DIFF
--- a/convex/skillsShMirrorVisibility.test.ts
+++ b/convex/skillsShMirrorVisibility.test.ts
@@ -132,7 +132,7 @@ describe("skills.sh mirror visibility operations", () => {
     expect(catalogControl).toBeNull();
   });
 
-  it("keeps the global lane closed when the eligible corpus does not match accepted rows", async () => {
+  it("keeps the global lane closed when an accepted row has no stored digest", async () => {
     const t = convexTest(schema, modules);
     await t.run(async (ctx) => {
       const leaderboardRunId = await ctx.db.insert(
@@ -175,7 +175,7 @@ describe("skills.sh mirror visibility operations", () => {
         reason: "CLAW-603 must remain hidden",
         confirm: "activate-skills-sh-public-test",
       }),
-    ).rejects.toThrow("eligible corpus count differs from accepted rows");
+    ).rejects.toThrow("stored corpus count differs from accepted rows");
   });
 
   it("verifies the complete imported corpus before opening the global lane", async () => {
@@ -188,20 +188,20 @@ describe("skills.sh mirror visibility operations", () => {
         sourceView: "leaderboard",
         sourceSnapshotHash: "a".repeat(64),
         status: "completed",
-        sourceTotal: 3,
+        sourceTotal: 4,
         sourcePageSize: 500,
         sourceMeasuredAt: new Date(now - 2_000).toISOString(),
         page: 1,
         offset: 0,
         counts: {
-          observed: 3,
-          inserted: 2,
+          observed: 4,
+          inserted: 3,
           updated: 0,
           unchanged: 0,
           rejected: 1,
           quarantined: 1,
           conflicts: 1,
-          detailsInserted: 2,
+          detailsInserted: 3,
           detailsUpdated: 0,
           detailsUnchanged: 0,
           detailsMissing: 0,
@@ -214,7 +214,7 @@ describe("skills.sh mirror visibility operations", () => {
         operations: {
           functionCalls: 1,
           dbReads: 2,
-          dbWrites: 2,
+          dbWrites: 3,
           sourceRequests: 2,
           sourceBytes: 100,
         },
@@ -285,6 +285,24 @@ describe("skills.sh mirror visibility operations", () => {
       await ctx.db.insert(
         "skillsShMirrorDigests",
         digest({
+          externalId: "patrick/skills/ineligible",
+          slug: "ineligible",
+          normalizedSlug: "ineligible",
+          normalizedSlugFirstToken: "ineligible",
+          displayName: "Ineligible",
+          normalizedDisplayName: "ineligible",
+          normalizedDisplayNameFirstToken: "ineligible",
+          searchText: "ineligible",
+          sourceUrl: "https://skills.sh/patrick/skills/ineligible",
+          githubPath: undefined,
+          githubCommit: undefined,
+          sourceContentHash: undefined,
+          lastObservedRunId: leaderboardRunId,
+        }),
+      );
+      await ctx.db.insert(
+        "skillsShMirrorDigests",
+        digest({
           externalId: "patrick/skills/failed-claim",
           slug: "failed-claim",
           normalizedSlug: "failed-claim",
@@ -347,10 +365,12 @@ describe("skills.sh mirror visibility operations", () => {
       ok: true,
       environment: "test",
       activated: true,
-      leaderboard: { sourceTotal: 3, accepted: 2, rejected: 1 },
+      leaderboard: { sourceTotal: 4, accepted: 3, rejected: 1 },
       trending: { sourceTotal: 1, joined: 1, missing: 0 },
       corpus: {
-        total: 2,
+        total: 3,
+        sourceEligible: 2,
+        activationRunAccepted: 3,
         eligible: 1,
         claimExcluded: 1,
         eligiblePublished: 1,

--- a/convex/skillsShMirrorVisibility.ts
+++ b/convex/skillsShMirrorVisibility.ts
@@ -532,7 +532,11 @@ export const finalizeActivationInternal = internalMutation({
 });
 
 export const getAuditPageInternal = internalQuery({
-  args: { paginationOpts: paginationOptsValidator },
+  args: {
+    paginationOpts: paginationOptsValidator,
+    leaderboardRunId: v.optional(v.id("skillsShMirrorRuns")),
+    trendingRunId: v.optional(v.id("skillsShMirrorRuns")),
+  },
   handler: async (ctx, args) => {
     if (args.paginationOpts.numItems < 1 || args.paginationOpts.numItems > MAX_BATCH_SIZE) {
       throw new Error(`audit batch size must be between 1 and ${MAX_BATCH_SIZE}`);
@@ -555,6 +559,7 @@ export const getAuditPageInternal = internalQuery({
       unsafePublished: 0,
       stale: 0,
       tombstoned: 0,
+      activationRunAccepted: 0,
     };
     for (const digest of page.page) {
       const sourceEligible = isSkillsShMirrorSourceEligible(digest);
@@ -574,12 +579,28 @@ export const getAuditPageInternal = internalQuery({
       if (!eligible && (digest.publicVisible || digest.installable)) counts.unsafePublished += 1;
       if (digest.sourceFreshnessStatus === "stale") counts.stale += 1;
       if (digest.tombstonedAt !== undefined) counts.tombstoned += 1;
+      // beginActivation selects the latest completed runs and its lock makes
+      // startRunInternal reject new imports, so this provenance is stable for the audit.
+      if (
+        ((args.leaderboardRunId !== undefined &&
+          digest.lastObservedRunId === args.leaderboardRunId) ||
+          (args.trendingRunId !== undefined && digest.lastObservedRunId === args.trendingRunId)) &&
+        digest.sourceFreshnessStatus === "observed-only"
+      ) {
+        counts.activationRunAccepted += 1;
+      }
     }
     return { ...page, page: counts };
   },
 });
 
-async function audit(ctx: Pick<ActionCtx, "runQuery">) {
+async function audit(
+  ctx: Pick<ActionCtx, "runQuery">,
+  activationRuns?: {
+    leaderboardRunId: Doc<"skillsShMirrorRuns">["_id"];
+    trendingRunId: Doc<"skillsShMirrorRuns">["_id"];
+  },
+) {
   let cursor: string | null = null;
   let batches = 0;
   const counts = {
@@ -596,10 +617,12 @@ async function audit(ctx: Pick<ActionCtx, "runQuery">) {
     unsafePublished: 0,
     stale: 0,
     tombstoned: 0,
+    activationRunAccepted: 0,
   };
   while (true) {
     const result = (await ctx.runQuery(internal.skillsShMirrorVisibility.getAuditPageInternal, {
       paginationOpts: { cursor, numItems: MAX_BATCH_SIZE },
+      ...activationRuns,
     })) as {
       continueCursor: string;
       isDone: boolean;
@@ -657,12 +680,18 @@ export const verifyAndActivateInternal = internalAction({
         throw new Error("skills.sh stored conflict accounting differs from rejected rows");
       }
       await reconcileEligibility(ctx, args.confirm);
-      const corpusAudit = await audit(ctx);
+      const corpusAudit = await audit(ctx, {
+        leaderboardRunId: leaderboardRun._id,
+        trendingRunId: trendingRun._id,
+      });
+      if (corpusAudit.counts.activationRunAccepted !== leaderboard.accepted + trending.hydrated) {
+        throw new Error("skills.sh stored corpus count differs from accepted rows");
+      }
       if (
-        corpusAudit.counts.eligible + corpusAudit.counts.claimExcluded !==
-        leaderboard.accepted + trending.hydrated
+        corpusAudit.counts.sourceEligible !==
+        corpusAudit.counts.eligible + corpusAudit.counts.claimExcluded
       ) {
-        throw new Error("skills.sh eligible corpus count differs from accepted rows");
+        throw new Error("skills.sh eligible corpus partition is inconsistent");
       }
       if (
         corpusAudit.counts.hiddenEligible !== 0 ||


### PR DESCRIPTION
## Summary

- preserve fail-closed storage accounting for accepted leaderboard and hydrated Trending rows
- distinguish stored accepted observations from the exact-source-eligible publication subset
- keep ineligible observations hidden while verifying the eligible/claim partition before atomic activation

## Test plan

- `bunx vitest run convex/skillsShMirrorVisibility.test.ts`
- autoreview (clean)
- `bun run ci:static`
- `bun run ci:unit`
- `bun run ci:types-build`
- `bun run ci:packages`
- `bun run ci:e2e-http`
- `bunx tsc -p packages/schema/tsconfig.json --noEmit`
- `bunx tsc -p packages/clawhub/tsconfig.json --noEmit`
- `bunx convex codegen`
