### PR TITLE
fix: sanitize nightly scan fixture ids

### DIFF
--- a/scripts/package-inspector-nightly-scan.test.ts
+++ b/scripts/package-inspector-nightly-scan.test.ts
@@ -1,6 +1,6 @@
 /* @vitest-environment node */
 
-import { access, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { access, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -131,6 +131,33 @@ describe("package-inspector-nightly-scan", () => {
     ).rejects.toThrow();
     await expect(access(path.join(scanRoot, "PaxHeader", "payload.js"))).resolves.toBeUndefined();
     await expect(access(path.join(scanRoot, "PaxHeader", "oversized"))).resolves.toBeUndefined();
+  });
+
+  it("writes a valid synthetic fixture id for a scoped package with an underscore", async () => {
+    const pluginRoot = await mkdtemp(path.join(tmpdir(), "clawhub-inspector-fixture-id-"));
+    temporaryRoots.push(pluginRoot);
+
+    await prepareExtractedPluginRoot(pluginRoot, "npm-pack", "@glin_1/miniabc");
+
+    const config = JSON.parse(
+      await readFile(path.join(pluginRoot, ".plugin-inspector.json"), "utf8"),
+    );
+    expect(config.plugin.id).toBe("glin-1-miniabc");
+  });
+
+  it.each([
+    ["plugin.with_dots_and_underscores", "plugin-with-dots-and-underscores"],
+    ["...___", "plugin"],
+  ])("normalizes synthetic fixture id %s to %s", async (packageName, expectedId) => {
+    const pluginRoot = await mkdtemp(path.join(tmpdir(), "clawhub-inspector-fixture-id-"));
+    temporaryRoots.push(pluginRoot);
+
+    await prepareExtractedPluginRoot(pluginRoot, "npm-pack", packageName);
+
+    const config = JSON.parse(
+      await readFile(path.join(pluginRoot, ".plugin-inspector.json"), "utf8"),
+    );
+    expect(config.plugin.id).toBe(expectedId);
   });
 
   it("reports the exact beta target and unchanged releases in the run summary", () => {

--- a/scripts/package-inspector-nightly-scan.ts
+++ b/scripts/package-inspector-nightly-scan.ts
@@ -488,7 +488,7 @@ async function writeSyntheticConfigIfNeeded(root: string, packageName: string) {
   }
   await writeFile(
     path.join(root, ".plugin-inspector.json"),
-    `${JSON.stringify({ version: 1, plugin: { id: safeArtifactName(packageName) } }, null, 2)}\n`,
+    `${JSON.stringify({ version: 1, plugin: { id: safeFixtureId(packageName) } }, null, 2)}\n`,
   );
 }
 
@@ -773,6 +773,15 @@ function safeArtifactName(value: string) {
     value
       .toLowerCase()
       .replace(/[^a-z0-9._-]+/g, "-")
+      .replace(/^-+|-+$/g, "") || "plugin"
+  );
+}
+
+function safeFixtureId(value: string) {
+  return (
+    value
+      .toLowerCase()
+      .replace(/[^a-z0-9-]+/g, "-")
       .replace(/^-+|-+$/g, "") || "plugin"
   );
 }


### PR DESCRIPTION
## Summary

- use a fixture-ID-specific sanitizer for synthetic Plugin Inspector configs
- normalize scoped, dotted, and underscored package names to lowercase hyphenated IDs
- preserve artifact path naming and provide a safe fallback when normalization is empty

## Validation

- `bunx vitest run scripts/package-inspector-nightly-scan.test.ts` (12/12)
- `bun run ci:static` (clean isolated clone; source worktree contains unrelated untracked artifacts)
- `bun run ci:unit` (5,824 passed; 2 skipped)
- `bun run ci:types-build`
- `bun run ci:packages`
- `bunx tsc -p packages/schema/tsconfig.json --noEmit`
- `bunx tsc -p packages/clawhub/tsconfig.json --noEmit`
- `.agents/skills/autoreview/scripts/autoreview --mode commit --commit HEAD --stream-engine-output` (clean)
