### PR TITLE
fix: accept direct workflow OIDC claims

### DIFF
--- a/convex/lib/githubActionsOidc.test.ts
+++ b/convex/lib/githubActionsOidc.test.ts
@@ -562,6 +562,7 @@ describe("verifyGitHubActionsSkillsShSyncJwt", () => {
       repository_owner: "openclaw",
       repository_owner_id: "252820863",
       workflow_ref: "openclaw/clawhub/.github/workflows/skills-sh-sync.yml@refs/heads/main",
+      job_workflow_ref: "openclaw/clawhub/.github/workflows/skills-sh-sync.yml@refs/heads/main",
       runner_environment: "github-hosted",
       environment: "Production",
       event_name: "schedule",

--- a/convex/lib/githubActionsOidc.ts
+++ b/convex/lib/githubActionsOidc.ts
@@ -211,7 +211,9 @@ async function verifyGitHubActionsWorkflowJwt(
       `GitHub OIDC workflow mismatch: expected ${trustedPublisher.workflowFilename}, got ${workflow.workflowFilename}`,
     );
   }
-  if (jobWorkflowRef) {
+  // GitHub now includes job_workflow_ref for direct jobs too; only a different
+  // workflow ref represents a reusable-workflow delegation.
+  if (jobWorkflowRef && jobWorkflowRef !== workflowRef) {
     const reusableWorkflow = parseWorkflowRef(jobWorkflowRef);
     if (!workflowPolicy.reusableWorkflow) {
       throw new Error("Reusable workflows may not run the skills.sh production sync");


### PR DESCRIPTION
## Summary

- Treat matching `workflow_ref` and `job_workflow_ref` claims as a direct GitHub Actions job.
- Preserve rejection of actual reusable-workflow delegation for the production skills.sh sync.
- Cover the exact live GitHub OIDC claim shape with a regression test.

## Validation

- `bunx vitest run convex/lib/githubActionsOidc.test.ts convex/httpApiV1/skillsShCatalogV1.test.ts`
- `bun run ci:static`
- `bun run ci:unit`
- `bun run ci:types-build`
- clean autoreview
