### PR TITLE
fix: normalize BOM-prefixed plugin manifests

### DIFF
--- a/scripts/package-inspector-nightly-scan.test.ts
+++ b/scripts/package-inspector-nightly-scan.test.ts
@@ -175,6 +175,9 @@ describe("package-inspector-nightly-scan", () => {
       await readFile(path.join(pluginRoot, ".plugin-inspector.json"), "utf8"),
     );
     expect(config.plugin.id).toBe("eu-compliance-skill");
+    expect(await readFile(path.join(pluginRoot, "package.json"), "utf8")).toBe(
+      '{"name":"eu-compliance-skill","version":"1.0.1"}\n',
+    );
   });
 
   it.each([

--- a/scripts/package-inspector-nightly-scan.ts
+++ b/scripts/package-inspector-nightly-scan.ts
@@ -495,7 +495,12 @@ async function writeSyntheticConfigIfNeeded(root: string, packageName: string) {
 async function readJsonIfExists(filePath: string) {
   if (!existsSync(filePath)) return null;
   const contents = await readFile(filePath, "utf8");
-  return JSON.parse(contents.startsWith("\uFEFF") ? contents.slice(1) : contents) as unknown;
+  const normalizedContents = contents.startsWith("\uFEFF") ? contents.slice(1) : contents;
+  const parsed = JSON.parse(normalizedContents) as unknown;
+  if (normalizedContents !== contents) {
+    await writeFile(filePath, normalizedContents);
+  }
+  return parsed;
 }
 
 async function removePosixArchiveMetadata(root: string): Promise<void> {


### PR DESCRIPTION
## Summary

- strip exactly one leading UTF-8 BOM before parsing extracted package metadata
- rewrite the temporary package.json without the BOM after successful parsing so later Inspector phases see valid JSON
- preserve failures for ordinary malformed JSON and multiple leading BOMs

## Validation

- focused nightly scan regression tests: 3 passed
- bun run ci:static
- bun run ci:unit: 5,834 passed, 2 skipped
- bun run ci:types-build
- bun run ci:packages
- structured autoreview: clean, no accepted/actionable findings