### PR TITLE
fix: order skills before plugins on homepage

### DIFF
--- a/src/__tests__/home-listing-section.claw591.test.tsx
+++ b/src/__tests__/home-listing-section.claw591.test.tsx
@@ -83,6 +83,13 @@ describe("HomeListingSection", () => {
     const second = makeTrending("second", "Second Skill", 3, 8000);
     render(<HomeListingSection initialListing={initialTrending([first, second])} />);
 
+    const contentTypeButtons = screen
+      .getByRole("group", { name: "Content type" })
+      .querySelectorAll("button");
+    expect(Array.from(contentTypeButtons, (button) => button.textContent)).toEqual([
+      "Skills",
+      "Plugins",
+    ]);
     expect(screen.getByRole("button", { name: "Skills" }).getAttribute("aria-pressed")).toBe(
       "true",
     );

--- a/src/__tests__/home-listing-section.test.tsx
+++ b/src/__tests__/home-listing-section.test.tsx
@@ -144,8 +144,8 @@ describe("HomeListingSection", () => {
       .getByRole("group", { name: "Content type" })
       .querySelectorAll("button");
     expect(Array.from(contentTypeButtons, (button) => button.textContent)).toEqual([
-      "Plugins",
       "Skills",
+      "Plugins",
     ]);
     expect(screen.getByRole("button", { name: "Plugins" }).getAttribute("aria-pressed")).toBe(
       "true",

--- a/src/components/HomeListingSection.tsx
+++ b/src/components/HomeListingSection.tsx
@@ -796,22 +796,22 @@ export function HomeListingSection({ initialListing = null }: HomeListingSection
             <button
               type="button"
               className={`home-v2-listing-kind-btn clawhub-segmented-btn oc-segmented-item${
-                kind === "plugins" ? " is-active" : ""
-              }`}
-              aria-pressed={kind === "plugins"}
-              onClick={() => handleKindChange("plugins")}
-            >
-              Plugins
-            </button>
-            <button
-              type="button"
-              className={`home-v2-listing-kind-btn clawhub-segmented-btn oc-segmented-item${
                 kind === "skills" ? " is-active" : ""
               }`}
               aria-pressed={kind === "skills"}
               onClick={() => handleKindChange("skills")}
             >
               Skills
+            </button>
+            <button
+              type="button"
+              className={`home-v2-listing-kind-btn clawhub-segmented-btn oc-segmented-item${
+                kind === "plugins" ? " is-active" : ""
+              }`}
+              aria-pressed={kind === "plugins"}
+              onClick={() => handleKindChange("plugins")}
+            >
+              Plugins
             </button>
           </div>
 


### PR DESCRIPTION
## Summary

- order the homepage content-type tabs as Skills, then Plugins
- preserve Skills as the default selected tab and Trending as the default sort
- cover the order for both Skills-active and Plugins-active states

## Test plan

- `bun run test -- src/__tests__/home-listing-section.claw591.test.tsx src/__tests__/home-listing-section.test.tsx`
- `bun run ci:static`
- `bun run ci:types-build`
- `bun run ci:unit -- --maxWorkers=4`
- `.agents/skills/autoreview/scripts/autoreview --mode local --stream-engine-output`
- real-browser responsive proof at 390x844, 768x1024, 1366x768, and 1440x900

## Screenshots

Captured from the real local ClawHub instance at `http://localhost:3000/` using the linked local Convex development configuration. Screenshots will be attached in a follow-up comment.
