### PR TITLE
fix: catalog previews cut Chinese and Japanese summaries at the first Latin word

### DIFF
--- a/src/lib/truncateText.test.ts
+++ b/src/lib/truncateText.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { PUBLIC_CATALOG_NAME_PREVIEW_LENGTH, truncateText } from "./truncateText";
+
+// Catalog summaries taken verbatim from fixtures/public-corpus/corpus.jsonl.
+const ZH_SUMMARY =
+  "5GC Web仪表自动化技能，支持AMF/UDM/AUSF/SMF/PGW-C/UPF/PGW-U/GNB/UE/PCF/NRF/QoS/TC/PCC/smpolicy的批量添加与编辑及PCF默认规则一键配置";
+const ZH_MIXED_SUMMARY =
+  "实施Claude Code架构的5阶段进化计划，将OpenClaw系统升级到生产级Agent架构。包括记忆系统升级、工具系统优化、多Agent协作增强、安全架构强化和Prompt优化。当用户需要：1) 将现有OpenClaw系统升级到Claude Code架构标准，2) 实施结构化记忆系统，3) 建立四层权限模型，4) 配置多Agent协作，5) 增强安全架构，6) 优化Prompt和上下文管理时使用此技能。";
+const JA_SUMMARY =
+  "Claude Code向けのワークフロー自動化スキルパックです。日々のリリース作業やレビュー依頼をまとめて処理し、開発チームの負担を減らします。設定ファイルは不要で、導入したその日から使えます。";
+
+describe("truncateText", () => {
+  it("returns short values unchanged", () => {
+    expect(truncateText("Deploy helper", 40)).toBe("Deploy helper");
+    expect(truncateText("  Deploy helper  ", 40)).toBe("Deploy helper");
+  });
+
+  it("collapses internal whitespace before measuring", () => {
+    expect(truncateText("Deploy\n\thelper   pack", 40)).toBe("Deploy helper pack");
+  });
+
+  it("cuts space-separated text at a word boundary", () => {
+    expect(truncateText("A skill that automates deployment pipelines", 40)).toBe(
+      "A skill that automates deployment…",
+    );
+    expect(truncateText("Generate release notes from your commit history", 30)).toBe(
+      "Generate release notes from…",
+    );
+    expect(truncateText("automation toolkit for release engineering teams", 30)).toBe(
+      "automation toolkit for…",
+    );
+  });
+
+  it("keeps the preview budget for Chinese summaries carrying an early Latin space", () => {
+    // The single space after "5GC" is the only space in 104 characters, so backtracking
+    // to it would leave a three-character preview.
+    expect(truncateText(ZH_SUMMARY, 80)).toBe(
+      "5GC Web仪表自动化技能，支持AMF/UDM/AUSF/SMF/PGW-C/UPF/PGW-U/GNB/UE/PCF/NRF/QoS/TC/PCC/smp…",
+    );
+    expect(truncateText(ZH_SUMMARY, 100)).toBe(
+      "5GC Web仪表自动化技能，支持AMF/UDM/AUSF/SMF/PGW-C/UPF/PGW-U/GNB/UE/PCF/NRF/QoS/TC/PCC/smpolicy的批量添加与编辑及PCF默认规…",
+    );
+  });
+
+  it("keeps the preview budget when a Latin product name opens a Chinese summary", () => {
+    expect(truncateText(ZH_MIXED_SUMMARY, 80)).toBe(
+      "实施Claude Code架构的5阶段进化计划，将OpenClaw系统升级到生产级Agent架构。包括记忆系统升级、工具系统优化、多Agent协作增强、安全架…",
+    );
+  });
+
+  it("keeps the preview budget for Japanese summaries carrying an early Latin space", () => {
+    expect(truncateText(JA_SUMMARY, 80)).toBe(
+      "Claude Code向けのワークフロー自動化スキルパックです。日々のリリース作業やレビュー依頼をまとめて処理し、開発チームの負担を減らします。設定ファイルは…",
+    );
+  });
+
+  it("cuts hard when the text contains no space at all", () => {
+    expect(truncateText("仪表自动化技能支持批量添加与编辑及默认规则一键配置", 10)).toBe(
+      "仪表自动化技能支持…",
+    );
+  });
+
+  it("never exceeds the requested budget", () => {
+    for (const sample of [ZH_SUMMARY, ZH_MIXED_SUMMARY, JA_SUMMARY]) {
+      for (const budget of [PUBLIC_CATALOG_NAME_PREVIEW_LENGTH, 80, 100]) {
+        expect(truncateText(sample, budget).length).toBeLessThanOrEqual(budget);
+      }
+    }
+  });
+});

