### PR TITLE
fix: reuse verified hourly native pools

### DIFF
--- a/convex/canonicalTrending.test.ts
+++ b/convex/canonicalTrending.test.ts
@@ -673,6 +673,41 @@ describe("canonical Trending snapshot storage", () => {
     ).resolves.toBeNull();
   });
 
+  it("reuses the verified native pool linked to a mixed hourly snapshot", async () => {
+    const t = convexTest(schema, modules);
+    const now = Date.now();
+    const source = await insertEligibleNativeSource(t, "mixed-hourly-native-pool");
+    await insertReadyNativePool(t, {
+      poolId: "skills-mixed-hourly-native-pool",
+      skillId: source.skillId,
+      now,
+    });
+    await t.mutation(internal.canonicalTrending.startSnapshotInternal, {
+      snapshotId: "skills-mixed-hourly-native-pool",
+      generatedAt: now - 1_000,
+      expiresAt: now + 24 * 60 * 60 * 1_000,
+      windowStartDay: 40,
+      windowEndDay: 40,
+      windowStartHour: 100,
+      windowEndHour: 123,
+    });
+    await t.mutation(internal.canonicalTrending.finalizeSnapshotInternal, {
+      snapshotId: "skills-mixed-hourly-native-pool",
+      completedAt: now - 500,
+      totalItems: 0,
+      sourceCounts: { clawhubTrending: 1, clawhubRising: 0, skillsShTrending: 1 },
+      operations: { documentsRead: 20, documentsWritten: 5, functionCalls: 4 },
+      nativePoolId: "skills-mixed-hourly-native-pool",
+    });
+
+    await expect(
+      t.query(internal.canonicalTrending.getReadyNativePoolInternal, { now }),
+    ).resolves.toMatchObject({
+      poolId: "skills-mixed-hourly-native-pool",
+      sourceCounts: { clawhubTrending: 1, clawhubRising: 0 },
+    });
+  });
+
   it("reuses an older verified native pool when a newer orphan exists", async () => {
     const t = convexTest(schema, modules);
     const now = Date.now();

--- a/convex/canonicalTrending.ts
+++ b/convex/canonicalTrending.ts
@@ -288,6 +288,8 @@ export const getReadyNativePoolInternal = internalQuery({
         .query("canonicalTrendingSnapshots")
         .withIndex("by_snapshot_id", (q) => q.eq("snapshotId", pool.poolId))
         .unique();
+      // Hourly mixed snapshots verify the linked native pool just as strictly as
+      // native-only preflight snapshots; the external lane is independent here.
       if (
         !snapshot ||
         snapshot.status !== "ready" ||
@@ -296,7 +298,7 @@ export const getReadyNativePoolInternal = internalQuery({
         snapshot.generatedAt !== pool.generatedAt ||
         snapshot.windowStartHour !== pool.windowStartHour ||
         snapshot.windowEndHour !== pool.windowEndHour ||
-        snapshot.sourceCounts?.skillsShTrending !== 0 ||
+        !snapshot.sourceCounts ||
         snapshot.sourceCounts.clawhubTrending !== pool.sourceCounts.clawhubTrending ||
         snapshot.sourceCounts.clawhubRising !== pool.sourceCounts.clawhubRising
       ) {


### PR DESCRIPTION
## Summary
- treat a ready mixed hourly snapshot as exact verification for its linked native candidate pool
- preserve pool identity, ranking version, time window, readiness, and exact native lane count checks
- cover the scheduled-sync case where a mixed hourly snapshot refreshes the pool before skills.sh activation

## Tests
- `bunx vitest run convex/canonicalTrending.test.ts convex/skillsShMirrorVisibility.test.ts`
- `bun run ci:static`
- `bun run ci:unit`
- `bun run ci:types-build`
- autoreview: clean