### PR TITLE
test: isolate production menu smoke routes

### DIFF
--- a/e2e/menu-smoke.pw.test.ts
+++ b/e2e/menu-smoke.pw.test.ts
@@ -24,10 +24,9 @@ test("skills loads without error", async ({ page }) => {
   await expectHealthyPage(page, errors);
 });
 
-test("header menu routes render", async ({ page }) => {
-  const errors = trackRuntimeErrors(page);
-
-  for (const label of navLabels) {
+for (const label of navLabels) {
+  test(`header menu ${label.toLowerCase()} route renders`, async ({ page }) => {
+    const errors = trackRuntimeErrors(page);
     await page.goto("/", { waitUntil: "domcontentloaded" });
     await waitForHydration(page);
 
@@ -43,7 +42,7 @@ test("header menu routes render", async ({ page }) => {
       await expect(page).toHaveURL(/\/plugins(\?|$)/);
       await expect(page.locator("h1", { hasText: "Plugins" })).toBeVisible();
     }
-  }
 
-  await expectHealthyPage(page, errors);
-});
+    await expectHealthyPage(page, errors);
+  });
+}


### PR DESCRIPTION
## Summary
- isolate Skills and Plugins header-navigation smoke journeys onto fresh Playwright pages
- prevent WebKit teardown cancellation from the hydrated Skills query from being attributed to the later Plugins route
- preserve runtime-error checking for each real destination independently

## RCA
The production smoke kept one runtime-error accumulator across two separate journeys. On Mobile Safari, the full-document navigation away from a hydrated `/skills` page reports the canceled Convex query as `pageerror:.../api/query due to access control checks`. The test deferred its assertion until after `/plugins`, so it misattributed that teardown event to an otherwise healthy Plugins page.

## Validation
- `PLAYWRIGHT_BASE_URL=https://clawhub.ai bunx playwright test --project=mobile-safari --workers=1 e2e/menu-smoke.pw.test.ts`
- `PLAYWRIGHT_BASE_URL=https://clawhub.ai bunx playwright test --project=chromium --workers=1 e2e/menu-smoke.pw.test.ts`
- `PLAYWRIGHT_BASE_URL=https://clawhub.ai bunx playwright test --workers=1 e2e/menu-smoke.pw.test.ts e2e/publish-entry-workflows.pw.test.ts e2e/upload-auth-smoke.pw.test.ts`
- `bun run ci:static`
- `bun run ci:unit` (5,877 passed, 2 skipped)
- `bunx tsc -p packages/schema/tsconfig.json --noEmit`
- `bunx tsc -p packages/clawhub/tsconfig.json --noEmit`
- autoreview clean
