### PR TITLE
fix: increase detail category spacing

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -7045,7 +7045,7 @@ code {
 .skill-hero-taxonomy-row {
   display: inline-flex;
   align-items: center;
-  gap: 16px;
+  gap: var(--space-5);
   min-width: 0;
   color: color-mix(in srgb, var(--ink-soft) 76%, var(--bg));
   font-size: 12px;
@@ -7055,7 +7055,7 @@ code {
 .skill-category-meta-list {
   display: inline-flex;
   align-items: center;
-  gap: 16px;
+  gap: var(--space-5);
   min-width: 0;
   color: color-mix(in srgb, var(--ink-soft) 76%, var(--bg));
 }


### PR DESCRIPTION
## Summary

- increase category-to-category spacing from 16px to the Carapace `--space-5` token (24px)
- apply the same 24px rhythm between the final category and the taxonomy divider
- preserve the existing icon-label spacing and mobile topic wrapping from #3315

Follow-up to #3315 after verifying the first spacing adjustment on production.

## Validation

- `bun run ci:static`
- `bun run ci:types-build`
- `SITE_URL= VITE_SITE_URL= VITE_CONVEX_URL=https://example.invalid bunx vitest run --coverage --maxWorkers=4` — 5,750 passed, 2 skipped
- focused reruns of both resource-timeout cases — passed
- `.agents/skills/autoreview/scripts/autoreview --mode local` — clean, no actionable findings
- real local ClawHub page at `http://localhost:3010/honcho-ai/plugins/openclaw-honcho`
- responsive browser verification at 390×844, 768×1024, 1366×768, and 1440×900 with no horizontal overflow

Screenshot proof will be attached in a PR comment.
