### PR TITLE
fix: bound prepublication scanner retries

### DIFF
--- a/convex/publishAttempts.test.ts
+++ b/convex/publishAttempts.test.ts
@@ -715,11 +715,75 @@ describe("publishAttempts", () => {
         checkClaimedAt: undefined,
         checkClaimExpiresAt: expect.any(Number),
         checkClaimLastError: "scanner unavailable",
+        checkFailureCount: 1,
         failedAt: undefined,
       }),
     );
     const patch = ctx.db.patch.mock.calls[0]?.[1] as { checkClaimExpiresAt: number };
     expect(patch.checkClaimExpiresAt).toBeGreaterThan(now);
+  });
+
+  it("terminalizes an attempt after three consecutive scanner execution failures", async () => {
+    const now = Date.now();
+    const ctx = {
+      db: {
+        get: vi.fn(async () => ({
+          _id: "publishAttempts:poison",
+          kind: "skill",
+          status: "pending_checks",
+          artifactFingerprint: "fingerprint",
+          checkClaimId: "checks:claim",
+          checkClaimExpiresAt: now + 60_000,
+          checkFailureCount: 2,
+          checks: {
+            trufflehog: { status: "clean", checkedAt: now - 300_000 },
+            clawscan: {
+              status: "failed",
+              checkedAt: now - 300_000,
+              summary: "ClawScan scanner did not complete: skillspector=failed",
+            },
+          },
+        })),
+        patch: vi.fn(),
+        insert: vi.fn(),
+        replace: vi.fn(),
+        delete: vi.fn(),
+        query: vi.fn(),
+        normalizeId: vi.fn(),
+        system: {},
+      },
+      storage: {
+        delete: vi.fn(),
+      },
+    };
+
+    await expect(
+      completePendingChecksHandler(ctx, {
+        attemptId: "publishAttempts:poison",
+        claimId: "checks:claim",
+        artifactFingerprint: "fingerprint",
+        trufflehog: { status: "clean" },
+        clawscan: {
+          status: "failed",
+          summary: "ClawScan scanner did not complete: skillspector=failed",
+        },
+      }),
+    ).resolves.toEqual({
+      attemptId: "publishAttempts:poison",
+      kind: "skill",
+      status: "failed",
+    });
+
+    expect(ctx.db.patch).toHaveBeenCalledWith(
+      "publishAttempts:poison",
+      expect.objectContaining({
+        status: "failed",
+        checkFailureCount: 3,
+        checkClaimExpiresAt: undefined,
+        checkClaimLastError: "ClawScan scanner did not complete: skillspector=failed",
+        failedAt: expect.any(Number),
+      }),
+    );
   });
 
   it("terminalizes an attempt when its staged target disappears during scanning", async () => {

--- a/convex/publishAttempts.ts
+++ b/convex/publishAttempts.ts
@@ -8,6 +8,7 @@ import { finalizeSkillPublishAttempt } from "./lib/skillPublish";
 const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
 const CHECK_CLAIM_LEASE_MS = 30 * 60 * 1000;
 const CHECK_RETRY_BACKOFF_MS = 5 * 60 * 1000;
+const MAX_CONSECUTIVE_SCANNER_FAILURES = 3;
 const FINALIZATION_CLAIM_LEASE_MS = 10 * 60 * 1000;
 const PUBLISH_ATTEMPT_STATUSES = [
   "pending_checks",
@@ -106,6 +107,14 @@ function scannerFailureSummary(args: {
   return "Pre-publication scanner failed before returning a verdict.";
 }
 
+function previousScannerFailureCount(attempt: Doc<"publishAttempts">) {
+  if (attempt.checkFailureCount !== undefined) return attempt.checkFailureCount;
+  return attempt.checks.trufflehog.status === "failed" ||
+    attempt.checks.clawscan.status === "failed"
+    ? 1
+    : 0;
+}
+
 function isTerminalFinalizationConflict(error: string | undefined) {
   return (
     typeof error === "string" &&
@@ -135,6 +144,7 @@ function releaseFinalizationClaimPatch(error: string | undefined, now: number) {
     checkClaimedAt: undefined,
     checkClaimExpiresAt: undefined,
     checkClaimLastError: undefined,
+    checkFailureCount: undefined,
     finalizationClaimId: undefined,
     finalizationClaimedAt: undefined,
     finalizationClaimExpiresAt: undefined,
@@ -607,6 +617,7 @@ export const completePendingPublishAttemptChecksInternal = internalMutation({
         checkClaimedAt: undefined,
         checkClaimExpiresAt: undefined,
         checkClaimLastError: undefined,
+        checkFailureCount: undefined,
         blockedAt: now,
         updatedAt: now,
       });
@@ -649,6 +660,7 @@ export const completePendingPublishAttemptChecksInternal = internalMutation({
         checkClaimedAt: undefined,
         checkClaimExpiresAt: undefined,
         checkClaimLastError: undefined,
+        checkFailureCount: undefined,
         blockedAt: now,
         updatedAt: now,
       });
@@ -660,17 +672,24 @@ export const completePendingPublishAttemptChecksInternal = internalMutation({
     }
 
     if (args.trufflehog.status === "failed" || args.clawscan.status === "failed") {
+      const checkFailureCount = previousScannerFailureCount(attempt) + 1;
+      const terminal = checkFailureCount >= MAX_CONSECUTIVE_SCANNER_FAILURES;
       await ctx.db.patch(attempt._id, {
-        status: "pending_checks",
+        status: terminal ? "failed" : "pending_checks",
         checks,
         checkClaimId: undefined,
         checkClaimedAt: undefined,
-        checkClaimExpiresAt: now + CHECK_RETRY_BACKOFF_MS,
+        checkClaimExpiresAt: terminal ? undefined : now + CHECK_RETRY_BACKOFF_MS,
         checkClaimLastError: scannerFailureSummary(args),
-        failedAt: undefined,
+        checkFailureCount,
+        failedAt: terminal ? now : undefined,
         updatedAt: now,
       });
-      return { attemptId: attempt._id, kind: attempt.kind, status: "pending_checks" as const };
+      return {
+        attemptId: attempt._id,
+        kind: attempt.kind,
+        status: terminal ? ("failed" as const) : ("pending_checks" as const),
+      };
     }
 
     if (attempt.kind === "skill" && attempt.skillVersionId && args.clawscanAnalysis) {
@@ -701,6 +720,7 @@ export const completePendingPublishAttemptChecksInternal = internalMutation({
       checkClaimedAt: undefined,
       checkClaimExpiresAt: undefined,
       checkClaimLastError: undefined,
+      checkFailureCount: undefined,
       updatedAt: now,
     });
     return { attemptId: attempt._id, kind: attempt.kind, status: "ready_to_finalize" as const };

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1304,6 +1304,7 @@ const publishAttempts = defineTable({
   checkClaimedAt: v.optional(v.number()),
   checkClaimExpiresAt: v.optional(v.number()),
   checkClaimLastError: v.optional(v.string()),
+  checkFailureCount: v.optional(v.number()),
   finalizationClaimId: v.optional(v.string()),
   finalizationClaimedAt: v.optional(v.number()),
   finalizationClaimExpiresAt: v.optional(v.number()),


### PR DESCRIPTION
## Summary

- bound consecutive pre-publication scanner execution failures to three attempts instead of retrying poison records forever
- preserve fail-closed behavior and legacy in-flight compatibility by counting an existing failed scanner state as the first failure
- clear the failure counter on clean, blocked, and finalization-retry transitions

## Production evidence

- production deployment `wry-manatee-359` was on `a5ffae2196` during diagnosis
- five old attempts remained `pending_checks` for 12–13 days while being actively retried every five minutes
- all five repeatedly ended with `ClawScan scanner did not complete: skillspector=failed`
- current fresh queue work continued draining; the five poison retries dominated `oldestPendingAgeSeconds`
- issue #3349 finalized cleanly and is a separate post-finalization consistency defect
- issue #3351 versions 1.0.0 and 1.1.0 both finalized cleanly and were not stuck queue records

## Validation

- `VITE_CONVEX_URL=https://example.invalid bun run test -- convex/publishAttempts.test.ts convex/publishAttempts.runtime.test.ts convex/prepublicationObservability.test.ts scripts/security/run-prepublication-worker.test.ts --coverage=false` — 58 passed
- `bun run ci:static`
- `bun run ci:unit` — 5,846 passed, 2 skipped; coverage gate passed
- `bun run ci:types-build`
- `bun run ci:packages`
- `bun run ci:static` and `bun run ci:types-build` rerun after rebasing onto `a15f97470f`
- `.agents/skills/autoreview/scripts/autoreview --mode local --stream-engine-output` — clean, no accepted/actionable findings

## Safety

- no production data changes
- no deployment or moderation actions
- terminal `failed` attempts remain republishable under the existing idempotency contract
