### PR TITLE
fix: align trending list headers to edges

### DIFF
--- a/src/routes/skills/-SkillsResults.tsx
+++ b/src/routes/skills/-SkillsResults.tsx
@@ -270,8 +270,11 @@ export function SkillsResults({
         </div>
       ) : (
         <div className="browse-list-stack">
-          <div className="browse-list-head" aria-hidden="true">
-            <span className="browse-list-head-icon-spacer" />
+          <div
+            className={`browse-list-head${showTrendingLayout ? " browse-list-head-trending" : ""}`}
+            aria-hidden="true"
+          >
+            {showTrendingLayout ? null : <span className="browse-list-head-icon-spacer" />}
             <span className="browse-list-head-label">Skill</span>
             {showTrendingLayout ? null : <span className="browse-list-head-label">Category</span>}
             <span className="browse-list-head-label browse-list-head-stat">

--- a/src/styles.css
+++ b/src/styles.css
@@ -17225,6 +17225,15 @@ a.agentic-risk-finding-title:focus-visible {
   justify-self: end;
 }
 
+.browse-page .browse-list-head.browse-list-head-trending {
+  grid-template-columns: minmax(0, 1fr) auto;
+}
+
+.browse-page .browse-list-head.browse-list-head-trending .browse-list-head-label,
+.browse-page .browse-list-head.browse-list-head-trending .browse-list-head-stat {
+  grid-column: auto;
+}
+
 @keyframes fadeIn {
   from {
     opacity: 0;


### PR DESCRIPTION
## Summary

- align the Trending `Skill` header to the left edge of the list
- align `24h downloads` to the right edge with a dedicated two-column header layout
- preserve the existing category-bearing layout for Featured, Official, and New

## Validation

- `bun run format:check -- src/routes/skills/-SkillsResults.tsx src/styles.css`
- `bunx vitest run src/__tests__/skills-index.claw591.test.tsx`
- `bun run ci:static`
- `bun run ci:unit`
- `bun run ci:types-build`
- `.agents/skills/autoreview/scripts/autoreview --mode local --stream-engine-output`
- real browser verification at `http://localhost:3000/skills?tab=trending&view=list` against the public ClawHub corpus at 1440x900, 768x1024, and 390x844

## UI proof

Before/after browser screenshots will be attached in the ClawHub UI Proof comment.
