### PR TITLE
fix: simplify skills.sh catalog presentation

### DIFF
--- a/src/__tests__/home-listing-section.claw591.test.tsx
+++ b/src/__tests__/home-listing-section.claw591.test.tsx
@@ -155,7 +155,7 @@ describe("HomeListingSection", () => {
     render(<HomeListingSection initialListing={initialTrending([external])} />);
 
     expect(screen.getByText("@doany-skills")).toBeTruthy();
-    expect(screen.getByText("skills.sh")).toBeTruthy();
+    expect(screen.queryByText("skills.sh")).toBeNull();
     expect(screen.getByLabelText("Downloads").textContent).toContain("12.3k");
   });
 

--- a/src/components/HomeListingSection.tsx
+++ b/src/components/HomeListingSection.tsx
@@ -136,7 +136,6 @@ function HomeListingSkillRow({ entry }: { entry: SkillPageEntry }) {
             <span className="home-v2-listing-row-name" title={item.displayName}>
               {truncateText(item.displayName, PUBLIC_CATALOG_NAME_PREVIEW_LENGTH)}
             </span>
-            {isSkillsSh ? <span className="home-v2-listing-source-badge">skills.sh</span> : null}
             {owner ? <span className="home-v2-listing-row-by">@{owner}</span> : null}
           </div>
           <p className="home-v2-listing-row-summary">

--- a/src/components/SkillsShCatalogDetail.test.tsx
+++ b/src/components/SkillsShCatalogDetail.test.tsx
@@ -95,7 +95,18 @@ describe("SkillsShCatalogDetailPage", () => {
   });
 
   it("renders only stored bounded content and no file explorer", () => {
-    render(<SkillsShCatalogDetailPage entry={makeEntry()} />);
+    const entry = makeEntry();
+    entry.content = {
+      ...entry.content!,
+      markdown: `---
+name: html
+description: Build useful HTML artifacts.
+---
+# Use this skill
+
+Build a useful artifact.`,
+    };
+    render(<SkillsShCatalogDetailPage entry={entry} />);
 
     const detailTabs = screen.getByRole("tablist", { name: "Skill detail tabs" });
     expect(detailTabs).toBeTruthy();
@@ -106,6 +117,8 @@ describe("SkillsShCatalogDetailPage", () => {
     expect(screen.queryByText("Files")).toBeNull();
     expect(screen.queryByText("File explorer")).toBeNull();
     expect(screen.queryByText("skills/html/SKILL.md")).toBeNull();
+    expect(screen.queryByText("name: html")).toBeNull();
+    expect(screen.queryByText("description: Build useful HTML artifacts.")).toBeNull();
     expect(screen.getByText("Content is truncated to the stored 64 KiB snapshot.")).toBeTruthy();
   });
 

--- a/src/components/SkillsShCatalogDetail.tsx
+++ b/src/components/SkillsShCatalogDetail.tsx
@@ -11,6 +11,7 @@ import { truncateText } from "../lib/truncateText";
 import { MarkdownPreview } from "./MarkdownPreview";
 import { SidebarMetadata } from "./SidebarMetadata";
 import { SkillDetailPageView, type SkillDetailViewSkill } from "./SkillDetailPageView";
+import { stripFrontmatter } from "./skillDetailUtils";
 import { SkillCommandLineCard } from "./SkillInstallSurface";
 import { Alert, AlertDescription } from "./ui/alert";
 import { Badge } from "./ui/badge";
@@ -275,7 +276,9 @@ function SkillsShContentTabs({ entry }: { entry: SkillsShCatalogDetail }) {
               </p>
             ) : null}
             <div className="skill-readme-preview">
-              <MarkdownPreview highlight={false}>{entry.content.markdown}</MarkdownPreview>
+              <MarkdownPreview highlight={false}>
+                {stripFrontmatter(entry.content.markdown)}
+              </MarkdownPreview>
             </div>
           </>
         ) : (

--- a/src/styles.css
+++ b/src/styles.css
@@ -23290,20 +23290,6 @@ a.search-empty-action {
   white-space: nowrap;
 }
 
-.home-v2-listing-source-badge {
-  flex: 0 0 auto;
-  padding: 2px 6px;
-  border: 1px solid color-mix(in srgb, var(--hv2-text-tertiary) 42%, transparent);
-  border-radius: var(--r-pill);
-  color: var(--hv2-text-tertiary);
-  font-family: var(--font-mono), ui-monospace, monospace;
-  font-size: 9px;
-  font-weight: 650;
-  line-height: 1.2;
-  letter-spacing: 0.02em;
-  white-space: nowrap;
-}
-
 .home-v2-listing-row-summary {
   margin: 0;
   font-size: 13px;


### PR DESCRIPTION
## Summary

- remove the `skills.sh` source badge from homepage skill rows while retaining upstream author and download count
- strip YAML frontmatter from stored skills.sh `SKILL.md` content using the same shared helper as normal skill pages
- add regressions for both presentation contracts

## Validation

- `VITE_CONVEX_URL=https://example.invalid bunx vitest run src/__tests__/home-listing-section.claw591.test.tsx src/__tests__/home-listing-section.test.tsx src/__tests__/skills-sh-route.test.ts src/components/SkillsShCatalogDetail.test.tsx src/components/SkillsShListItem.test.tsx --coverage.enabled=false` (29/29)
- `bun run ci:static`
- `bun run ci:types-build`
- `.agents/skills/autoreview/scripts/autoreview --mode local --stream-engine-output` (clean, no findings)
- real in-app browser proof at `http://127.0.0.1:3012/skills-sh/doany-skills/skills/reddit-automation` on desktop and mobile; frontmatter absent and mobile has no horizontal overflow
- `bun run ci:unit` completed 5,866/5,877 passing with 9 unrelated parallel timing failures; all 8 affected files then passed serially (413/413, 1 skipped)

## Install command verification

The UI displays `openclaw skills install skills-sh:doany-skills/skills/reddit-automation`, but released OpenClaw `2026.7.2` currently rejects it with `Invalid skill slug`. This PR does not change the OpenClaw CLI.
