### PR TITLE
fix: enforce publisher skill slug invariant

### DIFF
--- a/convex/maintenance.duplicateSlug.runtime.test.ts
+++ b/convex/maintenance.duplicateSlug.runtime.test.ts
@@ -1,0 +1,140 @@
+/* @vitest-environment edge-runtime */
+import { convexTest } from "convex-test";
+import { expect, it } from "vitest";
+import { internal } from "./_generated/api";
+import schema from "./schema";
+
+const modules = import.meta.glob("./**/*.ts");
+
+it("reports only active duplicate slugs within the same publisher", async () => {
+  const t = convexTest(schema, modules);
+  const ids = await t.run(async (ctx) => {
+    const userId = await ctx.db.insert("users", { handle: "owner" });
+    const publisherId = await ctx.db.insert("publishers", {
+      kind: "user",
+      handle: "owner",
+      displayName: "Owner",
+      linkedUserId: userId,
+      createdAt: 1,
+      updatedAt: 1,
+    });
+    const otherPublisherId = await ctx.db.insert("publishers", {
+      kind: "org",
+      handle: "other",
+      displayName: "Other",
+      createdAt: 1,
+      updatedAt: 1,
+    });
+    const makeSkill = (ownerPublisherId: typeof publisherId, softDeletedAt?: number) =>
+      ctx.db.insert("skills", {
+        slug: "same-slug",
+        displayName: "Skill",
+        ownerUserId: userId,
+        ownerPublisherId,
+        tags: {},
+        badges: {},
+        moderationStatus: softDeletedAt ? "hidden" : "active",
+        softDeletedAt,
+        stats: { comments: 0, downloads: 0, stars: 0, versions: 0 },
+        createdAt: 1,
+        updatedAt: 1,
+      });
+    const first = await makeSkill(publisherId);
+    const second = await makeSkill(publisherId);
+    await makeSkill(publisherId, 1);
+    await makeSkill(otherPublisherId);
+    return { publisherId, first, second };
+  });
+
+  const result = await t.action(internal.maintenance.scanActivePublisherSlugDuplicatesInternal, {
+    batchSize: 1,
+    maxBatches: 10,
+  });
+
+  expect(result.isDone).toBe(true);
+  expect(result.duplicateGroupsFound).toBe(1);
+  expect(result.findings).toEqual([
+    expect.objectContaining({
+      ownerPublisherId: ids.publisherId,
+      slug: "same-slug",
+      activeSkillIds: expect.arrayContaining([ids.first, ids.second]),
+    }),
+  ]);
+});
+
+it("merges an explicitly selected same-publisher duplicate by id", async () => {
+  const t = convexTest(schema, modules);
+  const ids = await t.run(async (ctx) => {
+    const userId = await ctx.db.insert("users", {
+      handle: "owner",
+      publishedSkills: 2,
+    });
+    const publisherId = await ctx.db.insert("publishers", {
+      kind: "user",
+      handle: "owner",
+      displayName: "Owner",
+      linkedUserId: userId,
+      createdAt: 1,
+      updatedAt: 1,
+    });
+    await ctx.db.patch(userId, { personalPublisherId: publisherId });
+    const baseSkill = {
+      slug: "duplicate",
+      displayName: "Duplicate",
+      ownerUserId: userId,
+      ownerPublisherId: publisherId,
+      tags: {},
+      badges: {},
+      moderationStatus: "active" as const,
+      stats: { comments: 0, downloads: 0, stars: 0, versions: 1 },
+      createdAt: 1,
+      updatedAt: 1,
+    };
+    const sourceSkillId = await ctx.db.insert("skills", baseSkill);
+    const targetSkillId = await ctx.db.insert("skills", baseSkill);
+    const sourceVersionId = await ctx.db.insert("skillVersions", {
+      skillId: sourceSkillId,
+      version: "1.0.0",
+      changelog: "old",
+      files: [],
+      parsed: { frontmatter: {} },
+      createdBy: userId,
+      createdAt: 1,
+    });
+    const targetVersionId = await ctx.db.insert("skillVersions", {
+      skillId: targetSkillId,
+      version: "2.0.0",
+      changelog: "latest",
+      files: [],
+      parsed: { frontmatter: {} },
+      createdBy: userId,
+      createdAt: 2,
+    });
+    await ctx.db.patch(sourceSkillId, { latestVersionId: sourceVersionId });
+    await ctx.db.patch(targetSkillId, { latestVersionId: targetVersionId });
+    return { sourceSkillId, targetSkillId, sourceVersionId, targetVersionId, userId };
+  });
+
+  const result = await t.mutation(internal.skills.mergeSamePublisherDuplicateSkillByIdInternal, {
+    sourceSkillId: ids.sourceSkillId,
+    targetSkillId: ids.targetSkillId,
+    expectedSlug: "duplicate",
+    expectedSourceVersionId: ids.sourceVersionId,
+    expectedTargetVersionId: ids.targetVersionId,
+    expectedTargetVersion: "2.0.0",
+  });
+
+  expect(result).toMatchObject({ ok: true, alreadyMerged: false });
+  const state = await t.run(async (ctx) => ({
+    source: await ctx.db.get(ids.sourceSkillId),
+    target: await ctx.db.get(ids.targetSkillId),
+    user: await ctx.db.get(ids.userId),
+  }));
+  expect(state.source).toMatchObject({
+    softDeletedAt: expect.any(Number),
+    canonicalSkillId: ids.targetSkillId,
+    moderationReason: "owner.merged",
+  });
+  expect(state.target?.softDeletedAt).toBeUndefined();
+  expect(state.user?.publishedSkills).toBe(1);
+});

