### PR TITLE
fix(ui): use Carapace tokens for download trends

### DIFF
--- a/src/__tests__/ui-design-contract.test.ts
+++ b/src/__tests__/ui-design-contract.test.ts
@@ -484,6 +484,22 @@ describe("restored UI design contract", () => {
     expect(lightRatio).toBeGreaterThanOrEqual(7);
   });
 
+  it("uses Carapace semantic tokens for metric trend lines", () => {
+    const css = styles();
+    const rootRule = cssRule(css, ":root");
+
+    expect(rootRule).toContain("--metric-trend-line: var(--oc-status-info-fg)");
+    expect(rootRule).toContain(
+      "--metric-trend-area: color-mix(in srgb, var(--oc-status-info-fg) 18%, transparent)",
+    );
+    expect(rootRule).toContain("--metric-trend-marker: var(--oc-chart-line)");
+    expect(cssRule(css, ".metric-trend-chart")).toContain("color: var(--metric-trend-line)");
+    expect(cssRule(css, ".metric-trend-marker-line")).toContain(
+      "stroke: var(--metric-trend-marker)",
+    );
+    expect(css).not.toMatch(/#(?:8eb8e8|4a7fd0|6b9fd4)/i);
+  });
+
   it("keeps detail heroes full width unless an explicit sidebar is present", () => {
     const shellSource = read("src/components/DetailPageShell.tsx");
     const css = styles();

--- a/src/styles.css
+++ b/src/styles.css
@@ -195,9 +195,9 @@
   --font-mono: var(--oc-font-mono);
 
   /* Metric trend sparklines */
-  --metric-trend-line: color-mix(in srgb, #8eb8e8 78%, var(--ink));
-  --metric-trend-area: color-mix(in srgb, #8eb8e8 20%, transparent);
-  --metric-trend-marker: color-mix(in srgb, #8eb8e8 42%, transparent);
+  --metric-trend-line: var(--oc-status-info-fg);
+  --metric-trend-area: color-mix(in srgb, var(--oc-status-info-fg) 18%, transparent);
+  --metric-trend-marker: var(--oc-chart-line);
 }
 
 /* Light theme — OpenClaw black, white, red */
@@ -250,11 +250,6 @@
   --shadow-dialog: var(--oc-shadow-lg);
   --shadow-hover: var(--oc-shadow-md);
   --shadow-card: var(--oc-shadow-sm);
-
-  /* Metric trend sparklines */
-  --metric-trend-line: color-mix(in srgb, #4a7fd0 84%, var(--ink));
-  --metric-trend-area: color-mix(in srgb, #4a7fd0 14%, transparent);
-  --metric-trend-marker: color-mix(in srgb, #4a7fd0 30%, transparent);
 
   /* Diff viewer — muted, readable in light mode */
   --diff-added: #16a34a;
@@ -317,11 +312,6 @@
     --shadow-dialog: var(--oc-shadow-lg);
     --shadow-hover: var(--oc-shadow-md);
     --shadow-card: var(--oc-shadow-sm);
-
-    /* Metric trend sparklines */
-    --metric-trend-line: color-mix(in srgb, #4a7fd0 84%, var(--ink));
-    --metric-trend-area: color-mix(in srgb, #4a7fd0 14%, transparent);
-    --metric-trend-marker: color-mix(in srgb, #4a7fd0 30%, transparent);
 
     /* Diff viewer — muted, readable in light mode */
     --diff-added: #16a34a;
@@ -7905,7 +7895,7 @@ a.skills-sh-security-audit-row:focus-visible {
   display: block;
   width: 100%;
   height: 34px;
-  color: var(--metric-trend-line, color-mix(in srgb, #6b9fd4 76%, var(--ink)));
+  color: var(--metric-trend-line);
   outline: none;
   touch-action: pan-y;
 }
@@ -7916,7 +7906,7 @@ a.skills-sh-security-audit-row:focus-visible {
 }
 
 .metric-trend-area {
-  fill: var(--metric-trend-area, color-mix(in srgb, #6b9fd4 18%, transparent));
+  fill: var(--metric-trend-area);
 }
 
 .metric-trend-line {
@@ -7928,7 +7918,7 @@ a.skills-sh-security-audit-row:focus-visible {
 }
 
 .metric-trend-marker-line {
-  stroke: var(--metric-trend-marker, color-mix(in srgb, #6b9fd4 36%, transparent));
+  stroke: var(--metric-trend-marker);
   stroke-width: 1.5;
 }
 


### PR DESCRIPTION
## Summary

- keep the download trend chart blue while replacing legacy hard-coded colors with Carapace semantic tokens
- derive the translucent area fill from the semantic blue series token and use the shared chart-line token for the marker
- add a design-contract regression test that rejects the removed legacy blues

## Validation

- `bun run ci:static`
- `bun run ci:unit` (448 files passed, 1 skipped; 5,906 tests passed, 2 skipped)
- `bun run ci:types-build`
- `bun run build`
- `bunx vitest run src/__tests__/ui-design-contract.test.ts` (19 passed)
- `.agents/skills/autoreview/scripts/autoreview --mode local` (clean)
- Carapace source audit (zero findings)

## Visual proof

Validated in the Codex app browser against a real local ClawHub and Convex instance at `/local/plugins/local-truncation-runtime-plugin`, using the fixture with 5 downloads and a 30-day trend. Light and dark screenshots will be attached in the proof comment.
