### PR TITLE
fix: normalize BOM-prefixed plugin manifests

### DIFF
--- a/scripts/package-inspector-nightly-scan.test.ts
+++ b/scripts/package-inspector-nightly-scan.test.ts
@@ -160,12 +160,16 @@ describe("package-inspector-nightly-scan", () => {
     expect(config.plugin.id).toBe(expectedId);
   });
 
-  it("accepts a UTF-8 BOM before a downloaded package.json", async () => {
+  it("accepts a UTF-8 BOM before downloaded plugin manifests", async () => {
     const pluginRoot = await mkdtemp(path.join(tmpdir(), "clawhub-inspector-package-json-"));
     temporaryRoots.push(pluginRoot);
     await writeFile(
       path.join(pluginRoot, "package.json"),
       '\uFEFF{"name":"eu-compliance-skill","version":"1.0.1"}\n',
+    );
+    await writeFile(
+      path.join(pluginRoot, "openclaw.plugin.json"),
+      '\uFEFF{"id":"eu-compliance-skill"}\n',
     );
 
     await expect(
@@ -177,6 +181,9 @@ describe("package-inspector-nightly-scan", () => {
     expect(config.plugin.id).toBe("eu-compliance-skill");
     expect(await readFile(path.join(pluginRoot, "package.json"), "utf8")).toBe(
       '{"name":"eu-compliance-skill","version":"1.0.1"}\n',
+    );
+    expect(await readFile(path.join(pluginRoot, "openclaw.plugin.json"), "utf8")).toBe(
+      '{"id":"eu-compliance-skill"}\n',
     );
   });
 

--- a/scripts/package-inspector-nightly-scan.ts
+++ b/scripts/package-inspector-nightly-scan.ts
@@ -376,6 +376,7 @@ export async function prepareExtractedPluginRoot(
   if (artifactKind === "legacy-zip") {
     await removePosixArchiveMetadata(scanRoot);
   }
+  await readJsonIfExists(path.join(scanRoot, "openclaw.plugin.json"));
   await writeSyntheticConfigIfNeeded(scanRoot, packageName);
   return scanRoot;
 }


### PR DESCRIPTION
## Summary

- normalize one leading UTF-8 BOM from extracted openclaw.plugin.json before Plugin Inspector runs
- reuse the package.json normalization path and preserve malformed-JSON failures
- cover the production artifact shape where both plugin manifests carry a BOM

## Validation

- focused BOM and invalid JSON regressions: 3 passed
- bun run ci:static
- bun run ci:unit: 5,834 passed, 2 skipped
- bun run ci:types-build
- bun run ci:packages
- structured autoreview: clean, no accepted/actionable findings