### PR TITLE
fix: resolve production skills sync environment

### DIFF
--- a/server/routes/ops/skills-sh/mirror-test.post.ts
+++ b/server/routes/ops/skills-sh/mirror-test.post.ts
@@ -1,5 +1,6 @@
 import { getVercelOidcToken } from "@vercel/oidc";
 import { defineEventHandler, getHeader, readBody } from "h3";
+import { resolveConvexProxyEnv } from "../../../convexProxy";
 import {
   buildSkillsShMirrorProofSnapshotId,
   fetchSkillsShMirrorBatch,
@@ -191,7 +192,7 @@ export function createSkillsShMirrorRoute(target: keyof typeof ROUTE_CONFIG) {
   return defineEventHandler(async (event) => {
     const policy =
       target === "production"
-        ? getSkillsShCatalogProductionSourcePolicy(process.env)
+        ? getSkillsShCatalogProductionSourcePolicy(resolveConvexProxyEnv(process.env))
         : getSkillsShCatalogTestSourcePolicy(process.env);
     if (!policy.allowed) return jsonResponse({ error: "not_found" }, 404);
     const authorization = getHeader(event, "authorization")?.trim() ?? "";

--- a/server/skillsShMirrorProductionRoute.test.ts
+++ b/server/skillsShMirrorProductionRoute.test.ts
@@ -9,6 +9,7 @@ const buildProofSnapshotIdMock = vi.fn();
 const measureProofSourceMock = vi.fn();
 const parseProofSnapshotIdMock = vi.fn();
 const productionPolicyMock = vi.fn();
+const resolveConvexProxyEnvMock = vi.fn();
 
 vi.mock("h3", () => ({
   defineEventHandler: (handler: unknown) => handler,
@@ -18,6 +19,10 @@ vi.mock("h3", () => ({
 
 vi.mock("@vercel/oidc", () => ({
   getVercelOidcToken: (...args: unknown[]) => getVercelOidcTokenMock(...args),
+}));
+
+vi.mock("./convexProxy", () => ({
+  resolveConvexProxyEnv: (...args: unknown[]) => resolveConvexProxyEnvMock(...args),
 }));
 
 vi.mock("./skillsShCatalogSource", () => ({
@@ -47,6 +52,8 @@ describe("skills.sh production mirror route", () => {
     measureProofSourceMock.mockReset();
     parseProofSnapshotIdMock.mockReset();
     productionPolicyMock.mockReset();
+    resolveConvexProxyEnvMock.mockReset();
+    resolveConvexProxyEnvMock.mockImplementation((env) => env);
     productionPolicyMock.mockReturnValue({ allowed: true, environment: "production" });
     getHeaderMock.mockReturnValue("Bearer github-actions-oidc");
     getVercelOidcTokenMock.mockResolvedValue("vercel-production-oidc");
@@ -79,6 +86,27 @@ describe("skills.sh production mirror route", () => {
     expect(await response.json()).toEqual({ control: null, runs: [] });
     expect(productionPolicyMock).toHaveBeenCalledOnce();
     expect(convexFetch).toHaveBeenCalledOnce();
+  });
+
+  it("validates production source policy against bundled frontend identity", async () => {
+    const resolvedEnv = {
+      VERCEL_ENV: "production",
+      VITE_CLAWHUB_DEPLOY_ENV: "production",
+      VITE_CONVEX_URL: "https://wry-manatee-359.convex.cloud",
+    };
+    resolveConvexProxyEnvMock.mockReturnValue(resolvedEnv);
+    readBodyMock.mockResolvedValue({ operation: "status" });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(JSON.stringify({ control: null, runs: [] }))),
+    );
+
+    const handler = (await import("./routes/ops/skills-sh/mirror.post")).default;
+    const response = (await handler({} as never)) as Response;
+
+    expect(response.status).toBe(200);
+    expect(resolveConvexProxyEnvMock).toHaveBeenCalledWith(process.env);
+    expect(productionPolicyMock).toHaveBeenCalledWith(resolvedEnv);
   });
 
   it("fails closed before the operator call when the production source policy is not exact", async () => {


### PR DESCRIPTION
## Summary

- resolve the effective bundled frontend environment before validating the production skills.sh source boundary
- preserve the existing exact production backend/runtime checks
- add regression coverage for Vercel runtime environments where baked `VITE_*` identity is not present in `process.env`

## Verification

- `bunx vitest run server/skillsShMirrorProductionRoute.test.ts server/convexProxy.test.ts server/skillsShCatalogSource.test.ts scripts/skills-sh-catalog/sync.test.ts scripts/skills-sh-sync-workflow.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode local --parallel-tests '<focused tests>'`
- `bun run ci:static`
- `bun run ci:unit`
- `bun run ci:types-build`
- `bun run ci:packages`
