### PR TITLE
feat: refresh beta plugin compatibility nightly

### DIFF
--- a/.github/workflows/plugin-inspector-bulk-scan.yml
+++ b/.github/workflows/plugin-inspector-bulk-scan.yml
@@ -1,6 +1,8 @@
 name: Plugin Inspector Bulk Scan
 
 on:
+  schedule:
+    - cron: "17 7 * * *"
   workflow_dispatch:
     inputs:
       batch_size:
@@ -16,6 +18,11 @@ on:
         description: "Maximum preview batches to scan when dry_run is enabled"
         required: false
         default: "20"
+      notify_owners:
+        description: "Email plugin owners when a manual scan finds issues"
+        required: false
+        default: true
+        type: boolean
       package_names:
         description: "Optional comma or newline separated package names to scan instead of the rolling cursor"
         required: false
@@ -62,6 +69,8 @@ jobs:
           PLUGIN_INSPECTOR_DRY_RUN: ${{ inputs.dry_run && '1' || '0' }}
           PLUGIN_INSPECTOR_DRY_RUN_MAX_BATCHES: ${{ inputs.dry_run_max_batches || '20' }}
           PLUGIN_INSPECTOR_PACKAGE_NAMES: ${{ inputs.package_names || '' }}
+          PLUGIN_INSPECTOR_OPENCLAW_VERSION: beta
+          PLUGIN_INSPECTOR_NOTIFY_OWNERS: ${{ github.event_name == 'schedule' && '0' || (inputs.notify_owners && '1' || '0') }}
           PLUGIN_INSPECTOR_SOURCE_PR: ${{ inputs.source_pr || '' }}
           PLUGIN_INSPECTOR_SOURCE_SHA: ${{ inputs.source_sha || '' }}
           PLUGIN_INSPECTOR_ARTIFACT_DIR: plugin-inspector-bulk-scan-reports

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -68,6 +68,7 @@ import {
 import { preflightHandler } from "./httpPreflight";
 import { installRateLimitedRoutes } from "./lib/httpRouteRateLimit";
 import {
+  packageInspectorAcknowledgeHttp,
   packageInspectorArtifactHttp,
   packageInspectorClaimHttp,
   packageInspectorResultsHttp,
@@ -275,6 +276,12 @@ http.route({
   path: "/api/v1/package-inspector/claim",
   method: "POST",
   handler: packageInspectorClaimHttp,
+});
+
+http.route({
+  path: "/api/v1/package-inspector/acknowledge",
+  method: "POST",
+  handler: packageInspectorAcknowledgeHttp,
 });
 
 http.route({

--- a/convex/lib/retentionPolicy.ts
+++ b/convex/lib/retentionPolicy.ts
@@ -135,6 +135,10 @@ export const RETENTION_POLICIES = {
     "Notification sent-log prevents duplicate emails.",
   ),
   packageInspectorScanCursors: permanent("Package inspector scan progress cursor."),
+  packageInspectorScanStates: derived(
+    "Successful beta scan identities used to skip unchanged release/target/inspector combinations.",
+    "packageReleases and successful Plugin Inspector runs",
+  ),
   securityScanJobs: permanent("Security scan job history and current processing state."),
   securityScanDispatchState: permanent("Security scan worker dispatch coordination state."),
   skillScanRequests: ephemeral(

--- a/convex/packageInspectorHttp.test.ts
+++ b/convex/packageInspectorHttp.test.ts
@@ -1,7 +1,28 @@
 /* @vitest-environment node */
 
-import { describe, expect, it } from "vitest";
-import { absolutePackageArtifactUrl } from "./packageInspectorHttp";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  absolutePackageArtifactUrl,
+  packageInspectorAcknowledgeHttp,
+  packageInspectorClaimHttp,
+  packageInspectorResultsHttp,
+} from "./packageInspectorHttp";
+
+type HttpHandler = {
+  _handler: (ctx: unknown, request: Request) => Promise<Response>;
+};
+
+const packageInspectorResultsHttpHandler = (packageInspectorResultsHttp as unknown as HttpHandler)
+  ._handler;
+const packageInspectorClaimHttpHandler = (packageInspectorClaimHttp as unknown as HttpHandler)
+  ._handler;
+const packageInspectorAcknowledgeHttpHandler = (
+  packageInspectorAcknowledgeHttp as unknown as HttpHandler
+)._handler;
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
 
 describe("package inspector HTTP helpers", () => {
   it("returns the protected artifact route for scan claims", () => {
@@ -10,5 +31,131 @@ describe("package inspector HTTP helpers", () => {
     expect(absolutePackageArtifactUrl(request, "packageReleases:demo-1")).toBe(
       "https://example.com/api/v1/package-inspector/artifact?releaseId=packageReleases%3Ademo-1",
     );
+  });
+
+  it("keeps owner notifications off when nightly results omit the opt-in", async () => {
+    vi.stubEnv("CLAWHUB_PLUGIN_INSPECTOR_WORKER_TOKEN", "worker-token");
+    const runAction = vi.fn();
+    const response = await packageInspectorResultsHttpHandler(
+      {
+        runMutation: vi.fn().mockResolvedValue({
+          ok: true,
+          inserted: 1,
+          shouldEmailOwner: true,
+        }),
+        runAction,
+      },
+      new Request("https://example.com/api/v1/package-inspector/results", {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer worker-token",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          packageId: "packages:demo",
+          releaseId: "packageReleases:demo-1",
+          inspectorVersion: "0.5.0",
+          targetOpenClawVersion: "2026.8.0-beta.1",
+          findings: [{ code: "missing-api", message: "API removed" }],
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(runAction).not.toHaveBeenCalled();
+  });
+
+  it("passes the exact beta target and inspector version into batch selection", async () => {
+    vi.stubEnv("CLAWHUB_PLUGIN_INSPECTOR_WORKER_TOKEN", "worker-token");
+    const runQuery = vi.fn().mockResolvedValue({
+      ok: true,
+      leased: false,
+      nextCursor: null,
+      skippedUnchanged: 1,
+      items: [],
+    });
+    const response = await packageInspectorClaimHttpHandler(
+      { runQuery },
+      new Request(
+        "https://example.com/api/v1/package-inspector/claim?dryRun=true&inspectorVersion=0.6.0&targetOpenClawVersion=2026.8.0-beta.1&notifyOwners=true",
+        { headers: { Authorization: "Bearer worker-token" } },
+      ),
+    );
+
+    expect(response.status).toBe(200);
+    expect(runQuery.mock.calls[0]?.[1]).toEqual({
+      batchSize: 25,
+      cursor: null,
+      inspectorVersion: "0.6.0",
+      targetOpenClawVersion: "2026.8.0-beta.1",
+      notifyOwners: true,
+    });
+  });
+
+  it("continues a persisted scan run from the caller cursor", async () => {
+    vi.stubEnv("CLAWHUB_PLUGIN_INSPECTOR_WORKER_TOKEN", "worker-token");
+    const runMutation = vi.fn().mockResolvedValue({
+      ok: true,
+      leased: false,
+      nextCursor: null,
+      skippedUnchanged: 0,
+      items: [],
+    });
+    const response = await packageInspectorClaimHttpHandler(
+      { runMutation },
+      new Request(
+        "https://example.com/api/v1/package-inspector/claim?runId=run-42&cursor=page-2&inspectorVersion=0.6.0&targetOpenClawVersion=2026.8.0-beta.1",
+        { headers: { Authorization: "Bearer worker-token" } },
+      ),
+    );
+
+    expect(response.status).toBe(200);
+    expect(runMutation.mock.calls[0]?.[1]).toEqual({
+      batchSize: 25,
+      cursor: "page-2",
+      runId: "run-42",
+      inspectorVersion: "0.6.0",
+      targetOpenClawVersion: "2026.8.0-beta.1",
+    });
+  });
+
+  it("acknowledges a processed batch cursor for the owning scan run", async () => {
+    vi.stubEnv("CLAWHUB_PLUGIN_INSPECTOR_WORKER_TOKEN", "worker-token");
+    const runMutation = vi.fn().mockResolvedValue({
+      ok: true,
+      cursor: "page-2",
+      completed: false,
+    });
+    const response = await packageInspectorAcknowledgeHttpHandler(
+      { runMutation },
+      new Request(
+        "https://example.com/api/v1/package-inspector/acknowledge?runId=run-42&cursor=page-2",
+        {
+          method: "POST",
+          headers: { Authorization: "Bearer worker-token" },
+        },
+      ),
+    );
+
+    expect(response.status).toBe(200);
+    expect(runMutation.mock.calls[0]?.[1]).toEqual({
+      runId: "run-42",
+      cursor: "page-2",
+    });
+  });
+
+  it("acknowledges the final processed batch with a null cursor", async () => {
+    vi.stubEnv("CLAWHUB_PLUGIN_INSPECTOR_WORKER_TOKEN", "worker-token");
+    const runMutation = vi.fn().mockResolvedValue({ ok: true, cursor: null, completed: true });
+    const response = await packageInspectorAcknowledgeHttpHandler(
+      { runMutation },
+      new Request("https://example.com/api/v1/package-inspector/acknowledge?runId=run-42", {
+        method: "POST",
+        headers: { Authorization: "Bearer worker-token" },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(runMutation.mock.calls[0]?.[1]).toEqual({ runId: "run-42", cursor: null });
   });
 });

--- a/convex/packageInspectorHttp.ts
+++ b/convex/packageInspectorHttp.ts
@@ -8,6 +8,7 @@ import { buildDeterministicPackageZip } from "./lib/skillZip";
 const internalRefs = internal as unknown as {
   packages: {
     claimPackageInspectorScanBatchInternal: unknown;
+    acknowledgePackageInspectorScanBatchInternal: unknown;
     previewPackageInspectorScanBatchInternal: unknown;
     getPackageInspectorArtifactInternal: unknown;
     ingestPackageInspectorScanResultsInternal: unknown;
@@ -62,7 +63,12 @@ export const packageInspectorClaimHttp = httpAction(async (ctx, request) => {
   const url = new URL(request.url);
   const batchSize = Number(url.searchParams.get("batchSize") ?? "25");
   const cursor = url.searchParams.get("cursor");
+  const runId = url.searchParams.get("runId")?.trim() || undefined;
   const dryRun = isTruthyParam(url.searchParams.get("dryRun"));
+  const inspectorVersion = url.searchParams.get("inspectorVersion")?.trim() || undefined;
+  const targetOpenClawVersion = url.searchParams.get("targetOpenClawVersion")?.trim() || undefined;
+  const notifyOwners = isTruthyParam(url.searchParams.get("notifyOwners"));
+  if (!dryRun && !runId) return text("Missing runId", 400);
   type ClaimResult = {
     ok: true;
     leased: boolean;
@@ -79,7 +85,11 @@ export const packageInspectorClaimHttp = httpAction(async (ctx, request) => {
   };
   const claimArgs = {
     batchSize: Number.isFinite(batchSize) ? batchSize : undefined,
-    ...(dryRun ? { cursor } : {}),
+    ...(dryRun || cursor ? { cursor } : {}),
+    ...(runId ? { runId } : {}),
+    ...(inspectorVersion ? { inspectorVersion } : {}),
+    ...(targetOpenClawVersion ? { targetOpenClawVersion } : {}),
+    ...(notifyOwners ? { notifyOwners: true } : {}),
   };
   const result = dryRun
     ? await runQueryRef<ClaimResult>(
@@ -100,6 +110,24 @@ export const packageInspectorClaimHttp = httpAction(async (ctx, request) => {
       downloadUrl: absolutePackageArtifactUrl(request, item.releaseId),
     })),
   });
+});
+
+export const packageInspectorAcknowledgeHttp = httpAction(async (ctx, request) => {
+  const auth = requireWorkerToken(request);
+  if (!auth.ok) return auth.response;
+  const url = new URL(request.url);
+  const runId = url.searchParams.get("runId")?.trim();
+  if (!runId) return text("Missing runId", 400);
+  const cursor = url.searchParams.get("cursor")?.trim() || null;
+  const result = await runMutationRef<{
+    ok: true;
+    cursor: string | null;
+    completed: boolean;
+  }>(ctx, internalRefs.packages.acknowledgePackageInspectorScanBatchInternal, {
+    runId,
+    cursor,
+  });
+  return json(result);
 });
 
 export const packageInspectorArtifactHttp = httpAction(async (ctx, request) => {
@@ -175,13 +203,16 @@ export const packageInspectorResultsHttp = httpAction(async (ctx, request) => {
     releaseId: payload.releaseId,
     inspectorVersion: payload.inspectorVersion,
     targetOpenClawVersion: payload.targetOpenClawVersion,
+    notifyOwners: payload.notifyOwners === true,
     findings: Array.isArray(payload.findings) ? payload.findings : [],
   });
-  if (result.shouldEmailOwner) {
+  if (payload.notifyOwners === true && result.shouldEmailOwner) {
     try {
       await runActionRef(ctx, internalRefs.packages.sendPackageInspectorFindingsEmailInternal, {
         packageId: payload.packageId,
         releaseId: payload.releaseId,
+        inspectorVersion: payload.inspectorVersion,
+        targetOpenClawVersion: payload.targetOpenClawVersion,
       });
     } catch (error) {
       console.error("Package Inspector findings email failed", error);

--- a/convex/packages.public.test.ts
+++ b/convex/packages.public.test.ts
@@ -12504,17 +12504,19 @@ describe("packages public queries", () => {
           if (table === "packageInspectorWarnings") {
             return {
               withIndex: vi.fn(() => ({
-                order: vi.fn(() => ({
-                  take: vi.fn().mockResolvedValue([
-                    {
-                      code: "missing-api",
-                      scanSource: "nightly",
-                      inspectorVersion: "0.6.0",
-                      targetOpenClawVersion: "2026.8.0-beta.1",
-                      message: "API removed",
-                      authorRemediation: { summary: "Use the replacement API." },
-                    },
-                  ]),
+                filter: vi.fn(() => ({
+                  order: vi.fn(() => ({
+                    take: vi.fn().mockResolvedValue([
+                      {
+                        code: "missing-api",
+                        scanSource: "nightly",
+                        inspectorVersion: "0.6.0",
+                        targetOpenClawVersion: "2026.8.0-beta.1",
+                        message: "API removed",
+                        authorRemediation: { summary: "Use the replacement API." },
+                      },
+                    ]),
+                  })),
                 })),
               })),
             };
@@ -12542,7 +12544,7 @@ describe("packages public queries", () => {
     ).resolves.toMatchObject({ packageName: "demo-plugin" });
   });
 
-  it("limits exact-target email context to findings from the current nightly scan", async () => {
+  it("selects the exact nightly scan before limiting owner email findings", async () => {
     const ctx = {
       db: {
         get: vi.fn(async (id: string) => {
@@ -12569,21 +12571,27 @@ describe("packages public queries", () => {
           if (table === "packageInspectorWarnings") {
             return {
               withIndex: vi.fn(() => ({
+                filter: vi.fn(() => ({
+                  order: vi.fn(() => ({
+                    take: vi.fn().mockResolvedValue([
+                      {
+                        code: "missing-api",
+                        scanSource: "nightly",
+                        inspectorVersion: "0.6.0",
+                        targetOpenClawVersion: "2026.8.0-beta.1",
+                        message: "API removed",
+                        authorRemediation: { summary: "Use the replacement API." },
+                      },
+                    ]),
+                  })),
+                })),
                 order: vi.fn(() => ({
                   take: vi.fn().mockResolvedValue([
                     {
-                      code: "publish-warning",
+                      code: "publish-warning-100",
                       scanSource: "publish",
-                      message: "Static package warning",
+                      message: "The release-wide limit was exhausted by publish findings.",
                       authorRemediation: { summary: "Fix the package metadata." },
-                    },
-                    {
-                      code: "missing-api",
-                      scanSource: "nightly",
-                      inspectorVersion: "0.6.0",
-                      targetOpenClawVersion: "2026.8.0-beta.1",
-                      message: "API removed",
-                      authorRemediation: { summary: "Use the replacement API." },
                     },
                   ]),
                 })),

--- a/convex/packages.public.test.ts
+++ b/convex/packages.public.test.ts
@@ -30,6 +30,7 @@ import {
   insertPackageInspectorWarningsInternal,
   ingestPackageInspectorScanResultsInternal,
   claimPackageInspectorScanBatchInternal,
+  acknowledgePackageInspectorScanBatchInternal,
   previewPackageInspectorScanBatchInternal,
   getPackageInspectorEmailContextInternal,
   markPackageInspectorFindingsEmailedInternal,
@@ -654,7 +655,15 @@ const ingestPackageInspectorScanResultsInternalHandler = (
 )._handler;
 const claimPackageInspectorScanBatchInternalHandler = (
   claimPackageInspectorScanBatchInternal as unknown as WrappedHandler<
-    { batchSize?: number; leaseMs?: number },
+    {
+      batchSize?: number;
+      leaseMs?: number;
+      cursor?: string | null;
+      runId?: string;
+      inspectorVersion?: string;
+      targetOpenClawVersion?: string;
+      notifyOwners?: boolean;
+    },
     {
       ok: true;
       leased: boolean;
@@ -669,13 +678,30 @@ const claimPackageInspectorScanBatchInternalHandler = (
     }
   >
 )._handler;
+const acknowledgePackageInspectorScanBatchInternalHandler = (
+  acknowledgePackageInspectorScanBatchInternal as unknown as WrappedHandler<
+    {
+      runId: string;
+      cursor: string | null;
+      leaseMs?: number;
+    },
+    { ok: true; cursor: string | null; completed: boolean }
+  >
+)._handler;
 const previewPackageInspectorScanBatchInternalHandler = (
   previewPackageInspectorScanBatchInternal as unknown as WrappedHandler<
-    { batchSize?: number; cursor?: string | null },
+    {
+      batchSize?: number;
+      cursor?: string | null;
+      inspectorVersion?: string;
+      targetOpenClawVersion?: string;
+      notifyOwners?: boolean;
+    },
     {
       ok: true;
       leased: false;
       nextCursor: string | null;
+      skippedUnchanged: number;
       items: Array<{
         packageId: string;
         releaseId: string;
@@ -690,7 +716,12 @@ const previewPackageInspectorScanBatchInternalHandler = (
 )._handler;
 const getPackageInspectorEmailContextInternalHandler = (
   getPackageInspectorEmailContextInternal as unknown as WrappedHandler<
-    { packageId: string; releaseId: string },
+    {
+      packageId: string;
+      releaseId: string;
+      inspectorVersion?: string;
+      targetOpenClawVersion?: string;
+    },
     {
       packageName: string;
       version: string;
@@ -712,6 +743,8 @@ const markPackageInspectorFindingsEmailedInternalHandler = (
       version: string;
       findingCount: number;
       email: string;
+      inspectorVersion?: string;
+      targetOpenClawVersion?: string;
     },
     { ok: true; created: boolean }
   >
@@ -8255,6 +8288,7 @@ describe("packages public queries", () => {
     const release = makeReleaseDoc({ integritySha256: "abc123" });
     const ctx = {
       db: {
+        get: vi.fn(),
         query: vi.fn((table: string) => {
           if (table === "packages") {
             return {
@@ -8277,6 +8311,11 @@ describe("packages public queries", () => {
           }
           throw new Error(`Unexpected table ${table}`);
         }),
+        insert: vi.fn(),
+        patch: vi.fn(),
+        replace: vi.fn(),
+        delete: vi.fn(),
+        normalizeId: vi.fn(() => null),
       },
     };
 
@@ -8302,6 +8341,7 @@ describe("packages public queries", () => {
     });
     const ctx = {
       db: {
+        get: vi.fn(),
         query: vi.fn((table: string) => {
           if (table === "packages") {
             return {
@@ -11743,7 +11783,58 @@ describe("packages public queries", () => {
     );
   });
 
-  it("records a clean beta scan identity without overwriting a previous target", async () => {
+  it("does not notify for preserved publish findings after a clean nightly scan", async () => {
+    const ctx = {
+      db: {
+        get: vi.fn(),
+        query: vi.fn((table: string) => {
+          if (table === "packageInspectorWarnings") {
+            return {
+              withIndex: vi.fn(() => ({
+                collect: vi.fn().mockResolvedValue([
+                  {
+                    _id: "packageInspectorWarnings:publish",
+                    scanSource: "publish",
+                    code: "manifest-name-missing",
+                    message: "manifest name is missing",
+                    authorRemediation: { summary: "Add a manifest name." },
+                  },
+                ]),
+              })),
+            };
+          }
+          if (table === "packageInspectorScanStates") {
+            return {
+              withIndex: vi.fn(() => ({ unique: vi.fn().mockResolvedValue(null) })),
+            };
+          }
+          throw new Error(`Unexpected table ${table}`);
+        }),
+        insert: vi.fn(),
+        patch: vi.fn(),
+        replace: vi.fn(),
+        delete: vi.fn(),
+        normalizeId: vi.fn(() => null),
+      },
+    };
+
+    await expect(
+      insertPackageInspectorWarningsInternalHandler(ctx as never, {
+        packageId: "packages:demo",
+        releaseId: "packageReleases:demo-1",
+        ownerUserId: "users:owner",
+        packageName: "demo-plugin",
+        version: "1.0.0",
+        scanSource: "nightly",
+        inspectorVersion: "0.6.0",
+        targetOpenClawVersion: "2026.8.0-beta.1",
+        notifyOwners: true,
+        findings: [],
+      }),
+    ).resolves.toEqual({ ok: true, inserted: 0, shouldEmailOwner: false });
+  });
+
+  it("records a clean beta scan identity and completes a no-op notification", async () => {
     const insert = vi.fn().mockResolvedValue("packageInspectorScanStates:demo");
     const deleteRow = vi.fn();
     const scanStateWithIndex = vi.fn((indexName: string) => ({
@@ -11813,6 +11904,7 @@ describe("packages public queries", () => {
         releaseId: "packageReleases:demo-1",
         inspectorVersion: "0.6.0",
         targetOpenClawVersion: "2026.8.0-beta.1",
+        notifyOwners: true,
         findings: [],
       }),
     ).resolves.toEqual({ ok: true, inserted: 0, shouldEmailOwner: false });
@@ -11828,18 +11920,25 @@ describe("packages public queries", () => {
       inspectorVersion: "0.6.0",
       targetOpenClawVersion: "2026.8.0-beta.1",
       completedAt: expect.any(Number),
+      notificationCompletedAt: expect.any(Number),
     });
   });
 
-  it("stores nightly plugin inspector errors as public findings", async () => {
+  it("stores nightly errors and does not reuse an earlier target's email dedupe", async () => {
     const insert = vi.fn();
     const ctx = {
       db: {
         get: vi.fn(),
-        query: vi.fn(() => ({
+        query: vi.fn((table: string) => ({
           withIndex: vi.fn(() => ({
             collect: vi.fn().mockResolvedValue([]),
-            unique: vi.fn().mockResolvedValue(null),
+            unique: vi
+              .fn()
+              .mockResolvedValue(
+                table === "packageInspectorFindingNotifications"
+                  ? { _id: "packageInspectorFindingNotifications:old-target" }
+                  : null,
+              ),
           })),
         })),
         insert,
@@ -11862,6 +11961,7 @@ describe("packages public queries", () => {
         scanSource: "nightly",
         inspectorVersion: "0.5.0",
         targetOpenClawVersion: "0.10.0",
+        notifyOwners: true,
         findings: [
           {
             id: "demo:missing-expected-seam",
@@ -11878,7 +11978,7 @@ describe("packages public queries", () => {
           },
         ],
       }),
-    ).resolves.toMatchObject({ ok: true, inserted: 1, shouldEmailOwner: false });
+    ).resolves.toMatchObject({ ok: true, inserted: 1, shouldEmailOwner: true });
 
     expect(insert).toHaveBeenCalledWith(
       "packageInspectorWarnings",
@@ -12018,6 +12118,11 @@ describe("packages public queries", () => {
             message: "legacy before_agent_start hook is deprecated",
             evidence: ["src/index.ts:4"],
             fixture: "demo",
+            authorRemediation: {
+              summary: "Move prompt mutation work to before_prompt_build.",
+              docsUrl:
+                "https://docs.openclaw.ai/clawhub/plugin-validation-fixes#legacy-before-agent-start",
+            },
           },
         ],
       }),
@@ -12247,6 +12352,49 @@ describe("packages public queries", () => {
     expect(insert).toHaveBeenCalledTimes(1);
   });
 
+  it("marks the exact scan notification complete after owner email succeeds", async () => {
+    const patch = vi.fn();
+    const ctx = {
+      db: {
+        get: vi.fn(),
+        query: vi.fn((table: string) => ({
+          withIndex: vi.fn(() => ({
+            unique: vi
+              .fn()
+              .mockResolvedValue(
+                table === "packageInspectorScanStates"
+                  ? { _id: "packageInspectorScanStates:demo" }
+                  : null,
+              ),
+          })),
+        })),
+        insert: vi.fn(),
+        patch,
+        replace: vi.fn(),
+        delete: vi.fn(),
+        normalizeId: vi.fn(() => null),
+      },
+    };
+
+    await expect(
+      markPackageInspectorFindingsEmailedInternalHandler(ctx as never, {
+        packageId: "packages:demo",
+        releaseId: "packageReleases:demo-1",
+        ownerUserId: "users:owner",
+        packageName: "demo-plugin",
+        version: "1.0.0",
+        findingCount: 2,
+        email: "owner@example.com",
+        inspectorVersion: "0.6.0",
+        targetOpenClawVersion: "2026.8.0-beta.1",
+      }),
+    ).resolves.toEqual({ ok: true, created: true });
+    expect(patch).toHaveBeenCalledWith(
+      "packageInspectorScanStates:demo",
+      expect.objectContaining({ notificationCompletedAt: expect.any(Number) }),
+    );
+  });
+
   it("excludes internal package inspector findings from owner emails", async () => {
     const ctx = {
       db: {
@@ -12329,7 +12477,140 @@ describe("packages public queries", () => {
     });
   });
 
-  it("claims only the scan page it can safely advance past", async () => {
+  it("builds email context for a new exact target despite an older release notification", async () => {
+    const ctx = {
+      db: {
+        get: vi.fn(async (id: string) => {
+          if (id === "packages:demo") {
+            return makePackageDoc({
+              _id: "packages:demo",
+              name: "demo-plugin",
+              ownerUserId: "users:owner",
+            });
+          }
+          if (id === "packageReleases:demo-1") {
+            return makeReleaseDoc({
+              _id: "packageReleases:demo-1",
+              packageId: "packages:demo",
+              version: "1.0.0",
+            });
+          }
+          if (id === "users:owner") {
+            return { _id: "users:owner", handle: "owner", email: "owner@example.com" };
+          }
+          return null;
+        }),
+        query: vi.fn((table: string) => {
+          if (table === "packageInspectorWarnings") {
+            return {
+              withIndex: vi.fn(() => ({
+                order: vi.fn(() => ({
+                  take: vi.fn().mockResolvedValue([
+                    {
+                      code: "missing-api",
+                      scanSource: "nightly",
+                      inspectorVersion: "0.6.0",
+                      targetOpenClawVersion: "2026.8.0-beta.1",
+                      message: "API removed",
+                      authorRemediation: { summary: "Use the replacement API." },
+                    },
+                  ]),
+                })),
+              })),
+            };
+          }
+          if (table === "packageInspectorScanStates") {
+            return {
+              withIndex: vi.fn(() => ({ unique: vi.fn().mockResolvedValue(null) })),
+            };
+          }
+          if (table === "packageInspectorFindingNotifications") {
+            throw new Error("Exact-target email context must not use release-wide dedupe");
+          }
+          throw new Error(`Unexpected table ${table}`);
+        }),
+      },
+    };
+
+    await expect(
+      getPackageInspectorEmailContextInternalHandler(ctx as never, {
+        packageId: "packages:demo",
+        releaseId: "packageReleases:demo-1",
+        inspectorVersion: "0.6.0",
+        targetOpenClawVersion: "2026.8.0-beta.1",
+      }),
+    ).resolves.toMatchObject({ packageName: "demo-plugin" });
+  });
+
+  it("limits exact-target email context to findings from the current nightly scan", async () => {
+    const ctx = {
+      db: {
+        get: vi.fn(async (id: string) => {
+          if (id === "packages:demo") {
+            return makePackageDoc({
+              _id: "packages:demo",
+              name: "demo-plugin",
+              ownerUserId: "users:owner",
+            });
+          }
+          if (id === "packageReleases:demo-1") {
+            return makeReleaseDoc({
+              _id: "packageReleases:demo-1",
+              packageId: "packages:demo",
+              version: "1.0.0",
+            });
+          }
+          if (id === "users:owner") {
+            return { _id: "users:owner", handle: "owner", email: "owner@example.com" };
+          }
+          return null;
+        }),
+        query: vi.fn((table: string) => {
+          if (table === "packageInspectorWarnings") {
+            return {
+              withIndex: vi.fn(() => ({
+                order: vi.fn(() => ({
+                  take: vi.fn().mockResolvedValue([
+                    {
+                      code: "publish-warning",
+                      scanSource: "publish",
+                      message: "Static package warning",
+                      authorRemediation: { summary: "Fix the package metadata." },
+                    },
+                    {
+                      code: "missing-api",
+                      scanSource: "nightly",
+                      inspectorVersion: "0.6.0",
+                      targetOpenClawVersion: "2026.8.0-beta.1",
+                      message: "API removed",
+                      authorRemediation: { summary: "Use the replacement API." },
+                    },
+                  ]),
+                })),
+              })),
+            };
+          }
+          if (table === "packageInspectorScanStates") {
+            return {
+              withIndex: vi.fn(() => ({ unique: vi.fn().mockResolvedValue(null) })),
+            };
+          }
+          throw new Error(`Unexpected table ${table}`);
+        }),
+      },
+    };
+
+    const result = await getPackageInspectorEmailContextInternalHandler(ctx as never, {
+      packageId: "packages:demo",
+      releaseId: "packageReleases:demo-1",
+      inspectorVersion: "0.6.0",
+      targetOpenClawVersion: "2026.8.0-beta.1",
+    });
+
+    expect(result?.findings.map((finding) => finding.code)).toEqual(["missing-api"]);
+  });
+
+  it("leases a scan page without advancing past unprocessed releases", async () => {
     const paginate = vi.fn(async () => ({
       page: [
         {
@@ -12401,6 +12682,7 @@ describe("packages public queries", () => {
       claimPackageInspectorScanBatchInternalHandler(ctx as never, {
         batchSize: 2,
         leaseMs: 60_000,
+        runId: "run-42",
       }),
     ).resolves.toMatchObject({
       ok: true,
@@ -12414,7 +12696,327 @@ describe("packages public queries", () => {
     expect(paginate).toHaveBeenCalledWith({ cursor: null, numItems: 2 });
     expect(insert).toHaveBeenCalledWith(
       "packageInspectorScanCursors",
-      expect.objectContaining({ cursor: "cursor-after-returned-page" }),
+      expect.objectContaining({
+        cursor: null,
+        pendingCursor: "cursor-after-returned-page",
+      }),
+    );
+  });
+
+  it("advances a leased scan page only after the owning run acknowledges it", async () => {
+    const patch = vi.fn();
+    const ctx = {
+      db: {
+        get: vi.fn(),
+        query: vi.fn((table: string) => {
+          if (table !== "packageInspectorScanCursors") {
+            throw new Error(`Unexpected table ${table}`);
+          }
+          return {
+            withIndex: vi.fn(() => ({
+              unique: vi.fn().mockResolvedValue({
+                _id: "packageInspectorScanCursors:nightly",
+                name: "nightly",
+                cursor: null,
+                pendingCursor: "page-2",
+                runId: "run-42",
+                leaseExpiresAt: Date.now() + 60_000,
+              }),
+            })),
+          };
+        }),
+        patch,
+        insert: vi.fn(),
+        replace: vi.fn(),
+        delete: vi.fn(),
+        normalizeId: vi.fn(() => null),
+      },
+    };
+
+    await expect(
+      acknowledgePackageInspectorScanBatchInternalHandler(ctx as never, {
+        runId: "  run-42  ",
+        cursor: "page-2",
+        leaseMs: 60_000,
+      }),
+    ).resolves.toEqual({ ok: true, cursor: "page-2", completed: false });
+    expect(patch).toHaveBeenCalledWith(
+      "packageInspectorScanCursors:nightly",
+      expect.objectContaining({
+        cursor: "page-2",
+        pendingCursor: undefined,
+        runId: "run-42",
+      }),
+    );
+  });
+
+  it("rejects acknowledgement from a different scan run", async () => {
+    const patch = vi.fn();
+    const ctx = {
+      db: {
+        get: vi.fn(),
+        query: vi.fn(() => ({
+          withIndex: vi.fn(() => ({
+            unique: vi.fn().mockResolvedValue({
+              _id: "packageInspectorScanCursors:nightly",
+              cursor: null,
+              pendingCursor: "page-2",
+              runId: "run-42",
+            }),
+          })),
+        })),
+        patch,
+        insert: vi.fn(),
+        replace: vi.fn(),
+        delete: vi.fn(),
+        normalizeId: vi.fn(() => null),
+      },
+    };
+
+    await expect(
+      acknowledgePackageInspectorScanBatchInternalHandler(ctx as never, {
+        runId: "run-other",
+        cursor: "page-2",
+      }),
+    ).rejects.toThrow("does not own the active lease");
+    expect(patch).not.toHaveBeenCalled();
+  });
+
+  it("continues only from the cursor owned by the same nightly scan run", async () => {
+    const paginate = vi.fn(async () => ({
+      page: [],
+      isDone: true,
+      continueCursor: null,
+    }));
+    const patch = vi.fn();
+    const ctx = {
+      db: {
+        get: vi.fn(),
+        query: vi.fn((table: string) => {
+          if (table === "packageInspectorScanCursors") {
+            return {
+              withIndex: vi.fn(() => ({
+                unique: vi.fn().mockResolvedValue({
+                  _id: "packageInspectorScanCursors:nightly",
+                  name: "nightly",
+                  runId: "run-42",
+                  cursor: "page-2",
+                  leaseExpiresAt: Date.now() + 60_000,
+                }),
+              })),
+            };
+          }
+          if (table === "packageReleases") {
+            return {
+              withIndex: vi.fn(() => ({ order: vi.fn(() => ({ paginate })) })),
+            };
+          }
+          throw new Error(`Unexpected table ${table}`);
+        }),
+        insert: vi.fn(),
+        patch,
+        replace: vi.fn(),
+        delete: vi.fn(),
+        normalizeId: vi.fn(() => null),
+      },
+    };
+
+    await expect(
+      claimPackageInspectorScanBatchInternalHandler(ctx as never, {
+        batchSize: 25,
+        leaseMs: 60_000,
+        cursor: "page-2",
+        runId: "run-42",
+      }),
+    ).resolves.toMatchObject({
+      ok: true,
+      leased: false,
+      nextCursor: null,
+      items: [],
+    });
+    expect(paginate).toHaveBeenCalledWith({ cursor: "page-2", numItems: 25 });
+    expect(patch).toHaveBeenCalledWith(
+      "packageInspectorScanCursors:nightly",
+      expect.objectContaining({ cursor: "page-2", pendingCursor: null, runId: "run-42" }),
+    );
+  });
+
+  it("reclaims an unacknowledged page immediately for the same nightly scan run", async () => {
+    const paginate = vi.fn(async () => ({
+      page: [],
+      isDone: true,
+      continueCursor: null,
+    }));
+    const patch = vi.fn();
+    const ctx = {
+      db: {
+        get: vi.fn(),
+        query: vi.fn((table: string) => {
+          if (table === "packageInspectorScanCursors") {
+            return {
+              withIndex: vi.fn(() => ({
+                unique: vi.fn().mockResolvedValue({
+                  _id: "packageInspectorScanCursors:nightly",
+                  name: "nightly",
+                  runId: "run-42",
+                  cursor: "page-1",
+                  pendingCursor: "page-2",
+                  leaseExpiresAt: Date.now() + 60_000,
+                }),
+              })),
+            };
+          }
+          if (table === "packageReleases") {
+            return {
+              withIndex: vi.fn(() => ({ order: vi.fn(() => ({ paginate })) })),
+            };
+          }
+          throw new Error(`Unexpected table ${table}`);
+        }),
+        insert: vi.fn(),
+        patch,
+        replace: vi.fn(),
+        delete: vi.fn(),
+        normalizeId: vi.fn(() => null),
+      },
+    };
+
+    await expect(
+      claimPackageInspectorScanBatchInternalHandler(ctx as never, {
+        batchSize: 25,
+        leaseMs: 60_000,
+        cursor: "page-1",
+        runId: "run-42",
+      }),
+    ).resolves.toMatchObject({
+      ok: true,
+      leased: false,
+      nextCursor: null,
+    });
+    expect(paginate).toHaveBeenCalledWith({ cursor: "page-1", numItems: 25 });
+    expect(patch).toHaveBeenCalledWith(
+      "packageInspectorScanCursors:nightly",
+      expect.objectContaining({
+        cursor: "page-1",
+        pendingCursor: null,
+        runId: "run-42",
+      }),
+    );
+  });
+
+  it("resumes the persisted cursor when the same nightly run restarts", async () => {
+    const paginate = vi.fn(async () => ({
+      page: [],
+      isDone: true,
+      continueCursor: null,
+    }));
+    const ctx = {
+      db: {
+        get: vi.fn(),
+        query: vi.fn((table: string) => {
+          if (table === "packageInspectorScanCursors") {
+            return {
+              withIndex: vi.fn(() => ({
+                unique: vi.fn().mockResolvedValue({
+                  _id: "packageInspectorScanCursors:nightly",
+                  runId: "run-42",
+                  cursor: "page-3",
+                  leaseExpiresAt: Date.now() + 60_000,
+                }),
+              })),
+            };
+          }
+          if (table === "packageReleases") {
+            return {
+              withIndex: vi.fn(() => ({ order: vi.fn(() => ({ paginate })) })),
+            };
+          }
+          throw new Error(`Unexpected table ${table}`);
+        }),
+        insert: vi.fn(),
+        patch: vi.fn(),
+        replace: vi.fn(),
+        delete: vi.fn(),
+        normalizeId: vi.fn(() => null),
+      },
+    };
+
+    await expect(
+      claimPackageInspectorScanBatchInternalHandler(ctx as never, {
+        cursor: "page-2",
+        runId: "run-42",
+      }),
+    ).resolves.toMatchObject({ ok: true, leased: false, nextCursor: null, items: [] });
+    expect(paginate).toHaveBeenCalledWith({ cursor: "page-3", numItems: 25 });
+  });
+
+  it("resumes the persisted cursor when a replacement nightly run acquires an expired lease", async () => {
+    const paginate = vi.fn(async () => ({
+      page: [
+        {
+          _id: "packageReleases:current",
+          packageId: "packages:current",
+          version: "1.0.0",
+          artifactKind: "legacy-zip",
+        },
+      ],
+      isDone: false,
+      continueCursor: "page-3",
+    }));
+    const patch = vi.fn();
+    const ctx = {
+      db: {
+        get: vi.fn(async (id: string) =>
+          id === "packages:current"
+            ? {
+                _id: "packages:current",
+                name: "current-plugin",
+                family: "code-plugin",
+                channel: "community",
+                ownerUserId: "users:owner",
+                latestReleaseId: "packageReleases:current",
+              }
+            : null,
+        ),
+        query: vi.fn((table: string) => {
+          if (table === "packageInspectorScanCursors") {
+            return {
+              withIndex: vi.fn(() => ({
+                unique: vi.fn().mockResolvedValue({
+                  _id: "packageInspectorScanCursors:nightly",
+                  runId: "run-old",
+                  cursor: "page-2",
+                  leaseExpiresAt: Date.now() - 1,
+                }),
+              })),
+            };
+          }
+          if (table === "packageReleases") {
+            return {
+              withIndex: vi.fn(() => ({ order: vi.fn(() => ({ paginate })) })),
+            };
+          }
+          throw new Error(`Unexpected table ${table}`);
+        }),
+        patch,
+        insert: vi.fn(),
+        replace: vi.fn(),
+        delete: vi.fn(),
+        normalizeId: vi.fn(() => null),
+      },
+    };
+
+    await expect(
+      claimPackageInspectorScanBatchInternalHandler(ctx as never, {
+        batchSize: 1,
+        cursor: null,
+        runId: "run-new",
+      }),
+    ).resolves.toMatchObject({ ok: true, leased: false, nextCursor: "page-3" });
+    expect(paginate).toHaveBeenCalledWith({ cursor: "page-2", numItems: 1 });
+    expect(patch).toHaveBeenCalledWith(
+      "packageInspectorScanCursors:nightly",
+      expect.objectContaining({ cursor: "page-2", pendingCursor: "page-3", runId: "run-new" }),
     );
   });
 
@@ -12498,6 +13100,7 @@ describe("packages public queries", () => {
       claimPackageInspectorScanBatchInternalHandler(ctx as never, {
         batchSize: 3,
         leaseMs: 60_000,
+        runId: "run-42",
       }),
     ).resolves.toMatchObject({
       ok: true,
@@ -12507,6 +13110,182 @@ describe("packages public queries", () => {
         { releaseId: "packageReleases:legacy-latest", packageName: "legacy-plugin" },
       ],
     });
+  });
+
+  it("skips latest releases already scanned by the same beta target and inspector", async () => {
+    const paginate = vi.fn(async () => ({
+      page: [
+        {
+          _id: "packageReleases:current",
+          packageId: "packages:modern",
+          version: "2.0.0",
+          artifactKind: "npm-pack",
+        },
+      ],
+      isDone: true,
+      continueCursor: null,
+    }));
+    const scanStateWithIndex = vi.fn(() => ({
+      unique: vi.fn().mockResolvedValue({
+        releaseId: "packageReleases:current",
+        inspectorVersion: "0.6.0",
+        targetOpenClawVersion: "2026.8.0-beta.1",
+      }),
+    }));
+    const ctx = {
+      db: {
+        get: vi.fn(async (id: string) =>
+          id === "packages:modern"
+            ? {
+                _id: "packages:modern",
+                name: "modern-plugin",
+                family: "code-plugin",
+                channel: "community",
+                ownerUserId: "users:owner",
+                latestReleaseId: "packageReleases:current",
+              }
+            : null,
+        ),
+        query: vi.fn((table: string) => {
+          if (table === "packageReleases") {
+            return {
+              withIndex: vi.fn(() => ({ order: vi.fn(() => ({ paginate })) })),
+            };
+          }
+          if (table === "packageInspectorScanStates") {
+            return { withIndex: scanStateWithIndex };
+          }
+          throw new Error(`Unexpected table ${table}`);
+        }),
+      },
+    };
+
+    await expect(
+      previewPackageInspectorScanBatchInternalHandler(ctx as never, {
+        batchSize: 1,
+        inspectorVersion: "0.6.0",
+        targetOpenClawVersion: "2026.8.0-beta.1",
+      }),
+    ).resolves.toMatchObject({
+      ok: true,
+      items: [],
+      skippedUnchanged: 1,
+    });
+    expect(scanStateWithIndex).toHaveBeenCalledWith(
+      "by_release_and_inspector_version_and_target_openclaw_version",
+      expect.any(Function),
+    );
+
+    await expect(
+      previewPackageInspectorScanBatchInternalHandler(ctx as never, {
+        batchSize: 1,
+        inspectorVersion: "0.6.0",
+        targetOpenClawVersion: "2026.8.0-beta.1",
+        notifyOwners: true,
+      }),
+    ).resolves.toMatchObject({
+      items: [{ releaseId: "packageReleases:current" }],
+      skippedUnchanged: 0,
+    });
+  });
+
+  it("continues through filtered source pages until the requested plugin batch is full", async () => {
+    const paginate = vi
+      .fn()
+      .mockResolvedValueOnce({
+        page: [
+          {
+            _id: "packageReleases:old",
+            packageId: "packages:modern",
+            version: "1.0.0",
+            artifactKind: "legacy-zip",
+          },
+          {
+            _id: "packageReleases:current",
+            packageId: "packages:modern",
+            version: "2.0.0",
+            artifactKind: "npm-pack",
+          },
+        ],
+        isDone: false,
+        continueCursor: "page-2",
+      })
+      .mockResolvedValueOnce({
+        page: [
+          {
+            _id: "packageReleases:other",
+            packageId: "packages:other",
+            version: "1.0.0",
+            artifactKind: "npm-pack",
+          },
+        ],
+        isDone: true,
+        continueCursor: null,
+      });
+    const ctx = {
+      db: {
+        get: vi.fn(async (id: string) =>
+          id === "packages:modern"
+            ? {
+                _id: "packages:modern",
+                name: "modern-plugin",
+                family: "code-plugin",
+                channel: "community",
+                ownerUserId: "users:owner",
+                latestReleaseId: "packageReleases:current",
+              }
+            : {
+                _id: "packages:other",
+                name: "other-plugin",
+                family: "bundle-plugin",
+                channel: "community",
+                ownerUserId: "users:owner",
+                latestReleaseId: "packageReleases:other",
+              },
+        ),
+        query: vi.fn((table: string) => {
+          if (table !== "packageReleases") throw new Error(`Unexpected table ${table}`);
+          return { withIndex: vi.fn(() => ({ order: vi.fn(() => ({ paginate })) })) };
+        }),
+      },
+    };
+
+    await expect(
+      previewPackageInspectorScanBatchInternalHandler(ctx as never, { batchSize: 2 }),
+    ).resolves.toMatchObject({
+      nextCursor: null,
+      items: [
+        { releaseId: "packageReleases:current", packageName: "modern-plugin" },
+        { releaseId: "packageReleases:other", packageName: "other-plugin" },
+      ],
+    });
+    expect(paginate).toHaveBeenNthCalledWith(1, { cursor: null, numItems: 2 });
+    expect(paginate).toHaveBeenNthCalledWith(2, { cursor: "page-2", numItems: 1 });
+  });
+
+  it("rejects a non-advancing nightly scan pagination cursor", async () => {
+    const paginate = vi.fn(async () => ({
+      page: [],
+      isDone: false,
+      continueCursor: "stuck-cursor",
+    }));
+    const ctx = {
+      db: {
+        get: vi.fn(),
+        query: vi.fn((table: string) => {
+          if (table !== "packageReleases") throw new Error(`Unexpected table ${table}`);
+          return { withIndex: vi.fn(() => ({ order: vi.fn(() => ({ paginate })) })) };
+        }),
+      },
+    };
+
+    await expect(
+      previewPackageInspectorScanBatchInternalHandler(ctx as never, {
+        cursor: "stuck-cursor",
+        batchSize: 25,
+      }),
+    ).rejects.toThrow("Package Inspector scan pagination cursor did not advance");
+    expect(paginate).toHaveBeenCalledTimes(1);
   });
 
   it("previews nightly plugin inspector batches without leasing or advancing the cursor", async () => {
@@ -12569,7 +13348,7 @@ describe("packages public queries", () => {
     await expect(
       previewPackageInspectorScanBatchInternalHandler(ctx as never, {
         cursor: "cursor-before-preview",
-        batchSize: 2,
+        batchSize: 1,
       }),
     ).resolves.toMatchObject({
       ok: true,
@@ -12584,7 +13363,7 @@ describe("packages public queries", () => {
         },
       ],
     });
-    expect(paginate).toHaveBeenCalledWith({ cursor: "cursor-before-preview", numItems: 2 });
+    expect(paginate).toHaveBeenCalledWith({ cursor: "cursor-before-preview", numItems: 1 });
     expect(insert).not.toHaveBeenCalled();
     expect(patch).not.toHaveBeenCalled();
   });
@@ -12681,6 +13460,7 @@ describe("packages public queries", () => {
       claimPackageInspectorScanBatchInternalHandler(ctx as never, {
         batchSize: 3,
         leaseMs: 60_000,
+        runId: "run-42",
       }),
     ).resolves.toMatchObject({
       ok: true,

--- a/convex/packages.public.test.ts
+++ b/convex/packages.public.test.ts
@@ -28,6 +28,7 @@ import {
   listPackageInspectorWarningsForManager,
   listPackageInspectorFindingsPublic,
   insertPackageInspectorWarningsInternal,
+  ingestPackageInspectorScanResultsInternal,
   claimPackageInspectorScanBatchInternal,
   previewPackageInspectorScanBatchInternal,
   getPackageInspectorEmailContextInternal,
@@ -608,6 +609,7 @@ const insertPackageInspectorWarningsInternalHandler = (
       scanSource?: "publish" | "nightly";
       inspectorVersion?: string;
       targetOpenClawVersion?: string;
+      notifyOwners?: boolean;
       findings?: Array<{
         id?: string;
         code: string;
@@ -625,6 +627,25 @@ const insertPackageInspectorWarningsInternalHandler = (
         issueClass?: string;
         evidence?: string[];
         fixture?: string;
+        authorRemediation?: TestPackageInspectorAuthorRemediation;
+      }>;
+    },
+    { ok: true; inserted: number; shouldEmailOwner: boolean }
+  >
+)._handler;
+const ingestPackageInspectorScanResultsInternalHandler = (
+  ingestPackageInspectorScanResultsInternal as unknown as WrappedHandler<
+    {
+      packageId: string;
+      releaseId: string;
+      inspectorVersion?: string;
+      targetOpenClawVersion?: string;
+      notifyOwners?: boolean;
+      findings: Array<{
+        id?: string;
+        code: string;
+        message: string;
+        level?: string;
         authorRemediation?: TestPackageInspectorAuthorRemediation;
       }>;
     },
@@ -11627,7 +11648,7 @@ describe("packages public queries", () => {
           },
         ],
       }),
-    ).resolves.toMatchObject({ ok: true, inserted: 1, shouldEmailOwner: true });
+    ).resolves.toMatchObject({ ok: true, inserted: 1, shouldEmailOwner: false });
 
     expect(insert).toHaveBeenCalledWith(
       "packageInspectorWarnings",
@@ -11637,6 +11658,177 @@ describe("packages public queries", () => {
         targetOpenClawVersion: "2026.5.0",
       }),
     );
+  });
+
+  it("replaces the current nightly beta findings while preserving publish findings", async () => {
+    const insert = vi.fn();
+    const deleteRow = vi.fn();
+    const ctx = {
+      db: {
+        get: vi.fn(),
+        query: vi.fn((table: string) => {
+          if (table === "packageInspectorWarnings") {
+            return {
+              withIndex: vi.fn(() => ({
+                collect: vi.fn().mockResolvedValue([
+                  {
+                    _id: "packageInspectorWarnings:static",
+                    scanSource: "publish",
+                    inspectorFindingId: "demo:manifest-name-missing",
+                    code: "manifest-name-missing",
+                    message: "manifest name is missing",
+                    authorRemediation: { summary: "Add a manifest name." },
+                  },
+                  {
+                    _id: "packageInspectorWarnings:old-beta",
+                    scanSource: "nightly",
+                    inspectorFindingId: "demo:old-beta-api",
+                    code: "old-beta-api",
+                    message: "old beta API is missing",
+                    targetOpenClawVersion: "2026.7.0-beta.1",
+                    authorRemediation: { summary: "Use the supported API." },
+                  },
+                ]),
+              })),
+            };
+          }
+          if (table === "packageInspectorFindingNotifications") {
+            return {
+              withIndex: vi.fn(() => ({ unique: vi.fn().mockResolvedValue(null) })),
+            };
+          }
+          throw new Error(`Unexpected table ${table}`);
+        }),
+        insert,
+        patch: vi.fn(),
+        replace: vi.fn(),
+        delete: deleteRow,
+        normalizeId: vi.fn((tableName: string, id: string) =>
+          id.startsWith(`${tableName}:`) ? id : null,
+        ),
+      },
+    };
+
+    await expect(
+      insertPackageInspectorWarningsInternalHandler(ctx as never, {
+        packageId: "packages:demo",
+        releaseId: "packageReleases:demo-1",
+        ownerUserId: "users:owner",
+        packageName: "demo-plugin",
+        version: "1.0.0",
+        scanSource: "nightly",
+        inspectorVersion: "0.6.0",
+        targetOpenClawVersion: "2026.8.0-beta.1",
+        findings: [
+          {
+            id: "demo:new-beta-api",
+            code: "new-beta-api",
+            level: "breakage",
+            message: "new beta API is missing",
+            authorRemediation: { summary: "Use the replacement API." },
+          },
+        ],
+      }),
+    ).resolves.toMatchObject({ ok: true, inserted: 1, shouldEmailOwner: false });
+
+    expect(deleteRow).toHaveBeenCalledTimes(1);
+    expect(deleteRow).toHaveBeenCalledWith("packageInspectorWarnings:old-beta");
+    expect(insert).toHaveBeenCalledWith(
+      "packageInspectorWarnings",
+      expect.objectContaining({
+        scanSource: "nightly",
+        targetOpenClawVersion: "2026.8.0-beta.1",
+        code: "new-beta-api",
+      }),
+    );
+  });
+
+  it("records a clean beta scan identity without overwriting a previous target", async () => {
+    const insert = vi.fn().mockResolvedValue("packageInspectorScanStates:demo");
+    const deleteRow = vi.fn();
+    const scanStateWithIndex = vi.fn((indexName: string) => ({
+      unique: vi.fn().mockResolvedValue(
+        indexName === "by_release"
+          ? {
+              _id: "packageInspectorScanStates:previous",
+              inspectorVersion: "0.5.0",
+              targetOpenClawVersion: "2026.7.0-beta.1",
+            }
+          : null,
+      ),
+    }));
+    const ctx = {
+      db: {
+        get: vi.fn(async (id: string) => {
+          if (id === "packages:demo") {
+            return {
+              _id: "packages:demo",
+              name: "demo-plugin",
+              ownerUserId: "users:owner",
+            };
+          }
+          if (id === "packageReleases:demo-1") {
+            return {
+              _id: "packageReleases:demo-1",
+              packageId: "packages:demo",
+              version: "1.0.0",
+            };
+          }
+          return null;
+        }),
+        query: vi.fn((table: string) => {
+          if (table === "packageInspectorWarnings") {
+            return {
+              withIndex: vi.fn(() => ({
+                collect: vi.fn().mockResolvedValue([
+                  {
+                    _id: "packageInspectorWarnings:old-beta",
+                    scanSource: "nightly",
+                    code: "old-beta-api",
+                    message: "old beta API is missing",
+                    authorRemediation: { summary: "Use the supported API." },
+                  },
+                ]),
+              })),
+            };
+          }
+          if (table === "packageInspectorScanStates") {
+            return { withIndex: scanStateWithIndex };
+          }
+          throw new Error(`Unexpected table ${table}`);
+        }),
+        insert,
+        patch: vi.fn(),
+        replace: vi.fn(),
+        delete: deleteRow,
+        normalizeId: vi.fn((tableName: string, id: string) =>
+          id.startsWith(`${tableName}:`) ? id : null,
+        ),
+      },
+    };
+
+    await expect(
+      ingestPackageInspectorScanResultsInternalHandler(ctx as never, {
+        packageId: "packages:demo",
+        releaseId: "packageReleases:demo-1",
+        inspectorVersion: "0.6.0",
+        targetOpenClawVersion: "2026.8.0-beta.1",
+        findings: [],
+      }),
+    ).resolves.toEqual({ ok: true, inserted: 0, shouldEmailOwner: false });
+
+    expect(deleteRow).toHaveBeenCalledWith("packageInspectorWarnings:old-beta");
+    expect(scanStateWithIndex).toHaveBeenCalledWith(
+      "by_release_and_inspector_version_and_target_openclaw_version",
+      expect.any(Function),
+    );
+    expect(insert).toHaveBeenCalledWith("packageInspectorScanStates", {
+      packageId: "packages:demo",
+      releaseId: "packageReleases:demo-1",
+      inspectorVersion: "0.6.0",
+      targetOpenClawVersion: "2026.8.0-beta.1",
+      completedAt: expect.any(Number),
+    });
   });
 
   it("stores nightly plugin inspector errors as public findings", async () => {
@@ -11686,7 +11878,7 @@ describe("packages public queries", () => {
           },
         ],
       }),
-    ).resolves.toMatchObject({ ok: true, inserted: 1, shouldEmailOwner: true });
+    ).resolves.toMatchObject({ ok: true, inserted: 1, shouldEmailOwner: false });
 
     expect(insert).toHaveBeenCalledWith(
       "packageInspectorWarnings",
@@ -11755,7 +11947,7 @@ describe("packages public queries", () => {
           },
         ],
       }),
-    ).resolves.toMatchObject({ ok: true, inserted: 1, shouldEmailOwner: true });
+    ).resolves.toMatchObject({ ok: true, inserted: 1, shouldEmailOwner: false });
 
     expect(insert).toHaveBeenCalledTimes(1);
     expect(insert).toHaveBeenCalledWith(
@@ -11818,6 +12010,7 @@ describe("packages public queries", () => {
         scanSource: "nightly",
         inspectorVersion: "0.5.0",
         targetOpenClawVersion: "0.10.0",
+        notifyOwners: true,
         findings: [
           {
             id: "demo:legacy-before-agent-start",

--- a/convex/packages.ts
+++ b/convex/packages.ts
@@ -9782,6 +9782,7 @@ async function insertPackageInspectorFindings(
     scanSource?: "publish" | "nightly";
     inspectorVersion?: string;
     targetOpenClawVersion?: string;
+    notifyOwners?: boolean;
     findings?: PackageInspectorFinding[];
     warnings?: PackageInspectorFinding[];
   },
@@ -9791,7 +9792,17 @@ async function insertPackageInspectorFindings(
     .query("packageInspectorWarnings")
     .withIndex("by_release", (q) => q.eq("releaseId", args.releaseId))
     .collect();
-  const existingAuthorWarnings = existingWarnings.filter(hasStoredAuthorRemediation);
+  const replaceNightlyFindings = args.scanSource === "nightly";
+  if (replaceNightlyFindings) {
+    for (const warning of existingWarnings) {
+      if (warning.scanSource === "nightly") await ctx.db.delete(warning._id);
+    }
+  }
+  const existingAuthorWarnings = existingWarnings.filter(
+    (warning) =>
+      hasStoredAuthorRemediation(warning) &&
+      !(replaceNightlyFindings && warning.scanSource === "nightly"),
+  );
   if (findings.length === 0 && existingAuthorWarnings.length === 0) {
     return { ok: true as const, inserted: 0, shouldEmailOwner: false };
   }
@@ -9856,7 +9867,10 @@ async function insertPackageInspectorFindings(
   return {
     ok: true as const,
     inserted,
-    shouldEmailOwner: !existingNotification && (inserted > 0 || existingAuthorWarnings.length > 0),
+    shouldEmailOwner:
+      (args.notifyOwners ?? args.scanSource !== "nightly") &&
+      !existingNotification &&
+      (inserted > 0 || existingAuthorWarnings.length > 0),
   };
 }
 
@@ -10134,6 +10148,7 @@ export const ingestPackageInspectorScanResultsInternal = internalMutation({
     releaseId: v.id("packageReleases"),
     inspectorVersion: v.optional(v.string()),
     targetOpenClawVersion: v.optional(v.string()),
+    notifyOwners: v.optional(v.boolean()),
     findings: v.array(packageInspectorFindingInputValidator),
   },
   handler: async (ctx, args) => {
@@ -10150,7 +10165,7 @@ export const ingestPackageInspectorScanResultsInternal = internalMutation({
     ) {
       throw new ConvexError("Package release not found");
     }
-    return await insertPackageInspectorFindings(ctx, {
+    const result = await insertPackageInspectorFindings(ctx, {
       packageId: pkg._id,
       releaseId: release._id,
       ownerUserId: pkg.ownerUserId,
@@ -10160,8 +10175,35 @@ export const ingestPackageInspectorScanResultsInternal = internalMutation({
       scanSource: "nightly",
       inspectorVersion: args.inspectorVersion,
       targetOpenClawVersion: args.targetOpenClawVersion,
+      notifyOwners: args.notifyOwners,
       findings: args.findings,
     });
+    const { inspectorVersion, targetOpenClawVersion } = args;
+    if (inspectorVersion && targetOpenClawVersion) {
+      const completedAt = Date.now();
+      const existingState = await ctx.db
+        .query("packageInspectorScanStates")
+        .withIndex("by_release_and_inspector_version_and_target_openclaw_version", (q) =>
+          q
+            .eq("releaseId", release._id)
+            .eq("inspectorVersion", inspectorVersion)
+            .eq("targetOpenClawVersion", targetOpenClawVersion),
+        )
+        .unique();
+      const state = {
+        packageId: pkg._id,
+        releaseId: release._id,
+        inspectorVersion,
+        targetOpenClawVersion,
+        completedAt,
+      };
+      if (existingState) {
+        await ctx.db.patch(existingState._id, { completedAt });
+      } else {
+        await ctx.db.insert("packageInspectorScanStates", state);
+      }
+    }
+    return result;
   },
 });
 

--- a/convex/packages.ts
+++ b/convex/packages.ts
@@ -3085,6 +3085,28 @@ async function takeAuthorRemediationWarningsByRelease(
   return findings.filter(hasStoredAuthorRemediation).slice(0, limit);
 }
 
+async function takeExactNightlyAuthorRemediationWarningsByRelease(
+  ctx: DbReaderCtx,
+  releaseId: Id<"packageReleases">,
+  inspectorVersion: string,
+  targetOpenClawVersion: string,
+  limit: number,
+) {
+  const findings = await ctx.db
+    .query("packageInspectorWarnings")
+    .withIndex("by_release_created", (q) => q.eq("releaseId", releaseId))
+    .filter((q) =>
+      q.and(
+        q.eq(q.field("scanSource"), "nightly"),
+        q.eq(q.field("inspectorVersion"), inspectorVersion),
+        q.eq(q.field("targetOpenClawVersion"), targetOpenClawVersion),
+      ),
+    )
+    .order("desc")
+    .take(authorRemediationScanLimit(limit));
+  return findings.filter(hasStoredAuthorRemediation).slice(0, limit);
+}
+
 function authorRemediationScanLimit(limit: number) {
   return Math.min(500, Math.max(limit * 5, 50));
 }
@@ -9973,16 +9995,17 @@ export const getPackageInspectorEmailContextInternal = internalQuery({
     if (!pkg || pkg.softDeletedAt || !release || release.softDeletedAt) return null;
     const owner = await ctx.db.get(pkg.ownerUserId);
     if (!owner || owner.deletedAt || owner.deactivatedAt || !owner.email) return null;
-    const allFindings = await takeAuthorRemediationWarningsByRelease(ctx, release._id, 100);
     const exactScanIdentity = Boolean(args.inspectorVersion && args.targetOpenClawVersion);
-    const findings = exactScanIdentity
-      ? allFindings.filter(
-          (finding) =>
-            finding.scanSource === "nightly" &&
-            finding.inspectorVersion === args.inspectorVersion &&
-            finding.targetOpenClawVersion === args.targetOpenClawVersion,
-        )
-      : allFindings;
+    const findings =
+      args.inspectorVersion && args.targetOpenClawVersion
+        ? await takeExactNightlyAuthorRemediationWarningsByRelease(
+            ctx,
+            release._id,
+            args.inspectorVersion,
+            args.targetOpenClawVersion,
+            100,
+          )
+        : await takeAuthorRemediationWarningsByRelease(ctx, release._id, 100);
     if (findings.length === 0) return null;
     const notificationCompleted = await hasCompletedPackageInspectorNotification(ctx, {
       releaseId: release._id,

--- a/convex/packages.ts
+++ b/convex/packages.ts
@@ -9770,6 +9770,34 @@ export const insertPackageInspectorWarningsInternal = internalMutation({
   },
 });
 
+async function hasCompletedPackageInspectorNotification(
+  ctx: DbReaderCtx,
+  args: {
+    releaseId: Id<"packageReleases">;
+    inspectorVersion?: string;
+    targetOpenClawVersion?: string;
+    exactScanIdentity: boolean;
+  },
+) {
+  if (args.exactScanIdentity && args.inspectorVersion && args.targetOpenClawVersion) {
+    const scanState = await ctx.db
+      .query("packageInspectorScanStates")
+      .withIndex("by_release_and_inspector_version_and_target_openclaw_version", (q) =>
+        q
+          .eq("releaseId", args.releaseId)
+          .eq("inspectorVersion", args.inspectorVersion as string)
+          .eq("targetOpenClawVersion", args.targetOpenClawVersion as string),
+      )
+      .unique();
+    return Boolean(scanState?.notificationCompletedAt);
+  }
+  const notification = await ctx.db
+    .query("packageInspectorFindingNotifications")
+    .withIndex("by_release", (q) => q.eq("releaseId", args.releaseId))
+    .unique();
+  return Boolean(notification);
+}
+
 async function insertPackageInspectorFindings(
   ctx: Pick<MutationCtx, "db">,
   args: {
@@ -9819,10 +9847,15 @@ async function insertPackageInspectorFindings(
       }),
     ),
   );
-  const existingNotification = await ctx.db
-    .query("packageInspectorFindingNotifications")
-    .withIndex("by_release", (q) => q.eq("releaseId", args.releaseId))
-    .unique();
+  const shouldNotifyOwner = args.notifyOwners ?? args.scanSource !== "nightly";
+  const notificationCompleted = shouldNotifyOwner
+    ? await hasCompletedPackageInspectorNotification(ctx, {
+        releaseId: args.releaseId,
+        inspectorVersion: args.inspectorVersion,
+        targetOpenClawVersion: args.targetOpenClawVersion,
+        exactScanIdentity: args.scanSource === "nightly",
+      })
+    : false;
   const now = Date.now();
   let inserted = 0;
   for (const warning of findings.slice(0, 100)) {
@@ -9868,9 +9901,11 @@ async function insertPackageInspectorFindings(
     ok: true as const,
     inserted,
     shouldEmailOwner:
-      (args.notifyOwners ?? args.scanSource !== "nightly") &&
-      !existingNotification &&
-      (inserted > 0 || existingAuthorWarnings.length > 0),
+      shouldNotifyOwner &&
+      !notificationCompleted &&
+      (args.scanSource === "nightly"
+        ? findings.length > 0
+        : inserted > 0 || existingAuthorWarnings.length > 0),
   };
 }
 
@@ -9884,25 +9919,42 @@ export const markPackageInspectorFindingsEmailedInternal = internalMutation({
     version: v.string(),
     findingCount: v.number(),
     email: v.string(),
+    inspectorVersion: v.optional(v.string()),
+    targetOpenClawVersion: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const existing = await ctx.db
       .query("packageInspectorFindingNotifications")
       .withIndex("by_release", (q) => q.eq("releaseId", args.releaseId))
       .unique();
-    if (existing) return { ok: true as const, created: false };
-    await ctx.db.insert("packageInspectorFindingNotifications", {
-      packageId: args.packageId,
-      releaseId: args.releaseId,
-      ownerUserId: args.ownerUserId,
-      ownerPublisherId: args.ownerPublisherId,
-      packageName: args.packageName,
-      version: args.version,
-      email: args.email,
-      findingCount: Math.max(0, Math.round(args.findingCount)),
-      sentAt: Date.now(),
-    });
-    return { ok: true as const, created: true };
+    const now = Date.now();
+    if (!existing) {
+      await ctx.db.insert("packageInspectorFindingNotifications", {
+        packageId: args.packageId,
+        releaseId: args.releaseId,
+        ownerUserId: args.ownerUserId,
+        ownerPublisherId: args.ownerPublisherId,
+        packageName: args.packageName,
+        version: args.version,
+        email: args.email,
+        findingCount: Math.max(0, Math.round(args.findingCount)),
+        sentAt: now,
+      });
+    }
+    const { inspectorVersion, targetOpenClawVersion } = args;
+    if (inspectorVersion && targetOpenClawVersion) {
+      const scanState = await ctx.db
+        .query("packageInspectorScanStates")
+        .withIndex("by_release_and_inspector_version_and_target_openclaw_version", (q) =>
+          q
+            .eq("releaseId", args.releaseId)
+            .eq("inspectorVersion", inspectorVersion)
+            .eq("targetOpenClawVersion", targetOpenClawVersion),
+        )
+        .unique();
+      if (scanState) await ctx.db.patch(scanState._id, { notificationCompletedAt: now });
+    }
+    return { ok: true as const, created: !existing };
   },
 });
 
@@ -9910,6 +9962,8 @@ export const getPackageInspectorEmailContextInternal = internalQuery({
   args: {
     packageId: v.id("packages"),
     releaseId: v.id("packageReleases"),
+    inspectorVersion: v.optional(v.string()),
+    targetOpenClawVersion: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const [pkg, release] = await Promise.all([
@@ -9919,13 +9973,24 @@ export const getPackageInspectorEmailContextInternal = internalQuery({
     if (!pkg || pkg.softDeletedAt || !release || release.softDeletedAt) return null;
     const owner = await ctx.db.get(pkg.ownerUserId);
     if (!owner || owner.deletedAt || owner.deactivatedAt || !owner.email) return null;
-    const findings = await takeAuthorRemediationWarningsByRelease(ctx, release._id, 100);
+    const allFindings = await takeAuthorRemediationWarningsByRelease(ctx, release._id, 100);
+    const exactScanIdentity = Boolean(args.inspectorVersion && args.targetOpenClawVersion);
+    const findings = exactScanIdentity
+      ? allFindings.filter(
+          (finding) =>
+            finding.scanSource === "nightly" &&
+            finding.inspectorVersion === args.inspectorVersion &&
+            finding.targetOpenClawVersion === args.targetOpenClawVersion,
+        )
+      : allFindings;
     if (findings.length === 0) return null;
-    const notification = await ctx.db
-      .query("packageInspectorFindingNotifications")
-      .withIndex("by_release", (q) => q.eq("releaseId", release._id))
-      .unique();
-    if (notification) return null;
+    const notificationCompleted = await hasCompletedPackageInspectorNotification(ctx, {
+      releaseId: release._id,
+      inspectorVersion: args.inspectorVersion,
+      targetOpenClawVersion: args.targetOpenClawVersion,
+      exactScanIdentity,
+    });
+    if (notificationCompleted) return null;
     return {
       packageId: pkg._id,
       releaseId: release._id,
@@ -9944,6 +10009,8 @@ export const sendPackageInspectorFindingsEmailInternal = internalAction({
   args: {
     packageId: v.id("packages"),
     releaseId: v.id("packageReleases"),
+    inspectorVersion: v.optional(v.string()),
+    targetOpenClawVersion: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const context = await runQueryRef<{
@@ -9992,6 +10059,8 @@ export const sendPackageInspectorFindingsEmailInternal = internalAction({
         version: context.version,
         findingCount: context.findings.length,
         email: context.ownerEmail,
+        inspectorVersion: args.inspectorVersion,
+        targetOpenClawVersion: args.targetOpenClawVersion,
       });
     }
     return { ok: true as const, sent };
@@ -10010,50 +10079,97 @@ type PackageInspectorScanBatchItem = {
 
 async function listPackageInspectorScanBatch(
   ctx: Pick<QueryCtx | MutationCtx, "db">,
-  args: { cursor?: string | null; batchSize?: number },
+  args: {
+    cursor?: string | null;
+    batchSize?: number;
+    inspectorVersion?: string;
+    targetOpenClawVersion?: string;
+    notifyOwners?: boolean;
+  },
 ) {
   const batchSize = Math.max(1, Math.min(Math.round(args.batchSize ?? 25), 50));
-  const page = await ctx.db
-    .query("packageReleases")
-    .withIndex("by_active_created", (q) => q.eq("softDeletedAt", undefined))
-    .order("asc")
-    .paginate({
-      cursor: args.cursor ?? null,
-      numItems: batchSize,
-    });
   const items: PackageInspectorScanBatchItem[] = [];
-  for (const release of page.page) {
-    if (items.length >= batchSize) break;
-    if (!isPublishedPackageRelease(release)) continue;
-    const pkg = await ctx.db.get(release.packageId);
-    if (
-      !pkg ||
-      pkg.softDeletedAt ||
-      (pkg.family !== "code-plugin" && pkg.family !== "bundle-plugin") ||
-      pkg.channel === "private" ||
-      isPackageBlockedFromPublic(resolvePublicPackageScanStatus(pkg, release))
-    ) {
-      continue;
+  let skippedUnchanged = 0;
+  let sourceCursor = args.cursor ?? null;
+  let nextCursor: string | null = sourceCursor;
+  let sourceReleasesRead = 0;
+  // Amortize filtered/unchanged releases without risking an unbounded Convex transaction.
+  const maxSourceReleases = 500;
+  while (items.length < batchSize && sourceReleasesRead < maxSourceReleases) {
+    const pageSize = Math.min(batchSize - items.length, maxSourceReleases - sourceReleasesRead);
+    const page = await ctx.db
+      .query("packageReleases")
+      .withIndex("by_active_created", (q) => q.eq("softDeletedAt", undefined))
+      .order("asc")
+      .paginate({
+        cursor: sourceCursor,
+        numItems: pageSize,
+      });
+    if (!page.isDone && page.continueCursor === sourceCursor) {
+      throw new Error("Package Inspector scan pagination cursor did not advance");
     }
-    const latestReleaseId = pkg.latestReleaseId ?? pkg.tags?.latest;
-    if (latestReleaseId !== release._id) continue;
-    items.push({
-      packageId: pkg._id,
-      releaseId: release._id,
-      ownerUserId: pkg.ownerUserId,
-      ownerPublisherId: pkg.ownerPublisherId,
-      packageName: pkg.name,
-      version: release.version,
-      artifactKind: release.artifactKind ?? "legacy-zip",
-    });
+    // Count the requested page budget as consumed even when Convex returns an
+    // empty split page, so filtered releases remain transaction-bounded.
+    sourceReleasesRead += pageSize;
+    for (const release of page.page) {
+      if (items.length >= batchSize) break;
+      if (!isPublishedPackageRelease(release)) continue;
+      const pkg = await ctx.db.get(release.packageId);
+      if (
+        !pkg ||
+        pkg.softDeletedAt ||
+        (pkg.family !== "code-plugin" && pkg.family !== "bundle-plugin") ||
+        pkg.channel === "private" ||
+        isPackageBlockedFromPublic(resolvePublicPackageScanStatus(pkg, release))
+      ) {
+        continue;
+      }
+      const latestReleaseId = pkg.latestReleaseId ?? pkg.tags?.latest;
+      if (latestReleaseId !== release._id) continue;
+      const { inspectorVersion, targetOpenClawVersion } = args;
+      if (inspectorVersion && targetOpenClawVersion) {
+        const scanState = await ctx.db
+          .query("packageInspectorScanStates")
+          .withIndex("by_release_and_inspector_version_and_target_openclaw_version", (q) =>
+            q
+              .eq("releaseId", release._id)
+              .eq("inspectorVersion", inspectorVersion)
+              .eq("targetOpenClawVersion", targetOpenClawVersion),
+          )
+          .unique();
+        if (scanState && (!args.notifyOwners || scanState.notificationCompletedAt)) {
+          skippedUnchanged += 1;
+          continue;
+        }
+      }
+      items.push({
+        packageId: pkg._id,
+        releaseId: release._id,
+        ownerUserId: pkg.ownerUserId,
+        ownerPublisherId: pkg.ownerPublisherId,
+        packageName: pkg.name,
+        version: release.version,
+        artifactKind: release.artifactKind ?? "legacy-zip",
+      });
+    }
+    nextCursor = page.isDone ? null : page.continueCursor;
+    if (page.isDone || items.length >= batchSize) break;
+    sourceCursor = page.continueCursor;
   }
-  return { items, nextCursor: page.isDone ? null : page.continueCursor };
+  return {
+    items,
+    nextCursor,
+    skippedUnchanged,
+  };
 }
 
 export const previewPackageInspectorScanBatchInternal = internalQuery({
   args: {
     batchSize: v.optional(v.number()),
     cursor: v.optional(v.union(v.string(), v.null())),
+    inspectorVersion: v.optional(v.string()),
+    targetOpenClawVersion: v.optional(v.string()),
+    notifyOwners: v.optional(v.boolean()),
   },
   handler: async (ctx, args) => {
     const result = await listPackageInspectorScanBatch(ctx, args);
@@ -10065,9 +10181,16 @@ export const claimPackageInspectorScanBatchInternal = internalMutation({
   args: {
     batchSize: v.optional(v.number()),
     leaseMs: v.optional(v.number()),
+    cursor: v.optional(v.union(v.string(), v.null())),
+    runId: v.string(),
+    inspectorVersion: v.optional(v.string()),
+    targetOpenClawVersion: v.optional(v.string()),
+    notifyOwners: v.optional(v.boolean()),
   },
   handler: async (ctx, args) => {
     const now = Date.now();
+    const runId = args.runId.trim();
+    if (!runId) throw new Error("Package Inspector scan runId is required");
     const leaseMs = Math.max(
       60_000,
       Math.min(Math.round(args.leaseMs ?? 30 * 60_000), 2 * 60 * 60_000),
@@ -10077,34 +10200,89 @@ export const claimPackageInspectorScanBatchInternal = internalMutation({
       .query("packageInspectorScanCursors")
       .withIndex("by_name", (q) => q.eq("name", cursorName))
       .unique();
-    if (cursorDoc?.leaseExpiresAt && cursorDoc.leaseExpiresAt > now) {
+    const expectedCursor = cursorDoc?.cursor ?? null;
+    const hasPendingBatch = Boolean(cursorDoc && Object.hasOwn(cursorDoc, "pendingCursor"));
+    // A GitHub workflow rerun keeps its run id. Let it reclaim an unacknowledged
+    // page immediately so a failed attempt does not strand the cursor until expiry.
+    const continuingSameRun = cursorDoc?.runId === runId;
+    if (cursorDoc?.leaseExpiresAt && cursorDoc.leaseExpiresAt > now && !continuingSameRun) {
       return {
         ok: true as const,
         leased: true as const,
         items: [],
-        nextCursor: cursorDoc.cursor ?? null,
+        nextCursor: hasPendingBatch ? (cursorDoc.pendingCursor ?? null) : expectedCursor,
       };
     }
 
-    const { items, nextCursor } = await listPackageInspectorScanBatch(ctx, {
-      cursor: cursorDoc?.cursor ?? null,
+    const { items, nextCursor, skippedUnchanged } = await listPackageInspectorScanBatch(ctx, {
+      cursor: expectedCursor,
       batchSize: args.batchSize,
+      inspectorVersion: args.inspectorVersion,
+      targetOpenClawVersion: args.targetOpenClawVersion,
+      notifyOwners: args.notifyOwners,
     });
     if (cursorDoc) {
       await ctx.db.patch(cursorDoc._id, {
-        cursor: nextCursor,
+        cursor: expectedCursor,
+        pendingCursor: nextCursor,
+        runId,
         leaseExpiresAt: now + leaseMs,
         updatedAt: now,
       });
     } else {
       await ctx.db.insert("packageInspectorScanCursors", {
         name: cursorName,
-        cursor: nextCursor,
+        cursor: expectedCursor,
+        pendingCursor: nextCursor,
+        runId,
         leaseExpiresAt: now + leaseMs,
         updatedAt: now,
       });
     }
-    return { ok: true as const, leased: false as const, items, nextCursor };
+    return {
+      ok: true as const,
+      leased: false as const,
+      items,
+      nextCursor,
+      skippedUnchanged,
+    };
+  },
+});
+
+export const acknowledgePackageInspectorScanBatchInternal = internalMutation({
+  args: {
+    runId: v.string(),
+    cursor: v.union(v.string(), v.null()),
+    leaseMs: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const now = Date.now();
+    const runId = args.runId.trim();
+    if (!runId) throw new Error("Package Inspector scan runId is required");
+    const leaseMs = Math.max(
+      60_000,
+      Math.min(Math.round(args.leaseMs ?? 30 * 60_000), 2 * 60 * 60_000),
+    );
+    const cursorDoc = await ctx.db
+      .query("packageInspectorScanCursors")
+      .withIndex("by_name", (q) => q.eq("name", "nightly"))
+      .unique();
+    if (!cursorDoc || cursorDoc.runId !== runId) {
+      throw new Error("Package Inspector scan run does not own the active lease");
+    }
+    if (!Object.hasOwn(cursorDoc, "pendingCursor") || cursorDoc.pendingCursor !== args.cursor) {
+      throw new Error("Package Inspector scan acknowledgement cursor does not match the lease");
+    }
+
+    const completed = args.cursor === null;
+    await ctx.db.patch(cursorDoc._id, {
+      cursor: args.cursor,
+      pendingCursor: undefined,
+      runId: completed ? undefined : runId,
+      leaseExpiresAt: completed ? now : now + leaseMs,
+      updatedAt: now,
+    });
+    return { ok: true as const, cursor: args.cursor, completed };
   },
 });
 
@@ -10196,9 +10374,17 @@ export const ingestPackageInspectorScanResultsInternal = internalMutation({
         inspectorVersion,
         targetOpenClawVersion,
         completedAt,
+        ...(args.notifyOwners === true && !result.shouldEmailOwner
+          ? { notificationCompletedAt: completedAt }
+          : {}),
       };
       if (existingState) {
-        await ctx.db.patch(existingState._id, { completedAt });
+        await ctx.db.patch(existingState._id, {
+          completedAt,
+          ...(state.notificationCompletedAt
+            ? { notificationCompletedAt: state.notificationCompletedAt }
+            : {}),
+        });
       } else {
         await ctx.db.insert("packageInspectorScanStates", state);
       }

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1980,6 +1980,8 @@ const packageInspectorFindingNotifications = defineTable({
 const packageInspectorScanCursors = defineTable({
   name: v.string(),
   cursor: v.optional(v.union(v.string(), v.null())),
+  pendingCursor: v.optional(v.union(v.string(), v.null())),
+  runId: v.optional(v.string()),
   leaseExpiresAt: v.optional(v.number()),
   updatedAt: v.number(),
 }).index("by_name", ["name"]);
@@ -1990,6 +1992,7 @@ const packageInspectorScanStates = defineTable({
   inspectorVersion: v.string(),
   targetOpenClawVersion: v.string(),
   completedAt: v.number(),
+  notificationCompletedAt: v.optional(v.number()),
 }).index("by_release_and_inspector_version_and_target_openclaw_version", [
   "releaseId",
   "inspectorVersion",

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1984,6 +1984,18 @@ const packageInspectorScanCursors = defineTable({
   updatedAt: v.number(),
 }).index("by_name", ["name"]);
 
+const packageInspectorScanStates = defineTable({
+  packageId: v.id("packages"),
+  releaseId: v.id("packageReleases"),
+  inspectorVersion: v.string(),
+  targetOpenClawVersion: v.string(),
+  completedAt: v.number(),
+}).index("by_release_and_inspector_version_and_target_openclaw_version", [
+  "releaseId",
+  "inspectorVersion",
+  "targetOpenClawVersion",
+]);
+
 const securityScanJobs = defineTable({
   targetKind: securityScanTargetKindValidator,
   skillVersionId: v.optional(v.id("skillVersions")),
@@ -4208,6 +4220,7 @@ export default defineSchema({
   packageInspectorWarnings,
   packageInspectorFindingNotifications,
   packageInspectorScanCursors,
+  packageInspectorScanStates,
   securityScanJobs,
   securityScanDispatchState,
   skillScanRequests,

--- a/scripts/package-inspector-nightly-scan.test.ts
+++ b/scripts/package-inspector-nightly-scan.test.ts
@@ -1,10 +1,16 @@
 /* @vitest-environment node */
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
+  acknowledgeBatch,
+  prepareBulkOpenClawTarget,
+  resolveNightlyOpenClawTarget,
+  resolveScanRunId,
+  renderImpactMarkdown,
   normalizeFindings,
   parsePackageNames,
   resolveArtifactKind,
+  summarizeImpact,
 } from "./package-inspector-nightly-scan";
 
 describe("package-inspector-nightly-scan", () => {
@@ -90,5 +96,83 @@ describe("package-inspector-nightly-scan", () => {
       ),
     ).toBe("legacy-zip");
     expect(resolveArtifactKind("npm-pack", new Headers())).toBe("npm-pack");
+  });
+
+  it("reports the exact beta target and unchanged releases in the run summary", () => {
+    const summary = summarizeImpact({
+      claimed: 2,
+      scanned: 1,
+      skippedUnchanged: 1,
+      batches: 1,
+      truncated: false,
+      nextCursor: null,
+      inspectorVersion: "0.6.0",
+      targetOpenClawVersion: "2026.8.0-beta.1",
+      entries: [],
+    });
+
+    expect(summary).toMatchObject({
+      inspectorVersion: "0.6.0",
+      targetOpenClawVersion: "2026.8.0-beta.1",
+      skippedUnchangedReleases: 1,
+    });
+    expect(renderImpactMarkdown(summary)).toContain("- Target OpenClaw: 2026.8.0-beta.1");
+    expect(renderImpactMarkdown(summary)).toContain("- Skipped unchanged releases: 1");
+  });
+
+  it("resolves and prepares the beta target once for reuse across the bulk run", async () => {
+    const resolved = { requestedVersion: "beta", version: "2026.8.0-beta.1" };
+    const prepared = { ...resolved, status: "ok", cache: { hit: false, key: "beta-key" } };
+    const resolveVersion = vi.fn().mockResolvedValue(resolved);
+    const prepare = vi.fn().mockResolvedValue(prepared);
+
+    await expect(
+      prepareBulkOpenClawTarget("beta", {
+        openClawTargets: { resolveVersion, prepare },
+      }),
+    ).resolves.toEqual({
+      exactVersion: "2026.8.0-beta.1",
+      target: prepared,
+    });
+    expect(resolveVersion).toHaveBeenCalledTimes(1);
+    expect(prepare).toHaveBeenCalledTimes(1);
+    expect(resolveNightlyOpenClawTarget(undefined)).toBe("beta");
+    expect(() => resolveNightlyOpenClawTarget("latest")).toThrow(
+      "Nightly plugin scans only support the OpenClaw beta target",
+    );
+  });
+
+  it("keeps the scan run identity stable across GitHub workflow reruns", () => {
+    expect(
+      resolveScanRunId({
+        GITHUB_RUN_ID: "12345",
+        GITHUB_RUN_ATTEMPT: "2",
+      }),
+    ).toBe("12345");
+    expect(
+      resolveScanRunId({
+        PLUGIN_INSPECTOR_RUN_ID: "manual-run",
+        GITHUB_RUN_ID: "12345",
+      }),
+    ).toBe("manual-run");
+  });
+
+  it("acknowledges a processed batch before the runner advances its cursor", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ ok: true, cursor: "page-2", completed: false }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(acknowledgeBatch("page-2", "run-42")).resolves.toMatchObject({
+      ok: true,
+      cursor: "page-2",
+    });
+    expect(fetchMock.mock.calls[0]?.[0]).toContain(
+      "/api/v1/package-inspector/acknowledge?runId=run-42&cursor=page-2",
+    );
+    vi.unstubAllGlobals();
   });
 });

--- a/scripts/package-inspector-nightly-scan.ts
+++ b/scripts/package-inspector-nightly-scan.ts
@@ -1,4 +1,5 @@
 import { spawnSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import { existsSync, readFileSync } from "node:fs";
 import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { createRequire } from "node:module";
@@ -21,6 +22,7 @@ type ClaimResponse = {
   leased: boolean;
   dryRun?: boolean;
   nextCursor?: string | null;
+  skippedUnchanged?: number;
   items: ClaimItem[];
 };
 
@@ -60,10 +62,33 @@ type UploadResult = {
   shouldEmailOwner: boolean;
 };
 
+type PluginInspectorModule = {
+  openClawTargets?: {
+    resolveVersion: (requestedVersion: string) => Promise<Record<string, unknown>>;
+    prepare: (resolvedTarget: Record<string, unknown>) => Promise<Record<string, unknown>>;
+  };
+  pluginRoot?: {
+    runCheck: (options: Record<string, unknown>) => Promise<{
+      report: Record<string, unknown>;
+      paths: { jsonPath: string };
+    }>;
+  };
+  ci?: {
+    writeOutputs: (
+      report: Record<string, unknown>,
+      options: { cwd: string; outDir: string },
+    ) => Promise<unknown>;
+  };
+  reports?: {
+    sanitizeArtifact: (report: Record<string, unknown>) => unknown;
+  };
+};
+
 const siteUrl = (process.env.CLAWHUB_SITE_URL ?? "https://clawhub.ai").replace(/\/+$/, "");
 const token = process.env.CLAWHUB_PLUGIN_INSPECTOR_WORKER_TOKEN;
 const batchSize = process.env.PLUGIN_INSPECTOR_BATCH_SIZE ?? "25";
 const dryRun = parseBoolean(process.env.PLUGIN_INSPECTOR_DRY_RUN);
+const notifyOwners = parseBoolean(process.env.PLUGIN_INSPECTOR_NOTIFY_OWNERS);
 const targetPackageNames = parsePackageNames(process.env.PLUGIN_INSPECTOR_PACKAGE_NAMES);
 const dryRunMaxBatches = Math.max(
   1,
@@ -74,19 +99,58 @@ const dryRunMaxBatches = Math.max(
 );
 const artifactRoot =
   process.env.PLUGIN_INSPECTOR_ARTIFACT_DIR ?? "plugin-inspector-bulk-scan-reports";
-const repoRoot = path.resolve(process.env.GITHUB_WORKSPACE ?? process.cwd());
-const clawhubCliEntry = path.join(repoRoot, "packages", "clawhub", "src", "cli.ts");
+const scanRunId = resolveScanRunId(process.env);
+
+export function resolveScanRunId(env: Record<string, string | undefined>) {
+  return env.PLUGIN_INSPECTOR_RUN_ID?.trim() || env.GITHUB_RUN_ID?.trim() || randomUUID();
+}
+
+export function resolveNightlyOpenClawTarget(value: string | undefined) {
+  const requested = value?.trim() || "beta";
+  if (requested !== "beta") {
+    throw new Error("Nightly plugin scans only support the OpenClaw beta target");
+  }
+  return requested;
+}
+
+export async function prepareBulkOpenClawTarget(
+  requestedVersion: string,
+  inspectorModule?: PluginInspectorModule,
+) {
+  const inspector =
+    inspectorModule ??
+    ((await import("@openclaw/plugin-inspector")) as unknown as PluginInspectorModule);
+  if (!inspector.openClawTargets) {
+    throw new Error(
+      "The bundled Plugin Inspector does not support version-resolved OpenClaw targets",
+    );
+  }
+  const resolved = await inspector.openClawTargets.resolveVersion(requestedVersion);
+  const target = await inspector.openClawTargets.prepare(resolved);
+  const exactVersion = stringValue(target.version) ?? stringValue(resolved.version);
+  if (!exactVersion) {
+    throw new Error("Plugin Inspector did not return an exact OpenClaw target version");
+  }
+  return { exactVersion, target };
+}
 
 export async function runPackageInspectorNightlyScan() {
   if (!token) throw new Error("CLAWHUB_PLUGIN_INSPECTOR_WORKER_TOKEN is required");
 
   const inspectorVersion = getInspectorVersion();
+  const inspectorModule =
+    (await import("@openclaw/plugin-inspector")) as unknown as PluginInspectorModule;
+  const requestedOpenClawVersion = resolveNightlyOpenClawTarget(
+    process.env.PLUGIN_INSPECTOR_OPENCLAW_VERSION,
+  );
+  const preparedTarget = await prepareBulkOpenClawTarget(requestedOpenClawVersion, inspectorModule);
   await mkdir(artifactRoot, { recursive: true });
 
   let hadWorkerFailure = false;
   const impactEntries: ImpactEntry[] = [];
   let claimed = 0;
   let scanned = 0;
+  let skippedUnchanged = 0;
   let cursor: string | null = null;
   let batches = 0;
   let truncated = false;
@@ -96,59 +160,105 @@ export async function runPackageInspectorNightlyScan() {
     batches = 1;
     claimed = items.length;
     for (const item of items) {
-      const result = await inspectPackageItem(item, inspectorVersion);
+      const result = await inspectPackageItem(
+        item,
+        inspectorVersion,
+        preparedTarget,
+        inspectorModule,
+      );
       if (result.failed) hadWorkerFailure = true;
       if (result.impactEntry) impactEntries.push(result.impactEntry);
       if (result.scanned) scanned += 1;
     }
   } else {
     do {
-      const claim = await claimBatch(cursor);
+      const claimCursor = cursor;
+      const claim = await claimBatch(
+        cursor,
+        inspectorVersion,
+        preparedTarget.exactVersion,
+        scanRunId,
+      );
+      if (claim.leased) {
+        throw new Error("Plugin Inspector bulk scan lease is owned by another run");
+      }
       batches += 1;
-      cursor = claim.nextCursor ?? null;
+      const nextCursor = claim.nextCursor ?? null;
       claimed += claim.items.length;
+      skippedUnchanged += claim.skippedUnchanged ?? 0;
+      let batchFailed = false;
 
       for (const item of claim.items) {
-        const result = await inspectPackageItem(item, inspectorVersion);
-        if (result.failed) hadWorkerFailure = true;
+        const result = await inspectPackageItem(
+          item,
+          inspectorVersion,
+          preparedTarget,
+          inspectorModule,
+        );
+        if (result.failed) {
+          hadWorkerFailure = true;
+          batchFailed = true;
+        }
         if (result.impactEntry) impactEntries.push(result.impactEntry);
         if (result.scanned) scanned += 1;
       }
 
-      if (!dryRun) break;
-      if (cursor && batches >= dryRunMaxBatches) {
-        truncated = true;
-        break;
+      if (!dryRun) {
+        if (batchFailed) {
+          cursor = claimCursor;
+          break;
+        }
+        await acknowledgeBatch(nextCursor, scanRunId);
       }
-    } while (dryRun && cursor);
+      cursor = nextCursor;
+
+      if (cursor && batches >= dryRunMaxBatches) {
+        if (dryRun) {
+          truncated = true;
+          break;
+        }
+      }
+    } while (cursor);
   }
 
+  const summary = summarizeImpact({
+    claimed,
+    scanned,
+    skippedUnchanged,
+    batches,
+    truncated,
+    nextCursor: cursor,
+    inspectorVersion,
+    targetOpenClawVersion: preparedTarget.exactVersion,
+    entries: impactEntries,
+  });
+  await writeFile(
+    path.join(artifactRoot, "run-summary.json"),
+    `${JSON.stringify(summary, null, 2)}\n`,
+  );
+  await writeFile(path.join(artifactRoot, "run-summary.md"), renderImpactMarkdown(summary));
   if (dryRun) {
-    const summary = summarizeImpact({
-      claimed,
-      scanned,
-      batches,
-      truncated,
-      nextCursor: cursor,
-      inspectorVersion,
-      entries: impactEntries,
-    });
     await writeFile(
       path.join(artifactRoot, "impact-summary.json"),
       `${JSON.stringify(summary, null, 2)}\n`,
     );
     await writeFile(path.join(artifactRoot, "impact-summary.md"), renderImpactMarkdown(summary));
-    console.log(
-      `Dry run scanned ${summary.scannedReleases} latest plugin releases: ${summary.pluginsWithErrors} with errors, ${summary.pluginsWithWarnings} with warnings, ${summary.impactedOwners} owner(s) impacted.`,
-    );
   }
+  console.log(
+    `Bulk scan target OpenClaw ${summary.targetOpenClawVersion}: scanned=${summary.scannedReleases}, skippedUnchanged=${summary.skippedUnchangedReleases}, errors=${summary.pluginsWithErrors}, warnings=${summary.pluginsWithWarnings}.`,
+  );
 
   if (hadWorkerFailure) {
     process.exitCode = 1;
   }
 }
 
-async function inspectPackageItem(item: ClaimItem, inspectorVersion: string) {
+async function inspectPackageItem(
+  item: ClaimItem,
+  inspectorVersion: string,
+  preparedTarget: { exactVersion: string; target: Record<string, unknown> },
+  inspectorModule: PluginInspectorModule,
+) {
   const workRoot = path.join(
     tmpdir(),
     `clawhub-plugin-inspector-bulk-scan-${Date.now()}-${Math.random().toString(16).slice(2)}`,
@@ -183,22 +293,37 @@ async function inspectPackageItem(item: ClaimItem, inspectorVersion: string) {
         ? path.join(pluginRoot, "package")
         : pluginRoot;
     await writeSyntheticConfigIfNeeded(scanRoot, item.packageName);
-    const scan = spawnSync(
-      "bun",
-      [clawhubCliEntry, "package", "validate", scanRoot, "--out", reportDir, "--json"],
-      { cwd: repoRoot, encoding: "utf8" },
-    );
-    await writeFile(path.join(reportDir, "stdout.txt"), scan.stdout ?? "");
-    await writeFile(path.join(reportDir, "stderr.txt"), scan.stderr ?? "");
-    const reportPath = path.join(reportDir, "plugin-inspector-report.json");
-    if (!existsSync(reportPath)) {
-      throw new Error(
-        scan.stderr || scan.stdout || `clawhub package validate exited ${scan.status}`,
-      );
+    if (!inspectorModule.pluginRoot || !inspectorModule.ci || !inspectorModule.reports) {
+      throw new Error("The bundled Plugin Inspector bulk APIs are unavailable");
     }
-    const report = JSON.parse(await readFile(reportPath, "utf8"));
+    const scan = await inspectorModule.pluginRoot.runCheck({
+      allowExecution: false,
+      authorFacing: true,
+      capture: false,
+      configPath: resolveInspectorConfigPath(scanRoot),
+      mockSdk: true,
+      outDir: reportDir,
+      pluginRoot: scanRoot,
+      targetOpenClaw: preparedTarget.target,
+    });
+    const report = scan.report;
+    await writeFile(scan.paths.jsonPath, `${JSON.stringify(report, null, 2)}\n`);
+    await inspectorModule.ci.writeOutputs(report, {
+      cwd: path.dirname(scan.paths.jsonPath),
+      outDir: ".",
+    });
+    await writeFile(
+      path.join(reportDir, "stdout.txt"),
+      `${JSON.stringify(inspectorModule.reports.sanitizeArtifact(report), null, 2)}\n`,
+    );
+    await writeFile(path.join(reportDir, "stderr.txt"), "");
     const findings = normalizeFindings(report);
     const targetOpenClawVersion = extractTargetOpenClawVersion(report.targetOpenClaw);
+    if (targetOpenClawVersion !== preparedTarget.exactVersion) {
+      throw new Error(
+        `Plugin Inspector reported OpenClaw ${targetOpenClawVersion ?? "unknown"}; expected ${preparedTarget.exactVersion}`,
+      );
+    }
     if (!dryRun) {
       const uploadResult = await postJson<UploadResult>(
         `${siteUrl}/api/v1/package-inspector/results`,
@@ -207,6 +332,7 @@ async function inspectPackageItem(item: ClaimItem, inspectorVersion: string) {
           releaseId: item.releaseId,
           inspectorVersion,
           targetOpenClawVersion,
+          notifyOwners,
           findings,
         },
       );
@@ -221,7 +347,7 @@ async function inspectPackageItem(item: ClaimItem, inspectorVersion: string) {
     return {
       failed: false,
       scanned: true,
-      impactEntry: dryRun ? toImpactEntry(item, findings, targetOpenClawVersion) : undefined,
+      impactEntry: toImpactEntry(item, findings, targetOpenClawVersion),
     };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
@@ -246,12 +372,39 @@ if (import.meta.main) {
   await runPackageInspectorNightlyScan();
 }
 
-async function claimBatch(cursor: string | null) {
+async function claimBatch(
+  cursor: string | null,
+  inspectorVersion: string,
+  targetOpenClawVersion: string,
+  runId: string,
+) {
   const url = new URL(`${siteUrl}/api/v1/package-inspector/claim`);
   url.searchParams.set("batchSize", batchSize);
   url.searchParams.set("dryRun", dryRun ? "true" : "false");
-  if (dryRun && cursor) url.searchParams.set("cursor", cursor);
+  url.searchParams.set("inspectorVersion", inspectorVersion);
+  url.searchParams.set("targetOpenClawVersion", targetOpenClawVersion);
+  url.searchParams.set("notifyOwners", notifyOwners ? "true" : "false");
+  if (!dryRun) url.searchParams.set("runId", runId);
+  if (cursor) url.searchParams.set("cursor", cursor);
   return await postJson<ClaimResponse>(url.toString(), {});
+}
+
+export async function acknowledgeBatch(cursor: string | null, runId: string) {
+  const url = new URL(`${siteUrl}/api/v1/package-inspector/acknowledge`);
+  url.searchParams.set("runId", runId);
+  if (cursor) url.searchParams.set("cursor", cursor);
+  return await postJson<{ ok: true; cursor: string | null; completed: boolean }>(
+    url.toString(),
+    {},
+  );
+}
+
+function resolveInspectorConfigPath(root: string) {
+  for (const filename of ["plugin-inspector.config.json", ".plugin-inspector.json"]) {
+    const candidate = path.join(root, filename);
+    if (existsSync(candidate)) return candidate;
+  }
+  return undefined;
 }
 
 async function resolveTargetPackageItems(packageNames: string[]): Promise<ClaimItem[]> {
@@ -433,13 +586,15 @@ function isErrorFinding(finding: Pick<NormalizedFinding, "level" | "severity">) 
   return finding.level === "breakage" || finding.level === "error" || finding.severity === "P0";
 }
 
-function summarizeImpact(args: {
+export function summarizeImpact(args: {
   claimed: number;
   scanned: number;
+  skippedUnchanged?: number;
   batches: number;
   truncated: boolean;
   nextCursor: string | null;
   inspectorVersion: string;
+  targetOpenClawVersion?: string;
   entries: ImpactEntry[];
 }) {
   const impactedOwners = new Set<string>();
@@ -475,12 +630,14 @@ function summarizeImpact(args: {
     generatedAt: new Date().toISOString(),
     siteUrl,
     inspectorVersion: args.inspectorVersion,
+    targetOpenClawVersion: args.targetOpenClawVersion,
     batchSize: Number.parseInt(batchSize, 10) || batchSize,
     batches: args.batches,
     truncated: args.truncated,
     nextCursor: args.nextCursor,
     claimedReleases: args.claimed,
     scannedReleases: args.scanned,
+    skippedUnchangedReleases: args.skippedUnchanged ?? 0,
     pluginsWithFindings: args.entries.filter((entry) => entry.findingCount > 0).length,
     pluginsWithErrors,
     pluginsWithWarnings,
@@ -496,14 +653,16 @@ function getInspectorVersion() {
   return process.env.PLUGIN_INSPECTOR_VERSION ?? resolveBundledPluginInspectorVersion();
 }
 
-function renderImpactMarkdown(summary: ReturnType<typeof summarizeImpact>) {
+export function renderImpactMarkdown(summary: ReturnType<typeof summarizeImpact>) {
   const lines = [
-    "# Plugin Inspector Bulk Scan Dry Run",
+    "# Plugin Inspector Bulk Scan Run",
     "",
     `- Generated: ${summary.generatedAt}`,
     `- Site: ${summary.siteUrl}`,
     `- Inspector: ${summary.inspectorVersion}`,
+    `- Target OpenClaw: ${summary.targetOpenClawVersion ?? "unknown"}`,
     `- Scanned latest releases: ${summary.scannedReleases}`,
+    `- Skipped unchanged releases: ${summary.skippedUnchangedReleases}`,
     `- Plugins with errors: ${summary.pluginsWithErrors}`,
     `- Plugins with warnings: ${summary.pluginsWithWarnings}`,
     `- Impacted owners: ${summary.impactedOwners}`,

--- a/src/__tests__/package-detail-route.test.tsx
+++ b/src/__tests__/package-detail-route.test.tsx
@@ -1976,8 +1976,6 @@ describe("plugin detail route", () => {
     expect(screen.queryByRole("tab", { name: /Validation/ })).toBeNull();
     expect(screen.queryByRole("link", { name: "2 warnings" })).toBeNull();
     expect(screen.getByText("Validate locally before publishing")).toBeTruthy();
-    expect(screen.getByText("clawhub package validate <path-to-plugin>")).toBeTruthy();
-    expect(screen.getByRole("toolbar", { name: "Validation actions" })).toBeTruthy();
     expect(document.getElementById("validation-toolbar-cli")?.getAttribute("aria-labelledby")).toBe(
       "validation-toolbar-label",
     );
@@ -1987,6 +1985,11 @@ describe("plugin detail route", () => {
     expect(titleActions?.textContent).toMatch(/1 warning/);
     expect(titleActions?.querySelector(".plugin-validation-panel-agent")).toBeNull();
     const validationToolbar = screen.getByRole("toolbar", { name: "Validation actions" });
+    expect(
+      within(validationToolbar).getByText(
+        "clawhub package validate <path-to-plugin> --openclaw-version 0.9.0",
+      ),
+    ).toBeTruthy();
     const commandBlock = validationToolbar.querySelector(".plugin-validation-command-block");
     expect(commandBlock?.querySelector(".plugin-validation-toolbar-label")).toBeTruthy();
     expect(validationToolbar.querySelector(":scope > .plugin-validation-toolbar-label")).toBeNull();
@@ -2017,10 +2020,10 @@ describe("plugin detail route", () => {
     expect(within(validationRegion).getByText("Target")).toBeTruthy();
     expect(within(validationRegion).getByText("OpenClaw 0.9.0")).toBeTruthy();
     expect(
-      within(validationRegion).getByText(
+      within(validationRegion).getAllByText(
         "clawhub package validate <path-to-plugin> --openclaw-version 0.9.0",
       ),
-    ).toBeTruthy();
+    ).toHaveLength(2);
     expect(screen.getByText(/Legacy before_agent_start hook is deprecated\./)).toBeTruthy();
     expect(screen.getByText(/We found/)).toBeTruthy();
     expect(screen.queryByText(/Hey,/)).toBeNull();

--- a/src/__tests__/package-publish-workflow.test.ts
+++ b/src/__tests__/package-publish-workflow.test.ts
@@ -37,13 +37,14 @@ describe("package publish workflow", () => {
     expect(workflow).toContain("actions/upload-artifact");
   });
 
-  it("runs manual plugin inspector bulk scans with the bundled CLI validator", () => {
+  it("runs nightly beta plugin scans while preserving manual dispatch", () => {
     const workflow = readFileSync(
       resolve(".github/workflows/plugin-inspector-bulk-scan.yml"),
       "utf8",
     );
     const parsedWorkflow = parseYaml(workflow) as {
       on?: {
+        schedule?: Array<{ cron?: string }>;
         workflow_dispatch?: {
           inputs?: {
             dry_run?: { default?: string };
@@ -56,6 +57,7 @@ describe("package publish workflow", () => {
     const http = readFileSync(resolve("convex/packageInspectorHttp.ts"), "utf8");
 
     expect(workflow).toContain("workflow_dispatch:");
+    expect(parsedWorkflow.on?.schedule).toEqual([{ cron: "17 7 * * *" }]);
     expect(workflow).toContain("Maximum plugin releases to scan");
     expect(workflow).toContain("Plugin Inspector Bulk Scan");
     expect(workflow).toContain("plugin-inspector-bulk-scan-reports");
@@ -64,14 +66,21 @@ describe("package publish workflow", () => {
     expect(workflow).toContain(
       "concurrency:\n  group: clawhub-plugin-inspector-bulk-scan\n  cancel-in-progress: false",
     );
-    expect(workflow).not.toMatch(/^\s*schedule:/m);
-    expect(workflow).not.toMatch(/^\s*-\s*cron:/m);
+    expect(workflow).toContain("PLUGIN_INSPECTOR_OPENCLAW_VERSION: beta");
+    expect(workflow).toContain("notify_owners:");
+    expect(workflow).toContain("default: true");
+    expect(workflow).toContain(
+      "PLUGIN_INSPECTOR_NOTIFY_OWNERS: ${{ github.event_name == 'schedule' && '0' || (inputs.notify_owners && '1' || '0') }}",
+    );
     expect(workflow).toContain("ref: main");
     expect(workflow).toContain("if: ${{ github.ref == 'refs/heads/main' }}");
     expect(workflow).toContain("bun install --frozen-lockfile");
     expect(workflow).toContain("CLAWHUB_PLUGIN_INSPECTOR_WORKER_TOKEN");
     expect(script).toContain("package-inspector/claim");
-    expect(script).toContain('"package", "validate"');
+    expect(script).toContain("prepareBulkOpenClawTarget");
+    expect(script).toContain("targetOpenClaw: preparedTarget.target");
+    expect(script).toContain("targetOpenClawVersion");
+    expect(script).toContain("skippedUnchanged");
     expect(script).toContain("resolveBundledPluginInspectorVersion");
     expect(http).toContain("package-inspector/artifact");
     expect(script).toContain("package-inspector/results");

--- a/src/routes/plugins/$name.tsx
+++ b/src/routes/plugins/$name.tsx
@@ -696,6 +696,14 @@ function pluginValidateCommand(openClawVersion?: string) {
     ? `${PLUGIN_VALIDATE_CLI} --openclaw-version ${openClawVersion}`
     : PLUGIN_VALIDATE_CLI;
 }
+
+function buildPluginValidateCommand(findings: PluginInspectorFinding[]) {
+  const exactTarget =
+    findings.find((finding) => finding.scanSource === "nightly" && finding.targetOpenClawVersion)
+      ?.targetOpenClawVersion ??
+    findings.find((finding) => finding.targetOpenClawVersion)?.targetOpenClawVersion;
+  return pluginValidateCommand(exactTarget);
+}
 const PLUGIN_VALIDATE_TOOLBAR_LABEL = "Validate locally before publishing";
 
 const INSPECTOR_ISSUE_CLASS_LABELS: Record<string, string> = {
@@ -768,7 +776,7 @@ function buildValidationAgentFixPrompt(args: {
     "",
     "Make the minimum code and manifest changes needed to resolve every issue below.",
     "After editing, run locally:",
-    PLUGIN_VALIDATE_CLI,
+    buildPluginValidateCommand(args.findings),
     "",
   );
 
@@ -1325,6 +1333,7 @@ function PluginDetailPageContent({ name, loaderData }: PluginDetailPageProps) {
     displayInspectorFindings?.filter((finding) => finding.findingKind !== "error") ?? []
   ).sort(compareInspectorFindings);
   const validationIssueCount = validationErrors.length + validationWarnings.length;
+  const validationCliCommand = buildPluginValidateCommand(displayInspectorFindings ?? []);
   const validationReleaseVersion = latestRelease?.version ?? pkg.latestVersion ?? null;
   const showValidationGroups = validationErrors.length > 0 && validationWarnings.length > 0;
   const validationAgentFixPrompt =
@@ -1396,9 +1405,9 @@ function PluginDetailPageContent({ name, loaderData }: PluginDetailPageProps) {
                     className="plugin-validation-toolbar-cli"
                     aria-labelledby="validation-toolbar-label"
                   >
-                    <code className="plugin-validation-command">{PLUGIN_VALIDATE_CLI}</code>
+                    <code className="plugin-validation-command">{validationCliCommand}</code>
                     <InstallCopyButton
-                      text={PLUGIN_VALIDATE_CLI}
+                      text={validationCliCommand}
                       ariaLabel="Copy validate command"
                       showLabel={false}
                       className="plugin-validation-toolbar-copy"


### PR DESCRIPTION
## Summary
- store exact Plugin Inspector and OpenClaw beta scan identity with resumable nightly cursor leases
- refresh only each plugin's latest release, replace prior nightly findings, and preserve publish-time findings
- keep nightly owner notifications disabled by default while supporting exact-target dedupe when explicitly enabled
- expose exact reproduction commands and stable GitHub rerun identity without running a production scan

## Validation
- `bunx vitest run convex/packages.public.test.ts convex/packageInspectorHttp.test.ts scripts/package-inspector-nightly-scan.test.ts src/__tests__/package-detail-route.test.tsx src/__tests__/package-publish-workflow.test.ts` (400 passed)
- `bunx convex codegen`
- `bun run ci:static`
- `bun run ci:types-build`
- `bun run ci:unit` (5,799 passed, 2 skipped)
- `bun run ci:packages`
- `bun run ci:e2e-http`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` (one reviewed false positive rejected: owner-email eligibility is filtered before `shouldEmailOwner` is computed)

No production scan or production deployment was run.
