### PR TITLE
fix: report broken worktree source symlinks

### DIFF
--- a/scripts/setup-worktree.test.ts
+++ b/scripts/setup-worktree.test.ts
@@ -6,6 +6,7 @@ import {
   mkdirSync,
   realpathSync,
   rmSync,
+  symlinkSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -342,6 +343,71 @@ describe("setup-worktree", () => {
     } finally {
       rmSync(root, { force: true, recursive: true });
     }
+  });
+
+  it("reports broken local-state symlinks in rejected worktree sources", () => {
+    withSourceAndCurrent((source, current) => {
+      symlinkSync("missing.env.local", join(source, ".env.local"));
+      symlinkSync("missing.convex", join(source, ".convex"));
+
+      expect(() =>
+        findSource(
+          {
+            force: false,
+            from: source,
+            quiet: true,
+          },
+          current,
+        ),
+      ).toThrow(
+        `Rejected sources:\n- ${source}: .env.local is a broken symlink to missing.env.local; .convex is a broken symlink to missing.convex`,
+      );
+    });
+  });
+
+  it("reports a broken Convex symlink when the source env remains readable", () => {
+    withSourceAndCurrent((source, current) => {
+      writeWorktree(source, "local-clawhub");
+      rmSync(join(source, ".convex"), { force: true, recursive: true });
+      symlinkSync("missing.convex", join(source, ".convex"));
+
+      expect(() =>
+        findSource(
+          {
+            force: false,
+            from: source,
+            quiet: true,
+          },
+          current,
+        ),
+      ).toThrow(`${source}: .convex is a broken symlink to missing.convex`);
+    });
+  });
+
+  it("accepts a remote source when only its unused Convex symlink is broken", () => {
+    withSourceAndCurrent((source, current) => {
+      writeWorktree(source, "remote-clawhub", {
+        env: {
+          CONVEX_DEPLOYMENT: "dev:remote-clawhub",
+          CONVEX_SITE_URL: null,
+          VITE_CONVEX_SITE_URL: null,
+          VITE_CONVEX_URL: "https://remote-clawhub.convex.cloud",
+        },
+      });
+      rmSync(join(source, ".convex"), { force: true, recursive: true });
+      symlinkSync("missing.convex", join(source, ".convex"));
+
+      expect(
+        findSource(
+          {
+            force: false,
+            from: source,
+            quiet: true,
+          },
+          current,
+        ).path,
+      ).toBe(source);
+    });
   });
 
   it("rejects local sources that point browser HTTP routes at the Convex function port", () => {

--- a/scripts/setup-worktree.ts
+++ b/scripts/setup-worktree.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 import { spawnSync } from "node:child_process";
-import { existsSync, lstatSync, readFileSync, rmSync, symlinkSync } from "node:fs";
+import { existsSync, lstatSync, readFileSync, readlinkSync, rmSync, symlinkSync } from "node:fs";
 import { basename, resolve } from "node:path";
 
 type Options = {
@@ -104,6 +104,25 @@ function readSource(path: string): Source | null {
   };
 }
 
+function describeUnavailableSource(path: string, names: readonly (".env.local" | ".convex")[]) {
+  const problems: string[] = [];
+
+  for (const name of names) {
+    const localPath = resolve(path, name);
+    if (existsSync(localPath)) continue;
+
+    try {
+      if (lstatSync(localPath).isSymbolicLink()) {
+        problems.push(`${name} is a broken symlink to ${readlinkSync(localPath)}`);
+      }
+    } catch {
+      // Missing local state is normal; dangling links require operator repair.
+    }
+  }
+
+  return problems.join("; ");
+}
+
 function readConvexConfig(convexPath: string) {
   const configPath = resolve(convexPath, "local/default/config.json");
   return existsSync(configPath) ? JSON.parse(readFileSync(configPath, "utf8")) : null;
@@ -200,8 +219,22 @@ export function findSource(options: Options, cwd = process.cwd()) {
 
   const rejected: string[] = [];
   for (const candidate of candidates) {
+    const unavailableEnv = describeUnavailableSource(candidate, [".env.local"]);
+    if (unavailableEnv) {
+      const unavailableConvex = describeUnavailableSource(candidate, [".convex"]);
+      const unavailable = [unavailableEnv, unavailableConvex].filter(Boolean).join("; ");
+      rejected.push(`${candidate}: ${unavailable}`);
+      continue;
+    }
     const source = readSource(candidate);
     if (!source) continue;
+    const unavailableConvex = source.env.CONVEX_DEPLOYMENT?.startsWith("local:")
+      ? describeUnavailableSource(candidate, [".convex"])
+      : "";
+    if (unavailableConvex) {
+      rejected.push(`${candidate}: ${unavailableConvex}`);
+      continue;
+    }
     const invalid = validateSource(source);
     if (!invalid) return source;
     rejected.push(`${candidate}: ${invalid}`);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where contributors running `setup:worktree` against a source worktree with dangling `.env.local` or `.convex` symlinks received only a generic “Could not find a usable worktree source” error.

## Why This Change Was Made

Source selection now distinguishes genuinely absent ignored state from dangling links and reports each broken target in the existing rejected-source diagnostics. `.convex` remains optional for remote deployments; the broken-link rejection applies only after `.env.local` identifies a `local:` deployment.

The managed-worktree environment configuration is unchanged: managed worktrees already copy `.worktreeinclude` state before validation, while Worktrunk’s existing pre-start hook owns the `copy-ignored` plus `--force --prefer-fallback` repair path.

## User Impact

Contributors see the exact broken local-state links that require repair. Remote-backed sources remain usable when an unrelated `.convex` symlink is dangling.

## Evidence

The focused suite now covers both broken-link diagnostics and the remote-source compatibility case:

- broken `.env.local` and `.convex` links are reported with their targets
- a readable local deployment rejects a broken `.convex` link
- a remote deployment accepts the same unused broken `.convex` link

Validation on current main `f9ea25e1`:

- `bunx vitest run scripts/setup-worktree.test.ts` — 19 passed
- `bun run ci:static` — passed
- `VITE_CONVEX_URL=https://example.invalid bun run ci:unit` — 5,922 passed, 2 skipped

