### PR TITLE
fix: normalize nested plugin manifests

### DIFF
--- a/scripts/package-inspector-nightly-scan.test.ts
+++ b/scripts/package-inspector-nightly-scan.test.ts
@@ -171,6 +171,12 @@ describe("package-inspector-nightly-scan", () => {
       path.join(pluginRoot, "openclaw.plugin.json"),
       '\uFEFF{"id":"eu-compliance-skill"}\n',
     );
+    const nestedPackageRoot = path.join(pluginRoot, "showmethemoney-skill", "demo-backend");
+    await mkdir(nestedPackageRoot, { recursive: true });
+    await writeFile(
+      path.join(nestedPackageRoot, "package.json"),
+      '\uFEFF{"name":"stablepay-demo-backend"}\n',
+    );
 
     await expect(
       prepareExtractedPluginRoot(pluginRoot, "npm-pack", "eu-compliance-skill"),
@@ -184,6 +190,9 @@ describe("package-inspector-nightly-scan", () => {
     );
     expect(await readFile(path.join(pluginRoot, "openclaw.plugin.json"), "utf8")).toBe(
       '{"id":"eu-compliance-skill"}\n',
+    );
+    expect(await readFile(path.join(nestedPackageRoot, "package.json"), "utf8")).toBe(
+      '{"name":"stablepay-demo-backend"}\n',
     );
   });
 

--- a/scripts/package-inspector-nightly-scan.ts
+++ b/scripts/package-inspector-nightly-scan.ts
@@ -376,7 +376,7 @@ export async function prepareExtractedPluginRoot(
   if (artifactKind === "legacy-zip") {
     await removePosixArchiveMetadata(scanRoot);
   }
-  await readJsonIfExists(path.join(scanRoot, "openclaw.plugin.json"));
+  await normalizePluginJsonManifests(scanRoot);
   await writeSyntheticConfigIfNeeded(scanRoot, packageName);
   return scanRoot;
 }
@@ -491,6 +491,23 @@ async function writeSyntheticConfigIfNeeded(root: string, packageName: string) {
     path.join(root, ".plugin-inspector.json"),
     `${JSON.stringify({ version: 1, plugin: { id: safeFixtureId(packageName) } }, null, 2)}\n`,
   );
+}
+
+async function normalizePluginJsonManifests(root: string): Promise<void> {
+  const entries = await readdir(root, { withFileTypes: true });
+  for (const entry of entries) {
+    const entryPath = path.join(root, entry.name);
+    if (entry.isDirectory()) {
+      await normalizePluginJsonManifests(entryPath);
+      continue;
+    }
+    if (
+      entry.isFile() &&
+      (entry.name === "package.json" || entry.name === "openclaw.plugin.json")
+    ) {
+      await readJsonIfExists(entryPath);
+    }
+  }
 }
 
 async function readJsonIfExists(filePath: string) {


### PR DESCRIPTION
## Summary
- normalize UTF-8 BOMs in nested plugin manifest files before inspection
- limit traversal to package.json and openclaw.plugin.json files
- cover the nested StablePay package layout and preserve invalid JSON failure behavior

## Validation
- bunx vitest run --configLoader runner scripts/package-inspector-nightly-scan.test.ts
- bun run ci:static
- bun run ci:unit
- bun run ci:types-build
- bun run ci:packages
- .agents/skills/autoreview/scripts/autoreview --mode local