### PR TITLE
fix: restore homepage catalog discovery

### DIFF
--- a/convex/httpApiV1.handlers.test.ts
+++ b/convex/httpApiV1.handlers.test.ts
@@ -11833,6 +11833,22 @@ describe("httpApiV1 handlers", () => {
     }
   });
 
+  it("plugins search forwards New eligibility to both plugin families", async () => {
+    const runQuery = vi.fn().mockResolvedValue([]);
+    const runMutation = vi.fn().mockResolvedValue(okRate());
+
+    const response = await __handlers.pluginsGetRouterV1Handler(
+      makeCtx({ runQuery, runMutation }),
+      new Request("https://example.com/api/v1/plugins/search?q=calendar&createdAfter=123"),
+    );
+
+    expect(response.status).toBe(200);
+    expect(runQuery).toHaveBeenCalledTimes(2);
+    for (const [, args] of runQuery.mock.calls) {
+      expect(args).toEqual(expect.objectContaining({ createdAfter: 123 }));
+    }
+  });
+
   it("plugins search maps retired v1 category filters to controlled categories", async () => {
     const runQuery = vi.fn().mockResolvedValue([]);
     const runMutation = vi.fn().mockResolvedValue(okRate());

--- a/convex/httpApiV1/packagesV1.ts
+++ b/convex/httpApiV1/packagesV1.ts
@@ -1180,6 +1180,7 @@ async function searchPackageCatalog(
     channel?: "official" | "community" | "private";
     isOfficial?: boolean;
     highlightedOnly?: boolean;
+    createdAfter?: number;
     category?: string;
     topic?: string;
     excludedScanStatuses?: Array<(typeof PACKAGE_SCAN_STATUS_VALUES)[number]>;
@@ -1196,6 +1197,7 @@ async function searchPackageCatalog(
       channel: args.channel,
       isOfficial: args.isOfficial,
       highlightedOnly: args.highlightedOnly,
+      createdAfter: args.createdAfter,
       category: args.category,
       topic: args.topic,
       excludedScanStatuses: args.excludedScanStatuses,
@@ -3587,6 +3589,14 @@ async function searchPackages(
   const highlightedOnlyParam = parseBooleanQueryParam(url.searchParams, "highlightedOnly");
   if (!highlightedOnlyParam.ok) return text(highlightedOnlyParam.message, 400, rate.headers);
   const highlightedOnly = featured.value === true || highlightedOnlyParam.value === true;
+  const rawCreatedAfter = url.searchParams.get("createdAfter")?.trim();
+  const createdAfter = rawCreatedAfter ? Number(rawCreatedAfter) : undefined;
+  if (
+    rawCreatedAfter &&
+    (createdAfter === undefined || !Number.isSafeInteger(createdAfter) || createdAfter < 0)
+  ) {
+    return text("Invalid createdAfter", 400, rate.headers);
+  }
   const rawCategory = url.searchParams.get("category")?.trim() || undefined;
   const category = resolvePluginCategoryFilter(rawCategory);
   const topic = url.searchParams.get("topic")?.trim().toLowerCase() || undefined;
@@ -3605,6 +3615,12 @@ async function searchPackages(
       400,
       rate.headers,
     );
+  }
+  if (
+    createdAfter !== undefined &&
+    (family === "skill" || family === "claw" || (!family && includeSkills))
+  ) {
+    return text("createdAfter is only supported for plugin package endpoints", 400, rate.headers);
   }
 
   let results: CatalogSearchEntry[];
@@ -3632,6 +3648,7 @@ async function searchPackages(
             channel: channelParam.value,
             isOfficial: isOfficial.value,
             highlightedOnly: highlightedOnly || undefined,
+            createdAfter,
             category,
             topic,
             excludedScanStatuses: excludedScanStatuses.value,
@@ -3658,6 +3675,7 @@ async function searchPackages(
         channel: channelParam.value,
         isOfficial: isOfficial.value,
         highlightedOnly: highlightedOnly || undefined,
+        createdAfter,
         category,
         topic,
         excludedScanStatuses: excludedScanStatuses.value,
@@ -3672,6 +3690,7 @@ async function searchPackages(
         channel: channelParam.value,
         isOfficial: isOfficial.value,
         highlightedOnly: highlightedOnly || undefined,
+        createdAfter,
         category,
         topic,
         excludedScanStatuses: excludedScanStatuses.value,

--- a/convex/packages.public.test.ts
+++ b/convex/packages.public.test.ts
@@ -387,6 +387,7 @@ const searchPublicHandler = (
       capabilityTag?: string;
       category?: string;
       topic?: string;
+      createdAfter?: number;
       excludedScanStatuses?: Array<"clean" | "suspicious" | "malicious" | "pending" | "not-run">;
     },
     Array<{ package: { name: string } }>
@@ -404,6 +405,7 @@ const searchForViewerInternalHandler = (
       capabilityTag?: string;
       category?: string;
       topic?: string;
+      createdAfter?: number;
       excludedScanStatuses?: Array<"clean" | "suspicious" | "malicious" | "pending" | "not-run">;
       viewerUserId?: string;
     },
@@ -18891,5 +18893,45 @@ describe("restorePackageInternal", () => {
       if (previous === undefined) delete process.env.CLAWHUB_EXPERIMENTAL_CLAWS;
       else process.env.CLAWHUB_EXPERIMENTAL_CLAWS = previous;
     }
+  });
+
+  it("continues past older search hits to find a later eligible New plugin", async () => {
+    const olderMatches = Array.from({ length: 50 }, (_, index) =>
+      makeDigest(`matching-old-${index}`, {
+        family: "code-plugin",
+        displayName: `Matching Old ${index}`,
+        createdAt: 10,
+      }),
+    );
+    const { ctx, paginate } = makeDigestCtx({
+      pages: [
+        {
+          page: olderMatches,
+          isDone: false,
+          continueCursor: "after-older",
+        },
+        {
+          page: [
+            makeDigest("matching-new", {
+              family: "code-plugin",
+              displayName: "Matching New",
+              createdAt: 200,
+            }),
+          ],
+          isDone: true,
+          continueCursor: "",
+        },
+      ],
+    });
+
+    const result = await searchPublicHandler(ctx, {
+      query: "matching",
+      family: "code-plugin",
+      limit: 1,
+      createdAfter: 100,
+    });
+
+    expect(result.map((entry) => entry.package.name)).toEqual(["matching-new"]);
+    expect(paginate).toHaveBeenCalledTimes(2);
   });
 });

--- a/convex/packages.ts
+++ b/convex/packages.ts
@@ -1389,6 +1389,7 @@ function digestMatchesFilters(
   args: {
     category?: string;
     topic?: string;
+    createdAfter?: number;
     excludedScanStatuses?: PackageListScanStatus[];
   },
 ) {
@@ -1404,6 +1405,7 @@ function digestMatchesFilters(
   if (args.topic && !getCatalogTopicSlugs(digest.topics).includes(args.topic)) {
     return false;
   }
+  if (args.createdAfter !== undefined && digest.createdAt < args.createdAfter) return false;
   return true;
 }
 
@@ -1416,6 +1418,7 @@ function digestMatchesSearchFilters(
     isOfficial?: boolean;
     category?: string;
     topic?: string;
+    createdAfter?: number;
     excludedScanStatuses?: PackageListScanStatus[];
   },
 ) {
@@ -4803,6 +4806,7 @@ export const searchPublic = query({
     highlightedOnly: v.optional(v.boolean()),
     category: v.optional(v.string()),
     topic: v.optional(v.string()),
+    createdAfter: v.optional(v.number()),
     excludedScanStatuses: v.optional(v.array(packageListScanStatusValidator)),
   },
   handler: async (ctx, args) => {
@@ -4829,6 +4833,7 @@ export const searchForViewerInternal = internalQuery({
     highlightedOnly: v.optional(v.boolean()),
     category: v.optional(v.string()),
     topic: v.optional(v.string()),
+    createdAfter: v.optional(v.number()),
     excludedScanStatuses: v.optional(v.array(packageListScanStatusValidator)),
     viewerUserId: v.optional(v.id("users")),
   },
@@ -4848,6 +4853,7 @@ async function searchPackagesImpl(
     highlightedOnly?: boolean;
     category?: string;
     topic?: string;
+    createdAfter?: number;
     excludedScanStatuses?: PackageListScanStatus[];
     viewerUserId?: Id<"users">;
   },
@@ -4872,6 +4878,9 @@ async function searchPackagesImpl(
     });
     const entries = highlightedEntries
       .filter(({ digest }) => isClawFamilyPubliclyVisible(digest.family))
+      .filter(({ digest }) =>
+        args.createdAfter === undefined ? true : digest.createdAt >= args.createdAfter,
+      )
       .filter(
         ({ digest }) =>
           !digest.scanStatus || !args.excludedScanStatuses?.includes(digest.scanStatus),
@@ -4972,7 +4981,7 @@ async function searchPackagesImpl(
       }
     };
 
-    if (topic && category) {
+    if ((topic && category) || args.createdAfter !== undefined) {
       const scanStates = searchFamilies.map((family) => ({
         family,
         cursor: null as string | null,

--- a/convex/search.test.ts
+++ b/convex/search.test.ts
@@ -29,6 +29,7 @@ vi.mock("./lib/embeddings", () => ({
 vi.mock("./lib/badges", () => ({
   isSkillHighlighted: (skill: { badges?: Record<string, unknown> }) =>
     Boolean(skill.badges?.highlighted),
+  isSkillOfficial: (skill: { badges?: Record<string, unknown> }) => Boolean(skill.badges?.official),
 }));
 
 type WrappedHandler<Result = { skill: { slug: string; _id: string } }> = {
@@ -2993,6 +2994,106 @@ describe("search helpers", () => {
 
     expect(result.map((entry) => entry.skill.slug)).toEqual(["search-term-clean"]);
   });
+
+  it("keeps a later official hit when higher-ranked hits are ineligible", async () => {
+    generateEmbeddingMock.mockRejectedValueOnce(new Error("embedding unavailable"));
+    const matches = [
+      {
+        skill: makePublicSkill({
+          id: "skills:exact-community",
+          slug: "helper",
+          displayName: "Helper",
+        }),
+        version: null,
+        ownerHandle: "community",
+        owner: null,
+      },
+      {
+        skill: makePublicSkill({
+          id: "skills:community",
+          slug: "helper-community",
+          displayName: "Helper Community",
+        }),
+        version: null,
+        ownerHandle: "community",
+        owner: null,
+      },
+      {
+        skill: makePublicSkill({
+          id: "skills:official",
+          slug: "helper-official",
+          displayName: "Helper Official",
+          official: true,
+        }),
+        version: null,
+        ownerHandle: "official",
+        owner: null,
+      },
+    ];
+    const runQuery = vi
+      .fn()
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce(matches)
+      .mockResolvedValueOnce([]);
+
+    const result = await searchSkillsHandler(
+      { vectorSearch: vi.fn(), runQuery },
+      { query: "helper", limit: 1, officialOnly: true },
+    );
+
+    expect(result.map((entry) => entry.skill.slug)).toEqual(["helper-official"]);
+  });
+
+  it("keeps a later new hit when higher-ranked hits predate the window", async () => {
+    generateEmbeddingMock.mockRejectedValueOnce(new Error("embedding unavailable"));
+    const matches = [
+      {
+        skill: makePublicSkill({
+          id: "skills:exact-old",
+          slug: "helper",
+          displayName: "Helper",
+          createdAt: 10,
+        }),
+        version: null,
+        ownerHandle: "owner",
+        owner: null,
+      },
+      {
+        skill: makePublicSkill({
+          id: "skills:older",
+          slug: "helper-older",
+          displayName: "Helper Older",
+          createdAt: 20,
+        }),
+        version: null,
+        ownerHandle: "owner",
+        owner: null,
+      },
+      {
+        skill: makePublicSkill({
+          id: "skills:new",
+          slug: "helper-new",
+          displayName: "Helper New",
+          createdAt: 200,
+        }),
+        version: null,
+        ownerHandle: "owner",
+        owner: null,
+      },
+    ];
+    const runQuery = vi
+      .fn()
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce(matches)
+      .mockResolvedValueOnce([]);
+
+    const result = await searchSkillsHandler(
+      { vectorSearch: vi.fn(), runQuery },
+      { query: "helper", limit: 1, createdAfter: 100 },
+    );
+
+    expect(result.map((entry) => entry.skill.slug)).toEqual(["helper-new"]);
+  });
 });
 
 function makePublicSkill(params: {
@@ -3007,8 +3108,12 @@ function makePublicSkill(params: {
   stars?: number;
   categories?: string[];
   topics?: string[];
+  official?: boolean;
+  createdAt?: number;
   githubScanStatus?: "pending" | "clean" | "suspicious" | "malicious" | "not-run";
 }) {
+  const badges: Record<string, { byUserId: string; at: number }> = {};
+  if (params.official) badges.official = { byUserId: "users:curator", at: 1 };
   return {
     _id: params.id,
     _creationTime: 1,
@@ -3025,7 +3130,7 @@ function makePublicSkill(params: {
     categories: params.categories,
     topics: params.topics,
     githubScanStatus: params.githubScanStatus,
-    badges: {},
+    badges,
     stats: {
       downloads: params.downloads ?? 0,
       installs: params.installs ?? 0,
@@ -3033,7 +3138,7 @@ function makePublicSkill(params: {
       versions: 1,
       comments: 0,
     },
-    createdAt: 1,
+    createdAt: params.createdAt ?? 1,
     updatedAt: 1,
   };
 }

--- a/convex/search.ts
+++ b/convex/search.ts
@@ -11,7 +11,7 @@ import { internal } from "./_generated/api";
 import type { Doc, Id } from "./_generated/dataModel";
 import type { ActionCtx, QueryCtx } from "./_generated/server";
 import { action, internalQuery } from "./functions";
-import { isSkillHighlighted } from "./lib/badges";
+import { isSkillHighlighted, isSkillOfficial } from "./lib/badges";
 import {
   classifyCanonicalSkillSearchMatch,
   compareCanonicalSkillSearchCandidates,
@@ -267,6 +267,16 @@ function matchesCatalogFilters(
   );
 }
 
+function matchesNativeSearchEligibility(
+  skill: Pick<HydratableSkill, "badges" | "createdAt">,
+  args: Pick<SkillSearchArgs, "officialOnly" | "createdAfter">,
+) {
+  return (
+    (!args.officialOnly || isSkillOfficial(skill)) &&
+    (args.createdAfter === undefined || skill.createdAt >= args.createdAfter)
+  );
+}
+
 function toPublicSearchSkill(skill: HydratableSkill) {
   if (shouldExcludeSkillFromPublicBrowse(skill)) return null;
   return toPublicSkill({
@@ -317,6 +327,12 @@ const skillSearchArgs = {
   topic: v.optional(v.string()),
 };
 
+const nativeSkillSearchArgs = {
+  ...skillSearchArgs,
+  officialOnly: v.optional(v.boolean()),
+  createdAfter: v.optional(v.number()),
+};
+
 type SkillSearchArgs = {
   query: string;
   limit?: number;
@@ -326,6 +342,8 @@ type SkillSearchArgs = {
   excludePendingScan?: boolean;
   categorySlug?: string;
   topic?: string;
+  officialOnly?: boolean;
+  createdAfter?: number;
 };
 
 const nativeSkillSearch = {
@@ -349,13 +367,16 @@ const nativeSkillSearch = {
             nonSuspiciousOnly: args.nonSuspiciousOnly,
             categorySlug,
             topic,
+            officialOnly: args.officialOnly,
+            createdAfter: args.createdAfter,
           })) as SkillSearchEntry[])
         : [];
       return exactSlugMatches
         .filter(
           (entry) =>
             (!args.highlightedOnly || isSkillHighlighted(entry.skill)) &&
-            (!args.excludePendingScan || entry.skill.githubScanStatus !== "pending"),
+            (!args.excludePendingScan || entry.skill.githubScanStatus !== "pending") &&
+            matchesNativeSearchEligibility(entry.skill, args),
         )
         .sort(compareSkillTrust)
         .slice(0, exactLimit)
@@ -371,6 +392,8 @@ const nativeSkillSearch = {
           nonSuspiciousOnly: args.nonSuspiciousOnly,
           categorySlug,
           topic,
+          officialOnly: args.officialOnly,
+          createdAfter: args.createdAfter,
         })) as SkillSearchEntry[] | SkillSearchEntry | null)
       : [];
     const exactSlugMatches = (
@@ -382,7 +405,8 @@ const nativeSkillSearch = {
     ).filter(
       (entry) =>
         (!args.highlightedOnly || isSkillHighlighted(entry.skill)) &&
-        (!args.excludePendingScan || entry.skill.githubScanStatus !== "pending"),
+        (!args.excludePendingScan || entry.skill.githubScanStatus !== "pending") &&
+        matchesNativeSearchEligibility(entry.skill, args),
     );
     const directPrefixMatches = (
       (await ctx.runQuery(internal.search.directPrefixSkillMatches, {
@@ -391,8 +415,14 @@ const nativeSkillSearch = {
         nonSuspiciousOnly: args.nonSuspiciousOnly,
         categorySlug,
         topic,
+        officialOnly: args.officialOnly,
+        createdAfter: args.createdAfter,
       })) as SkillSearchEntry[]
-    ).filter((entry) => !args.excludePendingScan || entry.skill.githubScanStatus !== "pending");
+    ).filter(
+      (entry) =>
+        (!args.excludePendingScan || entry.skill.githubScanStatus !== "pending") &&
+        matchesNativeSearchEligibility(entry.skill, args),
+    );
     let vector: number[] | null;
     try {
       vector = await generateEmbedding(query);
@@ -437,6 +467,8 @@ const nativeSkillSearch = {
             nonSuspiciousOnly: args.nonSuspiciousOnly,
             categorySlug,
             topic,
+            officialOnly: args.officialOnly,
+            createdAfter: args.createdAfter,
           })) as SkillSearchEntry[];
           hydrated = [...hydrated, ...newEntries];
         }
@@ -456,7 +488,8 @@ const nativeSkillSearch = {
         const filtered = hydrated.filter(
           (entry) =>
             (!args.highlightedOnly || isSkillHighlighted(entry.skill)) &&
-            (!args.excludePendingScan || entry.skill.githubScanStatus !== "pending"),
+            (!args.excludePendingScan || entry.skill.githubScanStatus !== "pending") &&
+            matchesNativeSearchEligibility(entry.skill, args),
         );
 
         exactMatches = filtered.filter((entry) =>
@@ -501,11 +534,14 @@ const nativeSkillSearch = {
             skipExactSlugLookup: true,
             categorySlug,
             topic,
+            officialOnly: args.officialOnly,
+            createdAfter: args.createdAfter,
           })) as SkillSearchEntry[]);
     const mergedMatches = mergeUniqueBySkillId(primaryMatches, fallbackMatches).filter(
       (entry) =>
         matchesCatalogFilters(entry.skill, categorySlug, topic) &&
-        (!args.excludePendingScan || entry.skill.githubScanStatus !== "pending"),
+        (!args.excludePendingScan || entry.skill.githubScanStatus !== "pending") &&
+        matchesNativeSearchEligibility(entry.skill, args),
     );
 
     const rankedMatches = mergedMatches
@@ -554,7 +590,7 @@ const nativeSkillSearch = {
 };
 
 export const searchNativeSkills: ReturnType<typeof action> = action({
-  args: skillSearchArgs,
+  args: nativeSkillSearchArgs,
   handler: async (ctx, args) => nativeSkillSearch.handler(ctx, args),
 });
 
@@ -909,6 +945,8 @@ export const getExactSkillSlugMatch = internalQuery({
     highlightedOnly: v.optional(v.boolean()),
     categorySlug: v.optional(v.string()),
     topic: v.optional(v.string()),
+    officialOnly: v.optional(v.boolean()),
+    createdAfter: v.optional(v.number()),
   },
   handler: async (ctx, args): Promise<SkillSearchEntry[]> => {
     const categorySlug = normalizeSkillCategoryFilter(args.categorySlug);
@@ -927,6 +965,7 @@ export const getExactSkillSlugMatch = internalQuery({
         if (args.nonSuspiciousOnly && isSkillSuspicious(skill)) return null;
         if (args.highlightedOnly && !isSkillHighlighted(skill)) return null;
         if (!matchesCatalogFilters(skill, categorySlug, topic)) return null;
+        if (!matchesNativeSearchEligibility(skill, args)) return null;
         if (!(await hasResolvablePublicBrowseVersionFromState(ctx, skill, undefined))) return null;
 
         const resolved = await getOwnerInfo(skill.ownerUserId, skill.ownerPublisherId);
@@ -1170,6 +1209,8 @@ export const directPrefixSkillMatches = internalQuery({
     nonSuspiciousOnly: v.optional(v.boolean()),
     categorySlug: v.optional(v.string()),
     topic: v.optional(v.string()),
+    officialOnly: v.optional(v.boolean()),
+    createdAfter: v.optional(v.number()),
   },
   handler: async (ctx, args): Promise<SkillSearchEntry[]> => {
     const categorySlug = normalizeSkillCategoryFilter(args.categorySlug);
@@ -1198,12 +1239,18 @@ export const directPrefixSkillMatches = internalQuery({
       return (
         !shouldExcludeSkillFromPublicBrowse(skill) &&
         (!args.highlightedOnly || isSkillHighlighted(skill)) &&
+        matchesNativeSearchEligibility(skill, args) &&
         passesAllQueryTokens(digest) &&
         matchesCatalogFilters(skill, categorySlug, topic)
       );
     };
     const needsExpandedRecall = Boolean(
-      categorySlug || topic || args.highlightedOnly || queryTokens.length > 1,
+      categorySlug ||
+      topic ||
+      args.highlightedOnly ||
+      args.officialOnly ||
+      args.createdAfter !== undefined ||
+      queryTokens.length > 1,
     );
     const directScanLimit = (candidateLimit: number) =>
       needsExpandedRecall ? MAX_FILTERED_DIRECT_SKILL_SCAN_CANDIDATES : candidateLimit;
@@ -1452,6 +1499,7 @@ export const directPrefixSkillMatches = internalQuery({
         const skill = digestToHydratableSkill(digest);
         if (args.nonSuspiciousOnly && isSkillSuspicious(skill)) return null;
         if (args.highlightedOnly && !isSkillHighlighted(skill)) return null;
+        if (!matchesNativeSearchEligibility(skill, args)) return null;
         if (!matchesCatalogFilters(skill, categorySlug, topic)) return null;
         if (!(await hasResolvablePublicBrowseVersionFromState(ctx, skill, digest.publicVersion))) {
           return null;
@@ -1481,6 +1529,8 @@ export const hydrateResults = internalQuery({
     nonSuspiciousOnly: v.optional(v.boolean()),
     categorySlug: v.optional(v.string()),
     topic: v.optional(v.string()),
+    officialOnly: v.optional(v.boolean()),
+    createdAfter: v.optional(v.number()),
   },
   handler: async (ctx, args): Promise<SkillSearchEntry[]> => {
     const categorySlug = normalizeSkillCategoryFilter(args.categorySlug);
@@ -1513,6 +1563,7 @@ export const hydrateResults = internalQuery({
         if (!skill || skill.softDeletedAt) return null;
         if (args.nonSuspiciousOnly && isSkillSuspicious(skill)) return null;
         if (!matchesCatalogFilters(skill, categorySlug, topic)) return null;
+        if (!matchesNativeSearchEligibility(skill, args)) return null;
         // Use pre-resolved owner from digest to avoid reading the users table.
         // Fall back to live lookup when digest owner is null (deactivated/deleted user).
         const preResolved = digest ? digestToOwnerInfo(digest) : null;
@@ -1555,6 +1606,8 @@ export const lexicalFallbackSkills = internalQuery({
     skipExactSlugLookup: v.optional(v.boolean()),
     categorySlug: v.optional(v.string()),
     topic: v.optional(v.string()),
+    officialOnly: v.optional(v.boolean()),
+    createdAfter: v.optional(v.number()),
   },
   handler: async (ctx, args): Promise<SkillSearchEntry[]> => {
     const categorySlug = normalizeSkillCategoryFilter(args.categorySlug);
@@ -1588,6 +1641,7 @@ export const lexicalFallbackSkills = internalQuery({
           !shouldExcludeSkillFromPublicBrowse(exactSlugSkill) &&
           (!args.nonSuspiciousOnly || !isSkillSuspicious(exactSlugSkill)) &&
           (!args.excludePendingScan || exactSlugSkill.githubScanStatus !== "pending") &&
+          matchesNativeSearchEligibility(exactSlugSkill, args) &&
           matchesCatalogFilters(exactSlugSkill, categorySlug, topic)
         ) {
           seenSkillIds.add(exactSlugSkill._id);
@@ -1625,13 +1679,20 @@ export const lexicalFallbackSkills = internalQuery({
             .order("desc");
 
     const filteredScanLimit =
-      categorySlug || topic || args.highlightedOnly ? FALLBACK_SCAN_LIMIT : scanLimit;
+      categorySlug ||
+      topic ||
+      args.highlightedOnly ||
+      args.officialOnly ||
+      args.createdAfter !== undefined
+        ? FALLBACK_SCAN_LIMIT
+        : scanLimit;
     const matchesFallbackRecallFilters = (digest: Doc<"skillSearchDigest">) => {
       const skill = digestToHydratableSkill(digest);
       return (
         !shouldExcludeSkillFromPublicBrowse(skill) &&
         (!args.highlightedOnly || isSkillHighlighted(skill)) &&
         (!args.excludePendingScan || skill.githubScanStatus !== "pending") &&
+        matchesNativeSearchEligibility(skill, args) &&
         matchesCatalogFilters(skill, categorySlug, topic) &&
         matchesExactTokens(args.queryTokens, [
           skill.displayName,
@@ -1661,6 +1722,7 @@ export const lexicalFallbackSkills = internalQuery({
         const skill = digestToHydratableSkill(digest);
         if (args.nonSuspiciousOnly && isSkillSuspicious(skill)) continue;
         if (args.excludePendingScan && skill.githubScanStatus === "pending") continue;
+        if (!matchesNativeSearchEligibility(skill, args)) continue;
         if (!matchesCatalogFilters(skill, categorySlug, topic)) continue;
         seenSkillIds.add(digest.skillId);
         candidates.push(skill);
@@ -1715,9 +1777,11 @@ export const lexicalFallbackSkills = internalQuery({
     const validEntries = entries.filter(Boolean) as SkillSearchEntry[];
     if (validEntries.length === 0) return [];
 
-    const filtered = args.highlightedOnly
-      ? validEntries.filter((entry) => isSkillHighlighted(entry.skill))
-      : validEntries;
+    const filtered = validEntries.filter(
+      (entry) =>
+        (!args.highlightedOnly || isSkillHighlighted(entry.skill)) &&
+        matchesNativeSearchEligibility(entry.skill, args),
+    );
     return filtered.slice(0, limit);
   },
 });

--- a/src/__tests__/home-listing-section.claw591.test.tsx
+++ b/src/__tests__/home-listing-section.claw591.test.tsx
@@ -206,6 +206,61 @@ describe("HomeListingSection", () => {
     expect(screen.getByLabelText("Source").textContent).toBe("skills.sh");
   });
 
+  it("searches within the canonical Trending feed without changing source or order", async () => {
+    const unrelated = makeTrending("unrelated", "Unrelated Skill", 5, 100, 5);
+    const external = {
+      ...makeTrending("calendar-external", "Calendar External", 0, 90, 0),
+      id: "skills-sh:example/calendar-external",
+      source: "skills-sh" as const,
+      canonicalUrl: "/skills-sh/example/calendar-external",
+      publisher: null,
+      sourceIdentity: {
+        id: "example/calendar-external",
+        owner: "example",
+        repo: "skills",
+        host: null,
+        lifetimeInstalls: 90,
+      },
+    };
+    const native = makeTrending("calendar-native", "Calendar Native", 3, 80, 3);
+    fetchCanonicalTrendingPageMock
+      .mockResolvedValueOnce(canonicalPage([unrelated], "trending-page-2"))
+      .mockResolvedValueOnce(canonicalPage([external, native]));
+
+    render(
+      <TooltipProvider>
+        <HomeListingSection initialListing={initialTrending([unrelated], true)} />
+      </TooltipProvider>,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Search catalog" }));
+    fireEvent.change(screen.getByRole("searchbox", { name: "Search skills" }), {
+      target: { value: "calendar" },
+    });
+
+    await waitFor(() => {
+      expect(
+        Array.from(
+          document.querySelectorAll(".home-v2-listing-row-name"),
+          (node) => node.textContent,
+        ),
+      ).toEqual(["Calendar External", "Calendar Native"]);
+    });
+    expect(fetchCanonicalTrendingPageMock).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ cursor: null }),
+    );
+    expect(fetchCanonicalTrendingPageMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ cursor: "trending-page-2" }),
+    );
+    expect(convexActionMock).not.toHaveBeenCalled();
+    expect(screen.getByText("skills.sh")).toBeTruthy();
+    expect(screen.getByRole("tab", { name: "Trending" }).getAttribute("aria-selected")).toBe(
+      "true",
+    );
+    expect(screen.queryByRole("combobox", { name: "Category" })).toBeNull();
+  });
+
   it("hides unavailable Trending and falls back to the Featured feed", async () => {
     render(<HomeListingSection initialListing={initialTrending([], false, "unavailable")} />);
 

--- a/src/__tests__/home-listing-section.claw591.test.tsx
+++ b/src/__tests__/home-listing-section.claw591.test.tsx
@@ -302,7 +302,9 @@ describe("HomeListingSection", () => {
         expect.objectContaining({ sort: "newest", createdAfter: expect.any(Number) }),
       );
     });
-    expect(screen.queryByRole("combobox", { name: "Category" })).toBeNull();
+    expect(screen.getByRole("combobox", { name: "Category" }).textContent).toContain(
+      "All categories",
+    );
 
     fireEvent.click(screen.getByRole("tab", { name: "Featured" }));
     await waitFor(() => {

--- a/src/__tests__/home-listing-section.test.tsx
+++ b/src/__tests__/home-listing-section.test.tsx
@@ -142,11 +142,15 @@ describe("HomeListingSection", () => {
 
     const toolbar = document.querySelector(".home-v2-listing-toolbar");
     const primary = document.querySelector(".home-v2-listing-primary");
+    const divider = document.querySelector(".home-v2-listing-divider");
     const catalogTabs = screen.getByRole("tablist", { name: "Catalog view" });
     const contentType = screen.getByRole("group", { name: "Content type" });
     const contentTypeButtons = contentType.querySelectorAll("button");
     expect(toolbar?.firstElementChild).toBe(primary);
     expect(primary?.firstElementChild).toBe(contentType);
+    expect(contentType.nextElementSibling).toBe(divider);
+    expect(divider?.getAttribute("aria-hidden")).toBe("true");
+    expect(divider?.nextElementSibling?.contains(catalogTabs)).toBe(true);
     expect(primary?.lastElementChild?.contains(catalogTabs)).toBe(true);
     expect(toolbar?.lastElementChild?.classList.contains("home-v2-listing-actions")).toBe(true);
     expect(Array.from(contentTypeButtons, (button) => button.textContent)).toEqual([

--- a/src/__tests__/home-listing-section.test.tsx
+++ b/src/__tests__/home-listing-section.test.tsx
@@ -310,6 +310,25 @@ describe("HomeListingSection", () => {
     );
   });
 
+  it("passes New plugin eligibility into catalog search", async () => {
+    render(<HomeListingSection initialListing={initialPluginListing()} />);
+    fireEvent.click(screen.getByRole("tab", { name: "New" }));
+    fireEvent.click(screen.getByRole("button", { name: "Search catalog" }));
+    fireEvent.change(screen.getByRole("searchbox", { name: "Search plugins" }), {
+      target: { value: "calendar" },
+    });
+
+    await waitFor(() => {
+      expect(fetchPluginCatalogMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          q: "calendar",
+          createdAfter: expect.any(Number),
+          limit: 20,
+        }),
+      );
+    });
+  });
+
   it("clears and hides the category filter when Trending is selected", async () => {
     render(<HomeListingSection initialListing={initialPluginListing()} />);
     fireEvent.click(screen.getByRole("button", { name: "Skills" }));

--- a/src/__tests__/home-listing-section.test.tsx
+++ b/src/__tests__/home-listing-section.test.tsx
@@ -142,7 +142,7 @@ describe("HomeListingSection", () => {
 
     const toolbar = document.querySelector(".home-v2-listing-toolbar");
     const primary = document.querySelector(".home-v2-listing-primary");
-    const divider = document.querySelector(".home-v2-listing-divider");
+    const divider = document.querySelector(".browse-controls-divider");
     const catalogTabs = screen.getByRole("tablist", { name: "Catalog view" });
     const contentType = screen.getByRole("group", { name: "Content type" });
     const contentTypeButtons = contentType.querySelectorAll("button");

--- a/src/__tests__/home-listing-section.test.tsx
+++ b/src/__tests__/home-listing-section.test.tsx
@@ -137,15 +137,18 @@ describe("HomeListingSection", () => {
     });
   });
 
-  it("renders listing tabs left, content tabs right, and only the list presentation", async () => {
+  it("renders kind and its tabs on the left, secondary controls on the right, and only lists", async () => {
     render(<HomeListingSection initialListing={initialPluginListing()} />);
 
     const toolbar = document.querySelector(".home-v2-listing-toolbar");
-    const sortTabs = screen.getByRole("tablist", { name: "Sort" });
+    const primary = document.querySelector(".home-v2-listing-primary");
+    const catalogTabs = screen.getByRole("tablist", { name: "Catalog view" });
     const contentType = screen.getByRole("group", { name: "Content type" });
     const contentTypeButtons = contentType.querySelectorAll("button");
-    expect(toolbar?.firstElementChild?.contains(sortTabs)).toBe(true);
-    expect(toolbar?.lastElementChild).toBe(contentType);
+    expect(toolbar?.firstElementChild).toBe(primary);
+    expect(primary?.firstElementChild).toBe(contentType);
+    expect(primary?.lastElementChild?.contains(catalogTabs)).toBe(true);
+    expect(toolbar?.lastElementChild?.classList.contains("home-v2-listing-actions")).toBe(true);
     expect(Array.from(contentTypeButtons, (button) => button.textContent)).toEqual([
       "Skills",
       "Plugins",
@@ -227,6 +230,45 @@ describe("HomeListingSection", () => {
     expect(screen.getByRole("tab", { name: "Featured" }).getAttribute("aria-selected")).toBe(
       "true",
     );
+  });
+
+  it("passes Official and New skill eligibility into native search", async () => {
+    convexActionMock.mockResolvedValue([]);
+    const { unmount } = render(<HomeListingSection initialListing={initialPluginListing()} />);
+    fireEvent.click(screen.getByRole("button", { name: "Skills" }));
+    fireEvent.click(screen.getByRole("tab", { name: "Official" }));
+    fireEvent.click(screen.getByRole("button", { name: "Search catalog" }));
+    fireEvent.change(screen.getByRole("searchbox", { name: "Search skills" }), {
+      target: { value: "official" },
+    });
+
+    await waitFor(() => {
+      expect(convexActionMock).toHaveBeenCalledWith(
+        "search:searchNativeSkills",
+        expect.objectContaining({ query: "official", limit: 20, officialOnly: true }),
+      );
+    });
+
+    unmount();
+    convexActionMock.mockClear();
+    render(<HomeListingSection initialListing={initialPluginListing()} />);
+    fireEvent.click(screen.getByRole("button", { name: "Skills" }));
+    fireEvent.click(screen.getByRole("tab", { name: "New" }));
+    fireEvent.click(screen.getByRole("button", { name: "Search catalog" }));
+    fireEvent.change(screen.getByRole("searchbox", { name: "Search skills" }), {
+      target: { value: "recent" },
+    });
+
+    await waitFor(() => {
+      expect(convexActionMock).toHaveBeenCalledWith(
+        "search:searchNativeSkills",
+        expect.objectContaining({
+          query: "recent",
+          limit: 20,
+          createdAfter: expect.any(Number),
+        }),
+      );
+    });
   });
 
   it("searches plugins within the selected tab and category", async () => {

--- a/src/__tests__/home-listing-section.test.tsx
+++ b/src/__tests__/home-listing-section.test.tsx
@@ -333,6 +333,44 @@ describe("HomeListingSection", () => {
     });
   });
 
+  it("clears a pending search load-more state when search closes", async () => {
+    type PluginResult = {
+      items: (typeof featuredPlugin)[];
+      nextCursor: string | null;
+    };
+    let resolveExpanded!: (result: PluginResult) => void;
+    const expandedResult = new Promise<PluginResult>((resolve) => {
+      resolveExpanded = resolve;
+    });
+    const searchItems = Array.from({ length: 20 }, (_, index) => ({
+      ...featuredPlugin,
+      name: `demo-plugin-${index}`,
+      displayName: `Demo Plugin ${index}`,
+    }));
+    fetchPluginCatalogMock.mockImplementation((args: { limit?: number }) =>
+      args.limit === 40
+        ? expandedResult
+        : Promise.resolve({ items: searchItems, nextCursor: "more" }),
+    );
+
+    render(<HomeListingSection initialListing={{ ...initialPluginListing(), hasMore: true }} />);
+    fireEvent.click(screen.getByRole("button", { name: "Search catalog" }));
+    fireEvent.change(screen.getByRole("searchbox", { name: "Search plugins" }), {
+      target: { value: "demo" },
+    });
+
+    const loadMore = await screen.findByRole("button", { name: "Load more" });
+    fireEvent.click(loadMore);
+    await screen.findByRole("button", { name: "Loading…" });
+    fireEvent.click(screen.getByRole("button", { name: "Close search" }));
+
+    const restoredLoadMore = await screen.findByRole("button", { name: "Load more" });
+    expect(restoredLoadMore.hasAttribute("disabled")).toBe(false);
+    expect(screen.getByText("Demo Plugin")).toBeTruthy();
+
+    resolveExpanded({ items: searchItems, nextCursor: null });
+  });
+
   it("clears and hides the category filter when Trending is selected", async () => {
     render(<HomeListingSection initialListing={initialPluginListing()} />);
     fireEvent.click(screen.getByRole("button", { name: "Skills" }));

--- a/src/__tests__/home-listing-section.test.tsx
+++ b/src/__tests__/home-listing-section.test.tsx
@@ -161,8 +161,10 @@ describe("HomeListingSection", () => {
       "Official",
       "New",
     ]);
-    expect(screen.queryByRole("button", { name: "Search catalog" })).toBeNull();
-    expect(screen.queryByRole("combobox", { name: "Category" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Search catalog" })).toBeTruthy();
+    expect(screen.getByRole("combobox", { name: "Category" }).textContent).toContain(
+      "All categories",
+    );
     expect(screen.queryByRole("button", { name: "List view" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Grid view" })).toBeNull();
     expect(screen.getByText("Demo Plugin")).toBeTruthy();
@@ -186,6 +188,101 @@ describe("HomeListingSection", () => {
     expect(loadingResults.querySelector(".browse-results-skeleton-icon")).toBeNull();
     expect(loadingResults.querySelector(".browse-list-head-icon-spacer")).toBeNull();
     expect(loadingResults.querySelectorAll(".skill-list-item-no-icon")).toHaveLength(6);
+  });
+
+  it("searches skills within the selected tab and category", async () => {
+    convexActionMock.mockResolvedValue([
+      {
+        skill: {
+          _id: "skills:featured-development",
+          slug: "featured-development",
+          displayName: "Featured Development Skill",
+          summary: "Builds software.",
+          categories: ["development"],
+          stats: { stars: 1, downloads: 10 },
+        },
+        ownerHandle: "builder",
+      },
+    ]);
+
+    render(<HomeListingSection initialListing={initialPluginListing()} />);
+    fireEvent.click(screen.getByRole("button", { name: "Skills" }));
+    fireEvent.click(screen.getByRole("tab", { name: "Featured" }));
+    fireEvent.click(screen.getByRole("combobox", { name: "Category" }));
+    fireEvent.click(screen.getByRole("radio", { name: "Development" }));
+    fireEvent.click(screen.getByRole("button", { name: "Search catalog" }));
+    fireEvent.change(screen.getByRole("searchbox", { name: "Search skills" }), {
+      target: { value: "development" },
+    });
+
+    await waitFor(() => {
+      expect(convexActionMock).toHaveBeenCalledWith("search:searchNativeSkills", {
+        query: "development",
+        limit: 20,
+        highlightedOnly: true,
+        categorySlug: "development",
+      });
+      expect(screen.getByText("Featured Development Skill")).toBeTruthy();
+    });
+    expect(screen.getByRole("tab", { name: "Featured" }).getAttribute("aria-selected")).toBe(
+      "true",
+    );
+  });
+
+  it("searches plugins within the selected tab and category", async () => {
+    fetchPluginCatalogMock.mockResolvedValue({
+      items: [
+        {
+          ...featuredPlugin,
+          name: "official-channel-plugin",
+          displayName: "Official Channel Plugin",
+          isOfficial: true,
+          categories: ["channels"],
+        },
+      ],
+      nextCursor: null,
+    });
+
+    render(<HomeListingSection initialListing={initialPluginListing()} />);
+    fireEvent.click(screen.getByRole("tab", { name: "Official" }));
+    fireEvent.click(screen.getByRole("combobox", { name: "Category" }));
+    fireEvent.click(screen.getByRole("radio", { name: "Channels" }));
+    fireEvent.click(screen.getByRole("button", { name: "Search catalog" }));
+    fireEvent.change(screen.getByRole("searchbox", { name: "Search plugins" }), {
+      target: { value: "channel" },
+    });
+
+    await waitFor(() => {
+      expect(fetchPluginCatalogMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          q: "channel",
+          category: "channels",
+          isOfficial: true,
+          limit: 20,
+        }),
+      );
+      expect(screen.getByText("Official Channel Plugin")).toBeTruthy();
+    });
+    expect(screen.getByRole("tab", { name: "Official" }).getAttribute("aria-selected")).toBe(
+      "true",
+    );
+  });
+
+  it("clears and hides the category filter when Trending is selected", async () => {
+    render(<HomeListingSection initialListing={initialPluginListing()} />);
+    fireEvent.click(screen.getByRole("button", { name: "Skills" }));
+    fireEvent.click(screen.getByRole("tab", { name: "Featured" }));
+    fireEvent.click(screen.getByRole("combobox", { name: "Category" }));
+    fireEvent.click(screen.getByRole("radio", { name: "Development" }));
+
+    expect(screen.getByRole("combobox", { name: "Category" }).textContent).toContain("Development");
+    fireEvent.click(screen.getByRole("tab", { name: "Trending" }));
+    expect(screen.queryByRole("combobox", { name: "Category" })).toBeNull();
+
+    fireEvent.click(screen.getByRole("tab", { name: "Featured" }));
+    expect(screen.getByRole("combobox", { name: "Category" }).textContent).toContain(
+      "All categories",
+    );
   });
 
   it("previews long skill and plugin names while retaining their full labels", async () => {

--- a/src/__tests__/ui-design-contract.test.ts
+++ b/src/__tests__/ui-design-contract.test.ts
@@ -436,9 +436,9 @@ describe("restored UI design contract", () => {
     expect(homeSource).not.toContain("Trending Now");
     expect(cssRule(css, ".home-v2-listing-toolbar")).toContain("display: flex");
     expect(cssRule(css, ".home-v2-listing-primary")).toContain("display: flex");
-    expect(cssRule(css, ".home-v2-listing-divider")).toContain("width: 1px");
-    expect(cssRule(css, ".home-v2-listing-divider")).toContain("height: 18px");
-    expect(cssRule(css, ".home-v2-listing-divider")).toContain("background: var(--hv2-border)");
+    expect(cssRule(css, ".browse-controls-divider")).toContain("width: 1px");
+    expect(cssRule(css, ".browse-controls-divider")).toContain("height: 18px");
+    expect(cssRule(css, ".browse-controls-divider")).toContain("background: var(--line)");
     expect(cssRule(css, ".home-v2-listing-actions")).toContain("margin-left: auto");
     expect(cssRule(css, ".home-v2-listing-sort-tabs")).toContain("overflow-x: auto");
     const mobileCatalog = cssMediaContaining(css, "(max-width: 768px)", [
@@ -448,7 +448,9 @@ describe("restored UI design contract", () => {
     ]);
     expect(mobileCatalog).toMatch(/\.home-v2-listing-toolbar \{[^}]*flex-direction:\s*column/s);
     expect(mobileCatalog).toMatch(/\.home-v2-listing-primary \{[^}]*flex-direction:\s*column/s);
-    expect(mobileCatalog).toMatch(/\.home-v2-listing-divider \{[^}]*display:\s*none/s);
+    expect(mobileCatalog).toMatch(
+      /\.home-v2-listing-primary > \.browse-controls-divider \{[^}]*display:\s*none/s,
+    );
     expect(mobileCatalog).toMatch(/\.home-v2-listing-actions \{[^}]*width:\s*100%/s);
     expect(cssRule(css, ".home-v2-listing-row::before")).toContain("border-radius: 0");
   });

--- a/src/__tests__/ui-design-contract.test.ts
+++ b/src/__tests__/ui-design-contract.test.ts
@@ -402,8 +402,13 @@ describe("restored UI design contract", () => {
     );
     expect(listingSource).not.toContain("home-v2-listing-view");
     expect(listingSource).not.toContain("HomeListingCategorySelect");
-    expect(listingSource).not.toContain("Search catalog");
+    expect(listingSource).toContain("BrowseSearchTrigger");
+    expect(listingSource).toContain("BrowseCategorySelect");
+    expect(listingSource).toContain('label="Search catalog"');
     expect(listingSource.indexOf('className="home-v2-listing-sort"')).toBeLessThan(
+      listingSource.indexOf('className="home-v2-listing-actions"'),
+    );
+    expect(listingSource.indexOf('className="home-v2-listing-actions"')).toBeLessThan(
       listingSource.indexOf('className="home-v2-listing-kind'),
     );
     expect(appsSource).toContain('className="home-v2-apps-tile"');
@@ -429,7 +434,7 @@ describe("restored UI design contract", () => {
     expect(homeSource).not.toContain("Featured skills");
     expect(homeSource).not.toContain("Trending Now");
     expect(cssRule(css, ".home-v2-listing-toolbar")).toContain("display: flex");
-    expect(cssRule(css, ".home-v2-listing-kind")).toContain("margin-left: auto");
+    expect(cssRule(css, ".home-v2-listing-actions")).toContain("margin-left: auto");
     expect(cssRule(css, ".home-v2-listing-row::before")).toContain("border-radius: 0");
   });
 

--- a/src/__tests__/ui-design-contract.test.ts
+++ b/src/__tests__/ui-design-contract.test.ts
@@ -436,6 +436,9 @@ describe("restored UI design contract", () => {
     expect(homeSource).not.toContain("Trending Now");
     expect(cssRule(css, ".home-v2-listing-toolbar")).toContain("display: flex");
     expect(cssRule(css, ".home-v2-listing-primary")).toContain("display: flex");
+    expect(cssRule(css, ".home-v2-listing-divider")).toContain("width: 1px");
+    expect(cssRule(css, ".home-v2-listing-divider")).toContain("height: 18px");
+    expect(cssRule(css, ".home-v2-listing-divider")).toContain("background: var(--hv2-border)");
     expect(cssRule(css, ".home-v2-listing-actions")).toContain("margin-left: auto");
     expect(cssRule(css, ".home-v2-listing-sort-tabs")).toContain("overflow-x: auto");
     const mobileCatalog = cssMediaContaining(css, "(max-width: 768px)", [
@@ -445,6 +448,7 @@ describe("restored UI design contract", () => {
     ]);
     expect(mobileCatalog).toMatch(/\.home-v2-listing-toolbar \{[^}]*flex-direction:\s*column/s);
     expect(mobileCatalog).toMatch(/\.home-v2-listing-primary \{[^}]*flex-direction:\s*column/s);
+    expect(mobileCatalog).toMatch(/\.home-v2-listing-divider \{[^}]*display:\s*none/s);
     expect(mobileCatalog).toMatch(/\.home-v2-listing-actions \{[^}]*width:\s*100%/s);
     expect(cssRule(css, ".home-v2-listing-row::before")).toContain("border-radius: 0");
   });

--- a/src/__tests__/ui-design-contract.test.ts
+++ b/src/__tests__/ui-design-contract.test.ts
@@ -405,11 +405,12 @@ describe("restored UI design contract", () => {
     expect(listingSource).toContain("BrowseSearchTrigger");
     expect(listingSource).toContain("BrowseCategorySelect");
     expect(listingSource).toContain('label="Search catalog"');
+    expect(listingSource).not.toContain("BrowseSort");
+    expect(listingSource.indexOf('className="home-v2-listing-kind')).toBeLessThan(
+      listingSource.indexOf('className="home-v2-listing-sort"'),
+    );
     expect(listingSource.indexOf('className="home-v2-listing-sort"')).toBeLessThan(
       listingSource.indexOf('className="home-v2-listing-actions"'),
-    );
-    expect(listingSource.indexOf('className="home-v2-listing-actions"')).toBeLessThan(
-      listingSource.indexOf('className="home-v2-listing-kind'),
     );
     expect(appsSource).toContain('className="home-v2-apps-tile"');
     expect(appsSource).toContain('className="home-v2-apps-workflow-header"');
@@ -434,7 +435,17 @@ describe("restored UI design contract", () => {
     expect(homeSource).not.toContain("Featured skills");
     expect(homeSource).not.toContain("Trending Now");
     expect(cssRule(css, ".home-v2-listing-toolbar")).toContain("display: flex");
+    expect(cssRule(css, ".home-v2-listing-primary")).toContain("display: flex");
     expect(cssRule(css, ".home-v2-listing-actions")).toContain("margin-left: auto");
+    expect(cssRule(css, ".home-v2-listing-sort-tabs")).toContain("overflow-x: auto");
+    const mobileCatalog = cssMediaContaining(css, "(max-width: 768px)", [
+      ".home-v2-listing-toolbar {",
+      ".home-v2-listing-primary {",
+      ".home-v2-listing-actions {",
+    ]);
+    expect(mobileCatalog).toMatch(/\.home-v2-listing-toolbar \{[^}]*flex-direction:\s*column/s);
+    expect(mobileCatalog).toMatch(/\.home-v2-listing-primary \{[^}]*flex-direction:\s*column/s);
+    expect(mobileCatalog).toMatch(/\.home-v2-listing-actions \{[^}]*width:\s*100%/s);
     expect(cssRule(css, ".home-v2-listing-row::before")).toContain("border-radius: 0");
   });
 

--- a/src/components/HomeListingSection.tsx
+++ b/src/components/HomeListingSection.tsx
@@ -23,7 +23,6 @@ import { formatCompactStat } from "../lib/numberFormat";
 import { fetchPluginCatalog, type PackageListItem } from "../lib/packageApi";
 import { buildPluginDetailHref } from "../lib/pluginRoutes";
 import { presentationTitle } from "../lib/presentationTitle";
-import type { PublicSkill, PublicUser } from "../lib/publicUser";
 import { PUBLIC_CATALOG_NAME_PREVIEW_LENGTH, truncateText } from "../lib/truncateText";
 import { MarketplaceIcon } from "./MarketplaceIcon";
 import {
@@ -57,12 +56,6 @@ const PLUGIN_LISTING_TABS: Array<{
 const LISTING_PAGE_SIZE = HOME_LISTING_PAGE_SIZE;
 const LISTING_SEARCH_DEBOUNCE_MS = 220;
 const EMPTY_CATEGORY_SLUGS: string[] = [];
-
-type SkillSearchHit = {
-  skill: PublicSkill;
-  ownerHandle?: string | null;
-  owner?: (PublicUser & { official?: boolean }) | null;
-};
 
 function HomeListingEmptyPanel({
   variant,
@@ -491,21 +484,14 @@ export function HomeListingSection({ initialListing = null }: HomeListingSection
                 query: trimmedSearch,
                 limit: fetchLimit,
                 ...(tab === "featured" ? { highlightedOnly: true } : {}),
+                ...(tab === "official" ? { officialOnly: true } : {}),
+                ...(tab === "new" ? { createdAfter: Date.now() - HOME_NEW_WINDOW_MS } : {}),
                 ...(categorySlug ? { categorySlug } : {}),
               })
               .then((hits) => {
                 if (controller.signal.aborted || requestId !== searchRequestRef.current) return;
-                const searchHits = hits as SkillSearchHit[];
-                const newestCutoff = Date.now() - HOME_NEW_WINDOW_MS;
-                const items = searchHits
-                  .filter((hit) => tab !== "official" || Boolean(hit.owner?.official))
-                  .filter((hit) => tab !== "new" || hit.skill.createdAt >= newestCutoff)
-                  .map((hit) => ({
-                    skill: hit.skill,
-                    ownerHandle: hit.ownerHandle,
-                    owner: hit.owner,
-                  }));
-                setSearchSkills(items);
+                const searchHits = hits as HomeNativeSkillListingEntry[];
+                setSearchSkills(searchHits);
                 setListingHasMore(searchHits.length >= fetchLimit);
                 setSearchStatus("idle");
               })
@@ -583,20 +569,49 @@ export function HomeListingSection({ initialListing = null }: HomeListingSection
     >
       <div className="home-v2-listing-controls">
         <div className="home-v2-listing-toolbar">
-          <div className="home-v2-listing-sort">
-            <div className="home-v2-listing-sort-tabs" role="tablist" aria-label="Sort">
-              {visibleTabs.map((item) => (
-                <button
-                  key={item.id}
-                  type="button"
-                  role="tab"
-                  aria-selected={tab === item.id}
-                  className={`home-v2-listing-tab${tab === item.id ? " is-active" : ""}`}
-                  onClick={() => handleTabChange(item.id)}
-                >
-                  {item.label}
-                </button>
-              ))}
+          <div className="home-v2-listing-primary">
+            <div
+              className="home-v2-listing-kind clawhub-segmented oc-segmented"
+              role="group"
+              aria-label="Content type"
+            >
+              <button
+                type="button"
+                className={`home-v2-listing-kind-btn clawhub-segmented-btn oc-segmented-item${
+                  kind === "skills" ? " is-active" : ""
+                }`}
+                aria-pressed={kind === "skills"}
+                onClick={() => handleKindChange("skills")}
+              >
+                Skills
+              </button>
+              <button
+                type="button"
+                className={`home-v2-listing-kind-btn clawhub-segmented-btn oc-segmented-item${
+                  kind === "plugins" ? " is-active" : ""
+                }`}
+                aria-pressed={kind === "plugins"}
+                onClick={() => handleKindChange("plugins")}
+              >
+                Plugins
+              </button>
+            </div>
+
+            <div className="home-v2-listing-sort">
+              <div className="home-v2-listing-sort-tabs" role="tablist" aria-label="Catalog view">
+                {visibleTabs.map((item) => (
+                  <button
+                    key={item.id}
+                    type="button"
+                    role="tab"
+                    aria-selected={tab === item.id}
+                    className={`home-v2-listing-tab${tab === item.id ? " is-active" : ""}`}
+                    onClick={() => handleTabChange(item.id)}
+                  >
+                    {item.label}
+                  </button>
+                ))}
+              </div>
             </div>
           </div>
 
@@ -613,33 +628,6 @@ export function HomeListingSection({ initialListing = null }: HomeListingSection
                 onChange={setCategorySlug}
               />
             )}
-          </div>
-
-          <div
-            className="home-v2-listing-kind clawhub-segmented oc-segmented"
-            role="group"
-            aria-label="Content type"
-          >
-            <button
-              type="button"
-              className={`home-v2-listing-kind-btn clawhub-segmented-btn oc-segmented-item${
-                kind === "skills" ? " is-active" : ""
-              }`}
-              aria-pressed={kind === "skills"}
-              onClick={() => handleKindChange("skills")}
-            >
-              Skills
-            </button>
-            <button
-              type="button"
-              className={`home-v2-listing-kind-btn clawhub-segmented-btn oc-segmented-item${
-                kind === "plugins" ? " is-active" : ""
-              }`}
-              aria-pressed={kind === "plugins"}
-              onClick={() => handleKindChange("plugins")}
-            >
-              Plugins
-            </button>
           </div>
         </div>
         <BrowseSearchPanel open={searchDisclosure.open}>

--- a/src/components/HomeListingSection.tsx
+++ b/src/components/HomeListingSection.tsx
@@ -7,6 +7,7 @@ import { PLUGIN_CATEGORIES, SKILL_CATEGORIES } from "../lib/categories";
 import {
   fetchHomePluginListing as fetchPluginListing,
   fetchHomeSkillListing as fetchSkillListing,
+  searchHomeTrendingSkillListing,
   HOME_LISTING_PAGE_SIZE,
   HOME_NEW_WINDOW_MS,
   homeListingCacheKey as listingCacheKey,
@@ -478,41 +479,53 @@ export function HomeListingSection({ initialListing = null }: HomeListingSection
 
     const handle = window.setTimeout(() => {
       const load =
-        kind === "skills"
-          ? convexHttp
-              .action(api.search.searchNativeSkills, {
-                query: trimmedSearch,
-                limit: fetchLimit,
-                ...(tab === "featured" ? { highlightedOnly: true } : {}),
-                ...(tab === "official" ? { officialOnly: true } : {}),
-                ...(tab === "new" ? { createdAfter: Date.now() - HOME_NEW_WINDOW_MS } : {}),
-                ...(categorySlug ? { categorySlug } : {}),
-              })
-              .then((hits) => {
+        kind === "skills" && tab === "trending"
+          ? searchHomeTrendingSkillListing(trimmedSearch, fetchLimit, controller.signal).then(
+              (result) => {
                 if (controller.signal.aborted || requestId !== searchRequestRef.current) return;
-                const searchHits = hits as HomeNativeSkillListingEntry[];
-                setSearchSkills(searchHits);
-                setListingHasMore(searchHits.length >= fetchLimit);
+                const unavailable = result.trendingState === "unavailable";
+                setCanonicalTrendingUnavailable(unavailable);
+                if (unavailable) {
+                  setTab("featured");
+                  return;
+                }
+                setSearchSkills(result.page);
+                setTrendingState(result.trendingState);
+                setListingHasMore(result.hasMore);
                 setSearchStatus("idle");
-              })
-          : fetchPluginCatalog({
-              q: trimmedSearch,
-              category: categorySlug,
-              featured: tab === "featured" ? true : undefined,
-              isOfficial: tab === "official" ? true : undefined,
-              limit: fetchLimit,
-              signal: controller.signal,
-            }).then((result) => {
-              if (controller.signal.aborted || requestId !== searchRequestRef.current) return;
-              const newestCutoff = Date.now() - HOME_NEW_WINDOW_MS;
-              const items =
-                tab === "new"
-                  ? result.items.filter((item) => item.createdAt >= newestCutoff)
-                  : result.items;
-              setSearchPlugins(items);
-              setListingHasMore(result.nextCursor !== null || result.items.length >= fetchLimit);
-              setSearchStatus("idle");
-            });
+              },
+            )
+          : kind === "skills"
+            ? convexHttp
+                .action(api.search.searchNativeSkills, {
+                  query: trimmedSearch,
+                  limit: fetchLimit,
+                  ...(tab === "featured" ? { highlightedOnly: true } : {}),
+                  ...(tab === "official" ? { officialOnly: true } : {}),
+                  ...(tab === "new" ? { createdAfter: Date.now() - HOME_NEW_WINDOW_MS } : {}),
+                  ...(categorySlug ? { categorySlug } : {}),
+                })
+                .then((hits) => {
+                  if (controller.signal.aborted || requestId !== searchRequestRef.current) return;
+                  const searchHits = hits as HomeNativeSkillListingEntry[];
+                  setSearchSkills(searchHits);
+                  setListingHasMore(searchHits.length >= fetchLimit);
+                  setSearchStatus("idle");
+                })
+            : fetchPluginCatalog({
+                q: trimmedSearch,
+                category: categorySlug,
+                featured: tab === "featured" ? true : undefined,
+                isOfficial: tab === "official" ? true : undefined,
+                createdAfter: tab === "new" ? Date.now() - HOME_NEW_WINDOW_MS : undefined,
+                limit: fetchLimit,
+                signal: controller.signal,
+              }).then((result) => {
+                if (controller.signal.aborted || requestId !== searchRequestRef.current) return;
+                setSearchPlugins(result.items);
+                setListingHasMore(result.nextCursor !== null || result.items.length >= fetchLimit);
+                setSearchStatus("idle");
+              });
 
       load
         .catch(() => {

--- a/src/components/HomeListingSection.tsx
+++ b/src/components/HomeListingSection.tsx
@@ -27,6 +27,7 @@ import { presentationTitle } from "../lib/presentationTitle";
 import { PUBLIC_CATALOG_NAME_PREVIEW_LENGTH, truncateText } from "../lib/truncateText";
 import { MarketplaceIcon } from "./MarketplaceIcon";
 import {
+  BrowseControlsDivider,
   BrowseCategorySelect,
   BrowseSearchInput,
   BrowseSearchPanel,
@@ -610,7 +611,7 @@ export function HomeListingSection({ initialListing = null }: HomeListingSection
               </button>
             </div>
 
-            <span className="home-v2-listing-divider" aria-hidden="true" />
+            <BrowseControlsDivider />
 
             <div className="home-v2-listing-sort">
               <div className="home-v2-listing-sort-tabs" role="tablist" aria-label="Catalog view">

--- a/src/components/HomeListingSection.tsx
+++ b/src/components/HomeListingSection.tsx
@@ -464,6 +464,7 @@ export function HomeListingSection({ initialListing = null }: HomeListingSection
       setSearchSkills([]);
       setSearchPlugins([]);
       setSearchStatus("idle");
+      setLoadingMore(false);
       return undefined;
     }
 

--- a/src/components/HomeListingSection.tsx
+++ b/src/components/HomeListingSection.tsx
@@ -1,10 +1,14 @@
 import { Link } from "@tanstack/react-router";
-import { CloudOff, Loader2, Moon, Plus } from "lucide-react";
-import { type ReactNode, useEffect, useRef, useState } from "react";
+import { Binoculars, CloudOff, Loader2, Moon, Plus, X } from "lucide-react";
+import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { api } from "../../convex/_generated/api";
+import { convexHttp } from "../convex/client";
+import { PLUGIN_CATEGORIES, SKILL_CATEGORIES } from "../lib/categories";
 import {
   fetchHomePluginListing as fetchPluginListing,
   fetchHomeSkillListing as fetchSkillListing,
   HOME_LISTING_PAGE_SIZE,
+  HOME_NEW_WINDOW_MS,
   homeListingCacheKey as listingCacheKey,
   isHomeTrendingSkillEntry,
   type HomeListingCacheEntry,
@@ -16,11 +20,19 @@ import {
   type TrendingFeedState,
 } from "../lib/homeListingData";
 import { formatCompactStat } from "../lib/numberFormat";
-import type { PackageListItem } from "../lib/packageApi";
+import { fetchPluginCatalog, type PackageListItem } from "../lib/packageApi";
 import { buildPluginDetailHref } from "../lib/pluginRoutes";
 import { presentationTitle } from "../lib/presentationTitle";
+import type { PublicSkill, PublicUser } from "../lib/publicUser";
 import { PUBLIC_CATALOG_NAME_PREVIEW_LENGTH, truncateText } from "../lib/truncateText";
 import { MarketplaceIcon } from "./MarketplaceIcon";
+import {
+  BrowseCategorySelect,
+  BrowseSearchInput,
+  BrowseSearchPanel,
+  BrowseSearchTrigger,
+  useBrowseSearchDisclosure,
+} from "./BrowseControls";
 import { OfficialBadge } from "./OfficialBadge";
 import { BrowseResultsSkeleton } from "./skeletons/BrowseResultsSkeleton";
 import { Badge } from "./ui/badge";
@@ -43,14 +55,30 @@ const PLUGIN_LISTING_TABS: Array<{
 ];
 
 const LISTING_PAGE_SIZE = HOME_LISTING_PAGE_SIZE;
+const LISTING_SEARCH_DEBOUNCE_MS = 220;
 const EMPTY_CATEGORY_SLUGS: string[] = [];
+
+type SkillSearchHit = {
+  skill: PublicSkill;
+  ownerHandle?: string | null;
+  owner?: (PublicUser & { official?: boolean }) | null;
+};
 
 function HomeListingEmptyPanel({
   variant,
+  query,
+  onClear,
 }: {
-  variant: "error" | "empty" | "trendingEmpty" | "trendingUnavailable";
+  variant: "error" | "empty" | "filter" | "search" | "trendingEmpty" | "trendingUnavailable";
+  query?: string;
+  onClear?: () => void;
 }) {
-  const Icon = variant === "error" || variant === "trendingUnavailable" ? CloudOff : Moon;
+  const Icon =
+    variant === "error" || variant === "trendingUnavailable"
+      ? CloudOff
+      : variant === "search"
+        ? Binoculars
+        : Moon;
   const title =
     variant === "trendingUnavailable"
       ? "24-hour Trending unavailable"
@@ -58,7 +86,9 @@ function HomeListingEmptyPanel({
         ? "No 24-hour activity yet"
         : variant === "error"
           ? "Listings took a coffee break"
-          : "Quiet shelf";
+          : variant === "search"
+            ? `No results for “${query}”`
+            : "Quiet shelf";
   const body =
     variant === "trendingUnavailable"
       ? "The canonical 24-hour feed isn't available right now. Try another tab."
@@ -66,7 +96,11 @@ function HomeListingEmptyPanel({
         ? "No skills have eligible activity in the current 24-hour window."
         : variant === "error"
           ? "We couldn't load this slice of the catalog. Give it another try in a moment."
-          : "Nothing on this tab right now. Peek at another tab.";
+          : variant === "search"
+            ? "Try another query or clear the search."
+            : variant === "filter"
+              ? "Nothing matches this category on the selected tab."
+              : "Nothing on this tab right now. Peek at another tab.";
 
   return (
     <div className="home-v2-listing-empty" role="status">
@@ -75,6 +109,12 @@ function HomeListingEmptyPanel({
       </div>
       <p className="home-v2-listing-empty-title">{title}</p>
       <p className="home-v2-listing-empty-body">{body}</p>
+      {onClear ? (
+        <button type="button" className="home-v2-listing-empty-action" onClick={onClear}>
+          <X size={15} aria-hidden="true" />
+          {variant === "search" ? "Clear search" : "Clear category"}
+        </button>
+      ) : null}
     </div>
   );
 }
@@ -255,6 +295,8 @@ function createInitialListingCache(initialListing: HomeListingInitialData | null
 }
 
 export function HomeListingSection({ initialListing = null }: HomeListingSectionProps = {}) {
+  const searchInputRef = useRef<HTMLInputElement>(null);
+  const searchRequestRef = useRef(0);
   const listingCacheRef = useRef<Map<string, HomeListingCacheEntry> | null>(null);
   listingCacheRef.current ??= createInitialListingCache(initialListing);
   const listingCache = listingCacheRef.current;
@@ -265,6 +307,8 @@ export function HomeListingSection({ initialListing = null }: HomeListingSection
       ? "featured"
       : (initialListing?.tab ?? "trending");
   const [tab, setTab] = useState<ListingTab>(initialTab);
+  const [categorySlug, setCategorySlug] = useState<string | undefined>();
+  const [searchQuery, setSearchQuery] = useState("");
   const [visibleCount, setVisibleCount] = useState(LISTING_PAGE_SIZE);
   const [fetchLimit, setFetchLimit] = useState(LISTING_PAGE_SIZE);
   const [skills, setSkills] = useState<SkillPageEntry[]>(
@@ -277,6 +321,9 @@ export function HomeListingSection({ initialListing = null }: HomeListingSection
     initialListing ? "idle" : "loading",
   );
   const [loadingMore, setLoadingMore] = useState(false);
+  const [searchSkills, setSearchSkills] = useState<SkillPageEntry[]>([]);
+  const [searchPlugins, setSearchPlugins] = useState<PackageListItem[]>([]);
+  const [searchStatus, setSearchStatus] = useState<"loading" | "idle" | "error">("idle");
   const [listingHasMore, setListingHasMore] = useState(initialListing?.hasMore ?? false);
   const [trendingState, setTrendingState] = useState<TrendingFeedState | undefined>(
     initialListing?.kind === "skills" ? initialListing.trendingState : undefined,
@@ -284,6 +331,20 @@ export function HomeListingSection({ initialListing = null }: HomeListingSection
   const [canonicalTrendingUnavailable, setCanonicalTrendingUnavailable] = useState(
     initialListing?.kind === "skills" && initialListing.trendingState === "unavailable",
   );
+  const clearSearch = useCallback(() => setSearchQuery(""), []);
+  const searchDisclosure = useBrowseSearchDisclosure({
+    value: searchQuery,
+    onClear: clearSearch,
+    inputRef: searchInputRef,
+  });
+
+  const trimmedSearch = searchQuery.trim();
+  const isSearchMode = trimmedSearch.length > 0;
+  const categorySlugs = useMemo(
+    () => (categorySlug ? [categorySlug] : EMPTY_CATEGORY_SLUGS),
+    [categorySlug],
+  );
+  const listingCategories = kind === "skills" ? SKILL_CATEGORIES : PLUGIN_CATEGORIES;
 
   const visibleTabs =
     kind === "skills"
@@ -292,17 +353,24 @@ export function HomeListingSection({ initialListing = null }: HomeListingSection
         )
       : PLUGIN_LISTING_TABS;
 
-  const activeItems = kind === "skills" ? skills : plugins;
-  const activeStatus = status;
+  const activeItems = isSearchMode
+    ? kind === "skills"
+      ? searchSkills
+      : searchPlugins
+    : kind === "skills"
+      ? skills
+      : plugins;
+  const activeStatus = isSearchMode ? searchStatus : status;
   const isEmpty = activeStatus === "idle" && activeItems.length === 0;
   const showListingMore =
     activeStatus === "idle" && (activeItems.length > visibleCount || listingHasMore);
 
   useEffect(() => {
+    if (isSearchMode) return undefined;
     const cacheKey = listingCacheKey({
       kind,
       tab,
-      categorySlugs: EMPTY_CATEGORY_SLUGS,
+      categorySlugs,
       fetchLimit,
     });
     const cached = listingCache.get(cacheKey);
@@ -339,29 +407,27 @@ export function HomeListingSection({ initialListing = null }: HomeListingSection
 
     const load =
       kind === "skills"
-        ? fetchSkillListing(tab, EMPTY_CATEGORY_SLUGS, fetchLimit, controller.signal).then(
-            (result) => {
-              if (controller.signal.aborted) return;
-              listingCache.set(cacheKey, {
-                kind: "skills",
-                items: result.page,
-                hasMore: result.hasMore,
-                trendingState: result.trendingState,
-              });
-              setSkills(result.page);
-              setTrendingState(result.trendingState);
-              if (tab === "trending") {
-                const unavailable = result.trendingState === "unavailable";
-                setCanonicalTrendingUnavailable(unavailable);
-                if (unavailable) setTab("featured");
-              }
-              setListingHasMore(result.hasMore);
-              setStatus("idle");
-            },
-          )
+        ? fetchSkillListing(tab, categorySlugs, fetchLimit, controller.signal).then((result) => {
+            if (controller.signal.aborted) return;
+            listingCache.set(cacheKey, {
+              kind: "skills",
+              items: result.page,
+              hasMore: result.hasMore,
+              trendingState: result.trendingState,
+            });
+            setSkills(result.page);
+            setTrendingState(result.trendingState);
+            if (tab === "trending") {
+              const unavailable = result.trendingState === "unavailable";
+              setCanonicalTrendingUnavailable(unavailable);
+              if (unavailable) setTab("featured");
+            }
+            setListingHasMore(result.hasMore);
+            setStatus("idle");
+          })
         : fetchPluginListing(
             tab === "trending" ? "new" : tab,
-            EMPTY_CATEGORY_SLUGS,
+            categorySlugs,
             fetchLimit,
             controller.signal,
           ).then((result) => {
@@ -396,15 +462,99 @@ export function HomeListingSection({ initialListing = null }: HomeListingSection
       });
 
     return () => controller.abort();
-  }, [fetchLimit, kind, listingCache, tab]);
+  }, [categorySlug, fetchLimit, isSearchMode, kind, listingCache, tab]);
+
+  useEffect(() => {
+    if (!isSearchMode) {
+      setSearchSkills([]);
+      setSearchPlugins([]);
+      setSearchStatus("idle");
+      return undefined;
+    }
+
+    searchRequestRef.current += 1;
+    const requestId = searchRequestRef.current;
+    const controller = new AbortController();
+    const isLoadMore = fetchLimit > LISTING_PAGE_SIZE;
+    if (isLoadMore) {
+      setLoadingMore(true);
+    } else {
+      setSearchStatus("loading");
+      setListingHasMore(false);
+    }
+
+    const handle = window.setTimeout(() => {
+      const load =
+        kind === "skills"
+          ? convexHttp
+              .action(api.search.searchNativeSkills, {
+                query: trimmedSearch,
+                limit: fetchLimit,
+                ...(tab === "featured" ? { highlightedOnly: true } : {}),
+                ...(categorySlug ? { categorySlug } : {}),
+              })
+              .then((hits) => {
+                if (controller.signal.aborted || requestId !== searchRequestRef.current) return;
+                const searchHits = hits as SkillSearchHit[];
+                const newestCutoff = Date.now() - HOME_NEW_WINDOW_MS;
+                const items = searchHits
+                  .filter((hit) => tab !== "official" || Boolean(hit.owner?.official))
+                  .filter((hit) => tab !== "new" || hit.skill.createdAt >= newestCutoff)
+                  .map((hit) => ({
+                    skill: hit.skill,
+                    ownerHandle: hit.ownerHandle,
+                    owner: hit.owner,
+                  }));
+                setSearchSkills(items);
+                setListingHasMore(searchHits.length >= fetchLimit);
+                setSearchStatus("idle");
+              })
+          : fetchPluginCatalog({
+              q: trimmedSearch,
+              category: categorySlug,
+              featured: tab === "featured" ? true : undefined,
+              isOfficial: tab === "official" ? true : undefined,
+              limit: fetchLimit,
+              signal: controller.signal,
+            }).then((result) => {
+              if (controller.signal.aborted || requestId !== searchRequestRef.current) return;
+              const newestCutoff = Date.now() - HOME_NEW_WINDOW_MS;
+              const items =
+                tab === "new"
+                  ? result.items.filter((item) => item.createdAt >= newestCutoff)
+                  : result.items;
+              setSearchPlugins(items);
+              setListingHasMore(result.nextCursor !== null || result.items.length >= fetchLimit);
+              setSearchStatus("idle");
+            });
+
+      load
+        .catch(() => {
+          if (controller.signal.aborted || requestId !== searchRequestRef.current) return;
+          if (isLoadMore) return;
+          if (kind === "skills") setSearchSkills([]);
+          else setSearchPlugins([]);
+          setSearchStatus("error");
+        })
+        .finally(() => {
+          if (controller.signal.aborted || requestId !== searchRequestRef.current) return;
+          setLoadingMore(false);
+        });
+    }, LISTING_SEARCH_DEBOUNCE_MS);
+
+    return () => {
+      controller.abort();
+      window.clearTimeout(handle);
+    };
+  }, [categorySlug, fetchLimit, isSearchMode, kind, tab, trimmedSearch]);
 
   useEffect(() => {
     setVisibleCount(LISTING_PAGE_SIZE);
     setFetchLimit(LISTING_PAGE_SIZE);
-  }, [kind, tab]);
+  }, [categorySlug, isSearchMode, kind, tab, trimmedSearch]);
 
-  const visibleSkills = skills.slice(0, visibleCount);
-  const visiblePlugins = plugins.slice(0, visibleCount);
+  const visibleSkills = (isSearchMode ? searchSkills : skills).slice(0, visibleCount);
+  const visiblePlugins = (isSearchMode ? searchPlugins : plugins).slice(0, visibleCount);
 
   const handleSeeMore = () => {
     setVisibleCount((count) => count + LISTING_PAGE_SIZE);
@@ -414,9 +564,15 @@ export function HomeListingSection({ initialListing = null }: HomeListingSection
   const handleKindChange = (nextKind: ListingKind) => {
     if (nextKind === kind) return;
     setKind(nextKind);
+    setCategorySlug(undefined);
     setTab(
       nextKind === "skills" ? (canonicalTrendingUnavailable ? "featured" : "trending") : "new",
     );
+  };
+
+  const handleTabChange = (nextTab: ListingTab) => {
+    if (nextTab === "trending") setCategorySlug(undefined);
+    setTab(nextTab);
   };
 
   return (
@@ -436,12 +592,27 @@ export function HomeListingSection({ initialListing = null }: HomeListingSection
                   role="tab"
                   aria-selected={tab === item.id}
                   className={`home-v2-listing-tab${tab === item.id ? " is-active" : ""}`}
-                  onClick={() => setTab(item.id)}
+                  onClick={() => handleTabChange(item.id)}
                 >
                   {item.label}
                 </button>
               ))}
             </div>
+          </div>
+
+          <div className="home-v2-listing-actions">
+            <BrowseSearchTrigger
+              open={searchDisclosure.open}
+              onOpen={searchDisclosure.openSearch}
+              label="Search catalog"
+            />
+            {kind === "skills" && tab === "trending" ? null : (
+              <BrowseCategorySelect
+                categories={listingCategories}
+                value={categorySlug}
+                onChange={setCategorySlug}
+              />
+            )}
           </div>
 
           <div
@@ -471,6 +642,17 @@ export function HomeListingSection({ initialListing = null }: HomeListingSection
             </button>
           </div>
         </div>
+        <BrowseSearchPanel open={searchDisclosure.open}>
+          <BrowseSearchInput
+            inputRef={searchInputRef}
+            label={kind === "skills" ? "Search skills" : "Search plugins"}
+            placeholder={kind === "skills" ? "Search skills..." : "Search plugins..."}
+            value={searchQuery}
+            onChange={setSearchQuery}
+            onClear={searchDisclosure.closeSearch}
+            closeLabel="Close search"
+          />
+        </BrowseSearchPanel>
       </div>
 
       {activeStatus === "idle" && activeItems.length > 0 ? (
@@ -501,11 +683,23 @@ export function HomeListingSection({ initialListing = null }: HomeListingSection
       {isEmpty ? (
         <HomeListingEmptyPanel
           variant={
-            kind === "skills" && tab === "trending"
-              ? trendingState === "unavailable"
-                ? "trendingUnavailable"
-                : "trendingEmpty"
-              : "empty"
+            isSearchMode
+              ? "search"
+              : categorySlug
+                ? "filter"
+                : kind === "skills" && tab === "trending"
+                  ? trendingState === "unavailable"
+                    ? "trendingUnavailable"
+                    : "trendingEmpty"
+                  : "empty"
+          }
+          query={isSearchMode ? trimmedSearch : undefined}
+          onClear={
+            isSearchMode
+              ? searchDisclosure.closeSearch
+              : categorySlug
+                ? () => setCategorySlug(undefined)
+                : undefined
           }
         />
       ) : null}

--- a/src/components/HomeListingSection.tsx
+++ b/src/components/HomeListingSection.tsx
@@ -610,6 +610,8 @@ export function HomeListingSection({ initialListing = null }: HomeListingSection
               </button>
             </div>
 
+            <span className="home-v2-listing-divider" aria-hidden="true" />
+
             <div className="home-v2-listing-sort">
               <div className="home-v2-listing-sort-tabs" role="tablist" aria-label="Catalog view">
                 {visibleTabs.map((item) => (

--- a/src/lib/homeListingData.claw591.test.ts
+++ b/src/lib/homeListingData.claw591.test.ts
@@ -42,6 +42,7 @@ import {
   fetchInitialHomeListing,
   HOME_LISTING_PAGE_SIZE,
   HOME_NEW_WINDOW_MS,
+  searchHomeTrendingSkillListing,
 } from "./homeListingData";
 
 describe("homeListingData", () => {
@@ -96,6 +97,21 @@ describe("homeListingData", () => {
       limit: 1,
       signal: undefined,
     });
+  });
+
+  it("limits Trending search pages while preserving buffered matches for See more", async () => {
+    const matches = Array.from({ length: 25 }, (_, index) =>
+      makeTrending(`calendar-${index}`, `Calendar ${index}`, 25 - index),
+    );
+    fetchCanonicalTrendingPageMock.mockResolvedValue(canonicalPage(matches, null));
+
+    const firstPage = await searchHomeTrendingSkillListing("calendar", 20);
+    expect(firstPage.page).toHaveLength(20);
+    expect(firstPage.hasMore).toBe(true);
+
+    const expandedPage = await searchHomeTrendingSkillListing("calendar", 40);
+    expect(expandedPage.page).toHaveLength(25);
+    expect(expandedPage.hasMore).toBe(false);
   });
 
   it("rejects a later canonical page failure instead of replacing loaded results", async () => {

--- a/src/lib/homeListingData.ts
+++ b/src/lib/homeListingData.ts
@@ -64,6 +64,7 @@ export const HOME_NEW_WINDOW_MS = 14 * 24 * 60 * 60 * 1_000;
 
 const PLUGIN_CATALOG_PAGE_LIMIT = 100;
 const LEGACY_NEW_PLUGIN_MAX_REQUESTS = 10;
+const TRENDING_SEARCH_PAGE_LIMIT = 100;
 // Featured is intentionally a finite editorial feed: the latest 40 badge-history rows.
 const FEATURED_SKILL_LIMIT = 40;
 
@@ -106,6 +107,83 @@ function uniqueHomePlugins(items: PackageListItem[]) {
   const byName = new Map<string, PackageListItem>();
   for (const item of items) byName.set(item.name, item);
   return [...byName.values()];
+}
+
+function trendingItemMatchesQuery(item: CanonicalTrendingItem, query: string) {
+  const tokens = query.trim().toLocaleLowerCase().split(/\s+/).filter(Boolean);
+  if (tokens.length === 0) return true;
+  const searchableText = [
+    item.slug,
+    item.displayName,
+    item.summary,
+    item.publisher?.handle,
+    item.publisher?.displayName,
+    item.sourceIdentity?.id,
+    item.sourceIdentity?.owner,
+    item.sourceIdentity?.repo,
+    item.sourceIdentity?.host,
+  ]
+    .filter((value): value is string => Boolean(value))
+    .join(" ")
+    .toLocaleLowerCase();
+  return tokens.every((token) => searchableText.includes(token));
+}
+
+export async function searchHomeTrendingSkillListing(
+  query: string,
+  numItems: number,
+  signal?: AbortSignal,
+) {
+  let capabilities: Awaited<ReturnType<typeof fetchCatalogDiscoveryCapabilities>>;
+  try {
+    capabilities = await fetchCatalogDiscoveryCapabilities();
+  } catch {
+    return { page: [], hasMore: false, trendingState: "unavailable" as const };
+  }
+  if (!capabilities.canonicalTrendingEnabled) {
+    return { page: [], hasMore: false, trendingState: "unavailable" as const };
+  }
+
+  const items: HomeTrendingSkillListingEntry[] = [];
+  let cursor: string | null = null;
+  let sawFeedItem = false;
+  try {
+    do {
+      // Trending is a ranked cross-source snapshot, so search must filter this
+      // feed in place instead of substituting the native catalog search.
+      const result = await fetchCanonicalTrendingPage({
+        cursor,
+        limit: TRENDING_SEARCH_PAGE_LIMIT,
+        signal,
+      });
+      sawFeedItem ||= result.items.length > 0;
+      items.push(
+        ...result.items
+          .filter((item) => trendingItemMatchesQuery(item, query))
+          .map((trending) => ({ trending })),
+      );
+      const nextCursor = result.nextCursor;
+      if (items.length >= numItems || !nextCursor || nextCursor === cursor) {
+        return {
+          page: items,
+          hasMore:
+            items.length > numItems ||
+            (items.length >= numItems && nextCursor !== null && nextCursor !== cursor),
+          trendingState: sawFeedItem ? ("available" as const) : ("empty" as const),
+        };
+      }
+      cursor = nextCursor;
+    } while (cursor);
+  } catch (error) {
+    if (signal?.aborted) throw error;
+    if (sawFeedItem) throw error;
+    return { page: [], hasMore: false, trendingState: "unavailable" as const };
+  }
+  return {
+    page: items,
+    hasMore: false,
+    trendingState: sawFeedItem ? ("available" as const) : ("empty" as const),
+  };
 }
 
 export async function fetchHomeSkillListing(

--- a/src/lib/homeListingData.ts
+++ b/src/lib/homeListingData.ts
@@ -165,7 +165,7 @@ export async function searchHomeTrendingSkillListing(
       const nextCursor = result.nextCursor;
       if (items.length >= numItems || !nextCursor || nextCursor === cursor) {
         return {
-          page: items,
+          page: items.slice(0, numItems),
           hasMore:
             items.length > numItems ||
             (items.length >= numItems && nextCursor !== null && nextCursor !== cursor),

--- a/src/lib/packageApi.test.ts
+++ b/src/lib/packageApi.test.ts
@@ -741,6 +741,7 @@ describe("fetchPluginCatalog", () => {
     const result = await fetchPluginCatalog({
       q: "demo",
       cursor: "cursor:plugins",
+      createdAfter: 123,
       limit: 10,
     });
 
@@ -751,6 +752,7 @@ describe("fetchPluginCatalog", () => {
     expect(url.pathname).toBe("/api/v1/plugins/search");
     expect(url.searchParams.has("cursor")).toBe(false);
     expect(url.searchParams.has("sort")).toBe(false);
+    expect(url.searchParams.get("createdAfter")).toBe("123");
   });
 
   it("ignores malformed plugin search entries defensively", async () => {

--- a/src/lib/packageApi.ts
+++ b/src/lib/packageApi.ts
@@ -341,6 +341,7 @@ export async function fetchPackages(params: {
   family?: "skill" | "code-plugin" | "bundle-plugin";
   isOfficial?: boolean;
   featured?: boolean;
+  createdAfter?: number;
   category?: string;
   topic?: string;
   officialFirst?: boolean;
@@ -359,6 +360,9 @@ export async function fetchPackages(params: {
       url.searchParams.set("isOfficial", String(params.isOfficial));
     }
     if (params.featured) url.searchParams.set("featured", "true");
+    if (typeof params.createdAfter === "number") {
+      url.searchParams.set("createdAfter", String(params.createdAfter));
+    }
     if (params.category) url.searchParams.set("category", params.category);
     if (params.topic) url.searchParams.set("topic", params.topic);
     if (params.officialFirst) url.searchParams.set("officialFirst", "true");
@@ -404,6 +408,7 @@ export async function fetchPluginCatalog(params: {
   family?: PluginFamily;
   isOfficial?: boolean;
   featured?: boolean;
+  createdAfter?: number;
   category?: string;
   topic?: string;
   officialFirst?: boolean;
@@ -420,6 +425,7 @@ export async function fetchPluginCatalog(params: {
       family: params.family,
       isOfficial: params.isOfficial,
       featured: params.featured,
+      createdAfter: params.createdAfter,
       category: params.category,
       topic: params.topic,
       officialFirst: params.officialFirst,
@@ -452,6 +458,9 @@ export async function fetchPluginCatalog(params: {
       url.searchParams.set("isOfficial", String(params.isOfficial));
     }
     if (params.featured) url.searchParams.set("featured", "true");
+    if (typeof params.createdAfter === "number") {
+      url.searchParams.set("createdAfter", String(params.createdAfter));
+    }
     if (params.category) url.searchParams.set("category", params.category);
     if (params.topic) url.searchParams.set("topic", params.topic);
     if (params.excludedScanStatuses?.length) {

--- a/src/styles.css
+++ b/src/styles.css
@@ -22333,9 +22333,17 @@ a.search-empty-action {
 .home-v2-listing-toolbar {
   display: flex;
   align-items: center;
-  gap: 20px;
+  gap: 16px;
   min-height: 44px;
   padding: 0;
+}
+
+.home-v2-listing-primary {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  flex: 1 1 auto;
+  min-width: 0;
 }
 
 .home-v2-listing-kind {
@@ -28690,34 +28698,33 @@ a.home-v2-byos-import:focus-visible svg:last-child {
     margin-bottom: 24px;
   }
   .home-v2-listing-toolbar {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) auto;
-    align-items: center;
+    flex-direction: column;
+    align-items: stretch;
     min-height: 0;
-    gap: 14px 12px;
+    gap: 14px;
+  }
+  .home-v2-listing-primary {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 12px;
+    width: 100%;
   }
   .home-v2-listing-divider {
     display: none;
   }
   .home-v2-listing-kind {
-    grid-column: 2;
-    grid-row: 1;
-    justify-self: end;
+    align-self: flex-start;
   }
   .home-v2-listing-actions {
-    display: contents;
+    width: 100%;
+    margin-left: 0;
   }
   .home-v2-listing-actions .browse-search-trigger {
-    grid-column: 1;
-    grid-row: 1;
-    justify-self: start;
     width: 44px;
     height: 44px;
   }
   .home-v2-listing-actions .browse-category-select {
-    grid-column: 1 / -1;
-    grid-row: 2;
-    width: 100%;
+    flex: 1 1 auto;
     max-width: none;
   }
   .home-v2-listing-actions .browse-category-trigger {
@@ -28725,23 +28732,21 @@ a.home-v2-byos-import:focus-visible svg:last-child {
     min-height: 48px;
     padding: 0 16px;
     border: 1px solid var(--hv2-border);
-    border-radius: 18px;
+    border-radius: var(--oc-radius-control);
     background: color-mix(in srgb, var(--hv2-surface) 76%, transparent);
   }
   .home-v2-listing-sort {
-    grid-column: 1 / -1;
-    grid-row: 3;
     align-self: auto;
-    gap: 20px;
+    width: 100%;
     min-height: 36px;
   }
   .home-v2-listing-sort-tabs {
-    justify-content: space-between;
+    justify-content: flex-start;
     gap: 16px;
     width: 100%;
   }
   .home-v2-listing-tab {
-    flex: 1 0 0;
+    flex: 1 0 auto;
     justify-content: center;
     min-width: max-content;
   }

--- a/src/styles.css
+++ b/src/styles.css
@@ -22339,7 +22339,7 @@ a.search-empty-action {
 }
 
 .home-v2-listing-kind {
-  margin-left: auto;
+  margin-left: 0;
 }
 
 .home-v2-listing-divider {
@@ -22353,11 +22353,16 @@ a.search-empty-action {
 .home-v2-listing-actions {
   display: inline-flex;
   align-items: center;
+  gap: 12px;
   flex-shrink: 0;
   margin-left: auto;
 }
 
-/* Search + category are ghost controls; view toggle stays segmented. */
+.home-v2-listing-actions .browse-category-select {
+  max-width: min(220px, 34vw);
+}
+
+/* Search and category remain ghost controls. */
 .home-v2-listing-actions-rail {
   display: inline-flex;
   align-items: center;
@@ -28699,9 +28704,33 @@ a.home-v2-byos-import:focus-visible svg:last-child {
     grid-row: 1;
     justify-self: end;
   }
-  .home-v2-listing-sort {
+  .home-v2-listing-actions {
+    display: contents;
+  }
+  .home-v2-listing-actions .browse-search-trigger {
+    grid-column: 1;
+    grid-row: 1;
+    justify-self: start;
+    width: 44px;
+    height: 44px;
+  }
+  .home-v2-listing-actions .browse-category-select {
     grid-column: 1 / -1;
     grid-row: 2;
+    width: 100%;
+    max-width: none;
+  }
+  .home-v2-listing-actions .browse-category-trigger {
+    width: 100%;
+    min-height: 48px;
+    padding: 0 16px;
+    border: 1px solid var(--hv2-border);
+    border-radius: 18px;
+    background: color-mix(in srgb, var(--hv2-surface) 76%, transparent);
+  }
+  .home-v2-listing-sort {
+    grid-column: 1 / -1;
+    grid-row: 3;
     align-self: auto;
     gap: 20px;
     min-height: 36px;

--- a/src/styles.css
+++ b/src/styles.css
@@ -22350,14 +22350,6 @@ a.search-empty-action {
   margin-left: 0;
 }
 
-.home-v2-listing-divider {
-  width: 1px;
-  align-self: center;
-  height: 18px;
-  flex-shrink: 0;
-  background: var(--hv2-border);
-}
-
 .home-v2-listing-actions {
   display: inline-flex;
   align-items: center;
@@ -28709,7 +28701,7 @@ a.home-v2-byos-import:focus-visible svg:last-child {
     gap: 12px;
     width: 100%;
   }
-  .home-v2-listing-divider {
+  .home-v2-listing-primary > .browse-controls-divider {
     display: none;
   }
   .home-v2-listing-kind {


### PR DESCRIPTION
## Summary

- proposes restoring homepage search and clearable category filtering for both Skills and Plugins, with the content-type selector and current tabs grouped on the left and secondary controls aligned on the right
- adds a short decorative divider between the content-type selector and catalog tabs on wide screens, hiding it when those controls stack on narrow screens
- keeps Skills Trending search inside the canonical global feed and its ordering, including skills.sh entries; entering Trending clears and hides category state
- applies Official/New skill eligibility and New plugin eligibility before result limiting, so an eligible later match remains reachable after initially ineligible hits
- preserves the current Skills tabs, the existing Plugin tabs, list-only rows, ordering, download counts, icons, and badges; this PR does not introduce a sort selector, grid, cards, or a view toggle

Closes #3417.

## Tests

- `bunx vitest run src/__tests__/home-listing-section.test.tsx src/__tests__/ui-design-contract.test.ts` — 31 passed
- `bun run ci:static`
- `npm_config_cache=/tmp/clawhub-npm-cache-3418-divider bun run ci:unit` — 5,975 passed, 2 skipped
- `bun run ci:types-build`

## UI proof

The [proof comment](https://github.com/openclaw/clawhub/pull/3418#issuecomment-5198050825) compares `upstream/main` with the proposed final SHA on desktop and mobile using the same local backend and fixture. It shows the proposed divider aligned between the grouped controls on desktop and absent when the toolbar stacks at 390px, without horizontal overflow.