--- a/src/lib/truncateText.test.ts
+++ b/src/lib/truncateText.test.ts
@@ -31,6 +31,20 @@ describe("truncateText", () => {
     );
   });
 
+  it("keeps the word boundary when a long Latin word ends the slice", () => {
+    // The only space sits before 60% of the slice, but the discarded tail is space-separated
+    // text, so the preview must still end on a word rather than mid-word.
+    expect(truncateText("Read this hyperextendedword", 20)).toBe("Read this…");
+    expect(truncateText("Ship internationalization", 22)).toBe("Ship…");
+  });
+
+  it("keeps the Latin word boundary when only a short CJK tail is discarded", () => {
+    // Here the boundary already keeps most of the slice, so backtracking loses nothing but a
+    // stray CJK character that reads as noise on its own.
+    expect(truncateText("Deploy helper for 中文文档管理", 20)).toBe("Deploy helper for…");
+    expect(truncateText("Release notes generator 日本語対応", 28)).toBe("Release notes generator…");
+  });
+
   it("keeps the preview budget for Chinese summaries carrying an early Latin space", () => {
     // The single space after "5GC" is the only space in 104 characters, so backtracking
     // to it would leave a three-character preview.

--- a/src/lib/truncateText.ts
+++ b/src/lib/truncateText.ts
@@ -4,13 +4,19 @@ export const PUBLIC_CATALOG_NAME_PREVIEW_LENGTH = 70;
 // single Latin space near the start of a summary. Backtracking to that space would drop
 // nearly the whole preview, so only honour a word boundary that keeps most of the slice.
 const WORD_BOUNDARY_MIN_KEPT_RATIO = 0.6;
+// Same character class as the catalog search tokenizer in convex/lib/searchText.ts.
+const CJK_RE = /[\u4e00-\u9fff\u3400-\u4dbf\u3041-\u3096\u30a1-\u30fa\uac00-\ud7af]/;
 
 export function truncateText(value: string, maxLength: number) {
   const normalized = value.trim().replace(/\s+/g, " ");
   if (normalized.length <= maxLength) return normalized;
   const truncated = normalized.slice(0, Math.max(0, maxLength - 1)).trimEnd();
   const wordBoundary = truncated.lastIndexOf(" ");
+  // The ratio only guards non-spacing scripts. Space-separated text keeps its word boundary
+  // however long the trailing word is.
+  const discardsCJK = CJK_RE.test(truncated.slice(wordBoundary + 1));
   const keepsMostOfSlice = wordBoundary >= truncated.length * WORD_BOUNDARY_MIN_KEPT_RATIO;
-  const text = wordBoundary > 0 && keepsMostOfSlice ? truncated.slice(0, wordBoundary) : truncated;
+  const honoursBoundary = wordBoundary > 0 && (keepsMostOfSlice || !discardsCJK);
+  const text = honoursBoundary ? truncated.slice(0, wordBoundary) : truncated;
   return `${text}…`;
 }

--- a/src/lib/truncateText.ts
+++ b/src/lib/truncateText.ts
@@ -1,10 +1,16 @@
 export const PUBLIC_CATALOG_NAME_PREVIEW_LENGTH = 70;
 
+// Scripts that do not separate words with spaces (Chinese, Japanese, Korean) often carry a
+// single Latin space near the start of a summary. Backtracking to that space would drop
+// nearly the whole preview, so only honour a word boundary that keeps most of the slice.
+const WORD_BOUNDARY_MIN_KEPT_RATIO = 0.6;
+
 export function truncateText(value: string, maxLength: number) {
   const normalized = value.trim().replace(/\s+/g, " ");
   if (normalized.length <= maxLength) return normalized;
   const truncated = normalized.slice(0, Math.max(0, maxLength - 1)).trimEnd();
   const wordBoundary = truncated.lastIndexOf(" ");
-  const text = wordBoundary > 0 ? truncated.slice(0, wordBoundary) : truncated;
+  const keepsMostOfSlice = wordBoundary >= truncated.length * WORD_BOUNDARY_MIN_KEPT_RATIO;
+  const text = wordBoundary > 0 && keepsMostOfSlice ? truncated.slice(0, wordBoundary) : truncated;
   return `${text}…`;
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where visitors browsing the catalog see Chinese, Japanese and Korean
summaries cut down to a handful of characters. The trigger is a summary that opens
with a Latin token — a product name, a protocol, a version number — followed by text
in a script that does not separate words with spaces.

The affected surface is every catalog card rendered through `truncateText`: the home
listing sections, the skills and plugins catalogs, the search results list, publisher
cards, and the dashboard catalog view.

## Why This Change Was Made

`truncateText` slices to the budget and then backtracks to the last space inside that
slice, so a preview never ends mid-word. The rule assumes spaces mark word boundaries
throughout the text. In Chinese, Japanese and Korean they usually do not, and often the
only space in an entire summary sits immediately after an opening Latin token — so the
backtrack rewinds past everything else.

Taking `5gc-automation` from `fixtures/public-corpus/corpus.jsonl`: the summary is 104
characters and its only space follows `5GC`. At the 100-character budget the card
renders `5GC…`. `huangli-query-cn` is worse — its preview is the single character `|`.

The word-boundary rule is still right for space-separated text, so it is kept and only
skipped when two conditions hold at once: honouring it would discard most of the slice,
and the part being discarded is actually non-spacing script. The second condition keeps
the fallback off Latin text, and the character class it tests is the one the catalog
search tokenizer already uses (`CJK_RE` in `convex/lib/searchText.ts`, character for
character). When the fallback does apply, the preview is cut at the budget, which is what
the repository's other two truncators already do:

- `convex/publisherAbuse.ts` — `value.slice(0, maxLength).trimEnd()`
- `convex/lib/skillSummary.ts` — `compact.slice(0, MAX_SUMMARY_CHARS - 3).trimEnd()`

`src/lib/truncateText.ts` is the only place in the repository that backtracks to a
space; `git grep 'lastIndexOf(" ")'` returns one hit.

Non-goals, kept out to hold the change to one concern:

- Grapheme-aware or width-aware truncation. The budget stays a UTF-16 length, unchanged.
- Sharing one truncation helper across `src/` and `convex/`. The three call sites now
  agree on behavior; consolidating them is a separate refactor.

## User Impact

Catalog cards for Chinese, Japanese and Korean skills now show the same amount of text
as cards for English ones. Previously a publisher whose summary opened with a Latin
product name got a preview that carried none of their description, and a visitor
scanning the catalog had nothing to read on those rows. Cards for space-separated text
are byte-for-byte unchanged.

## Evidence

Base commit: `a9d04bb0`. The fix is not on `main` — `truncateText` there still applies
`lastIndexOf(" ")` unconditionally, and the file has no test.

### Measured against the repository's own corpus

`fixtures/public-corpus/corpus.jsonl`, 1250 real catalog records, run through the actual
call budgets (`displayName` 70, `summary` 80 and 100):

```
corpus records                        : 1250
preview outputs changed by the fix    : 40
distinct catalog entries improved     : 25
space-separated previews in the corpus: 1362
  ... of those, unchanged by the fix  : 1362

worst previews on main (characters kept out of the budget):
  budget  kept  entry                      rendered on main
      80     1  huangli-query-cn          |…
     100     1  huangli-query-cn          |…
      80     1  zhongguo-nongli-query     |…
      80     3  5gc-automation            5GC…
     100     3  5gc-automation            5GC…
      80     8  claude-code-evolution     实施Claude…
     100     8  claude-code-evolution     实施Claude…
      80     8  cmz-token-optimizer       智能模型路由 -…
     100     8  cmz-token-optimizer       智能模型路由 -…
      80     8  long57777-continuous-learning  持续学习套件 -…
      70     8  trading-plan-generator    基于 Brent…
      80     8  trading-plan-generator    基于 Brent…
```

All 1362 space-separated previews in that corpus produce identical output before and
after, so the word-boundary behavior English summaries rely on is untouched.

### Read out of a mounted `SkillCard`

`SkillCard` rendered with `@testing-library/react`, reading `.skill-card-title` and
`.skill-card-summary` from the DOM. Same props on both sides; only `truncateText`
differs.

| entry | field | on `main` | with this change |
|---|---|---|---|
| `5gc-automation` | summary (budget 100, source 104) | `5GC…` — 4 chars | full 100 chars |
| `claude-code-evolution` | summary (budget 100, source 145) | `实施Claude…` — 9 chars | full 100 chars |
| `deploy-helper` | title (budget 70, source 80) | 68 chars | 68 chars, identical |
| `deploy-helper` | summary (budget 100, source 123) | 85 chars | 85 chars, identical |

Rendered summary on `main`:

```
slug: 5gc-automation
  summary(budget 100, source 104 chars): 5GC…
         rendered length: 4
```

and with this change:

```
slug: 5gc-automation
  summary(budget 100, source 104 chars): 5GC Web仪表自动化技能，支持AMF/UDM/AUSF/SMF/PGW-C/UPF/PGW-U/GNB/UE/PCF/NRF/QoS/TC/PCC/smpolicy的批量添加与编辑及PCF默认规…
         rendered length: 100
```

### Real-browser before/after on a running ClawHub

The measurements above are source-level. This one is the rendered catalog in a real
browser, against real catalog data - no jsdom, no fixture stubbing.

Setup: `bun run build` then `bun run preview`, pointed at the same public Convex
deployment the repository's own Playwright job uses
(`VITE_CONVEX_URL=https://wry-manatee-359.convex.cloud`). Chromium via Playwright then
loads `/skills?tab=trending`, `/skills?tab=new` and `/`, and reads back every rendered
preview that ends in an ellipsis. Both arms are full rebuilds of the same tree; the only
difference is `src/lib/truncateText.ts`.

Two comparisons were run against the same three pages.

**`main` (a9d04bb0) against this branch — the CJK repair on real cards.** Three rendered
previews differ, all three CJK, each one going from a truncated fragment to the full
80-character budget of the card that renders them:

```
main (29 chars): ## 使用方法 将本技能包导入支持 `SKILL.md`…
fix  (80 chars): ## 使用方法 将本技能包导入支持 `SKILL.md` 的技能环境后，在需要制作抖音卖书视频时调用本技能，并提供书名、作者、出版社、版本或商品链接、封面、目…

main (25 chars): 定位：顶级摄影指导 + 跨平台AI提示词专家 +…
fix  (80 chars): 定位：顶级摄影指导 + 跨平台AI提示词专家 + 一键直接生图引擎。融合《完美摄影摆姿》、《拍出绝世光线》与《50张人像摄影背后的故事与技法》三部名著摄影理论…

main (38 chars): 思维永生 · MindVault — Agent 对话归档与思考辅助系统。…
fix  (80 chars): 思维永生 · MindVault — Agent 对话归档与思考辅助系统。 提供对话备份(JSONL)+规则萃取+项目快照三层记忆能力，以及DRAS-V五步思…
```

Every one of them is a live catalog record cut at the Latin space that follows its opening
token. No Latin-script preview differs between these two arms, so the word-boundary
behavior English cards rely on is untouched on real data as well.

**The reviewed head (0b51dc30) against this branch — the review finding on real cards.**
Both arms captured 31 truncated previews, 8 of them CJK. Exactly one preview differs,
and it is a real catalog record rather than a constructed string:

```
BEFORE (0b51dc30, the reviewed head)
  # <emoji> Reddit Automation *Built by the team at [doany.ai](https://doany.ai/?utm_s…

AFTER (c53b7860)
  # <emoji> Reddit Automation *Built by the team at…
```

The reviewed head cut inside a URL query string; the boundary is restored. The other 22
Latin previews were already ending on a word and are unchanged, and all 8 CJK previews are
byte-identical across these two arms - which is the point: the CJK repair shown in the
first comparison survives this revision untouched. The record opens with an emoji, redacted to `<emoji>` above; everything
else in those two lines is reproduced exactly as rendered, including the trailing
ellipsis the helper emits.

### Focused tests

`src/lib/truncateText.test.ts` is new — the module had no test file, despite being
inside the coverage `include` glob. On the parent commit the three budget assertions
fail and the five contract assertions pass:

```
 FAIL  src/lib/truncateText.test.ts > truncateText > keeps the preview budget for Chinese summaries carrying an early Latin space
 FAIL  src/lib/truncateText.test.ts > truncateText > keeps the preview budget when a Latin product name opens a Chinese summary
AssertionError: expected '实施Claude…' to be '实施Claude Code架构的5阶段进化计划，将OpenClaw系统升级…'
 FAIL  src/lib/truncateText.test.ts > truncateText > keeps the preview budget for Japanese summaries carrying an early Latin space
AssertionError: expected 'Claude…' to be 'Claude Code向けのワークフロー自動化スキルパックです。日々のリリ…'

 Test Files  1 failed (1)
      Tests  3 failed | 5 passed (8)
```

With the change:

```
 Test Files  1 passed (1)
      Tests  10 passed (10)
```

The two tests added in the latest revision cover the review finding on the kept-ratio
fallback: one asserts a long Latin word keeps its boundary, the other asserts a short CJK
tail is still discarded in favour of that boundary. Both halves of the condition are
load-bearing - replacing `keepsMostOfSlice || !discardsCJK` with either half alone turns
exactly one of them red:

```
control (unmutated)             : 10 passed (10)
mutant A: keepsMostOfSlice only : 1 failed - keeps the word boundary when a long Latin word ends the slice
mutant B: !discardsCJK only     : 1 failed - keeps the Latin word boundary when only a short CJK tail is discarded
restored                        : 10 passed (10)
```

### CI

- `bun run lint`, `bun run deadcode:ci`, `bun run check:peers`, `bun audit`,
  `bun run llms:check`, `bun run check:release-workflow-action-pins` — all pass.
- `bun run format:check` fails on `CLAUDE.md` and
  `.agents/skills/autoreview/CLAUDE.md`. That is pre-existing: the same two files, and
  only those two, fail on `main` at `a9d04bb0`. The two files in this PR are formatted
  with `oxfmt`.
- `VITE_CONVEX_URL=https://example.invalid bun run ci:unit` on this branch:
  `14 failed | 431 passed | 1 skipped (446)` files, `24 failed | 5781 passed` tests.
  On `main`: `14 failed | 430 passed | 1 skipped (445)` files,
  `24 failed | 5773 passed` tests. The sorted list of failing files is identical on both
  sides — they are the suites that shell out to `bun`, plus
  `convex/lib/githubAccount.test.ts` and `src/routes/-management.test.tsx`. This branch
  adds one file and ten passing tests and introduces no new failure.

The Vercel check on this PR stays pending OpenClaw Foundation authorization, as it does
on every fork PR.

Written with AI assistance. I ran the focused tests, the corpus measurement and the
mounted-component render above myself, diffed the full unit suite against `main`, and
can maintain this code.



