### PR TITLE
fix: hide unavailable Trending tabs

### DIFF
--- a/src/__tests__/home-listing-section.claw591.test.tsx
+++ b/src/__tests__/home-listing-section.claw591.test.tsx
@@ -98,9 +98,9 @@ describe("HomeListingSection", () => {
     );
     expect(screen.getAllByRole("tab").map((tab) => tab.textContent)).toEqual([
       "Trending",
-      "New",
       "Featured",
       "Official",
+      "New",
     ]);
     expect(screen.queryByRole("tab", { name: "Top" })).toBeNull();
     expect(screen.queryByRole("combobox", { name: "Category" })).toBeNull();
@@ -117,12 +117,46 @@ describe("HomeListingSection", () => {
     expect(screen.queryByText("skills.sh")).toBeNull();
   });
 
-  it("shows canonical Trending as unavailable without substituting legacy skills", () => {
+  it("hides unavailable Trending and falls back to the native New feed", async () => {
     render(<HomeListingSection initialListing={initialTrending([], false, "unavailable")} />);
 
-    expect(screen.getByText("24-hour Trending unavailable")).toBeTruthy();
-    expect(screen.getByText(/canonical 24-hour feed isn't available/i)).toBeTruthy();
-    expect(screen.queryByText("Quiet shelf")).toBeNull();
+    expect(screen.queryByRole("tab", { name: "Trending" })).toBeNull();
+    expect(screen.getAllByRole("tab").map((tab) => tab.textContent)).toEqual([
+      "Featured",
+      "Official",
+      "New",
+    ]);
+    expect(screen.getByRole("tab", { name: "New" }).getAttribute("aria-selected")).toBe("true");
+    expect(screen.queryByText("24-hour Trending unavailable")).toBeNull();
+    await waitFor(() =>
+      expect(convexQueryMock).toHaveBeenCalledWith(
+        "skills:listPublicPageV4",
+        expect.objectContaining({ sort: "newest", createdAfter: expect.any(Number) }),
+      ),
+    );
+  });
+
+  it("falls back when Trending becomes unavailable after mount", async () => {
+    fetchCatalogDiscoveryCapabilitiesMock.mockResolvedValue({
+      apiVersion: 1,
+      canonicalTrendingEnabled: false,
+    });
+
+    render(<HomeListingSection />);
+
+    await waitFor(() => expect(screen.queryByRole("tab", { name: "Trending" })).toBeNull());
+    expect(screen.getAllByRole("tab").map((tab) => tab.textContent)).toEqual([
+      "Featured",
+      "Official",
+      "New",
+    ]);
+    expect(screen.getByRole("tab", { name: "New" }).getAttribute("aria-selected")).toBe("true");
+    expect(screen.queryByText("24-hour Trending unavailable")).toBeNull();
+    expect(fetchCanonicalTrendingPageMock).not.toHaveBeenCalled();
+    expect(convexQueryMock).toHaveBeenCalledWith(
+      "skills:listPublicPageV4",
+      expect.objectContaining({ sort: "newest", createdAfter: expect.any(Number) }),
+    );
   });
 
   it("labels an empty canonical 24-hour window honestly", () => {
@@ -132,16 +166,16 @@ describe("HomeListingSection", () => {
     expect(screen.getByText(/eligible activity in the current 24-hour window/i)).toBeTruthy();
   });
 
-  it("shows New, Featured, and Official for plugins but never plugin Trending", async () => {
+  it("shows Featured, Official, and New for plugins but never plugin Trending", async () => {
     render(<HomeListingSection initialListing={initialTrending([])} />);
 
     fireEvent.click(screen.getByRole("button", { name: "Plugins" }));
 
     expect(screen.getByRole("tab", { name: "New" }).getAttribute("aria-selected")).toBe("true");
     expect(screen.getAllByRole("tab").map((tab) => tab.textContent)).toEqual([
-      "New",
       "Featured",
       "Official",
+      "New",
     ]);
     expect(screen.queryByRole("tab", { name: "Trending" })).toBeNull();
     expect(screen.queryByRole("tab", { name: "Top" })).toBeNull();

--- a/src/__tests__/home-listing-section.test.tsx
+++ b/src/__tests__/home-listing-section.test.tsx
@@ -157,9 +157,9 @@ describe("HomeListingSection", () => {
       "true",
     );
     expect(screen.getAllByRole("tab").map((tab) => tab.textContent)).toEqual([
-      "New",
       "Featured",
       "Official",
+      "New",
     ]);
     expect(screen.getByText("Demo Plugin")).toBeTruthy();
     expect(document.querySelector(".home-v2-listing-list")).toBeTruthy();

--- a/src/__tests__/skills-index.claw591.test.tsx
+++ b/src/__tests__/skills-index.claw591.test.tsx
@@ -1,5 +1,5 @@
 /* @vitest-environment jsdom */
-import { act, fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Route as SkillsRoute, SkillsIndex } from "../routes/skills/index";
@@ -103,7 +103,7 @@ describe("SkillsIndex", () => {
     expect(screen.getByRole("radio", { name: "Trending" }).getAttribute("aria-checked")).toBe(
       "true",
     );
-    expect(tabLabels()).toEqual(["Trending", "New", "Featured", "Official"]);
+    expect(tabLabels()).toEqual(["Trending", "Featured", "Official", "New"]);
     expect(screen.queryByRole("radio", { name: "Top" })).toBeNull();
     expect(screen.queryByRole("radio", { name: "All" })).toBeNull();
     expect(screen.queryByRole("combobox", { name: "Sort" })).toBeNull();
@@ -134,7 +134,7 @@ describe("SkillsIndex", () => {
     expect(screen.queryByText(/Not scanned by ClawHub/i)).toBeNull();
   });
 
-  it("shows Trending unavailable without reading the legacy leaderboard", async () => {
+  it("hides disabled Trending and falls back to the native New feed", async () => {
     fetchCatalogDiscoveryCapabilitiesMock.mockResolvedValue({
       apiVersion: 0,
       canonicalTrendingEnabled: false,
@@ -142,18 +142,24 @@ describe("SkillsIndex", () => {
 
     render(<SkillsIndex />);
 
-    expect(await screen.findByText("24-hour Trending unavailable")).toBeTruthy();
+    await waitFor(() => expect(screen.queryByRole("radio", { name: "Trending" })).toBeNull());
+    expect(tabLabels()).toEqual(["Featured", "Official", "New"]);
+    expect(screen.getByRole("radio", { name: "New" }).getAttribute("aria-checked")).toBe("true");
+    expect(screen.queryByText("24-hour Trending unavailable")).toBeNull();
     expect(fetchCanonicalTrendingPageMock).not.toHaveBeenCalled();
-    expect(convexHttpMock.query).not.toHaveBeenCalled();
+    expect(convexHttpMock.query).toHaveBeenCalled();
   });
 
-  it("shows stale canonical Trending as unavailable without a legacy retry", async () => {
+  it("hides stale Trending and falls back without a legacy retry", async () => {
     fetchCanonicalTrendingPageMock.mockRejectedValue(new Error("Trending snapshot expired"));
 
     render(<SkillsIndex />);
 
-    expect(await screen.findByText("24-hour Trending unavailable")).toBeTruthy();
-    expect(convexHttpMock.query).not.toHaveBeenCalled();
+    await waitFor(() => expect(screen.queryByRole("radio", { name: "Trending" })).toBeNull());
+    expect(tabLabels()).toEqual(["Featured", "Official", "New"]);
+    expect(screen.getByRole("radio", { name: "New" }).getAttribute("aria-checked")).toBe("true");
+    expect(screen.queryByText("24-hour Trending unavailable")).toBeNull();
+    expect(convexHttpMock.query).toHaveBeenCalled();
   });
 
   it("labels an empty canonical 24-hour window honestly", async () => {

--- a/src/__tests__/skills-index.test.tsx
+++ b/src/__tests__/skills-index.test.tsx
@@ -120,7 +120,7 @@ describe("SkillsIndex", () => {
     const tabs = Array.from(
       screen.getByRole("radiogroup", { name: "Skill view" }).querySelectorAll('[role="radio"]'),
     ).map((option) => option.textContent);
-    expect(tabs).toEqual(["Trending", "New", "Featured", "Official"]);
+    expect(tabs).toEqual(["Trending", "Featured", "Official", "New"]);
   });
 
   it("renders desktop category navigation and keeps the responsive category dropdown", async () => {
@@ -432,7 +432,7 @@ describe("SkillsIndex", () => {
     const tabs = Array.from(
       screen.getByRole("radiogroup", { name: "Skill view" }).querySelectorAll('[role="radio"]'),
     ).map((option) => option.textContent);
-    expect(tabs).toEqual(["Trending", "New", "Featured", "Official"]);
+    expect(tabs).toEqual(["Trending", "Featured", "Official", "New"]);
   });
 
   it("keeps the skills sort option list stable while typing a search", async () => {

--- a/src/components/HomeListingSection.tsx
+++ b/src/components/HomeListingSection.tsx
@@ -58,18 +58,18 @@ type ListingView = "list" | "grid";
 
 const SKILL_LISTING_TABS: Array<{ id: ListingTab; label: string }> = [
   { id: "trending", label: "Trending" },
-  { id: "new", label: "New" },
   { id: "featured", label: "Featured" },
   { id: "official", label: "Official" },
+  { id: "new", label: "New" },
 ];
 
 const PLUGIN_LISTING_TABS: Array<{
   id: Exclude<ListingTab, "trending">;
   label: string;
 }> = [
-  { id: "new", label: "New" },
   { id: "featured", label: "Featured" },
   { id: "official", label: "Official" },
+  { id: "new", label: "New" },
 ];
 
 const LISTING_PAGE_SIZE = HOME_LISTING_PAGE_SIZE;
@@ -469,7 +469,11 @@ export function HomeListingSection({ initialListing = null }: HomeListingSection
   const listingCache = listingCacheRef.current;
 
   const [kind, setKind] = useState<ListingKind>(initialListing?.kind ?? "skills");
-  const [tab, setTab] = useState<ListingTab>(initialListing?.tab ?? "trending");
+  const initialTab =
+    initialListing?.kind === "skills" && initialListing.trendingState === "unavailable"
+      ? "new"
+      : (initialListing?.tab ?? "trending");
+  const [tab, setTab] = useState<ListingTab>(initialTab);
   const [view, setView] = useState<ListingView>("list");
   const [categorySlugs, setCategorySlugs] = useState<string[]>([]);
   const [visibleCount, setVisibleCount] = useState(LISTING_PAGE_SIZE);
@@ -493,6 +497,9 @@ export function HomeListingSection({ initialListing = null }: HomeListingSection
   const [trendingState, setTrendingState] = useState<TrendingFeedState | undefined>(
     initialListing?.kind === "skills" ? initialListing.trendingState : undefined,
   );
+  const [canonicalTrendingUnavailable, setCanonicalTrendingUnavailable] = useState(
+    initialListing?.kind === "skills" && initialListing.trendingState === "unavailable",
+  );
 
   const trimmedSearch = searchQuery.trim();
   const isSearchMode = trimmedSearch.length > 0;
@@ -506,7 +513,12 @@ export function HomeListingSection({ initialListing = null }: HomeListingSection
     [categorySlugs, listingCategories],
   );
 
-  const visibleTabs = kind === "skills" ? SKILL_LISTING_TABS : PLUGIN_LISTING_TABS;
+  const visibleTabs =
+    kind === "skills"
+      ? SKILL_LISTING_TABS.filter(
+          (candidate) => candidate.id !== "trending" || !canonicalTrendingUnavailable,
+        )
+      : PLUGIN_LISTING_TABS;
 
   const activeItems = isSearchMode
     ? kind === "skills"
@@ -562,6 +574,11 @@ export function HomeListingSection({ initialListing = null }: HomeListingSection
       if (cached.kind === "skills") {
         setSkills(cached.items);
         setTrendingState(cached.trendingState);
+        if (tab === "trending") {
+          const unavailable = cached.trendingState === "unavailable";
+          setCanonicalTrendingUnavailable(unavailable);
+          if (unavailable) setTab("new");
+        }
       } else {
         setPlugins(cached.items);
         setTrendingState(undefined);
@@ -596,6 +613,11 @@ export function HomeListingSection({ initialListing = null }: HomeListingSection
             });
             setSkills(result.page);
             setTrendingState(result.trendingState);
+            if (tab === "trending") {
+              const unavailable = result.trendingState === "unavailable";
+              setCanonicalTrendingUnavailable(unavailable);
+              if (unavailable) setTab("new");
+            }
             setListingHasMore(result.hasMore);
             setStatus("idle");
           })
@@ -773,7 +795,7 @@ export function HomeListingSection({ initialListing = null }: HomeListingSection
     if (nextKind === kind) return;
     setKind(nextKind);
     setCategorySlugs([]);
-    setTab(nextKind === "skills" ? "trending" : "new");
+    setTab(nextKind === "skills" && !canonicalTrendingUnavailable ? "trending" : "new");
   };
 
   const removeCategory = (slug: string) => {

--- a/src/routes/skills/-useSkillsBrowseModel.ts
+++ b/src/routes/skills/-useSkillsBrowseModel.ts
@@ -108,6 +108,7 @@ export function useSkillsBrowseModel({
   searchInputRef: RefObject<HTMLInputElement | null>;
 }) {
   const [query, setQuery] = useState(search.q ?? "");
+  const [canonicalTrendingUnavailable, setCanonicalTrendingUnavailable] = useState(false);
   const searchRequest = useRef(0);
   const loadMoreRef = useRef<HTMLDivElement | null>(null);
   const loadMoreInFlightRef = useRef(false);
@@ -126,7 +127,11 @@ export function useSkillsBrowseModel({
   const excludeCategoryKeywords =
     activeCategory?.slug === "other" ? ALL_CATEGORY_KEYWORDS : undefined;
   const hasQuery = trimmedQuery.length > 0;
-  const catalogTab = normalizeSkillsCatalogTab(search.tab, search);
+  const requestedCatalogTab = normalizeSkillsCatalogTab(search.tab, search);
+  const catalogTab =
+    requestedCatalogTab === "trending" && canonicalTrendingUnavailable
+      ? "new"
+      : requestedCatalogTab;
   const requestedSort = hasQuery
     ? search.sort === "default"
       ? "recommended"
@@ -181,6 +186,7 @@ export function useSkillsBrowseModel({
           const capabilities = await fetchCatalogDiscoveryCapabilities();
           if (!capabilities.canonicalTrendingEnabled) {
             if (generation !== fetchGeneration.current) return;
+            setCanonicalTrendingUnavailable(true);
             setListResults([]);
             setListCursor(null);
             setListAutoLoadPaused(false);
@@ -195,6 +201,7 @@ export function useSkillsBrowseModel({
           });
           if (generation !== fetchGeneration.current) return;
           const entries = result.items.map((trending) => ({ trending }));
+          setCanonicalTrendingUnavailable(false);
           setListResults((prev) => (cursor ? [...prev, ...entries] : entries));
           setListCursor(result.nextCursor);
           setListAutoLoadPaused(false);
@@ -264,6 +271,7 @@ export function useSkillsBrowseModel({
           console.error("Failed to fetch skills page:", err);
         }
         if (catalogTab === "trending" && !pageCursor) {
+          setCanonicalTrendingUnavailable(true);
           setListResults([]);
           setTrendingState("unavailable");
         }
@@ -618,6 +626,7 @@ export function useSkillsBrowseModel({
     activeFilters,
     activeCategory: activeCategory?.slug,
     activeTopic,
+    canonicalTrendingUnavailable,
     catalogTab,
     canAutoLoad,
     canLoadMore,

--- a/src/routes/skills/index.tsx
+++ b/src/routes/skills/index.tsx
@@ -39,9 +39,9 @@ import {
 
 const SKILLS_VIEW_OPTIONS = [
   { value: "trending", label: "Trending" },
-  { value: "new", label: "New" },
   { value: "featured", label: "Featured" },
   { value: "official", label: "Official" },
+  { value: "new", label: "New" },
 ];
 const SKILLS_INITIAL_SEARCH_LIMIT = 25;
 
@@ -140,6 +140,9 @@ export function SkillsIndex() {
   });
 
   const activeView = model.catalogTab;
+  const viewOptions = model.canonicalTrendingUnavailable
+    ? SKILLS_VIEW_OPTIONS.filter((option) => option.value !== "trending")
+    : SKILLS_VIEW_OPTIONS;
   const hasActiveFilters =
     model.catalogTab !== "trending" ||
     model.hasQuery ||
@@ -244,7 +247,7 @@ export function SkillsIndex() {
         <BrowseControlsRow>
           <BrowseTabs
             ariaLabel="Skill view"
-            options={SKILLS_VIEW_OPTIONS}
+            options={viewOptions}
             value={activeView}
             onChange={(value) => {
               if (value) handleViewChange(value);


### PR DESCRIPTION
## Summary
- hide canonical Trending when the feed is disabled, stale, or unavailable
- fall back to the native New feed without an error panel
- order available tabs as Trending, Featured, Official, New
- keep plugin tabs ordered Featured, Official, New while plugin Trending is unavailable
- automatically restore Trending after the canonical feed becomes healthy and the page reloads

## Validation
- focused UI/model suites: 71 tests passed
- `bunx vitest run src/__tests__/home-listing-section.test.tsx`: 15 passed
- `bun run ci:static`
- `bun run ci:unit`: 439 files passed, 5,750 tests passed, coverage thresholds green
- `bun run ci:types-build`
- autoreview clean after one accepted live-transition fix

## Browser proof
- local ClawHub at `http://localhost:3417`, connected to the production read backend
- homepage and `/skills` hide unavailable Trending and select New
- homepage Plugins shows Featured, Official, New with New selected
