### PR TITLE
fix: polish plugin detail metadata

### DIFF
--- a/src/__tests__/package-detail-route.test.tsx
+++ b/src/__tests__/package-detail-route.test.tsx
@@ -2017,7 +2017,8 @@ describe("plugin detail route", () => {
     expect(within(validationRegion).getByText("Target")).toBeTruthy();
     expect(within(validationRegion).getByText("OpenClaw 0.9.0")).toBeTruthy();
     expect(screen.getByText(/Legacy before_agent_start hook is deprecated\./)).toBeTruthy();
-    expect(screen.getByText(/Hey, we found/)).toBeTruthy();
+    expect(screen.getByText(/We found/)).toBeTruthy();
+    expect(screen.queryByText(/Hey,/)).toBeNull();
     expect(screen.getByText("1 issue")).toBeTruthy();
     expect(
       within(screen.getByRole("region", { name: "Validation" })).getByText("demo-plugin"),

--- a/src/routes/plugins/$name.tsx
+++ b/src/routes/plugins/$name.tsx
@@ -737,9 +737,8 @@ function ValidationSummaryHint({
 
   return (
     <>
-      Hey, we found <strong>{issueLabel}</strong> with {versionLabel} of{" "}
-      <strong>{packageName}</strong>. Review the findings below, apply the fix, and upload a new
-      version.
+      We found <strong>{issueLabel}</strong> with {versionLabel} of <strong>{packageName}</strong>.
+      Review the findings below, apply the fix, and upload a new version.
     </>
   );
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -7045,7 +7045,7 @@ code {
 .skill-hero-taxonomy-row {
   display: inline-flex;
   align-items: center;
-  gap: 10px;
+  gap: 16px;
   min-width: 0;
   color: color-mix(in srgb, var(--ink-soft) 76%, var(--bg));
   font-size: 12px;
@@ -7053,10 +7053,9 @@ code {
 }
 
 .skill-category-meta-list {
-  --skill-category-meta-gap: 6px;
   display: inline-flex;
   align-items: center;
-  gap: var(--skill-category-meta-gap);
+  gap: 16px;
   min-width: 0;
   color: color-mix(in srgb, var(--ink-soft) 76%, var(--bg));
 }
@@ -7064,7 +7063,7 @@ code {
 .skill-category-meta-link {
   display: inline-flex;
   align-items: center;
-  gap: var(--skill-category-meta-gap);
+  gap: 6px;
   min-width: 0;
   color: color-mix(in srgb, var(--ink-soft) 76%, var(--bg));
   font-size: 12px;
@@ -7112,6 +7111,22 @@ code {
 .skill-hero-topic:focus-visible {
   color: var(--ink);
   text-decoration: none;
+}
+
+@media (max-width: 600px) {
+  .skill-hero-taxonomy-row {
+    display: flex;
+    flex-wrap: wrap;
+    row-gap: 10px;
+  }
+
+  .skill-hero-taxonomy-separator {
+    display: none;
+  }
+
+  .skill-hero-topic-list {
+    flex-basis: 100%;
+  }
 }
 
 .skill-settings-link {


### PR DESCRIPTION
## Summary

- give each detail-header category its own 16px item spacing while preserving the compact 6px icon-to-label gap
- increase the final category-to-divider spacing and wrap taxonomy metadata cleanly on narrow screens
- remove the conversational `Hey,` prefix from plugin validation summaries

## Validation

- `bun run ci:static`
- `VITE_CONVEX_URL=https://example.invalid bunx vitest run src/__tests__/package-detail-route.test.tsx` (44 passed)
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --parallel-tests 'bun run ci:unit && bun run ci:types-build' --stream-engine-output` (clean review; full unit and type/build gates passed)
- Codex app browser at `http://localhost:3010/honcho-ai/plugins/openclaw-honcho` (desktop category/divider gaps measured at 16px; 390px viewport wraps without horizontal overflow)

## UI proof

Before/after evidence will be published in the ClawHub UI Proof comment immediately after PR creation.
