### PR TITLE
fix: verify publishable skills.sh Trending count

### DIFF
--- a/convex/skillsShMirrorVisibility.test.ts
+++ b/convex/skillsShMirrorVisibility.test.ts
@@ -178,7 +178,7 @@ describe("skills.sh mirror visibility operations", () => {
     ).rejects.toThrow("stored corpus count differs from accepted rows");
   });
 
-  it("verifies the complete imported corpus before opening the global lane", async () => {
+  it("verifies the imported corpus and only publishable Trending joins before opening", async () => {
     const t = convexTest(schema, modules);
     const now = Date.now();
     const window = getCompletedRolling24HourWindow(now);
@@ -229,13 +229,13 @@ describe("skills.sh mirror visibility operations", () => {
         sourceView: "trending",
         sourceSnapshotHash: "b".repeat(64),
         status: "completed",
-        sourceTotal: 1,
+        sourceTotal: 2,
         sourcePageSize: 500,
         sourceMeasuredAt: new Date(now - 1_000).toISOString(),
         page: 1,
         offset: 0,
         counts: {
-          observed: 1,
+          observed: 2,
           inserted: 0,
           updated: 0,
           unchanged: 0,
@@ -248,9 +248,9 @@ describe("skills.sh mirror visibility operations", () => {
           detailsTruncated: 0,
           tombstoned: 0,
           reactivated: 0,
-          trendingJoined: 1,
+          trendingJoined: 2,
           trendingUpdated: 0,
-          trendingUnchanged: 1,
+          trendingUnchanged: 2,
           trendingMissing: 0,
           trendingStaleRejected: 0,
           trendingHydrationAttempts: 0,
@@ -298,6 +298,10 @@ describe("skills.sh mirror visibility operations", () => {
           githubCommit: undefined,
           sourceContentHash: undefined,
           lastObservedRunId: leaderboardRunId,
+          trendingObservedRunId: trendingRunId,
+          trendingRank: 2,
+          trendingLifetimeInstalls: 8,
+          trendingObservedAt: now - 1_000,
         }),
       );
       await ctx.db.insert(
@@ -366,11 +370,12 @@ describe("skills.sh mirror visibility operations", () => {
       environment: "test",
       activated: true,
       leaderboard: { sourceTotal: 4, accepted: 3, rejected: 1 },
-      trending: { sourceTotal: 1, joined: 1, missing: 0 },
+      trending: { sourceTotal: 2, joined: 2, missing: 0 },
       corpus: {
         total: 3,
         sourceEligible: 2,
         activationRunAccepted: 3,
+        activationRunTrendingEligible: 1,
         eligible: 1,
         claimExcluded: 1,
         eligiblePublished: 1,

--- a/convex/skillsShMirrorVisibility.ts
+++ b/convex/skillsShMirrorVisibility.ts
@@ -560,6 +560,7 @@ export const getAuditPageInternal = internalQuery({
       stale: 0,
       tombstoned: 0,
       activationRunAccepted: 0,
+      activationRunTrendingEligible: 0,
     };
     for (const digest of page.page) {
       const sourceEligible = isSkillsShMirrorSourceEligible(digest);
@@ -588,6 +589,16 @@ export const getAuditPageInternal = internalQuery({
         digest.sourceFreshnessStatus === "observed-only"
       ) {
         counts.activationRunAccepted += 1;
+      }
+      if (
+        args.trendingRunId !== undefined &&
+        digest.trendingObservedRunId === args.trendingRunId &&
+        publicationFlags.publicVisible &&
+        publicationFlags.installable &&
+        Number.isSafeInteger(digest.trendingRank) &&
+        (digest.trendingRank ?? 0) >= 1
+      ) {
+        counts.activationRunTrendingEligible += 1;
       }
     }
     return { ...page, page: counts };
@@ -618,6 +629,7 @@ async function audit(
     stale: 0,
     tombstoned: 0,
     activationRunAccepted: 0,
+    activationRunTrendingEligible: 0,
   };
   while (true) {
     const result = (await ctx.runQuery(internal.skillsShMirrorVisibility.getAuditPageInternal, {
@@ -710,7 +722,8 @@ export const verifyAndActivateInternal = internalAction({
       };
       if (
         trendingSnapshot.status !== "ready" ||
-        trendingSnapshot.sourceCounts.skillsShTrending !== trending.joined
+        trendingSnapshot.sourceCounts.skillsShTrending !==
+          corpusAudit.counts.activationRunTrendingEligible
       ) {
         throw new Error("skills.sh Trending activation snapshot failed source verification");
       }


### PR DESCRIPTION
## Summary

- keep raw skills.sh Trending joined/missing source accounting unchanged
- count exact-run Trending rows that pass the settled publication predicate and rank validation during the bounded activation audit
- verify canonical Trending materialization against that publishable candidate count
- cover a joined-but-ineligible row in the atomic activation regression

## Tests

- `bunx vitest run convex/skillsShMirrorVisibility.test.ts convex/canonicalTrending.test.ts`
- `bun run ci:static`
- `bun run ci:unit`
- `bun run ci:types-build`
- `.agents/skills/autoreview/scripts/autoreview --mode local --stream-engine-output` (clean)
