### PR TITLE
fix(web): stop emitting unused client font bundles

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,6 @@
         "@convex-dev/rate-limiter": "0.3.2",
         "@fontsource/bricolage-grotesque": "5.3.0",
         "@fontsource/ibm-plex-mono": "5.3.0",
-        "@fontsource/manrope": "5.3.0",
         "@fontsource/noto-sans-sc": "5.3.0",
         "@monaco-editor/react": "4.7.0",
         "@openclaw/carapace": "git+https://github.com/openclaw/carapace.git#v0.6.1",
@@ -342,8 +341,6 @@
     "@fontsource/bricolage-grotesque": ["@fontsource/bricolage-grotesque@5.3.0", "", {}, "sha512-MdOVb/5in11IfN/IQJOExMuu6AroCIQbirl0yX7NUvKk+h0HYIKfGaVAXRS/gCPil4aFxWhjZnOw28tUwv7tFw=="],
 
     "@fontsource/ibm-plex-mono": ["@fontsource/ibm-plex-mono@5.3.0", "", {}, "sha512-eTgnZjZEGk1QtD3ZstF+Vclo2HLAni8YMy34/DxllwZvyz1lR/1RF/xTiAquOBO7MvqBx8D2Ig2WCPMVfdZu7Q=="],
-
-    "@fontsource/manrope": ["@fontsource/manrope@5.3.0", "", {}, "sha512-obJ1Dv3+uCA6HlHgW8u4BGYxJR9In2HW7gjJhlflEvkrj1X1iSEwu0fToL+JYGC/FEKFfIz1sBuPduvcL2gIAA=="],
 
     "@fontsource/noto-sans-sc": ["@fontsource/noto-sans-sc@5.3.0", "", {}, "sha512-HeqIlGm0+ohOKxZLuHj1qW6r6avHH0OWdKERAcSDI0RQ+MXrteuLKA+M+5eOA8rYy0MFvOR5AT0fQo2rUkye0Q=="],
 

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -58,7 +58,6 @@ const config = {
         "@react-email/components",
         "@fontsource/bricolage-grotesque",
         "@fontsource/ibm-plex-mono",
-        "@fontsource/manrope",
         "@fontsource/noto-sans-sc",
         "tailwindcss",
         "tw-animate-css",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,6 @@
     "@convex-dev/rate-limiter": "0.3.2",
     "@fontsource/bricolage-grotesque": "5.3.0",
     "@fontsource/ibm-plex-mono": "5.3.0",
-    "@fontsource/manrope": "5.3.0",
     "@fontsource/noto-sans-sc": "5.3.0",
     "@monaco-editor/react": "4.7.0",
     "@openclaw/carapace": "git+https://github.com/openclaw/carapace.git#v0.6.1",

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,9 +1,6 @@
 @import "tailwindcss";
 @import "tw-animate-css";
 @import "./publisher-profile.css";
-@import "@fontsource/bricolage-grotesque/latin.css";
-@import "@fontsource/manrope/latin.css";
-@import "@fontsource/ibm-plex-mono/latin.css";
 
 @theme {
   /* Colors — core palette */


### PR DESCRIPTION
Related: #2925

## What Problem This Solves

The production build emits 42 client Fontsource assets and registers 21 unused font faces even though the current Carapace typography contract does not reference those families.

## Why This Change Was Made

This removes the three client CSS imports and the now-unused Manrope dependency. Bricolage Grotesque and IBM Plex Mono remain dependencies because server-side Open Graph generation still loads their font binaries.

## User Impact

There is no visual change. The client build stops emitting 767,488 bytes of unused font assets and sends a smaller initial stylesheet while preserving the current Carapace v0.6.1 font stacks and Open Graph rendering.

## Evidence

Refreshed production build and Chrome comparison on current main `f9ea25e1` with Carapace v0.6.1:

| Measurement | current main | proposed `f01a6e90` |
| --- | ---: | ---: |
| Emitted client `.woff` / `.woff2` assets | 42 / 767,488 bytes | 0 / 0 bytes |
| Registered browser font faces | 21 unused | 0 |
| Main stylesheet, raw | 775,130 bytes | 770,111 bytes |
| Font network requests | 0 | 0 |

The 1440×4131 full-page homepage screenshots are pixel-identical: zero changed channels and a maximum channel delta of zero. Computed body, heading, and monospace stacks are identical in Chrome. The proof comment embeds the refreshed baseline and proposed screenshots.

Validation:

- `bun run ci:static` — passed
- `VITE_CONVEX_URL=https://example.invalid bun run ci:unit` — 5,919 passed, 2 skipped
- `bun run ci:types-build` — passed
- production asset inventory and no-cache Chrome comparison — passed

