### PR TITLE
test: harden timing-sensitive full-unit fixtures

### DIFF
--- a/scripts/claws-feed-openclaw-e2e.test.ts
+++ b/scripts/claws-feed-openclaw-e2e.test.ts
@@ -1,10 +1,12 @@
 import { execFile } from "node:child_process";
 import { createHash } from "node:crypto";
+import { once } from "node:events";
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { createServer, type Server } from "node:http";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { promisify } from "node:util";
+import { crc32, createDeflateRaw } from "node:zlib";
 import { EXPERIMENTAL_CLAW_FEED_ID, serializeExperimentalClawFeed } from "clawhub-schema";
 import { gzipSync, strToU8, zipSync } from "fflate";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
@@ -76,6 +78,62 @@ function deterministicLinkArchive() {
     offset += part.byteLength;
   }
   return gzipSync(tar);
+}
+
+async function compactZipOfZeros(path: string, unpackedSize: number) {
+  const deflate = createDeflateRaw({ level: 9 });
+  const compressedChunks: Buffer[] = [];
+  deflate.on("data", (chunk: Buffer) => compressedChunks.push(chunk));
+  const finished = once(deflate, "end");
+  const zeroChunk = Buffer.alloc(64 * 1024);
+  let remaining = unpackedSize;
+  let checksum = 0;
+  while (remaining > 0) {
+    const chunk = zeroChunk.subarray(0, Math.min(remaining, zeroChunk.byteLength));
+    checksum = crc32(chunk, checksum);
+    remaining -= chunk.byteLength;
+    if (!deflate.write(chunk)) await once(deflate, "drain");
+  }
+  deflate.end();
+  await finished;
+
+  const compressed = Buffer.concat(compressedChunks);
+  const encodedPath = strToU8(path);
+  const localHeaderSize = 30;
+  const centralHeaderSize = 46;
+  const endRecordSize = 22;
+  const centralOffset = localHeaderSize + encodedPath.byteLength + compressed.byteLength;
+  const centralSize = centralHeaderSize + encodedPath.byteLength;
+  const archive = new Uint8Array(centralOffset + centralSize + endRecordSize);
+  const view = new DataView(archive.buffer);
+
+  view.setUint32(0, 0x04034b50, true);
+  view.setUint16(4, 20, true);
+  view.setUint16(8, 8, true);
+  view.setUint32(14, checksum, true);
+  view.setUint32(18, compressed.byteLength, true);
+  view.setUint32(22, unpackedSize, true);
+  view.setUint16(26, encodedPath.byteLength, true);
+  archive.set(encodedPath, localHeaderSize);
+  archive.set(compressed, localHeaderSize + encodedPath.byteLength);
+
+  view.setUint32(centralOffset, 0x02014b50, true);
+  view.setUint16(centralOffset + 4, 20, true);
+  view.setUint16(centralOffset + 6, 20, true);
+  view.setUint16(centralOffset + 10, 8, true);
+  view.setUint32(centralOffset + 16, checksum, true);
+  view.setUint32(centralOffset + 20, compressed.byteLength, true);
+  view.setUint32(centralOffset + 24, unpackedSize, true);
+  view.setUint16(centralOffset + 28, encodedPath.byteLength, true);
+  archive.set(encodedPath, centralOffset + centralHeaderSize);
+
+  const endOffset = centralOffset + centralSize;
+  view.setUint32(endOffset, 0x06054b50, true);
+  view.setUint16(endOffset + 8, 1, true);
+  view.setUint16(endOffset + 10, 1, true);
+  view.setUint32(endOffset + 12, centralSize, true);
+  view.setUint32(endOffset + 16, centralOffset, true);
+  return archive;
 }
 
 async function npmPackFixture(destination: string) {
@@ -240,7 +298,8 @@ describe("published Claw to OpenClaw dry-run proof", () => {
   it("rejects ZIP artifacts whose expanded content exceeds the package limit", async () => {
     const root = await mkdtemp(join(tmpdir(), "clawhub-hosted-e2e-large-zip-"));
     try {
-      const archive = zipSync({ "package/large.bin": new Uint8Array(50 * 1024 * 1024 + 1) });
+      const archive = await compactZipOfZeros("package/large.bin", 50 * 1024 * 1024 + 1);
+      expect(archive.byteLength).toBeLessThan(64 * 1024);
       await expect(extractSafeClawZip(archive, root)).rejects.toThrow("50MB unpacked limit");
     } finally {
       await rm(root, { recursive: true, force: true });

--- a/scripts/security/run-codex-scan-worker-clawscan.test.ts
+++ b/scripts/security/run-codex-scan-worker-clawscan.test.ts
@@ -1,5 +1,5 @@
 /* @vitest-environment node */
-import { execFile } from "node:child_process";
+import { execFile, execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -22,6 +22,17 @@ async function tempDir() {
   const dir = await mkdtemp(join(tmpdir(), "clawhub-codex-worker-test-"));
   tempDirs.push(dir);
   return dir;
+}
+
+async function readStartedPid(path: string) {
+  while (true) {
+    const contents = await readFile(path, "utf8").catch((error: NodeJS.ErrnoException) => {
+      if (error.code === "ENOENT") return "";
+      throw error;
+    });
+    if (contents) return Number(contents);
+    await new Promise<void>((resolvePromise) => setImmediate(resolvePromise));
+  }
 }
 
 function skillVersionJob(jobId: string): ClaimedJob {
@@ -997,22 +1008,37 @@ child_pid=$!
 printf '%s' "$child_pid" > "${workspace}/descendant.pid"
 wait "$child_pid"`,
     );
+    const descendantPidPath = join(workspace, "descendant.pid");
     const previousCommand = process.env.CODEX_SECURITY_SCAN_CLAWSCAN_COMMAND;
     const previousTimeout = process.env.CODEX_SECURITY_SCAN_CLAWSCAN_TIMEOUT_MS;
     process.env.CODEX_SECURITY_SCAN_CLAWSCAN_COMMAND = fakeClawScan;
-    process.env.CODEX_SECURITY_SCAN_CLAWSCAN_TIMEOUT_MS = "2000";
+    process.env.CODEX_SECURITY_SCAN_CLAWSCAN_TIMEOUT_MS = "500";
+    vi.useFakeTimers({ toFake: ["setTimeout"] });
     let descendantPid: number | undefined;
 
     try {
-      await expect(
-        runClawScan(skillVersionJob("securityScanJobs:process-tree-timeout"), workspace, () => {}),
-      ).rejects.toThrow("timed out");
+      const scanPromise = runClawScan(
+        skillVersionJob("securityScanJobs:process-tree-timeout"),
+        workspace,
+        () => {},
+      );
+      void scanPromise.catch(() => undefined);
+      descendantPid = await readStartedPid(descendantPidPath);
+      await vi.advanceTimersByTimeAsync(10_500);
+      await expect(scanPromise).rejects.toThrow("timed out");
+      vi.useRealTimers();
 
-      descendantPid = Number(await readFile(join(workspace, "descendant.pid"), "utf8"));
       let descendantRunning = true;
       for (let attempt = 0; attempt < 20; attempt += 1) {
         try {
-          process.kill(descendantPid, 0);
+          // Signal 0 also succeeds for terminated zombies until their parent reaps them.
+          const state = execFileSync("ps", ["-o", "state=", "-p", String(descendantPid)], {
+            encoding: "utf8",
+          }).trim();
+          if (state.startsWith("Z")) {
+            descendantRunning = false;
+            break;
+          }
           await new Promise((resolvePromise) => setTimeout(resolvePromise, 25));
         } catch {
           descendantRunning = false;
@@ -1021,6 +1047,7 @@ wait "$child_pid"`,
       }
       expect(descendantRunning).toBe(false);
     } finally {
+      vi.useRealTimers();
       if (descendantPid) {
         try {
           process.kill(descendantPid, "SIGKILL");


### PR DESCRIPTION
## Summary

- replace the synchronous 50 MiB JavaScript ZIP fixture with a structurally valid compact ZIP whose native DEFLATE stream genuinely expands past the 50 MiB limit
- synchronize the ClawScan timeout test on descendant startup, advance only the timeout clock deterministically, and recognize a killed zombie as terminated while its parent reaps it
- leave product runtime, suite concurrency, and global timeouts unchanged

## Root cause

Both failures were scheduler-sensitive test assumptions exposed by full-suite contention, not product defects or leaked processes. The ZIP test spent its 15-second budget allocating and synchronously compressing 50 MiB in JavaScript. The ClawScan test assumed two wall-clock seconds was enough for the fake scanner to create its descendant PID and then treated `kill(pid, 0)` success for zombies as proof the descendant was still running.

An exactly 15-Testbox controlled matrix covered isolated tests, paired/default-pool runs, CPU stress, filesystem stress, and two full `ci:unit` runs. CPU stress stretched the paired tests from about 3.7 seconds to 8.7-9.9 seconds; filesystem stress only reached 4.3-5.2 seconds. Both full suites passed at about 280 seconds with 871-873 MiB max RSS, and final snapshots showed no residual Vitest or ClawScan processes.

## Validation

- `bun run ci:unit` (447 files passed, 5,876 tests passed on rebased exact head)
- `bun run ci:static`
- `bun run ci:types-build`
- 10/10 repeated paired targeted runs
- focused ZIP and ClawScan timeout tests
- autoreview (clean after accepting one security-coverage finding)
- `git diff --check`