--- a/convex/maintenance.test.ts
+++ b/convex/maintenance.test.ts
@@ -48,11 +48,15 @@ vi.mock("./_generated/api", () => ({
       inspectSkillLineageCycleInternal: Symbol("inspectSkillLineageCycleInternal"),
       applySkillLineageCycleRepairInternal: Symbol("applySkillLineageCycleRepairInternal"),
       repairSkillLineageCyclesInternal: Symbol("repairSkillLineageCyclesInternal"),
+      inspectHeartflowDuplicateSkillsInternal: Symbol("inspectHeartflowDuplicateSkillsInternal"),
     },
     skills: {
       backfillLatestSkillModerationInternal: Symbol("skills.backfillLatestSkillModerationInternal"),
       getVersionByIdInternal: Symbol("skills.getVersionByIdInternal"),
       getOwnerSkillActivityInternal: Symbol("skills.getOwnerSkillActivityInternal"),
+      mergeSamePublisherDuplicateSkillByIdInternal: Symbol(
+        "skills.mergeSamePublisherDuplicateSkillByIdInternal",
+      ),
     },
     users: {
       getByIdInternal: Symbol("users.getByIdInternal"),
@@ -85,6 +89,7 @@ const {
   nominateEmptySkillSpammersInternalHandler,
   repairLegacyPluginSkillSpectorBatchInternalHandler,
   repairLegacyPublisherOwnershipForUserHandler,
+  repairHeartflowDuplicateSkillsInternalHandler,
   repairSkillLineageCyclesInternalHandler,
   resyncPluginCatalogMetadataDigestsBatchInternal,
   resyncPluginCatalogMetadataDigestsInternal,
@@ -97,6 +102,47 @@ const { getAuthUserId } = await import("@convex-dev/auth/server");
 beforeEach(() => {
   vi.mocked(getAuthUserId).mockReset();
   vi.mocked(getAuthUserId).mockResolvedValue(null);
+});
+
+describe("maintenance HeartFlow duplicate repair", () => {
+  it("defaults to a zero-write dry run and returns the guarded repair pairs", async () => {
+    const pairs = [
+      {
+        slug: "heartflow",
+        sourceSkillId: "skills:old",
+        targetSkillId: "skills:new",
+        expectedTargetVersion: "6.4.1",
+        status: "ready",
+        source: { version: "6.4.0" },
+        target: { version: "6.4.1" },
+      },
+    ];
+    const runQuery = vi.fn().mockResolvedValue(pairs);
+    const runMutation = vi.fn();
+
+    const result = await repairHeartflowDuplicateSkillsInternalHandler(
+      { runQuery, runMutation } as never,
+      {},
+    );
+
+    expect(result).toMatchObject({
+      ok: true,
+      dryRun: true,
+      writesApplied: 0,
+      confirmRequired: "merge-heartflow-duplicate-skills-2026-08-04",
+      pairs,
+    });
+    expect(runMutation).not.toHaveBeenCalled();
+  });
+
+  it("refuses an apply without the exact confirmation token", async () => {
+    await expect(
+      repairHeartflowDuplicateSkillsInternalHandler(
+        { runQuery: vi.fn(), runMutation: vi.fn() } as never,
+        { dryRun: false },
+      ),
+    ).rejects.toThrow("merge-heartflow-duplicate-skills-2026-08-04");
+  });
 });
 
 function makeBlob(text: string) {

--- a/convex/maintenance.ts
+++ b/convex/maintenance.ts
@@ -46,6 +46,75 @@ const PUBLISHER_ABUSE_SIGNAL_SMOKE_OWNER_KEY =
 const PUBLISHER_ABUSE_SIGNAL_SMOKE_CONFIRM =
   "create-publisher-abuse-hermit-digest-smoke-2026-07-03" as const;
 const SKILL_LINEAGE_CYCLE_REPAIR_CONFIRM = "repair-skill-lineage-cycles-2026-07-23" as const;
+const HEARTFLOW_DUPLICATE_REPAIR_CONFIRM = "merge-heartflow-duplicate-skills-2026-08-04" as const;
+const HEARTFLOW_DUPLICATE_PAIRS = [
+  {
+    slug: "heartflow",
+    sourceSkillId: "kd7d384mr4pc7ezmf0apvwmqtn8992b6" as Id<"skills">,
+    targetSkillId: "kd7dmapx3bfr9j5capz3s3errh87hytn" as Id<"skills">,
+    expectedSourceVersionId: "k97bfwtwqvs304xbwz4fb400a58a00fq" as Id<"skillVersions">,
+    expectedTargetVersionId: "k97deresd77zj06xkvk5xxxh1h8bf900" as Id<"skillVersions">,
+    expectedTargetVersion: "6.4.1",
+  },
+  {
+    slug: "mark-heartflow-skill",
+    sourceSkillId: "kd7bhw61fc55a9jd2yb4yfrsg588wmnx" as Id<"skills">,
+    targetSkillId: "kd70mrrjtpgs0cw8vpf0vc0g558a5365" as Id<"skills">,
+    expectedSourceVersionId: "k974gwc5wdwe6mh20veqk4j8e58a2w2m" as Id<"skillVersions">,
+    expectedTargetVersionId: "k976jhrj92aa7fns2j39cm9q1s8b4t7r" as Id<"skillVersions">,
+    expectedTargetVersion: "6.0.66",
+  },
+  {
+    slug: "heartflow-engine",
+    sourceSkillId: "kd78tjvftk71c2xcce7djd2znd88v17h" as Id<"skills">,
+    targetSkillId: "kd72yfs8takacq1d8kefnmsv7h8aq1dg" as Id<"skills">,
+    expectedSourceVersionId: "k970ak5ecrkqya71zf1tj6e1nd89xngx" as Id<"skillVersions">,
+    expectedTargetVersionId: "k975bysehhqb3mzyjcp9s3mxys8arpkj" as Id<"skillVersions">,
+    expectedTargetVersion: "6.0.22",
+  },
+] as const;
+const activePublisherSlugScanRowValidator = v.object({
+  skillId: v.id("skills"),
+  ownerPublisherId: v.optional(v.id("publishers")),
+  slug: v.string(),
+  active: v.boolean(),
+  latestVersionId: v.optional(v.id("skillVersions")),
+  latestVersion: v.optional(v.string()),
+  moderationStatus: v.string(),
+  canonicalSkillId: v.optional(v.id("skills")),
+  createdAt: v.number(),
+  updatedAt: v.number(),
+});
+type ActivePublisherSlugScanRow = {
+  skillId: Id<"skills">;
+  ownerPublisherId?: Id<"publishers">;
+  slug: string;
+  active: boolean;
+  latestVersionId?: Id<"skillVersions">;
+  latestVersion?: string;
+  moderationStatus: string;
+  canonicalSkillId?: Id<"skills">;
+  createdAt: number;
+  updatedAt: number;
+};
+type HeartflowDuplicateInspection = {
+  slug: string;
+  sourceSkillId: Id<"skills">;
+  targetSkillId: Id<"skills">;
+  expectedSourceVersionId: Id<"skillVersions">;
+  expectedTargetVersionId: Id<"skillVersions">;
+  expectedTargetVersion: string;
+  status: "ready" | "already_repaired" | "blocked";
+  source: unknown;
+  target: unknown;
+};
+type HeartflowDuplicateRepairResult = {
+  ok: true;
+  dryRun: boolean;
+  writesApplied: number;
+  confirmRequired?: typeof HEARTFLOW_DUPLICATE_REPAIR_CONFIRM;
+  pairs: HeartflowDuplicateInspection[];
+};
 const legacyPluginSkillSpectorRepairFamilyValidator = v.union(
   v.literal("code-plugin"),
   v.literal("bundle-plugin"),
@@ -3085,6 +3154,244 @@ export const repairSkillLineageCyclesInternal = internalAction({
     maxBatches: v.optional(v.number()),
   },
   handler: repairSkillLineageCyclesInternalHandler,
+});
+
+export const getActivePublisherSlugInvariantPageInternal = internalQuery({
+  args: {
+    cursor: v.optional(v.string()),
+    batchSize: v.number(),
+  },
+  handler: async (ctx, args) => {
+    const page = await ctx.db
+      .query("skills")
+      .withIndex("by_owner_publisher_slug")
+      .paginate({ cursor: args.cursor ?? null, numItems: clampInt(args.batchSize, 1, 200) });
+    return {
+      items: page.page.map(
+        (skill): ActivePublisherSlugScanRow => ({
+          skillId: skill._id,
+          ownerPublisherId: skill.ownerPublisherId,
+          slug: skill.slug,
+          active: !skill.softDeletedAt,
+          latestVersionId: skill.latestVersionId,
+          latestVersion: skill.latestVersionSummary?.version,
+          moderationStatus: skill.moderationStatus ?? "unknown",
+          canonicalSkillId: skill.canonicalSkillId,
+          createdAt: skill.createdAt,
+          updatedAt: skill.updatedAt,
+        }),
+      ),
+      cursor: page.continueCursor,
+      isDone: page.isDone,
+    };
+  },
+});
+
+function activePublisherSlugGroupKey(row: ActivePublisherSlugScanRow) {
+  return row.ownerPublisherId ? `${row.ownerPublisherId}\u0000${row.slug}` : null;
+}
+
+function formatActivePublisherSlugDuplicateGroup(rows: ActivePublisherSlugScanRow[]) {
+  const activeRows = rows.filter((row) => row.active);
+  if (activeRows.length < 2 || !activeRows[0]?.ownerPublisherId) return null;
+  return {
+    ownerPublisherId: activeRows[0].ownerPublisherId,
+    slug: activeRows[0].slug,
+    activeSkillIds: activeRows.map((row) => row.skillId),
+    skills: activeRows.map(({ active: _active, ...row }) => row),
+  };
+}
+
+export const scanActivePublisherSlugDuplicatesInternal = internalAction({
+  args: {
+    cursor: v.optional(v.string()),
+    batchSize: v.optional(v.number()),
+    maxBatches: v.optional(v.number()),
+    continuation: v.optional(
+      v.object({
+        key: v.string(),
+        rows: v.array(activePublisherSlugScanRowValidator),
+      }),
+    ),
+  },
+  handler: async (ctx, args) => {
+    const batchSize = clampInt(args.batchSize ?? 200, 1, 200);
+    const maxBatches = clampInt(args.maxBatches ?? 200, 1, 200);
+    const findings: NonNullable<ReturnType<typeof formatActivePublisherSlugDuplicateGroup>>[] = [];
+    let cursor: string | null = args.cursor ?? null;
+    let currentKey = args.continuation?.key ?? null;
+    let currentRows = (args.continuation?.rows ?? []) as ActivePublisherSlugScanRow[];
+    let rowsScanned = 0;
+    let isDone = false;
+
+    const finishCurrentGroup = () => {
+      const finding = formatActivePublisherSlugDuplicateGroup(currentRows);
+      if (finding) findings.push(finding);
+      currentRows = [];
+    };
+
+    for (let batch = 0; batch < maxBatches; batch++) {
+      const page = (await ctx.runQuery(
+        internal.maintenance.getActivePublisherSlugInvariantPageInternal,
+        { cursor: cursor ?? undefined, batchSize },
+      )) as {
+        items: ActivePublisherSlugScanRow[];
+        cursor: string | null;
+        isDone: boolean;
+      };
+      cursor = page.cursor;
+      isDone = page.isDone;
+      rowsScanned += page.items.length;
+
+      for (const row of page.items) {
+        const key = activePublisherSlugGroupKey(row);
+        if (key !== currentKey) {
+          finishCurrentGroup();
+          currentKey = key;
+        }
+        if (key && row.active) currentRows.push(row);
+      }
+      if (isDone) break;
+    }
+
+    if (isDone) finishCurrentGroup();
+    return {
+      ok: true as const,
+      invariant: "one active skill per ownerPublisherId and slug",
+      rowsScanned,
+      duplicateGroupsFound: findings.length,
+      findings,
+      cursor,
+      isDone,
+      ...(!isDone && currentKey ? { continuation: { key: currentKey, rows: currentRows } } : {}),
+    };
+  },
+});
+
+export const inspectHeartflowDuplicateSkillsInternal = internalQuery({
+  args: {},
+  handler: async (ctx) => {
+    return await Promise.all(
+      HEARTFLOW_DUPLICATE_PAIRS.map(async (pair) => {
+        const [source, target] = await Promise.all([
+          ctx.db.get(pair.sourceSkillId),
+          ctx.db.get(pair.targetSkillId),
+        ]);
+        const [sourceVersion, targetVersion] = await Promise.all([
+          source?.latestVersionId ? ctx.db.get(source.latestVersionId) : null,
+          target?.latestVersionId ? ctx.db.get(target.latestVersionId) : null,
+        ]);
+        const alreadyRepaired = Boolean(
+          source?.softDeletedAt &&
+          source.canonicalSkillId === target?._id &&
+          source.forkOf?.skillId === target?._id,
+        );
+        const ready = Boolean(
+          source &&
+          target &&
+          !source.softDeletedAt &&
+          !target.softDeletedAt &&
+          source.ownerPublisherId &&
+          source.ownerPublisherId === target.ownerPublisherId &&
+          source.slug === pair.slug &&
+          target.slug === pair.slug &&
+          source.latestVersionId === pair.expectedSourceVersionId &&
+          target.latestVersionId === pair.expectedTargetVersionId &&
+          targetVersion?.version === pair.expectedTargetVersion,
+        );
+        return {
+          ...pair,
+          status: alreadyRepaired
+            ? ("already_repaired" as const)
+            : ready
+              ? ("ready" as const)
+              : ("blocked" as const),
+          source: source
+            ? {
+                skillId: source._id,
+                ownerUserId: source.ownerUserId,
+                ownerPublisherId: source.ownerPublisherId ?? null,
+                slug: source.slug,
+                version: sourceVersion?.version ?? null,
+                softDeletedAt: source.softDeletedAt ?? null,
+                canonicalSkillId: source.canonicalSkillId ?? null,
+                stats: source.stats,
+                statsInstallsAllTime: source.statsInstallsAllTime ?? null,
+                createdAt: source.createdAt,
+                updatedAt: source.updatedAt,
+              }
+            : null,
+          target: target
+            ? {
+                skillId: target._id,
+                ownerUserId: target.ownerUserId,
+                ownerPublisherId: target.ownerPublisherId ?? null,
+                slug: target.slug,
+                version: targetVersion?.version ?? null,
+                softDeletedAt: target.softDeletedAt ?? null,
+                canonicalSkillId: target.canonicalSkillId ?? null,
+                stats: target.stats,
+                statsInstallsAllTime: target.statsInstallsAllTime ?? null,
+                createdAt: target.createdAt,
+                updatedAt: target.updatedAt,
+              }
+            : null,
+        };
+      }),
+    );
+  },
+});
+
+// Incident-specific and temporary: dry-run first, then apply only with the exact token.
+// npx convex run maintenance:repairHeartflowDuplicateSkillsInternal '{}' --prod
+export async function repairHeartflowDuplicateSkillsInternalHandler(
+  ctx: ActionCtx,
+  args: { dryRun?: boolean; confirm?: string },
+): Promise<HeartflowDuplicateRepairResult> {
+  const dryRun = args.dryRun !== false;
+  if (!dryRun && args.confirm !== HEARTFLOW_DUPLICATE_REPAIR_CONFIRM) {
+    throw new ConvexError(`Pass confirm="${HEARTFLOW_DUPLICATE_REPAIR_CONFIRM}" to apply.`);
+  }
+  const pairs = (await ctx.runQuery(
+    internal.maintenance.inspectHeartflowDuplicateSkillsInternal,
+    {},
+  )) as HeartflowDuplicateInspection[];
+  const blocked = pairs.filter((pair) => pair.status === "blocked");
+  if (blocked.length > 0) {
+    throw new ConvexError(`HeartFlow repair preflight blocked for ${blocked.length} pair(s).`);
+  }
+  if (dryRun) {
+    return {
+      ok: true,
+      dryRun: true,
+      writesApplied: 0,
+      confirmRequired: HEARTFLOW_DUPLICATE_REPAIR_CONFIRM,
+      pairs,
+    };
+  }
+
+  let writesApplied = 0;
+  for (const pair of pairs) {
+    if (pair.status === "already_repaired") continue;
+    await ctx.runMutation(internal.skills.mergeSamePublisherDuplicateSkillByIdInternal, {
+      sourceSkillId: pair.sourceSkillId,
+      targetSkillId: pair.targetSkillId,
+      expectedSlug: pair.slug,
+      expectedSourceVersionId: pair.expectedSourceVersionId,
+      expectedTargetVersionId: pair.expectedTargetVersionId,
+      expectedTargetVersion: pair.expectedTargetVersion,
+    });
+    writesApplied++;
+  }
+  return { ok: true, dryRun: false, writesApplied, pairs };
+}
+
+export const repairHeartflowDuplicateSkillsInternal = internalAction({
+  args: {
+    dryRun: v.optional(v.boolean()),
+    confirm: v.optional(v.string()),
+  },
+  handler: repairHeartflowDuplicateSkillsInternalHandler,
 });
 
 function isActiveLegacyPublisherRepairUser(

--- a/convex/skillTransfers.duplicateSlug.runtime.test.ts
+++ b/convex/skillTransfers.duplicateSlug.runtime.test.ts
@@ -1,0 +1,184 @@
+/// <reference types="vite/client" />
+/* @vitest-environment edge-runtime */
+import { convexTest } from "convex-test";
+import { expect, it } from "vitest";
+import { internal } from "./_generated/api";
+import schema from "./schema";
+
+const modules = import.meta.glob("./**/*.ts");
+
+it("preserves publisher-scoped slug uniqueness when accepting a transfer", async () => {
+  const t = convexTest(schema, modules);
+  const ids = await t.run(async (ctx) => {
+    const sourceUserId = await ctx.db.insert("users", {
+      handle: "source",
+      displayName: "Source",
+    });
+    const sourcePublisherId = await ctx.db.insert("publishers", {
+      kind: "user",
+      handle: "source",
+      displayName: "Source",
+      linkedUserId: sourceUserId,
+      createdAt: 1,
+      updatedAt: 1,
+    });
+    await ctx.db.patch(sourceUserId, { personalPublisherId: sourcePublisherId });
+
+    const destinationUserId = await ctx.db.insert("users", {
+      handle: "destination",
+      displayName: "Destination",
+    });
+    const destinationPublisherId = await ctx.db.insert("publishers", {
+      kind: "user",
+      handle: "destination",
+      displayName: "Destination",
+      linkedUserId: destinationUserId,
+      createdAt: 1,
+      updatedAt: 1,
+    });
+    await ctx.db.patch(destinationUserId, { personalPublisherId: destinationPublisherId });
+
+    const transferredSkillId = await ctx.db.insert("skills", {
+      slug: "same-slug",
+      displayName: "Transferred lineage",
+      ownerUserId: sourceUserId,
+      ownerPublisherId: sourcePublisherId,
+      tags: {},
+      badges: {},
+      moderationStatus: "active",
+      stats: { comments: 0, downloads: 0, stars: 0, versions: 0 },
+      createdAt: 1,
+      updatedAt: 1,
+    });
+    await ctx.db.insert("skills", {
+      slug: "same-slug",
+      displayName: "Existing destination lineage",
+      ownerUserId: destinationUserId,
+      ownerPublisherId: destinationPublisherId,
+      tags: {},
+      badges: {},
+      moderationStatus: "active",
+      stats: { comments: 0, downloads: 0, stars: 0, versions: 0 },
+      createdAt: 2,
+      updatedAt: 2,
+    });
+    const transferId = await ctx.db.insert("skillOwnershipTransfers", {
+      skillId: transferredSkillId,
+      fromUserId: sourceUserId,
+      toUserId: destinationUserId,
+      status: "pending",
+      requestedAt: 3,
+      expiresAt: Date.now() + 60_000,
+    });
+    return { destinationPublisherId, destinationUserId, transferId, transferredSkillId };
+  });
+
+  const result = await t.mutation(internal.skillTransfers.acceptTransferInternal, {
+    actorUserId: ids.destinationUserId,
+    transferId: ids.transferId,
+  });
+  expect(result).toMatchObject({ ok: false });
+
+  const destinationMatches = await t.run(async (ctx) =>
+    ctx.db
+      .query("skills")
+      .withIndex("by_owner_publisher_slug", (q) =>
+        q.eq("ownerPublisherId", ids.destinationPublisherId).eq("slug", "same-slug"),
+      )
+      .collect(),
+  );
+  expect(destinationMatches).toHaveLength(1);
+  const unchanged = await t.run(async (ctx) => ({
+    skill: await ctx.db.get(ids.transferredSkillId),
+    transfer: await ctx.db.get(ids.transferId),
+  }));
+  expect(unchanged.skill?.ownerPublisherId).not.toBe(ids.destinationPublisherId);
+  expect(unchanged.transfer?.status).toBe("pending");
+});
+
+it("rejects a transfer when one of its redirects collides at the destination", async () => {
+  const t = convexTest(schema, modules);
+  const ids = await t.run(async (ctx) => {
+    const sourceUserId = await ctx.db.insert("users", { handle: "source" });
+    const sourcePublisherId = await ctx.db.insert("publishers", {
+      kind: "user",
+      handle: "source",
+      displayName: "Source",
+      linkedUserId: sourceUserId,
+      createdAt: 1,
+      updatedAt: 1,
+    });
+    await ctx.db.patch(sourceUserId, { personalPublisherId: sourcePublisherId });
+    const destinationUserId = await ctx.db.insert("users", { handle: "destination" });
+    const destinationPublisherId = await ctx.db.insert("publishers", {
+      kind: "user",
+      handle: "destination",
+      displayName: "Destination",
+      linkedUserId: destinationUserId,
+      createdAt: 1,
+      updatedAt: 1,
+    });
+    await ctx.db.patch(destinationUserId, { personalPublisherId: destinationPublisherId });
+    const transferredSkillId = await ctx.db.insert("skills", {
+      slug: "new-name",
+      displayName: "Transferred",
+      ownerUserId: sourceUserId,
+      ownerPublisherId: sourcePublisherId,
+      tags: {},
+      badges: {},
+      moderationStatus: "active",
+      stats: { comments: 0, downloads: 0, stars: 0, versions: 0 },
+      createdAt: 1,
+      updatedAt: 1,
+    });
+    await ctx.db.insert("skillSlugAliases", {
+      slug: "old-name",
+      skillId: transferredSkillId,
+      ownerUserId: sourceUserId,
+      ownerPublisherId: sourcePublisherId,
+      createdAt: 1,
+      updatedAt: 1,
+    });
+    const destinationSkillId = await ctx.db.insert("skills", {
+      slug: "destination-skill",
+      displayName: "Destination",
+      ownerUserId: destinationUserId,
+      ownerPublisherId: destinationPublisherId,
+      tags: {},
+      badges: {},
+      moderationStatus: "active",
+      stats: { comments: 0, downloads: 0, stars: 0, versions: 0 },
+      createdAt: 1,
+      updatedAt: 1,
+    });
+    await ctx.db.insert("skillSlugAliases", {
+      slug: "old-name",
+      skillId: destinationSkillId,
+      ownerUserId: destinationUserId,
+      ownerPublisherId: destinationPublisherId,
+      createdAt: 1,
+      updatedAt: 1,
+    });
+    const transferId = await ctx.db.insert("skillOwnershipTransfers", {
+      skillId: transferredSkillId,
+      fromUserId: sourceUserId,
+      toUserId: destinationUserId,
+      status: "pending",
+      requestedAt: 3,
+      expiresAt: Date.now() + 60_000,
+    });
+    return { destinationUserId, transferId, transferredSkillId, sourcePublisherId };
+  });
+
+  const result = await t.mutation(internal.skillTransfers.acceptTransferInternal, {
+    actorUserId: ids.destinationUserId,
+    transferId: ids.transferId,
+  });
+  expect(result).toMatchObject({ ok: false, error: expect.stringContaining("redirect") });
+  const unchanged = await t.run(async (ctx) => ({
+    skill: await ctx.db.get(ids.transferredSkillId),
+    transfer: await ctx.db.get(ids.transferId),
+  }));
+  expect(unchanged.skill?.ownerPublisherId).toBe(ids.sourcePublisherId);
+  expect(unchanged.transfer?.status).toBe("pending");
+});

--- a/convex/skillTransfers.test.ts
+++ b/convex/skillTransfers.test.ts
@@ -351,12 +351,18 @@ describe("skillTransfers", () => {
             return null;
           }),
           query: vi.fn((table: string) => {
+            if (table === "skills") {
+              return {
+                withIndex: () => ({
+                  collect: async () => [],
+                }),
+              };
+            }
             if (table === "skillSlugAliases") {
               return {
                 withIndex: (indexName: string) => {
-                  expect(indexName).toBe("by_skill");
                   return {
-                    collect: async () => aliases,
+                    collect: async () => (indexName === "by_skill" ? aliases : []),
                   };
                 },
               };
@@ -548,6 +554,13 @@ describe("skillTransfers", () => {
             return null;
           }),
           query: vi.fn((table: string) => {
+            if (table === "skills") {
+              return {
+                withIndex: () => ({
+                  collect: async () => [],
+                }),
+              };
+            }
             if (table === "publisherMembers") {
               return {
                 withIndex: () => ({

--- a/convex/skillTransfers.ts
+++ b/convex/skillTransfers.ts
@@ -42,6 +42,70 @@ async function assertCanRequestSkillTransfer(
   });
 }
 
+async function findTransferDestinationSlugConflict(
+  ctx: MutationCtx,
+  params: {
+    skill: Doc<"skills">;
+    aliases: Doc<"skillSlugAliases">[];
+    destinationUserId: Id<"users">;
+    destinationPublisher: Doc<"publishers">;
+  },
+) {
+  const slugs = new Set([params.skill.slug, ...params.aliases.map((alias) => alias.slug)]);
+
+  for (const slug of slugs) {
+    const [publisherSkills, legacySkills, publisherAliases, legacyAliases] = await Promise.all([
+      ctx.db
+        .query("skills")
+        .withIndex("by_owner_publisher_slug", (q) =>
+          q.eq("ownerPublisherId", params.destinationPublisher._id).eq("slug", slug),
+        )
+        .collect(),
+      ctx.db
+        .query("skills")
+        .withIndex("by_owner_slug", (q) =>
+          q.eq("ownerUserId", params.destinationUserId).eq("slug", slug),
+        )
+        .collect(),
+      ctx.db
+        .query("skillSlugAliases")
+        .withIndex("by_owner_publisher_slug", (q) =>
+          q.eq("ownerPublisherId", params.destinationPublisher._id).eq("slug", slug),
+        )
+        .collect(),
+      ctx.db
+        .query("skillSlugAliases")
+        .withIndex("by_owner_slug", (q) =>
+          q.eq("ownerUserId", params.destinationUserId).eq("slug", slug),
+        )
+        .collect(),
+    ]);
+
+    const conflictingSkill = [...publisherSkills, ...legacySkills].find(
+      (candidate) =>
+        candidate._id !== params.skill._id &&
+        !candidate.softDeletedAt &&
+        (!candidate.ownerPublisherId ||
+          candidate.ownerPublisherId === params.destinationPublisher._id),
+    );
+    if (conflictingSkill) {
+      return `Destination owner @${params.destinationPublisher.handle} already has skill "${slug}". Rename or merge it before accepting this transfer.`;
+    }
+
+    const conflictingAlias = [...publisherAliases, ...legacyAliases].find(
+      (candidate) =>
+        candidate.skillId !== params.skill._id &&
+        (!candidate.ownerPublisherId ||
+          candidate.ownerPublisherId === params.destinationPublisher._id),
+    );
+    if (conflictingAlias) {
+      return `Destination owner @${params.destinationPublisher.handle} already has a redirect for skill "${slug}". Rename or merge it before accepting this transfer.`;
+    }
+  }
+
+  return null;
+}
+
 async function getActivePendingTransferForSkill(ctx: unknown, skillId: Id<"skills">, now: number) {
   const db = (
     ctx as {
@@ -211,16 +275,27 @@ export const acceptTransferInternal = internalMutation({
     });
     if (!newPublisher) throw new Error("Failed to resolve publisher for new owner");
 
+    const aliases = await ctx.db
+      .query("skillSlugAliases")
+      .withIndex("by_skill", (q) => q.eq("skillId", skill._id))
+      .collect();
+    const destinationConflict = await findTransferDestinationSlugConflict(ctx, {
+      skill,
+      aliases,
+      destinationUserId: args.actorUserId,
+      destinationPublisher: newPublisher,
+    });
+    if (destinationConflict) {
+      // Keep the request pending so the owners can resolve the namespace collision and retry.
+      return { ok: false as const, error: destinationConflict };
+    }
+
     await ctx.db.patch(skill._id, {
       ownerUserId: args.actorUserId,
       ownerPublisherId: newPublisher._id,
       updatedAt: now,
     });
 
-    const aliases = await ctx.db
-      .query("skillSlugAliases")
-      .withIndex("by_skill", (q) => q.eq("skillId", skill._id))
-      .collect();
     for (const alias of aliases) {
       await ctx.db.patch(alias._id, {
         ownerUserId: args.actorUserId,

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -11281,6 +11281,61 @@ export const mergeOwnedSkillIntoCanonicalInternal = internalMutation({
   },
 });
 
+export const mergeSamePublisherDuplicateSkillByIdInternal = internalMutation({
+  args: {
+    sourceSkillId: v.id("skills"),
+    targetSkillId: v.id("skills"),
+    expectedSlug: v.string(),
+    expectedSourceVersionId: v.id("skillVersions"),
+    expectedTargetVersionId: v.id("skillVersions"),
+    expectedTargetVersion: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const source = await ctx.db.get(args.sourceSkillId);
+    const target = await ctx.db.get(args.targetSkillId);
+    if (!source || !target) throw new ConvexError("Duplicate repair skill not found");
+    if (
+      source.softDeletedAt &&
+      source.canonicalSkillId === target._id &&
+      source.forkOf?.skillId === target._id
+    ) {
+      return { ok: true as const, alreadyMerged: true as const };
+    }
+    if (source.softDeletedAt || target.softDeletedAt) {
+      throw new ConvexError("Duplicate repair requires two active skills");
+    }
+    if (
+      !source.ownerPublisherId ||
+      source.ownerPublisherId !== target.ownerPublisherId ||
+      source.slug !== target.slug ||
+      source.slug !== args.expectedSlug
+    ) {
+      throw new ConvexError("Duplicate repair invariant changed before apply");
+    }
+    if (
+      source.latestVersionId !== args.expectedSourceVersionId ||
+      target.latestVersionId !== args.expectedTargetVersionId
+    ) {
+      throw new ConvexError("Duplicate repair lineage changed before apply");
+    }
+    const targetVersion = target.latestVersionId ? await ctx.db.get(target.latestVersionId) : null;
+    if (targetVersion?.version !== args.expectedTargetVersion) {
+      throw new ConvexError("Duplicate repair target version changed before apply");
+    }
+
+    const result = await mergeOwnedSkillIntoCanonicalByActor(
+      ctx,
+      target.ownerUserId,
+      source.slug,
+      target.slug,
+      undefined,
+      undefined,
+      { sourceSkillId: source._id, targetSkillId: target._id },
+    );
+    return { ...result, alreadyMerged: false as const };
+  },
+});
+
 async function canManageSkillOwnerForActor(
   ctx: QueryCtx | MutationCtx,
   actor: Doc<"users">,
@@ -11423,6 +11478,7 @@ async function mergeOwnedSkillIntoCanonicalByActor(
   targetSlugArg: string,
   sourceOwnerHandle?: string,
   targetOwnerHandle?: string,
+  skillIds?: { sourceSkillId: Id<"skills">; targetSkillId: Id<"skills"> },
 ) {
   const user = await ctx.db.get(actorUserId);
   if (!user || user.deletedAt || user.deactivatedAt) {
@@ -11430,31 +11486,33 @@ async function mergeOwnedSkillIntoCanonicalByActor(
   }
 
   const now = Date.now();
-  const sourceSlug = sourceSlugArg.trim().toLowerCase();
-  const targetSlug = targetSlugArg.trim().toLowerCase();
-  if (!sourceSlug || !targetSlug) {
-    throw new ConvexError("Source slug and target slug are required");
-  }
-  const sourceOwnerKey = normalizePublisherHandle(sourceOwnerHandle);
-  const targetOwnerKey = normalizePublisherHandle(targetOwnerHandle);
-  if (sourceSlug === targetSlug && sourceOwnerKey === targetOwnerKey) {
-    throw new ConvexError("Source and target must be different skills");
-  }
+  let source: Doc<"skills"> | null;
+  let target: Doc<"skills"> | null;
+  if (skillIds) {
+    [source, target] = await Promise.all([
+      ctx.db.get(skillIds.sourceSkillId),
+      ctx.db.get(skillIds.targetSkillId),
+    ]);
+  } else {
+    const sourceSlug = sourceSlugArg.trim().toLowerCase();
+    const targetSlug = targetSlugArg.trim().toLowerCase();
+    if (!sourceSlug || !targetSlug) {
+      throw new ConvexError("Source slug and target slug are required");
+    }
+    const sourceOwnerKey = normalizePublisherHandle(sourceOwnerHandle);
+    const targetOwnerKey = normalizePublisherHandle(targetOwnerHandle);
+    if (sourceSlug === targetSlug && sourceOwnerKey === targetOwnerKey) {
+      throw new ConvexError("Source and target must be different skills");
+    }
 
-  const sourceResolved = await resolveSkillBySlugOrAliasForOwner(
-    ctx,
-    sourceSlug,
-    sourceOwnerHandle,
-  );
-  const source = sourceResolved.skill;
+    const [sourceResolved, targetResolved] = await Promise.all([
+      resolveSkillBySlugOrAliasForOwner(ctx, sourceSlug, sourceOwnerHandle),
+      resolveSkillBySlugOrAliasForOwner(ctx, targetSlug, targetOwnerHandle),
+    ]);
+    source = sourceResolved.skill;
+    target = targetResolved.skill;
+  }
   if (!source || source.softDeletedAt) throw new ConvexError("Source skill not found");
-
-  const targetResolved = await resolveSkillBySlugOrAliasForOwner(
-    ctx,
-    targetSlug,
-    targetOwnerHandle,
-  );
-  const target = targetResolved.skill;
   if (!target || target.softDeletedAt) throw new ConvexError("Target skill not found");
   if (source._id === target._id) {
     throw new ConvexError("Source and target must be different skills");
@@ -11524,10 +11582,11 @@ async function mergeOwnedSkillIntoCanonicalByActor(
       addedOwnerAliasSlugs.add(source.slug);
     }
   } else {
-    if (!targetAliasSlugs.has(source.slug)) {
+    const sharedOwnerSlug = sourceOwnerMatchesTargetOwner && source.slug === target.slug;
+    if (!sharedOwnerSlug && !targetAliasSlugs.has(source.slug)) {
       addedSkillAliasSlugs.add(source.slug);
     }
-    addedOwnerAliasSlugs.add(source.slug);
+    if (!sharedOwnerSlug) addedOwnerAliasSlugs.add(source.slug);
   }
 
   if (sourceOwnerMatchesTargetOwner) {


### PR DESCRIPTION
## Summary

- block skill-transfer acceptance when the destination publisher already owns the incoming canonical slug or any incoming redirect slug
- leave conflicting transfers pending so publishers can rename or merge and retry
- add a bounded invariant scan for multiple active skills with the same `(ownerPublisherId, slug)`
- add an incident-specific, dry-run-first HeartFlow repair that merges three exact loser IDs into three pinned survivors

## Why

The duplicate HeartFlow rows were created when transfer acceptance changed `ownerPublisherId` without checking the recipient publisher's existing skill and redirect namespace. Convex indexes accelerate lookups but are not unique constraints, so the database accepted both rows. The earlier deterministic resolver selection would only mask that invalid state and could select the wrong lineage.

RCA evidence: https://github.com/openclaw/clawhub/pull/3383#issuecomment-5184666680

## Safety

- conflict reads and ownership writes occur in one Convex mutation, so OCC protects concurrent acceptance/publish races
- duplicate reads remain fail-closed; no newest-wins resolver is added
- the scan excludes cross-publisher reuse and soft-deleted merge/history rows
- HeartFlow apply is confirmation-gated, ID-specific, idempotent, and atomically pins both source and survivor latest-version IDs
- production data will not be changed until the deployed dry-run is reviewed separately

## Validation

- `bunx vitest run convex/skillTransfers.duplicateSlug.runtime.test.ts convex/maintenance.duplicateSlug.runtime.test.ts convex/skillTransfers.test.ts convex/maintenance.test.ts --reporter=dot`
- `bun run ci:static`
- `bun run ci:unit`
- `bun run ci:types-build`
- `bun run ci:packages`
- `bunx tsc -p packages/schema/tsconfig.json --noEmit`
- `bunx tsc -p packages/clawhub/tsconfig.json --noEmit`
- autoreview clean against `origin/main`
