### PR TITLE
fix: Japanese searches skip the category and summary result tiers

### DIFF
--- a/convex/lib/searchText.test.ts
+++ b/convex/lib/searchText.test.ts
@@ -94,8 +94,31 @@ describe("searchText", () => {
     });
 
     it("handles Japanese text", () => {
-      const tokens = tokenize("こんにちは世界");
-      expect(tokens.length).toBeGreaterThan(0);
+      expect(tokenize("こんにちは世界")).toEqual(["こんにちは", "世界"]);
+    });
+
+    it("keeps katakana words that contain a prolonged sound mark intact", () => {
+      expect(tokenize("データベース")).toEqual(["データベース"]);
+      expect(tokenize("データベース管理")).toEqual(["データベース", "管理"]);
+      expect(tokenize("ユーザーインターフェース")).toEqual(["ユーザー", "インターフェース"]);
+    });
+
+    it("keeps the iteration mark attached to the character it repeats", () => {
+      expect(tokenize("人々")).toEqual(["人々"]);
+      expect(tokenize("時々")).toEqual(["時々"]);
+    });
+
+    it("matches Japanese query tokens against Japanese skill names", () => {
+      const queryTokens = tokenize("データベース");
+      expect(matchesExactTokens(queryTokens, ["データベース管理ツール"])).toBe(true);
+    });
+
+    it("lets katakana queries reach the exploratory match tiers", () => {
+      // Exploratory tiers require every query token to clear a three-character floor.
+      const queryTokens = tokenize("データベース");
+      expect(matchesExploratoryTokenPrefixes(queryTokens, ["データベース管理ツール"], 3)).toBe(
+        true,
+      );
     });
 
     it("handles Korean text", () => {

--- a/convex/lib/searchText.test.ts
+++ b/convex/lib/searchText.test.ts
@@ -108,6 +108,14 @@ describe("searchText", () => {
       expect(tokenize("時々")).toEqual(["時々"]);
     });
 
+    it("keeps the marks attached when Intl.Segmenter is unavailable", () => {
+      // segmentCJKByChar is the no-Segmenter fallback. Emitting ー or 々 on their own
+      // would leave one-character tokens that exploratory matching discards.
+      expect(__test.segmentCJKByChar("データベース")).toEqual(["デー", "タ", "ベー", "ス"]);
+      expect(__test.segmentCJKByChar("人々")).toEqual(["人々"]);
+      expect(__test.segmentCJKByChar("時々の記録")).toEqual(["時々", "の", "記", "録"]);
+    });
+
     it("matches Japanese query tokens against Japanese skill names", () => {
       const queryTokens = tokenize("データベース");
       expect(matchesExactTokens(queryTokens, ["データベース管理ツール"])).toBe(true);

--- a/convex/lib/searchText.ts
+++ b/convex/lib/searchText.ts
@@ -1,4 +1,6 @@
-const CJK_RE = /[\u4e00-\u9fff\u3400-\u4dbf\u3041-\u3096\u30a1-\u30fa\uac00-\ud7af]/;
+// U+30FC (ー) and U+3005 (々) extend the word they follow, so the pre-split in tokenize()
+// must keep them with that word instead of treating them as separators.
+const CJK_RE = /[\u4e00-\u9fff\u3400-\u4dbf\u3041-\u3096\u30a1-\u30fa\u30fc\u3005\uac00-\ud7af]/;
 
 const hasSegmenter = typeof Intl !== "undefined" && "Segmenter" in Intl;
 
@@ -116,7 +118,7 @@ export function tokenize(value: string): string[] {
   const tokens: string[] = [];
 
   const parts = normalized.split(
-    /([^\u4e00-\u9fff\u3400-\u4dbf\u3041-\u3096\u30a1-\u30fa\uac00-\ud7af]+)/g,
+    /([^\u4e00-\u9fff\u3400-\u4dbf\u3041-\u3096\u30a1-\u30fa\u30fc\u3005\uac00-\ud7af]+)/g,
   );
 
   for (const part of parts) {

--- a/convex/lib/searchText.ts
+++ b/convex/lib/searchText.ts
@@ -2,6 +2,10 @@
 // must keep them with that word instead of treating them as separators.
 const CJK_RE = /[\u4e00-\u9fff\u3400-\u4dbf\u3041-\u3096\u30a1-\u30fa\u30fc\u3005\uac00-\ud7af]/;
 
+// The same two marks the class above admits: they extend the preceding character rather
+// than standing on their own, so the per-character fallback must not emit them alone.
+const CJK_EXTENDER_RE = /[\u30fc\u3005]/;
+
 const hasSegmenter = typeof Intl !== "undefined" && "Segmenter" in Intl;
 
 let zhSegmenter: Intl.Segmenter | null = null;
@@ -36,9 +40,12 @@ function getKoSegmenter(): Intl.Segmenter {
 function segmentCJKByChar(text: string): string[] {
   const tokens: string[] = [];
   for (const ch of text) {
-    if (CJK_RE.test(ch)) {
-      tokens.push(ch);
+    if (!CJK_RE.test(ch)) continue;
+    if (CJK_EXTENDER_RE.test(ch) && tokens.length > 0) {
+      tokens[tokens.length - 1] += ch;
+      continue;
     }
+    tokens.push(ch);
   }
   return tokens;
 }

--- a/convex/lib/skillSearchDigest.ts
+++ b/convex/lib/skillSearchDigest.ts
@@ -146,6 +146,12 @@ export function getFirstSearchToken(value: string) {
   return tokenize(value)[0];
 }
 
+// The skills.sh mirror persists the same tokenizer-derived first tokens, but its columns
+// are required, so it falls back to the normalized text when the tokenizer yields nothing.
+export function getMirrorFirstSearchToken(value: string) {
+  return getFirstSearchToken(value) ?? normalizeSkillSearchText(value);
+}
+
 /**
  * Map a digest row to the HydratableSkill shape expected by toPublicSkill /
  * isPublicSkillDoc / isSkillSuspicious.  Fully type-checked: if

--- a/convex/maintenance.test.ts
+++ b/convex/maintenance.test.ts
@@ -36,6 +36,9 @@ vi.mock("./_generated/api", () => ({
       backfillSkillSearchDigestFirstTokensInternal: Symbol(
         "backfillSkillSearchDigestFirstTokensInternal",
       ),
+      backfillSkillsShMirrorDigestFirstTokensInternal: Symbol(
+        "backfillSkillsShMirrorDigestFirstTokensInternal",
+      ),
       getEmptySkillCleanupPageInternal: Symbol("getEmptySkillCleanupPageInternal"),
       applyEmptySkillCleanupInternal: Symbol("applyEmptySkillCleanupInternal"),
       nominateUserForEmptySkillSpamInternal: Symbol("nominateUserForEmptySkillSpamInternal"),
@@ -79,6 +82,7 @@ const {
   backfillLatestVersionSummaryInternal,
   backfillSkillSearchDigestModerationVerdictsInternal,
   backfillSkillSearchDigestFirstTokensInternal,
+  backfillSkillsShMirrorDigestFirstTokensInternal,
   backfillPublisherStatsInternalHandler,
   backfillSkillFingerprintsInternalHandler,
   backfillSkillSummariesInternalHandler,
@@ -2129,7 +2133,95 @@ describe("backfillSkillSearchDigestFirstTokensInternal", () => {
       { cursor: "next-page", batchSize: undefined, delayMs: 600_000, dryRun: false },
     );
   });
+});
 
+describe("backfillSkillsShMirrorDigestFirstTokensInternal", () => {
+  const mirrorPage = () => [
+    {
+      _id: "skillsShMirrorDigests:stale",
+      slug: "database",
+      displayName: "データベース管理",
+      normalizedSlugFirstToken: "database",
+      normalizedDisplayNameFirstToken: "デ",
+    },
+    {
+      _id: "skillsShMirrorDigests:fresh",
+      slug: "deploy",
+      displayName: "Deploy helper",
+      normalizedSlugFirstToken: "deploy",
+      normalizedDisplayNameFirstToken: "deploy",
+    },
+  ];
+
+  it("repairs mirrored rows whose stored first tokens predate the tokenizer", async () => {
+    const paginate = vi.fn().mockResolvedValue({
+      page: mirrorPage(),
+      continueCursor: "next-page",
+      isDone: false,
+    });
+    const query = vi.fn().mockReturnValue({ paginate });
+    const patch = vi.fn().mockResolvedValue(undefined);
+    const runAfter = vi.fn().mockResolvedValue(undefined);
+
+    const result = await (
+      backfillSkillsShMirrorDigestFirstTokensInternal as unknown as { _handler: Function }
+    )._handler(
+      {
+        db: { query, get: vi.fn(), patch, normalizeId: vi.fn() },
+        scheduler: { runAfter },
+      } as never,
+      { cursor: "start", batchSize: 25 },
+    );
+
+    expect(result).toEqual({
+      scanned: 2,
+      patched: 1,
+      cursor: "next-page",
+      isDone: false,
+      dryRun: false,
+    });
+    expect(query).toHaveBeenCalledWith("skillsShMirrorDigests");
+    expect(paginate).toHaveBeenCalledWith({ cursor: "start", numItems: 25 });
+    expect(patch).toHaveBeenCalledTimes(1);
+    expect(patch).toHaveBeenCalledWith("skillsShMirrorDigests:stale", {
+      normalizedSlugFirstToken: "database",
+      normalizedDisplayNameFirstToken: "データベース",
+    });
+    expect(runAfter).toHaveBeenCalledWith(
+      500,
+      internal.maintenance.backfillSkillsShMirrorDigestFirstTokensInternal,
+      { cursor: "next-page", batchSize: 25, delayMs: undefined, dryRun: false },
+    );
+  });
+
+  it("reports would-be patches without writing or scheduling in dry run mode", async () => {
+    const paginate = vi.fn().mockResolvedValue({
+      page: mirrorPage(),
+      continueCursor: "next-page",
+      isDone: false,
+    });
+    const query = vi.fn().mockReturnValue({ paginate });
+    const patch = vi.fn().mockResolvedValue(undefined);
+    const runAfter = vi.fn().mockResolvedValue(undefined);
+
+    const result = await (
+      backfillSkillsShMirrorDigestFirstTokensInternal as unknown as { _handler: Function }
+    )._handler(
+      {
+        db: { query, get: vi.fn(), patch, normalizeId: vi.fn() },
+        scheduler: { runAfter },
+      } as never,
+      { dryRun: true },
+    );
+
+    expect(result.patched).toBe(1);
+    expect(result.dryRun).toBe(true);
+    expect(patch).not.toHaveBeenCalled();
+    expect(runAfter).not.toHaveBeenCalled();
+  });
+});
+
+describe("backfillSkillSearchDigestFirstTokensInternal dry run", () => {
   it("reports would-be patches without writing or scheduling in dry run mode", async () => {
     const paginate = vi.fn().mockResolvedValue({
       page: [

--- a/convex/maintenance.test.ts
+++ b/convex/maintenance.test.ts
@@ -2080,9 +2080,53 @@ describe("backfillSkillSearchDigestFirstTokensInternal", () => {
       normalizedDisplayNameFirstToken: "データベース",
     });
     expect(runAfter).toHaveBeenCalledWith(
-      0,
+      500,
       internal.maintenance.backfillSkillSearchDigestFirstTokensInternal,
-      { cursor: "next-page", batchSize: 25, dryRun: false },
+      { cursor: "next-page", batchSize: 25, delayMs: undefined, dryRun: false },
+    );
+  });
+
+  it("spaces the next batch by the requested delay and clamps it", async () => {
+    const paginate = vi.fn().mockResolvedValue({
+      page: [
+        {
+          _id: "skillSearchDigest:stale",
+          skillId: "skills:stale",
+          normalizedSlugFirstToken: "database",
+          normalizedDisplayNameFirstToken: "デ",
+        },
+      ],
+      continueCursor: "next-page",
+      isDone: false,
+    });
+    const query = vi.fn().mockReturnValue({ paginate });
+    const get = vi.fn().mockResolvedValue({
+      _id: "skills:stale",
+      slug: "database",
+      displayName: "データベース管理",
+    });
+    const patch = vi.fn().mockResolvedValue(undefined);
+    const runAfter = vi.fn().mockResolvedValue(undefined);
+    const handler = (
+      backfillSkillSearchDigestFirstTokensInternal as unknown as { _handler: Function }
+    )._handler;
+    const ctx = {
+      db: { query, get, patch, normalizeId: vi.fn() },
+      scheduler: { runAfter },
+    } as never;
+
+    await handler(ctx, { delayMs: 2_000 });
+    expect(runAfter).toHaveBeenLastCalledWith(
+      2_000,
+      internal.maintenance.backfillSkillSearchDigestFirstTokensInternal,
+      { cursor: "next-page", batchSize: undefined, delayMs: 2_000, dryRun: false },
+    );
+
+    await handler(ctx, { delayMs: 600_000 });
+    expect(runAfter).toHaveBeenLastCalledWith(
+      60_000,
+      internal.maintenance.backfillSkillSearchDigestFirstTokensInternal,
+      { cursor: "next-page", batchSize: undefined, delayMs: 600_000, dryRun: false },
     );
   });
 

--- a/convex/maintenance.test.ts
+++ b/convex/maintenance.test.ts
@@ -2015,6 +2015,11 @@ describe("maintenance empty skill nominations", () => {
   });
 });
 
+const SKILL_SEARCH_DIGEST_FIRST_TOKEN_BACKFILL_CONFIRM =
+  "backfill-skill-search-digest-first-tokens";
+const SKILLS_SH_MIRROR_DIGEST_FIRST_TOKEN_BACKFILL_CONFIRM =
+  "backfill-skills-sh-mirror-digest-first-tokens";
+
 describe("backfillSkillSearchDigestFirstTokensInternal", () => {
   it("repairs digest rows whose stored first tokens predate the tokenizer", async () => {
     const paginate = vi.fn().mockResolvedValue({
@@ -2065,7 +2070,12 @@ describe("backfillSkillSearchDigestFirstTokensInternal", () => {
         db: { query, get, patch, normalizeId: vi.fn() },
         scheduler: { runAfter },
       } as never,
-      { cursor: "start", batchSize: 25 },
+      {
+        cursor: "start",
+        batchSize: 25,
+        dryRun: false,
+        confirm: SKILL_SEARCH_DIGEST_FIRST_TOKEN_BACKFILL_CONFIRM,
+      },
     );
 
     expect(result).toEqual({
@@ -2075,6 +2085,7 @@ describe("backfillSkillSearchDigestFirstTokensInternal", () => {
       cursor: "next-page",
       isDone: false,
       dryRun: false,
+      confirmRequired: undefined,
     });
     expect(query).toHaveBeenCalledWith("skillSearchDigest");
     expect(paginate).toHaveBeenCalledWith({ cursor: "start", numItems: 25 });
@@ -2083,11 +2094,81 @@ describe("backfillSkillSearchDigestFirstTokensInternal", () => {
       normalizedSlugFirstToken: "database",
       normalizedDisplayNameFirstToken: "データベース",
     });
+    // The scheduled page has to carry the token, otherwise the run stalls on its own guard.
     expect(runAfter).toHaveBeenCalledWith(
       500,
       internal.maintenance.backfillSkillSearchDigestFirstTokensInternal,
-      { cursor: "next-page", batchSize: 25, delayMs: undefined, dryRun: false },
+      {
+        cursor: "next-page",
+        batchSize: 25,
+        delayMs: undefined,
+        dryRun: false,
+        confirm: SKILL_SEARCH_DIGEST_FIRST_TOKEN_BACKFILL_CONFIRM,
+      },
     );
+  });
+
+  it("previews without writing or scheduling when arguments are omitted", async () => {
+    const paginate = vi.fn().mockResolvedValue({
+      page: [
+        {
+          _id: "skillSearchDigest:stale",
+          skillId: "skills:stale",
+          normalizedSlugFirstToken: "database",
+          normalizedDisplayNameFirstToken: "デ",
+        },
+      ],
+      continueCursor: "next-page",
+      isDone: false,
+    });
+    const query = vi.fn().mockReturnValue({ paginate });
+    const get = vi.fn().mockResolvedValue({
+      _id: "skills:stale",
+      slug: "database",
+      displayName: "データベース管理",
+    });
+    const patch = vi.fn().mockResolvedValue(undefined);
+    const runAfter = vi.fn().mockResolvedValue(undefined);
+
+    const result = await (
+      backfillSkillSearchDigestFirstTokensInternal as unknown as { _handler: Function }
+    )._handler(
+      {
+        db: { query, get, patch, normalizeId: vi.fn() },
+        scheduler: { runAfter },
+      } as never,
+      {},
+    );
+
+    expect(result.dryRun).toBe(true);
+    expect(result.patched).toBe(1);
+    expect(result.confirmRequired).toBe(SKILL_SEARCH_DIGEST_FIRST_TOKEN_BACKFILL_CONFIRM);
+    expect(patch).not.toHaveBeenCalled();
+    expect(runAfter).not.toHaveBeenCalled();
+  });
+
+  it("rejects an apply that omits the confirmation token", async () => {
+    const paginate = vi.fn();
+    const query = vi.fn().mockReturnValue({ paginate });
+    const patch = vi.fn();
+    const runAfter = vi.fn();
+    const ctx = {
+      db: { query, get: vi.fn(), patch, normalizeId: vi.fn() },
+      scheduler: { runAfter },
+    } as never;
+    const handler = (
+      backfillSkillSearchDigestFirstTokensInternal as unknown as { _handler: Function }
+    )._handler;
+
+    await expect(handler(ctx, { dryRun: false })).rejects.toThrow(
+      `Pass confirm="${SKILL_SEARCH_DIGEST_FIRST_TOKEN_BACKFILL_CONFIRM}" to apply.`,
+    );
+    await expect(handler(ctx, { dryRun: false, confirm: "wrong-token" })).rejects.toThrow(
+      `Pass confirm="${SKILL_SEARCH_DIGEST_FIRST_TOKEN_BACKFILL_CONFIRM}" to apply.`,
+    );
+    expect(paginate).not.toHaveBeenCalled();
+    expect(patch).not.toHaveBeenCalled();
+    expect(runAfter).not.toHaveBeenCalled();
   });
 
   it("spaces the next batch by the requested delay and clamps it", async () => {
@@ -2119,18 +2200,38 @@ describe("backfillSkillSearchDigestFirstTokensInternal", () => {
       scheduler: { runAfter },
     } as never;
 
-    await handler(ctx, { delayMs: 2_000 });
+    await handler(ctx, {
+      delayMs: 2_000,
+      dryRun: false,
+      confirm: SKILL_SEARCH_DIGEST_FIRST_TOKEN_BACKFILL_CONFIRM,
+    });
     expect(runAfter).toHaveBeenLastCalledWith(
       2_000,
       internal.maintenance.backfillSkillSearchDigestFirstTokensInternal,
-      { cursor: "next-page", batchSize: undefined, delayMs: 2_000, dryRun: false },
+      {
+        cursor: "next-page",
+        batchSize: undefined,
+        delayMs: 2_000,
+        dryRun: false,
+        confirm: SKILL_SEARCH_DIGEST_FIRST_TOKEN_BACKFILL_CONFIRM,
+      },
     );
 
-    await handler(ctx, { delayMs: 600_000 });
+    await handler(ctx, {
+      delayMs: 600_000,
+      dryRun: false,
+      confirm: SKILL_SEARCH_DIGEST_FIRST_TOKEN_BACKFILL_CONFIRM,
+    });
     expect(runAfter).toHaveBeenLastCalledWith(
       60_000,
       internal.maintenance.backfillSkillSearchDigestFirstTokensInternal,
-      { cursor: "next-page", batchSize: undefined, delayMs: 600_000, dryRun: false },
+      {
+        cursor: "next-page",
+        batchSize: undefined,
+        delayMs: 600_000,
+        dryRun: false,
+        confirm: SKILL_SEARCH_DIGEST_FIRST_TOKEN_BACKFILL_CONFIRM,
+      },
     );
   });
 });
@@ -2170,7 +2271,12 @@ describe("backfillSkillsShMirrorDigestFirstTokensInternal", () => {
         db: { query, get: vi.fn(), patch, normalizeId: vi.fn() },
         scheduler: { runAfter },
       } as never,
-      { cursor: "start", batchSize: 25 },
+      {
+        cursor: "start",
+        batchSize: 25,
+        dryRun: false,
+        confirm: SKILLS_SH_MIRROR_DIGEST_FIRST_TOKEN_BACKFILL_CONFIRM,
+      },
     );
 
     expect(result).toEqual({
@@ -2179,6 +2285,7 @@ describe("backfillSkillsShMirrorDigestFirstTokensInternal", () => {
       cursor: "next-page",
       isDone: false,
       dryRun: false,
+      confirmRequired: undefined,
     });
     expect(query).toHaveBeenCalledWith("skillsShMirrorDigests");
     expect(paginate).toHaveBeenCalledWith({ cursor: "start", numItems: 25 });
@@ -2190,8 +2297,71 @@ describe("backfillSkillsShMirrorDigestFirstTokensInternal", () => {
     expect(runAfter).toHaveBeenCalledWith(
       500,
       internal.maintenance.backfillSkillsShMirrorDigestFirstTokensInternal,
-      { cursor: "next-page", batchSize: 25, delayMs: undefined, dryRun: false },
+      {
+        cursor: "next-page",
+        batchSize: 25,
+        delayMs: undefined,
+        dryRun: false,
+        confirm: SKILLS_SH_MIRROR_DIGEST_FIRST_TOKEN_BACKFILL_CONFIRM,
+      },
     );
+  });
+
+  it("previews without writing or scheduling when arguments are omitted", async () => {
+    const paginate = vi.fn().mockResolvedValue({
+      page: mirrorPage(),
+      continueCursor: "next-page",
+      isDone: false,
+    });
+    const query = vi.fn().mockReturnValue({ paginate });
+    const patch = vi.fn().mockResolvedValue(undefined);
+    const runAfter = vi.fn().mockResolvedValue(undefined);
+
+    const result = await (
+      backfillSkillsShMirrorDigestFirstTokensInternal as unknown as { _handler: Function }
+    )._handler(
+      {
+        db: { query, get: vi.fn(), patch, normalizeId: vi.fn() },
+        scheduler: { runAfter },
+      } as never,
+      {},
+    );
+
+    expect(result.dryRun).toBe(true);
+    expect(result.patched).toBe(1);
+    expect(result.confirmRequired).toBe(SKILLS_SH_MIRROR_DIGEST_FIRST_TOKEN_BACKFILL_CONFIRM);
+    expect(patch).not.toHaveBeenCalled();
+    expect(runAfter).not.toHaveBeenCalled();
+  });
+
+  it("rejects an apply that omits the confirmation token", async () => {
+    const paginate = vi.fn();
+    const query = vi.fn().mockReturnValue({ paginate });
+    const patch = vi.fn();
+    const runAfter = vi.fn();
+    const ctx = {
+      db: { query, get: vi.fn(), patch, normalizeId: vi.fn() },
+      scheduler: { runAfter },
+    } as never;
+    const handler = (
+      backfillSkillsShMirrorDigestFirstTokensInternal as unknown as { _handler: Function }
+    )._handler;
+
+    await expect(handler(ctx, { dryRun: false })).rejects.toThrow(
+      `Pass confirm="${SKILLS_SH_MIRROR_DIGEST_FIRST_TOKEN_BACKFILL_CONFIRM}" to apply.`,
+    );
+    await expect(
+      handler(ctx, {
+        dryRun: false,
+        // The native token must not unlock the mirror path.
+        confirm: SKILL_SEARCH_DIGEST_FIRST_TOKEN_BACKFILL_CONFIRM,
+      }),
+    ).rejects.toThrow(
+      `Pass confirm="${SKILLS_SH_MIRROR_DIGEST_FIRST_TOKEN_BACKFILL_CONFIRM}" to apply.`,
+    );
+    expect(paginate).not.toHaveBeenCalled();
+    expect(patch).not.toHaveBeenCalled();
+    expect(runAfter).not.toHaveBeenCalled();
   });
 
   it("reports would-be patches without writing or scheduling in dry run mode", async () => {

--- a/convex/maintenance.test.ts
+++ b/convex/maintenance.test.ts
@@ -33,6 +33,9 @@ vi.mock("./_generated/api", () => ({
       backfillSkillSearchDigestModerationVerdictsInternal: Symbol(
         "backfillSkillSearchDigestModerationVerdictsInternal",
       ),
+      backfillSkillSearchDigestFirstTokensInternal: Symbol(
+        "backfillSkillSearchDigestFirstTokensInternal",
+      ),
       getEmptySkillCleanupPageInternal: Symbol("getEmptySkillCleanupPageInternal"),
       applyEmptySkillCleanupInternal: Symbol("applyEmptySkillCleanupInternal"),
       nominateUserForEmptySkillSpamInternal: Symbol("nominateUserForEmptySkillSpamInternal"),
@@ -75,6 +78,7 @@ vi.mock("./lib/skillSummary", () => ({
 const {
   backfillLatestVersionSummaryInternal,
   backfillSkillSearchDigestModerationVerdictsInternal,
+  backfillSkillSearchDigestFirstTokensInternal,
   backfillPublisherStatsInternalHandler,
   backfillSkillFingerprintsInternalHandler,
   backfillSkillSummariesInternalHandler,
@@ -2004,5 +2008,119 @@ describe("maintenance empty skill nominations", () => {
         sampleSlugs: ["spam-a", "spam-b"],
       },
     ]);
+  });
+});
+
+describe("backfillSkillSearchDigestFirstTokensInternal", () => {
+  it("repairs digest rows whose stored first tokens predate the tokenizer", async () => {
+    const paginate = vi.fn().mockResolvedValue({
+      page: [
+        {
+          _id: "skillSearchDigest:stale",
+          skillId: "skills:stale",
+          normalizedSlugFirstToken: "database",
+          normalizedDisplayNameFirstToken: "デ",
+        },
+        {
+          _id: "skillSearchDigest:fresh",
+          skillId: "skills:fresh",
+          normalizedSlugFirstToken: "deploy",
+          normalizedDisplayNameFirstToken: "deploy",
+        },
+        {
+          _id: "skillSearchDigest:orphan",
+          skillId: "skills:missing",
+          normalizedSlugFirstToken: "gone",
+          normalizedDisplayNameFirstToken: "gone",
+        },
+      ],
+      continueCursor: "next-page",
+      isDone: false,
+    });
+    const query = vi.fn().mockReturnValue({ paginate });
+    const get = vi
+      .fn()
+      .mockResolvedValueOnce({
+        _id: "skills:stale",
+        slug: "database",
+        displayName: "データベース管理",
+      })
+      .mockResolvedValueOnce({
+        _id: "skills:fresh",
+        slug: "deploy",
+        displayName: "Deploy helper",
+      })
+      .mockResolvedValueOnce(null);
+    const patch = vi.fn().mockResolvedValue(undefined);
+    const runAfter = vi.fn().mockResolvedValue(undefined);
+
+    const result = await (
+      backfillSkillSearchDigestFirstTokensInternal as unknown as { _handler: Function }
+    )._handler(
+      {
+        db: { query, get, patch, normalizeId: vi.fn() },
+        scheduler: { runAfter },
+      } as never,
+      { cursor: "start", batchSize: 25 },
+    );
+
+    expect(result).toEqual({
+      scanned: 3,
+      patched: 1,
+      missingSkills: 1,
+      cursor: "next-page",
+      isDone: false,
+      dryRun: false,
+    });
+    expect(query).toHaveBeenCalledWith("skillSearchDigest");
+    expect(paginate).toHaveBeenCalledWith({ cursor: "start", numItems: 25 });
+    expect(patch).toHaveBeenCalledTimes(1);
+    expect(patch).toHaveBeenCalledWith("skillSearchDigest:stale", {
+      normalizedSlugFirstToken: "database",
+      normalizedDisplayNameFirstToken: "データベース",
+    });
+    expect(runAfter).toHaveBeenCalledWith(
+      0,
+      internal.maintenance.backfillSkillSearchDigestFirstTokensInternal,
+      { cursor: "next-page", batchSize: 25, dryRun: false },
+    );
+  });
+
+  it("reports would-be patches without writing or scheduling in dry run mode", async () => {
+    const paginate = vi.fn().mockResolvedValue({
+      page: [
+        {
+          _id: "skillSearchDigest:stale",
+          skillId: "skills:stale",
+          normalizedSlugFirstToken: "database",
+          normalizedDisplayNameFirstToken: "デ",
+        },
+      ],
+      continueCursor: "next-page",
+      isDone: false,
+    });
+    const query = vi.fn().mockReturnValue({ paginate });
+    const get = vi.fn().mockResolvedValue({
+      _id: "skills:stale",
+      slug: "database",
+      displayName: "データベース管理",
+    });
+    const patch = vi.fn().mockResolvedValue(undefined);
+    const runAfter = vi.fn().mockResolvedValue(undefined);
+
+    const result = await (
+      backfillSkillSearchDigestFirstTokensInternal as unknown as { _handler: Function }
+    )._handler(
+      {
+        db: { query, get, patch, normalizeId: vi.fn() },
+        scheduler: { runAfter },
+      } as never,
+      { dryRun: true },
+    );
+
+    expect(result.patched).toBe(1);
+    expect(result.dryRun).toBe(true);
+    expect(patch).not.toHaveBeenCalled();
+    expect(runAfter).not.toHaveBeenCalled();
   });
 });

--- a/convex/maintenance.ts
+++ b/convex/maintenance.ts
@@ -30,7 +30,7 @@ import {
 } from "./lib/skillQuality";
 import { getFrontmatterValue, hashSkillFiles } from "./lib/skills";
 import { computeIsSuspicious } from "./lib/skillSafety";
-import { getFirstSearchToken } from "./lib/skillSearchDigest";
+import { getFirstSearchToken, getMirrorFirstSearchToken } from "./lib/skillSearchDigest";
 import { generateSkillSummary } from "./lib/skillSummary";
 
 const DEFAULT_BATCH_SIZE = 50;
@@ -2766,6 +2766,87 @@ export const backfillSkillSearchDigestFirstTokens: ReturnType<typeof action> = a
     assertRole(user, ["admin"]);
     return await ctx.runMutation(
       internal.maintenance.backfillSkillSearchDigestFirstTokensInternal,
+      args,
+    );
+  },
+});
+
+// Recompute the stored first-token fields on skillsShMirrorDigests rows. The skills.sh
+// mirror derives them through the same tokenizer as the native digest above, and external
+// candidate search range-scans them, so a tokenizer change strands mirrored rows the same
+// way. Run once after deploying such a change:
+//   npx convex run maintenance:backfillSkillsShMirrorDigestFirstTokens --prod
+export const backfillSkillsShMirrorDigestFirstTokensInternal = internalMutation({
+  args: {
+    cursor: v.optional(v.string()),
+    batchSize: v.optional(v.number()),
+    delayMs: v.optional(v.number()),
+    dryRun: v.optional(v.boolean()),
+  },
+  handler: async (ctx, args) => {
+    const batchSize = clampInt(args.batchSize ?? 100, 10, 200);
+    // The catalog subscribes to mirrored rows too, so pages are spaced apart here as well.
+    const delayMs = clampInt(args.delayMs ?? 500, 0, 60_000);
+    const dryRun = args.dryRun ?? false;
+    const { page, continueCursor, isDone } = await ctx.db
+      .query("skillsShMirrorDigests")
+      .paginate({ cursor: args.cursor ?? null, numItems: batchSize });
+
+    let patched = 0;
+    for (const digest of page) {
+      const normalizedSlugFirstToken = getMirrorFirstSearchToken(digest.slug);
+      const normalizedDisplayNameFirstToken = getMirrorFirstSearchToken(digest.displayName);
+      if (
+        digest.normalizedSlugFirstToken === normalizedSlugFirstToken &&
+        digest.normalizedDisplayNameFirstToken === normalizedDisplayNameFirstToken
+      ) {
+        continue;
+      }
+
+      patched++;
+      if (!dryRun) {
+        await ctx.db.patch(digest._id, {
+          normalizedSlugFirstToken,
+          normalizedDisplayNameFirstToken,
+        });
+      }
+    }
+
+    if (!dryRun && !isDone) {
+      await ctx.scheduler.runAfter(
+        delayMs,
+        internal.maintenance.backfillSkillsShMirrorDigestFirstTokensInternal,
+        {
+          cursor: continueCursor,
+          batchSize: args.batchSize,
+          delayMs: args.delayMs,
+          dryRun,
+        },
+      );
+    }
+
+    return {
+      scanned: page.length,
+      patched,
+      cursor: continueCursor,
+      isDone,
+      dryRun,
+    };
+  },
+});
+
+export const backfillSkillsShMirrorDigestFirstTokens: ReturnType<typeof action> = action({
+  args: {
+    cursor: v.optional(v.string()),
+    batchSize: v.optional(v.number()),
+    delayMs: v.optional(v.number()),
+    dryRun: v.optional(v.boolean()),
+  },
+  handler: async (ctx, args) => {
+    const { user } = await requireUserFromAction(ctx);
+    assertRole(user, ["admin"]);
+    return await ctx.runMutation(
+      internal.maintenance.backfillSkillsShMirrorDigestFirstTokensInternal,
       args,
     );
   },

--- a/convex/maintenance.ts
+++ b/convex/maintenance.ts
@@ -2690,10 +2690,14 @@ export const backfillSkillSearchDigestFirstTokensInternal = internalMutation({
   args: {
     cursor: v.optional(v.string()),
     batchSize: v.optional(v.number()),
+    delayMs: v.optional(v.number()),
     dryRun: v.optional(v.boolean()),
   },
   handler: async (ctx, args) => {
     const batchSize = clampInt(args.batchSize ?? 100, 10, 200);
+    // Catalog search subscribes to skillSearchDigest, so batches are spaced out to keep the
+    // backfill from driving reactive re-reads back to back.
+    const delayMs = clampInt(args.delayMs ?? 500, 0, 60_000);
     const dryRun = args.dryRun ?? false;
     const { page, continueCursor, isDone } = await ctx.db
       .query("skillSearchDigest")
@@ -2728,11 +2732,12 @@ export const backfillSkillSearchDigestFirstTokensInternal = internalMutation({
 
     if (!dryRun && !isDone) {
       await ctx.scheduler.runAfter(
-        0,
+        delayMs,
         internal.maintenance.backfillSkillSearchDigestFirstTokensInternal,
         {
           cursor: continueCursor,
           batchSize: args.batchSize,
+          delayMs: args.delayMs,
           dryRun,
         },
       );
@@ -2753,6 +2758,7 @@ export const backfillSkillSearchDigestFirstTokens: ReturnType<typeof action> = a
   args: {
     cursor: v.optional(v.string()),
     batchSize: v.optional(v.number()),
+    delayMs: v.optional(v.number()),
     dryRun: v.optional(v.boolean()),
   },
   handler: async (ctx, args) => {

--- a/convex/maintenance.ts
+++ b/convex/maintenance.ts
@@ -30,6 +30,7 @@ import {
 } from "./lib/skillQuality";
 import { getFrontmatterValue, hashSkillFiles } from "./lib/skills";
 import { computeIsSuspicious } from "./lib/skillSafety";
+import { getFirstSearchToken } from "./lib/skillSearchDigest";
 import { generateSkillSummary } from "./lib/skillSummary";
 
 const DEFAULT_BATCH_SIZE = 50;
@@ -2675,6 +2676,90 @@ export const backfillSkillSearchDigestModerationVerdicts: ReturnType<typeof acti
     assertRole(user, ["admin"]);
     return await ctx.runMutation(
       internal.maintenance.backfillSkillSearchDigestModerationVerdictsInternal,
+      args,
+    );
+  },
+});
+
+// Recompute the stored first-token fields on skillSearchDigest rows. Those values are
+// produced by the search tokenizer, so a tokenizer change leaves already-written rows
+// holding tokens the current search no longer looks for. Run once after deploying such a
+// change:
+//   npx convex run maintenance:backfillSkillSearchDigestFirstTokens --prod
+export const backfillSkillSearchDigestFirstTokensInternal = internalMutation({
+  args: {
+    cursor: v.optional(v.string()),
+    batchSize: v.optional(v.number()),
+    dryRun: v.optional(v.boolean()),
+  },
+  handler: async (ctx, args) => {
+    const batchSize = clampInt(args.batchSize ?? 100, 10, 200);
+    const dryRun = args.dryRun ?? false;
+    const { page, continueCursor, isDone } = await ctx.db
+      .query("skillSearchDigest")
+      .paginate({ cursor: args.cursor ?? null, numItems: batchSize });
+
+    let patched = 0;
+    let missingSkills = 0;
+    for (const digest of page) {
+      const skill = await ctx.db.get(digest.skillId);
+      if (!skill) {
+        missingSkills++;
+        continue;
+      }
+
+      const normalizedSlugFirstToken = getFirstSearchToken(skill.slug);
+      const normalizedDisplayNameFirstToken = getFirstSearchToken(skill.displayName);
+      if (
+        digest.normalizedSlugFirstToken === normalizedSlugFirstToken &&
+        digest.normalizedDisplayNameFirstToken === normalizedDisplayNameFirstToken
+      ) {
+        continue;
+      }
+
+      patched++;
+      if (!dryRun) {
+        await ctx.db.patch(digest._id, {
+          normalizedSlugFirstToken,
+          normalizedDisplayNameFirstToken,
+        });
+      }
+    }
+
+    if (!dryRun && !isDone) {
+      await ctx.scheduler.runAfter(
+        0,
+        internal.maintenance.backfillSkillSearchDigestFirstTokensInternal,
+        {
+          cursor: continueCursor,
+          batchSize: args.batchSize,
+          dryRun,
+        },
+      );
+    }
+
+    return {
+      scanned: page.length,
+      patched,
+      missingSkills,
+      cursor: continueCursor,
+      isDone,
+      dryRun,
+    };
+  },
+});
+
+export const backfillSkillSearchDigestFirstTokens: ReturnType<typeof action> = action({
+  args: {
+    cursor: v.optional(v.string()),
+    batchSize: v.optional(v.number()),
+    dryRun: v.optional(v.boolean()),
+  },
+  handler: async (ctx, args) => {
+    const { user } = await requireUserFromAction(ctx);
+    assertRole(user, ["admin"]);
+    return await ctx.runMutation(
+      internal.maintenance.backfillSkillSearchDigestFirstTokensInternal,
       args,
     );
   },

--- a/convex/maintenance.ts
+++ b/convex/maintenance.ts
@@ -2681,24 +2681,39 @@ export const backfillSkillSearchDigestModerationVerdicts: ReturnType<typeof acti
   },
 });
 
+const SKILL_SEARCH_DIGEST_FIRST_TOKEN_BACKFILL_CONFIRM =
+  "backfill-skill-search-digest-first-tokens" as const;
+const SKILLS_SH_MIRROR_DIGEST_FIRST_TOKEN_BACKFILL_CONFIRM =
+  "backfill-skills-sh-mirror-digest-first-tokens" as const;
+
 // Recompute the stored first-token fields on skillSearchDigest rows. Those values are
 // produced by the search tokenizer, so a tokenizer change leaves already-written rows
 // holding tokens the current search no longer looks for. Run once after deploying such a
-// change:
+// change, preview first:
 //   npx convex run maintenance:backfillSkillSearchDigestFirstTokens --prod
+//   npx convex run maintenance:backfillSkillSearchDigestFirstTokens \
+//     '{"dryRun": false, "confirm": "backfill-skill-search-digest-first-tokens"}' --prod
 export const backfillSkillSearchDigestFirstTokensInternal = internalMutation({
   args: {
     cursor: v.optional(v.string()),
     batchSize: v.optional(v.number()),
     delayMs: v.optional(v.number()),
     dryRun: v.optional(v.boolean()),
+    confirm: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const batchSize = clampInt(args.batchSize ?? 100, 10, 200);
     // Catalog search subscribes to skillSearchDigest, so batches are spaced out to keep the
     // backfill from driving reactive re-reads back to back.
     const delayMs = clampInt(args.delayMs ?? 500, 0, 60_000);
-    const dryRun = args.dryRun ?? false;
+    // Preview unless the caller opts into applying, matching the catalog-digest resync
+    // contract: an omitted argument must never start a table-wide write.
+    const dryRun = args.dryRun !== false;
+    if (!dryRun && args.confirm !== SKILL_SEARCH_DIGEST_FIRST_TOKEN_BACKFILL_CONFIRM) {
+      throw new ConvexError(
+        `Pass confirm="${SKILL_SEARCH_DIGEST_FIRST_TOKEN_BACKFILL_CONFIRM}" to apply.`,
+      );
+    }
     const { page, continueCursor, isDone } = await ctx.db
       .query("skillSearchDigest")
       .paginate({ cursor: args.cursor ?? null, numItems: batchSize });
@@ -2739,6 +2754,8 @@ export const backfillSkillSearchDigestFirstTokensInternal = internalMutation({
           batchSize: args.batchSize,
           delayMs: args.delayMs,
           dryRun,
+          // Continuations re-enter the same guard, so the token has to travel with them.
+          confirm: args.confirm,
         },
       );
     }
@@ -2750,6 +2767,7 @@ export const backfillSkillSearchDigestFirstTokensInternal = internalMutation({
       cursor: continueCursor,
       isDone,
       dryRun,
+      confirmRequired: dryRun ? SKILL_SEARCH_DIGEST_FIRST_TOKEN_BACKFILL_CONFIRM : undefined,
     };
   },
 });
@@ -2760,6 +2778,7 @@ export const backfillSkillSearchDigestFirstTokens: ReturnType<typeof action> = a
     batchSize: v.optional(v.number()),
     delayMs: v.optional(v.number()),
     dryRun: v.optional(v.boolean()),
+    confirm: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const { user } = await requireUserFromAction(ctx);
@@ -2774,20 +2793,29 @@ export const backfillSkillSearchDigestFirstTokens: ReturnType<typeof action> = a
 // Recompute the stored first-token fields on skillsShMirrorDigests rows. The skills.sh
 // mirror derives them through the same tokenizer as the native digest above, and external
 // candidate search range-scans them, so a tokenizer change strands mirrored rows the same
-// way. Run once after deploying such a change:
+// way. Run once after deploying such a change, preview first:
 //   npx convex run maintenance:backfillSkillsShMirrorDigestFirstTokens --prod
+//   npx convex run maintenance:backfillSkillsShMirrorDigestFirstTokens \
+//     '{"dryRun": false, "confirm": "backfill-skills-sh-mirror-digest-first-tokens"}' --prod
 export const backfillSkillsShMirrorDigestFirstTokensInternal = internalMutation({
   args: {
     cursor: v.optional(v.string()),
     batchSize: v.optional(v.number()),
     delayMs: v.optional(v.number()),
     dryRun: v.optional(v.boolean()),
+    confirm: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const batchSize = clampInt(args.batchSize ?? 100, 10, 200);
     // The catalog subscribes to mirrored rows too, so pages are spaced apart here as well.
     const delayMs = clampInt(args.delayMs ?? 500, 0, 60_000);
-    const dryRun = args.dryRun ?? false;
+    // Same preview-then-confirm contract as the native backfill above.
+    const dryRun = args.dryRun !== false;
+    if (!dryRun && args.confirm !== SKILLS_SH_MIRROR_DIGEST_FIRST_TOKEN_BACKFILL_CONFIRM) {
+      throw new ConvexError(
+        `Pass confirm="${SKILLS_SH_MIRROR_DIGEST_FIRST_TOKEN_BACKFILL_CONFIRM}" to apply.`,
+      );
+    }
     const { page, continueCursor, isDone } = await ctx.db
       .query("skillsShMirrorDigests")
       .paginate({ cursor: args.cursor ?? null, numItems: batchSize });
@@ -2821,6 +2849,7 @@ export const backfillSkillsShMirrorDigestFirstTokensInternal = internalMutation(
           batchSize: args.batchSize,
           delayMs: args.delayMs,
           dryRun,
+          confirm: args.confirm,
         },
       );
     }
@@ -2831,6 +2860,7 @@ export const backfillSkillsShMirrorDigestFirstTokensInternal = internalMutation(
       cursor: continueCursor,
       isDone,
       dryRun,
+      confirmRequired: dryRun ? SKILLS_SH_MIRROR_DIGEST_FIRST_TOKEN_BACKFILL_CONFIRM : undefined,
     };
   },
 });
@@ -2841,6 +2871,7 @@ export const backfillSkillsShMirrorDigestFirstTokens: ReturnType<typeof action> 
     batchSize: v.optional(v.number()),
     delayMs: v.optional(v.number()),
     dryRun: v.optional(v.boolean()),
+    confirm: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const { user } = await requireUserFromAction(ctx);

--- a/convex/skillSearchDigestFirstTokens.runtime.test.ts
+++ b/convex/skillSearchDigestFirstTokens.runtime.test.ts
@@ -1,0 +1,137 @@
+/// <reference types="vite/client" />
+/* @vitest-environment edge-runtime */
+import { convexTest } from "convex-test";
+import { describe, expect, it } from "vitest";
+import { internal } from "./_generated/api";
+import { getFirstSearchToken } from "./lib/skillSearchDigest";
+import schema from "./schema";
+
+const modules = import.meta.glob("./**/*.ts");
+
+// What a row written before ー joined the CJK class holds for this display name.
+const STALE_FIRST_TOKEN = "デ";
+const DISPLAY_NAME = "データベース管理";
+const SLUG = "database-kanri";
+
+async function insertDigestWithStaleFirstToken(t: ReturnType<typeof convexTest>) {
+  return await t.run(async (ctx) => {
+    const now = Date.now();
+    const userId = await ctx.db.insert("users", {
+      handle: "patrick",
+      displayName: "Patrick",
+      createdAt: now,
+      updatedAt: now,
+    });
+    const skillId = await ctx.db.insert("skills", {
+      slug: SLUG,
+      displayName: DISPLAY_NAME,
+      ownerUserId: userId,
+      tags: {},
+      stats: { downloads: 0, stars: 0, versions: 1, comments: 0 },
+      createdAt: now,
+      updatedAt: now,
+    });
+    const versionId = await ctx.db.insert("skillVersions", {
+      skillId,
+      version: "1.0.0",
+      changelog: "Initial",
+      files: [],
+      parsed: { frontmatter: {} },
+      createdBy: userId,
+      createdAt: now,
+    });
+    const digestId = await ctx.db.insert("skillSearchDigest", {
+      skillId,
+      slug: SLUG,
+      displayName: DISPLAY_NAME,
+      normalizedSlug: SLUG,
+      normalizedSlugFirstToken: "database",
+      normalizedDisplayName: DISPLAY_NAME,
+      normalizedDisplayNameFirstToken: STALE_FIRST_TOKEN,
+      ownerUserId: userId,
+      ownerHandle: "patrick",
+      ownerKind: "user",
+      ownerName: "patrick",
+      ownerDisplayName: "Patrick",
+      latestVersionId: versionId,
+      latestVersionSkillId: skillId,
+      publicVersion: { status: "available", versionId },
+      tags: {},
+      stats: { downloads: 0, stars: 0, versions: 1, comments: 0 },
+      createdAt: now,
+      updatedAt: now,
+    });
+    return { digestId, skillId };
+  });
+}
+
+describe("skillSearchDigest first-token resynchronization", () => {
+  it("repairs a pre-existing row the current tokenizer no longer agrees with", async () => {
+    const t = convexTest(schema, modules);
+    const { digestId } = await insertDigestWithStaleFirstToken(t);
+
+    const expected = getFirstSearchToken(DISPLAY_NAME);
+    expect(expected).not.toBe(STALE_FIRST_TOKEN);
+
+    const before = await t.run(async (ctx) => await ctx.db.get(digestId));
+    expect(before?.normalizedDisplayNameFirstToken).toBe(STALE_FIRST_TOKEN);
+
+    const result = await t.mutation(
+      internal.maintenance.backfillSkillSearchDigestFirstTokensInternal,
+      {},
+    );
+    expect(result.patched).toBe(1);
+    expect(result.missingSkills).toBe(0);
+
+    const after = await t.run(async (ctx) => await ctx.db.get(digestId));
+    expect(after?.normalizedDisplayNameFirstToken).toBe(expected);
+    expect(after?.normalizedSlugFirstToken).toBe(getFirstSearchToken(SLUG));
+  });
+
+  it("makes the row reachable again through the index the search actually queries", async () => {
+    const t = convexTest(schema, modules);
+    await insertDigestWithStaleFirstToken(t);
+
+    const token = getFirstSearchToken(DISPLAY_NAME) as string;
+    const upperBound =
+      token.slice(0, -1) + String.fromCharCode(token.charCodeAt(token.length - 1) + 1);
+    const recall = async () =>
+      await t.run(
+        async (ctx) =>
+          await ctx.db
+            .query("skillSearchDigest")
+            .withIndex("by_active_normalized_display_name_first_token", (q) =>
+              q
+                .eq("softDeletedAt", undefined)
+                .gte("normalizedDisplayNameFirstToken", token)
+                .lt("normalizedDisplayNameFirstToken", upperBound),
+            )
+            .collect(),
+      );
+
+    // The row is on disk and matches the query the user typed, but the stored token
+    // predates the tokenizer, so the range bound the search computes never reaches it.
+    expect(await recall()).toHaveLength(0);
+
+    await t.mutation(internal.maintenance.backfillSkillSearchDigestFirstTokensInternal, {});
+
+    expect(await recall()).toHaveLength(1);
+  });
+
+  it("leaves an already-current row untouched", async () => {
+    const t = convexTest(schema, modules);
+    const { digestId } = await insertDigestWithStaleFirstToken(t);
+
+    await t.mutation(internal.maintenance.backfillSkillSearchDigestFirstTokensInternal, {});
+    const second = await t.mutation(
+      internal.maintenance.backfillSkillSearchDigestFirstTokensInternal,
+      {},
+    );
+
+    expect(second.scanned).toBe(1);
+    expect(second.patched).toBe(0);
+
+    const row = await t.run(async (ctx) => await ctx.db.get(digestId));
+    expect(row?.normalizedDisplayNameFirstToken).toBe(getFirstSearchToken(DISPLAY_NAME));
+  });
+});

--- a/convex/skillSearchDigestFirstTokens.runtime.test.ts
+++ b/convex/skillSearchDigestFirstTokens.runtime.test.ts
@@ -12,6 +12,12 @@ const modules = import.meta.glob("./**/*.ts");
 const STALE_FIRST_TOKEN = "デ";
 const DISPLAY_NAME = "データベース管理";
 const SLUG = "database-kanri";
+// The backfill previews unless an apply is confirmed, so the runtime cases that expect
+// writes have to opt in the same way an operator does.
+const APPLY = {
+  dryRun: false,
+  confirm: "backfill-skill-search-digest-first-tokens",
+} as const;
 
 async function insertDigestWithStaleFirstToken(t: ReturnType<typeof convexTest>) {
   return await t.run(async (ctx) => {
@@ -76,9 +82,19 @@ describe("skillSearchDigest first-token resynchronization", () => {
     const before = await t.run(async (ctx) => await ctx.db.get(digestId));
     expect(before?.normalizedDisplayNameFirstToken).toBe(STALE_FIRST_TOKEN);
 
-    const result = await t.mutation(
+    // An unconfirmed call reports the same repair without performing it.
+    const preview = await t.mutation(
       internal.maintenance.backfillSkillSearchDigestFirstTokensInternal,
       {},
+    );
+    expect(preview.patched).toBe(1);
+    expect(preview.dryRun).toBe(true);
+    const afterPreview = await t.run(async (ctx) => await ctx.db.get(digestId));
+    expect(afterPreview?.normalizedDisplayNameFirstToken).toBe(STALE_FIRST_TOKEN);
+
+    const result = await t.mutation(
+      internal.maintenance.backfillSkillSearchDigestFirstTokensInternal,
+      APPLY,
     );
     expect(result.patched).toBe(1);
     expect(result.missingSkills).toBe(0);
@@ -113,7 +129,7 @@ describe("skillSearchDigest first-token resynchronization", () => {
     // predates the tokenizer, so the range bound the search computes never reaches it.
     expect(await recall()).toHaveLength(0);
 
-    await t.mutation(internal.maintenance.backfillSkillSearchDigestFirstTokensInternal, {});
+    await t.mutation(internal.maintenance.backfillSkillSearchDigestFirstTokensInternal, APPLY);
 
     expect(await recall()).toHaveLength(1);
   });
@@ -122,10 +138,10 @@ describe("skillSearchDigest first-token resynchronization", () => {
     const t = convexTest(schema, modules);
     const { digestId } = await insertDigestWithStaleFirstToken(t);
 
-    await t.mutation(internal.maintenance.backfillSkillSearchDigestFirstTokensInternal, {});
+    await t.mutation(internal.maintenance.backfillSkillSearchDigestFirstTokensInternal, APPLY);
     const second = await t.mutation(
       internal.maintenance.backfillSkillSearchDigestFirstTokensInternal,
-      {},
+      APPLY,
     );
 
     expect(second.scanned).toBe(1);

--- a/convex/skillsShMirror.ts
+++ b/convex/skillsShMirror.ts
@@ -8,7 +8,7 @@ import { ConvexError, type Infer, v } from "convex/values";
 import type { Doc, Id } from "./_generated/dataModel";
 import type { MutationCtx, QueryCtx } from "./_generated/server";
 import { internalMutation, internalQuery } from "./functions";
-import { tokenize } from "./lib/searchText";
+import { getMirrorFirstSearchToken } from "./lib/skillSearchDigest";
 import { assertSkillsShMirrorEnvironmentAllowed } from "./lib/skillsShCatalogEnvironment";
 import { skillsShMirrorFreshObservationFlags } from "./lib/skillsShPublicVisibility";
 
@@ -404,10 +404,6 @@ function normalizedTopicLabel(value: string) {
   return value.normalize("NFKC").trim().replace(/\s+/g, " ");
 }
 
-function firstSearchToken(value: string) {
-  return tokenize(value)[0] ?? normalizedSearchText(value);
-}
-
 function requiredSearchValue(name: string, value: string) {
   const normalized = normalizedSearchText(value);
   if (!normalized) throw new ConvexError(`${name} is required`);
@@ -433,9 +429,9 @@ function searchFields(row: MirrorRow) {
     .slice(0, 512);
   return {
     normalizedSlug,
-    normalizedSlugFirstToken: firstSearchToken(row.slug),
+    normalizedSlugFirstToken: getMirrorFirstSearchToken(row.slug),
     normalizedDisplayName,
-    normalizedDisplayNameFirstToken: firstSearchToken(row.displayName),
+    normalizedDisplayNameFirstToken: getMirrorFirstSearchToken(row.displayName),
     ...(searchSummary ? { searchSummary } : {}),
     searchText: [
       row.displayName,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where searching in Japanese returns fewer skills than it should. A query
whose katakana contains the prolonged sound mark `ー` — which covers most of the loanword
vocabulary this registry is full of, `データベース`, `サーバー`, `ユーザーインターフェース`,
`コンピューター` — never reaches the category, topic and summary match tiers, and matches
only on name and slug.

The affected surfaces are skill search on `/search`, the skills and plugins catalog
search, and the search digest that backs the catalog index.

## Why This Change Was Made

`tokenize()` delegates word segmentation to `Intl.Segmenter`, which handles Japanese
correctly. But before the segmenter runs, the text is split on a hand-written character
class, and that class omits `ー` (U+30FC) and `々` (U+3005). Both are therefore treated as
separators, so the word is already in pieces by the time the segmenter sees it:

| input | `tokenize()` on `main` | with this change |
|---|---|---|
| `データベース` | `["デ", "タベ", "ス"]` | `["データベース"]` |
| `データベース管理` | `["デ", "タベ", "ス", "管理"]` | `["データベース", "管理"]` |
| `ユーザーインターフェース` | `["ユ", "ザ", "インタ", "フェ", "ス"]` | `["ユーザー", "インターフェース"]` |
| `コンピューター` | `["コンピュ", "タ"]` | `["コンピューター"]` |
| `人々` | `["人"]` — the `々` is dropped | `["人々"]` |

Two things follow from that.

Exploratory search requires *every* query token to clear a three-character floor
(`EXPLORATORY_SEARCH_MIN_TOKEN_LENGTH`, defined identically in `convex/search.ts`,
`convex/skills.ts` and `convex/packages.ts`, enforced by
`matchesExploratoryTokenPrefixes`). `["デ", "タベ", "ス"]` cannot clear it, so rank tiers 2
and 3 — category/topic and summary — are unreachable for these queries.
`["データベース"]` clears it.

And `getFirstSearchToken` in `convex/lib/skillSearchDigest.ts` is `tokenize(value)[0]`.
Its result is stored as `normalizedDisplayNameFirstToken` and `normalizedSlugFirstToken`,
which are indexed columns used as range-scan bounds in `convex/search.ts`. A skill named
`データベース管理` indexes under the single character `デ` instead of `データベース`, so the
bound stops being selective.

The same file already disagrees with itself about this. `detectCJKLanguage`, 53 lines
below, counts katakana with the full Unicode block `/[゠-ヿ]/`, which does match
`ー` — that is how the text is correctly routed to the Japanese segmenter in the first
place. The pre-split then excludes the character the language detector just counted. This
change makes the pre-split agree with it.

I deliberately added only `ー` and `々` rather than widening to the full katakana
block. Widening produces identical `tokenize()` output — `Intl.Segmenter` already reports
`・` (U+30FB) as not word-like — but it would also pull `・`, `゠` and `ヿ` into the
`segmentCJKByChar` fallback as standalone tokens. The narrow change avoids that.

Non-goals:

- Replacing the hand-written ranges with Unicode property escapes. That is a larger
  change to a hot path and `\p{Script=Katakana}` does not match `ー` either, so it would
  not fix this on its own.
- Re-indexing existing rows. The digest is recomputed on write; this only changes what
  future writes and queries produce.

## User Impact

Japanese-language searches now reach the same result tiers as English and Chinese ones,
so a query like `データベース` can match a skill on its category, topics or summary rather
than only on its name. Japanese skills also index under their actual first word instead
of a single character.

## Evidence

Base commit: `a9d04bb0`. The fix is not on `main` — both character classes there still
end `ァ-ヺ가-힯`.

### Focused tests

`convex/lib/searchText.test.ts` already existed, but its only Japanese assertion was
`expect(tokens.length).toBeGreaterThan(0)`, while the Chinese cases directly above it
assert real segmentation. This raises the Japanese cases to that standard and adds the
regressions. On the parent commit:

```
 FAIL  convex/lib/searchText.test.ts > searchText > CJK tokenization > keeps katakana words that contain a prolonged sound mark intact
AssertionError: expected [ 'デ', 'タベ', 'ス' ] to deeply equal [ 'データベース' ]
 FAIL  convex/lib/searchText.test.ts > searchText > CJK tokenization > keeps the iteration mark attached to the character it repeats
AssertionError: expected [ '人' ] to deeply equal [ '人々' ]
 FAIL  convex/lib/searchText.test.ts > searchText > CJK tokenization > lets katakana queries reach the exploratory match tiers
AssertionError: expected false to be true

 Test Files  1 failed (1)
      Tests  3 failed | 15 passed (18)
```

With the change:

```
 Test Files  1 passed (1)
      Tests  18 passed (18)
```

The 15 assertions that already passed still pass, including every Chinese, Korean and
ASCII case — `tokenize("中文搜索")`, `tokenize("안녕하세요")`, `tokenize("React 组件开发")`
and `tokenize("Minimax Usage /minimax-usage")` all produce identical output before and
after.

### The two consequences, measured

```
matchesExploratoryTokenPrefixes(tokenize("データベース"), ["データベース管理ツール"], 3)
  on main          : false
  with this change : true

getFirstSearchToken("データベース管理")     // = tokenize(value)[0]
  on main          : "デ"
  with this change : "データベース"
```

The intra-file inconsistency, checked directly:

```
/[゠-ヿ]/.test("ー")   // detectCJKLanguage  -> true
/[ァ-ヺ]/.test("ー")   // CJK_RE on main     -> false
```

### Deployment consequence: rows written before this tokenizer

`skillSearchDigest.normalizedSlugFirstToken` and `normalizedDisplayNameFirstToken` are
produced by this tokenizer (`getFirstSearchToken` is `tokenize(value)[0]`), and
`convex/search.ts:1327-1364` uses them as range-index bounds. Those rows are recomputed
only when their skill is written, so after deploying this change an untouched row keeps
the old one-character token while the search computes the new longer one. The row stays
on disk and drops out of that first-token range lookup.

Measured on the samples this branch is about - two rows that do not move are kept in as
the control:

```
DRIFT  データベース管理        main="デ"        branch="データベース"
DRIFT  ユーザーインターフェース  main="ユ"        branch="ユーザー"
DRIFT  人々の記録             main="人"        branch="人々"
DRIFT  時々のレポート          main="時"        branch="時々"
DRIFT  コードレビュー          main="コ"        branch="コード"
DRIFT  サーバー監視ツール       main="サ"        branch="サーバー"
same   こんにちは世界          main="こんにちは"  branch="こんにちは"
same   中文文档管理            main="中文"       branch="中文"
drifted 6 / 8
```

`maintenance.ts` gains `backfillSkillSearchDigestFirstTokens`, a cursor-paginated
internal mutation that self-schedules until done, plus the admin-gated action that starts
it. It is written against the shape the file already uses for
`backfillSkillSearchDigestModerationVerdicts` directly above it: same args, same
`clampInt(batchSize, 10, 200)`, same `dryRun`, same return record.

### Batch spacing between backfill pages

`skillSearchDigest` is read by live catalog-search subscriptions, and
`.agents/skills/clawhub-convex/SKILL.md:102` asks for a delay between backfill batches
that write reactively subscribed tables. The mutation takes an optional `delayMs`,
clamped the way the batch size already is, and hands it to the `runAfter` that schedules
the next page:

```ts
const delayMs = clampInt(args.delayMs ?? 500, 0, 60_000);
```

That follows `repairLegacyPublisherOwnershipForUserHandler`
(`convex/maintenance.ts:3272`), which is the one backfill in this file that already
spaces its own batches. Two assertions cover it - the 500 ms default, and an explicit
2000 ms plus the clamp that turns 600000 ms into 60000 ms. Restoring `runAfter(0, ...)`
turns both of them red:

```
control (unmutated)      : 37 passed (37)
mutant: runAfter(0, ...) : 2 failed - repairs digest rows whose stored first tokens
                           predate the tokenizer; spaces the next batch by the
                           requested delay and clamps it
restored                 : 37 passed (37)
```

### Real Convex runtime: a pre-existing row, before and after

A browser capture cannot show this one. Search runs inside Convex, so a locally changed
tokenizer is not what a deployed frontend talks to. The equivalent real setup is
`convex-test`, which runs the actual Convex query engine and the real schema against an
in-memory database - the same harness `convex/catalogFeed.runtime.test.ts` and
`convex/publishAttempts.runtime.test.ts` already use.

`convex/skillSearchDigestFirstTokens.runtime.test.ts` inserts a real `skills` row and a
real `skillSearchDigest` row holding the pre-change token `デ`, then queries the index the
search actually queries (`by_active_normalized_display_name_first_token`) with the bounds
the search computes:

```
stored row  : normalizedDisplayNameFirstToken = "デ"
query bounds: gte "データベース"  lt "データベーソ"

recall before backfill : 0 rows
backfill               : { scanned: 1, patched: 1, missingSkills: 0 }
recall after backfill  : 1 row
```

The second run of the backfill over the same data reports `patched: 0`, so it is
idempotent and safe to re-run.

### Live local Convex: the admin backfill path end to end

The runtime test above proves the index behavior. This is the same migration driven
through the CLI against a real Convex backend - an anonymous local deployment created by
`bunx convex dev`, cloud port 3210, site port 3211.

This transcript was recorded at `8d376a48`, before the confirmation guard below existed.
The two dry runs at steps 4 and 7 behave identically today. The applying call at step 5
is now a preview as written and needs
`{"batchSize":10,"delayMs":15000,"dryRun":false,"confirm":"backfill-skill-search-digest-first-tokens"}`
to do what its output shows. What a page does once it starts - the paging, the 15 s
spacing, the idempotence - is what that commit leaves untouched.

`fixtures/public-corpus/corpus.jsonl` holds no record whose slug or display name carries
`ー` (U+30FC) or `々` (U+3005) - zero of its 1250 rows - so the 13 seeded skills are
constructed: twelve Japanese display names carrying those marks, plus one Latin control.
They are seeded while `a9d04bb0` is the deployed code, so their digest rows are written by
the old tokenizer, and this branch is deployed over them afterwards. Cursor strings are
cut from the output below; nothing else is edited.

```
## 4. dry run: how many stored rows the new tokenizer disagrees with
$ bunx convex run maintenance:backfillSkillSearchDigestFirstTokensInternal {"dryRun":true}
{
  "dryRun": true,
  "isDone": true,
  "missingSkills": 0,
  "patched": 12,
  "scanned": 13
}
## 5. one page, spaced 15s before the next one is scheduled
[11:02:59] starting page 1
$ bunx convex run maintenance:backfillSkillSearchDigestFirstTokensInternal {"batchSize":10,"delayMs":15000}
{
  "dryRun": false,
  "isDone": false,
  "missingSkills": 0,
  "patched": 10,
  "scanned": 10
}
## 6. poll until the scheduled continuation lands
[11:03:02] poll 01 -> "patched":2
[11:03:03] poll 02 -> "patched":2
[11:03:05] poll 03 -> "patched":2
[11:03:07] poll 04 -> "patched":2
[11:03:08] poll 05 -> "patched":2
[11:03:10] poll 06 -> "patched":2
[11:03:11] poll 07 -> "patched":2
[11:03:13] poll 08 -> "patched":2
[11:03:14] poll 09 -> "patched":2
[11:03:16] poll 10 -> "patched":2
[11:03:18] poll 11 -> "patched":0
## 7. idempotence: a further pass patches nothing
$ bunx convex run maintenance:backfillSkillSearchDigestFirstTokensInternal {"dryRun":true}
{
  "dryRun": true,
  "isDone": true,
  "missingSkills": 0,
  "patched": 0,
  "scanned": 13
}
```

Twelve of the thirteen stored rows disagree with the new tokenizer and the Latin control
does not. The first page patches ten and returns `isDone: false`; the remaining two stay
stale for the whole 15 s the scheduled continuation waits, then land between `11:03:16`
and `11:03:18`. A further dry run patches nothing, so a re-run is safe.

What this run does not show is a user-visible recall change. `convex run
search:searchSkills` for `データベース`, `サーバー`, `人々` and `Deploy`, before and after
deploying this branch over the stale rows, returned the same one row each time. The
first-token range lookup is one of several candidate sources inside `nativeSkillSearch`,
and full-text search on `displayName` still matched on a catalog this small. The recall
this backfill restores is specific to that range lookup, which is what the runtime test
isolates.

### The mirrored skills.sh catalog carries the same keys

`skillsShMirrorDigests` persists its own `normalizedSlugFirstToken` and
`normalizedDisplayNameFirstToken`, and `convex/search.ts:1073-1099` range-scans both when
it collects external candidates. They come out of the same tokenizer this PR widens -
`convex/skillsShMirror.ts` had its own `firstSearchToken`, `tokenize(value)[0] ??
normalizedSearchText(value)` - so mirrored rows drift exactly the way native digest rows
do, and the native backfill above cannot reach them because it pages `skillSearchDigest`.

`backfillSkillsShMirrorDigestFirstTokens` is the mirror-side counterpart: same args, same
`clampInt(batchSize, 10, 200)`, same `delayMs`, same `dryRun`, same admin-gated action.
The two copies of the first-token rule are now one - `getMirrorFirstSearchToken` in
`convex/lib/skillSearchDigest.ts`, next to the `getFirstSearchToken` the native digest
already used - so they cannot drift apart again.

Both halves are covered, and each is load-bearing:

```
control (unmutated)                              : 39 passed (39)
mutant A: stop recomputing the display-name token: 2 failed
mutant B: runAfter(0, ...) instead of delayMs     : 1 failed
restored                                         : 39 passed (39)
```

On the live local deployment the mutation reaches the real table - seeding the one
mirrored row `devSeed:seedCanonicalSearchFixture` creates and running the backfill over it
reports `{ scanned: 1, patched: 0 }`, correct for a Latin display name. The drift case
itself is proved in `convex/maintenance.test.ts` rather than live: nothing in the local
dev-seed path produces a mirrored row with a Japanese display name, and the importer
protocol that would create one needs a run, a stored source page and a batch lease.

### The no-Segmenter fallback

Admitting the two marks into `CJK_RE` also reaches `segmentCJKByChar`, the path taken when
`Intl.Segmenter` is missing. It emits one token per character, so the marks came out
standing alone - one-character tokens that exploratory matching discards at its
three-character floor. Measured before the fix:

```
segmentCJKByChar("データベース") -> ["デ","ー","タ","ベ","ー","ス"]
segmentCJKByChar("人々")       -> ["人","々"]
```

They are now attached to the character they extend (`["デー","タ","ベー","ス"]`,
`["人々"]`), which is the same rule the widened class states. Removing that branch turns
exactly one test red.

### Preview by default, confirmation to apply

Both backfills first landed here with `dryRun` defaulting to `false`, and their public
actions forward omitted arguments to the mutation unchanged. A bare
`npx convex run maintenance:backfillSkillSearchDigestFirstTokens` therefore patched
`skillSearchDigest` and scheduled every remaining page: a table-wide write against a
reactively subscribed table, started by a command that reads like an inspection.

They now follow the contract `resyncPluginCatalogMetadataDigestsBatchInternal` already
uses in this file:

```ts
const dryRun = args.dryRun !== false;
if (!dryRun && args.confirm !== SKILL_SEARCH_DIGEST_FIRST_TOKEN_BACKFILL_CONFIRM) {
  throw new ConvexError(
    `Pass confirm="${SKILL_SEARCH_DIGEST_FIRST_TOKEN_BACKFILL_CONFIRM}" to apply.`,
  );
}
```

Three details beyond copying that shape:

- The scheduled continuation carries `confirm` with it. Without that, page two throws on
  the guard page one passed, and a confirmed run stalls after its first batch.
- The native and mirror paths take different tokens
  (`backfill-skill-search-digest-first-tokens` and
  `backfill-skills-sh-mirror-digest-first-tokens`), so neither one starts the other
  table's rewrite.
- A preview returns `confirmRequired`, so the token comes out of the dry run an operator
  already has to do rather than out of the source.

Four new tests cover it, two per path: omitted arguments preview without writing or
scheduling, and an apply with no token or the other path's token throws before the first
`paginate`. The three existing tests that exercise a real page now pass the token and
assert it in the `runAfter` payload. The runtime test drives the guard through a Convex
backend as well - the unconfirmed call reports `patched: 1` and leaves the row holding
its stale `デ`, and only the confirmed call rewrites it.

### Live local Convex: the guard itself

Same setup as the transcript above, rebuilt: an anonymous local deployment, thirteen
constructed rows seeded while `a9d04bb0` is deployed so their digest rows carry the old
tokenizer's output, then this branch deployed over them. Eleven of the thirteen drift.
Cursor strings are cut; nothing else is edited.

```
## 1. omitted arguments
$ bunx convex run maintenance:backfillSkillSearchDigestFirstTokensInternal {}
{
  "confirmRequired": "backfill-skill-search-digest-first-tokens",
  "dryRun": true,
  "isDone": true,
  "missingSkills": 0,
  "patched": 11,
  "scanned": 13
}
## 2. apply with no token
$ bunx convex run maintenance:backfillSkillSearchDigestFirstTokensInternal {"dryRun":false}
Uncaught ConvexError: Pass confirm="backfill-skill-search-digest-first-tokens" to apply.
    at handler (../convex/maintenance.ts:2713:8)
exit=1
## 3. apply with the mirror path's token
$ ... {"dryRun":false,"confirm":"backfill-skills-sh-mirror-digest-first-tokens"}
Uncaught ConvexError: Pass confirm="backfill-skill-search-digest-first-tokens" to apply.
exit=1
## 4. neither rejected call wrote anything
$ bunx convex run maintenance:backfillSkillSearchDigestFirstTokensInternal {}
  "dryRun": true, "patched": 11, "scanned": 13
## 5. confirmed apply
$ ... {"dryRun":false,"confirm":"backfill-skill-search-digest-first-tokens"}
  "dryRun": false, "isDone": true, "missingSkills": 0, "patched": 11, "scanned": 13
## 6. idempotence
$ bunx convex run maintenance:backfillSkillSearchDigestFirstTokensInternal {}
  "dryRun": true, "patched": 0, "scanned": 13
```

The mirror action rejects the same way, including the native path's token, on a mirror
table this fixture leaves empty (`scanned: 0`), so that pair shows the guard rather than
a migration:

```
$ bunx convex run maintenance:backfillSkillsShMirrorDigestFirstTokensInternal {"dryRun":false}
Uncaught ConvexError: Pass confirm="backfill-skills-sh-mirror-digest-first-tokens" to apply.
    at handler (../convex/maintenance.ts:2815:8)
exit=1
$ ... {"dryRun":false,"confirm":"backfill-skill-search-digest-first-tokens"}
Uncaught ConvexError: Pass confirm="backfill-skills-sh-mirror-digest-first-tokens" to apply.
exit=1
$ ... {"dryRun":false,"confirm":"backfill-skills-sh-mirror-digest-first-tokens"}
  "dryRun": false, "isDone": true, "patched": 0, "scanned": 0
```

The token has to survive the scheduler or a confirmed run applies its first page and then
throws on the guard that page just passed. Re-seeded, then one confirmed page of ten with
the continuation 15 s out, polled by dry run:

```
[22:07:35] page 1
$ ... {"batchSize":10,"delayMs":15000,"dryRun":false,"confirm":"backfill-skill-search-digest-first-tokens"}
  "dryRun": false, "isDone": false, "missingSkills": 0, "patched": 10, "scanned": 10
[22:07:39] poll 1 -> "patched":1
[22:07:41] poll 2 -> "patched":1
[22:07:43] poll 3 -> "patched":1
[22:07:45] poll 4 -> "patched":1
[22:07:47] poll 5 -> "patched":1
[22:07:49] poll 6 -> "patched":1
[22:07:51] poll 7 -> "patched":1
[22:07:53] poll 8 -> "patched":1
[22:07:55] poll 9 -> "patched":0
[22:07:57] poll 10 -> "patched":0
```

The eleventh row stays stale for the whole delay and then lands. A continuation that lost
the token would have thrown instead, and that row would still read `"patched":1` at poll
10.

### Rollout

Both backfills are admin-gated and are meant to run once after this deploys, native
first, then mirror. Both preview by default, so this form counts rows without writing:

```
npx convex run maintenance:backfillSkillSearchDigestFirstTokens --prod
npx convex run maintenance:backfillSkillsShMirrorDigestFirstTokens --prod
```

Applying takes the token that preview returns as `confirmRequired`:

```
npx convex run maintenance:backfillSkillSearchDigestFirstTokens \
  '{"dryRun": false, "confirm": "backfill-skill-search-digest-first-tokens"}' --prod
npx convex run maintenance:backfillSkillsShMirrorDigestFirstTokens \
  '{"dryRun": false, "confirm": "backfill-skills-sh-mirror-digest-first-tokens"}' --prod
```

Both accept `{"delayMs": N}` if the default 500 ms between pages is too tight. Both are
idempotent, so a re-run after a partial pass is safe.

### CI

- `bun run lint`, `bun run deadcode:ci`, `bun run ci:types-build` — all pass.
- `bunx tsc -p packages/schema/tsconfig.json --noEmit` and
  `bunx tsc -p packages/clawhub/tsconfig.json --noEmit` — both clean.
- `bun run format:check` fails on `CLAUDE.md` and
  `.agents/skills/autoreview/CLAUDE.md`. That is pre-existing: the same two files, and
  only those two, fail on `main` at `a9d04bb0`. The two files in this PR are formatted
  with `oxfmt`.
- `VITE_CONVEX_URL=https://example.invalid bun run ci:unit` on this branch:
  `14 failed | 431 passed | 1 skipped (446)` files, `24 failed | 5790 passed | 9 skipped`
  tests. On `main` at `a9d04bb0`: `14 failed | 430 passed | 1 skipped (445)` files and
  `24 failed | 5773 passed | 9 skipped` tests. The sorted list of failing files is
  identical on both sides — they are the suites that shell out to `bun`, plus
  `convex/lib/githubAccount.test.ts` and `src/routes/-management.test.tsx`. The failure
  count is the same 24 on both sides. This branch adds one file and seventeen passing
  tests and introduces no new failure.

The Vercel check on this PR stays pending OpenClaw Foundation authorization, as it does
on every fork PR.

Written with AI assistance. I ran the focused tests, the drift measurement and the
Convex runtime proof above myself,
diffed the full unit suite against `main`, and can maintain this code.



