### PR TITLE
fix: rank native Trending by downloads

### DIFF
--- a/convex/canonicalTrending.test.ts
+++ b/convex/canonicalTrending.test.ts
@@ -256,7 +256,7 @@ describe("canonical Trending snapshot storage", () => {
       snapshotId: "skills-1000",
       generatedAt: new Date(now - 1_000).toISOString(),
       windowHours: 24,
-      rankingVersion: "skills-trending-v3",
+      rankingVersion: "skills-trending-v4",
       items: [
         { id: "clawhub:one", rank: 1, lane: "clawhub-trending" },
         { id: "clawhub:two", rank: 2, lane: "clawhub-trending" },
@@ -645,7 +645,7 @@ describe("canonical Trending snapshot storage", () => {
       snapshotId: "skills-native-preflight-ready",
       generatedAt: new Date(now - 1_000).toISOString(),
       windowHours: 24,
-      rankingVersion: "skills-trending-v3",
+      rankingVersion: "skills-trending-v4",
       totalItems: 1,
       sourceCounts: { clawhubTrending: 1, clawhubRising: 0, skillsShTrending: 0 },
       operations: { documentsRead: 10, documentsWritten: 2, functionCalls: 3 },

--- a/convex/canonicalTrending.ts
+++ b/convex/canonicalTrending.ts
@@ -101,6 +101,7 @@ const nativeLaneValidator = v.union(v.literal("clawhub-trending"), v.literal("cl
 const nativePoolItemValidator = v.object({
   identity: v.string(),
   publisherKey: v.string(),
+  downloads24h: v.optional(v.number()),
   installs24h: v.number(),
   bookmarks24h: v.number(),
   createdAt: v.number(),
@@ -771,6 +772,7 @@ export const materializeInternal = internalAction({
                 identity: row.identity,
                 lane: row.lane,
                 publisherKey: row.publisherKey,
+                downloads24h: row.downloads24h ?? row.card.metrics.trending24hDownloads ?? 0,
                 installs24h: row.installs24h,
                 bookmarks24h: row.bookmarks24h,
                 createdAt: row.createdAt,
@@ -903,6 +905,7 @@ export const materializeInternal = internalAction({
                   items: batch.map((candidate) => ({
                     identity: candidate.identity,
                     publisherKey: candidate.publisherKey,
+                    downloads24h: candidate.downloads24h,
                     installs24h: candidate.installs24h,
                     bookmarks24h: candidate.bookmarks24h,
                     createdAt: candidate.createdAt,

--- a/convex/canonicalTrendingTestFixtures.test.ts
+++ b/convex/canonicalTrendingTestFixtures.test.ts
@@ -122,7 +122,7 @@ describe("CLAW-590 permanent Test snapshot ownership", () => {
         snapshotId: SNAPSHOT_ID,
         kind: "skills",
         status: "failed",
-        rankingVersion: "skills-trending-v3",
+        rankingVersion: "skills-trending-v4",
         generatedAt: 1_000,
         completedAt: 2_000,
         expiresAt: Date.now() + 100_000,

--- a/convex/lib/canonicalTrending.test.ts
+++ b/convex/lib/canonicalTrending.test.ts
@@ -21,6 +21,7 @@ function candidate(
     identity,
     lane,
     publisherKey: identity,
+    downloads24h: 0,
     installs24h: 0,
     bookmarks24h: 0,
     createdAt: 0,
@@ -139,23 +140,38 @@ describe("canonical Trending ordering", () => {
     expect(result.map((entry) => entry.identity)).toEqual(["alpha-1", "alpha-2", "alpha-3"]);
   });
 
-  it("sorts native metrics and preserves exact skills.sh upstream rank", () => {
+  it("sorts native downloads first and preserves exact skills.sh upstream rank", () => {
     const pools = sortCanonicalTrendingPools({
       clawhubTrending: [
-        candidate("c-low", "clawhub-trending", { installs24h: 2, bookmarks24h: 9 }),
+        candidate("c-most-downloads", "clawhub-trending", {
+          downloads24h: 4,
+          installs24h: 1,
+        }),
+        candidate("c-low", "clawhub-trending", {
+          downloads24h: 3,
+          installs24h: 2,
+          bookmarks24h: 9,
+        }),
         candidate("c-high-bookmarks", "clawhub-trending", {
+          downloads24h: 3,
           installs24h: 3,
           bookmarks24h: 5,
         }),
-        candidate("c-high", "clawhub-trending", { installs24h: 3, bookmarks24h: 1 }),
+        candidate("c-high", "clawhub-trending", {
+          downloads24h: 3,
+          installs24h: 3,
+          bookmarks24h: 1,
+        }),
       ],
       clawhubRising: [
         candidate("r-old", "clawhub-rising", {
+          downloads24h: 2,
           installs24h: 1,
           bookmarks24h: 1,
           createdAt: 10,
         }),
         candidate("r-new", "clawhub-rising", {
+          downloads24h: 2,
           installs24h: 1,
           bookmarks24h: 1,
           createdAt: 20,
@@ -169,6 +185,7 @@ describe("canonical Trending ordering", () => {
     });
 
     expect(pools.clawhubTrending.map((entry) => entry.identity)).toEqual([
+      "c-most-downloads",
       "c-high-bookmarks",
       "c-high",
       "c-low",
@@ -180,9 +197,9 @@ describe("canonical Trending ordering", () => {
   it("retains only the strongest bounded candidates for a lane", () => {
     const retained = retainTopCanonicalTrendingCandidates(
       [
-        candidate("low", "clawhub-trending", { installs24h: 1 }),
-        candidate("high", "clawhub-trending", { installs24h: 9 }),
-        candidate("middle", "clawhub-trending", { installs24h: 4 }),
+        candidate("low", "clawhub-trending", { downloads24h: 1, installs24h: 9 }),
+        candidate("high", "clawhub-trending", { downloads24h: 9, installs24h: 1 }),
+        candidate("middle", "clawhub-trending", { downloads24h: 4, installs24h: 4 }),
       ],
       "clawhub-trending",
       2,

--- a/convex/lib/canonicalTrending.ts
+++ b/convex/lib/canonicalTrending.ts
@@ -1,7 +1,7 @@
 import { type Infer, v } from "convex/values";
 import type { Doc } from "../_generated/dataModel";
 
-export const CANONICAL_TRENDING_RANKING_VERSION = "skills-trending-v3";
+export const CANONICAL_TRENDING_RANKING_VERSION = "skills-trending-v4";
 export const CANONICAL_TRENDING_WINDOW_HOURS = 24;
 export const CANONICAL_TRENDING_FIRST_PAGE_SIZE = 20;
 export const CANONICAL_TRENDING_PUBLISHER_CAP = 2;
@@ -152,6 +152,7 @@ export function buildNativeCanonicalTrendingCandidate(
     identity,
     lane: "clawhub-trending",
     publisherKey: String(digest.ownerPublisherId ?? digest.ownerUserId),
+    downloads24h: Math.max(0, usage.downloads),
     installs24h: Math.max(0, usage.installs),
     bookmarks24h: Math.max(0, usage.bookmarks),
     createdAt: digest.createdAt,
@@ -221,6 +222,7 @@ export function buildExternalCanonicalTrendingCandidate(
     identity,
     lane: "skills-sh-trending",
     publisherKey: digest.owner ?? digest.sourceHost ?? digest.externalId,
+    downloads24h: 0,
     installs24h: 0,
     bookmarks24h: 0,
     createdAt: digest.firstObservedAt,
@@ -275,6 +277,7 @@ export type CanonicalTrendingCandidate = {
   identity: string;
   lane: CanonicalTrendingLane;
   publisherKey: string;
+  downloads24h: number;
   installs24h: number;
   bookmarks24h: number;
   createdAt: number;
@@ -327,6 +330,7 @@ function compareCanonicalTrendingLaneCandidates(
     );
   }
   return (
+    compareNumberDesc(left.downloads24h, right.downloads24h) ||
     compareNumberDesc(left.installs24h, right.installs24h) ||
     compareNumberDesc(left.bookmarks24h, right.bookmarks24h) ||
     compareNumberDesc(

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -2812,6 +2812,8 @@ const canonicalTrendingNativePoolItems = defineTable({
   position: v.number(),
   identity: v.string(),
   publisherKey: v.string(),
+  // Optional only for pools materialized before downloads became the native ranking signal.
+  downloads24h: v.optional(v.number()),
   installs24h: v.number(),
   bookmarks24h: v.number(),
   createdAt: v.number(),

--- a/convex/skillsShMirrorVisibility.ts
+++ b/convex/skillsShMirrorVisibility.ts
@@ -887,6 +887,7 @@ export const getAuditPageInternal = internalQuery({
             identity: candidate.identity,
             lane: candidate.lane,
             publisherKey: candidate.publisherKey,
+            downloads24h: candidate.downloads24h,
             installs24h: candidate.installs24h,
             bookmarks24h: candidate.bookmarks24h,
             createdAt: candidate.createdAt,

--- a/src/__tests__/home-listing-section.claw591.test.tsx
+++ b/src/__tests__/home-listing-section.claw591.test.tsx
@@ -81,8 +81,8 @@ describe("HomeListingSection", () => {
   });
 
   it("shows canonical Trending download totals without changing order", () => {
-    const first = makeTrending("first", "First Skill", 17, 9000, 71);
-    const second = makeTrending("second", "Second Skill", 3, 8000, 29);
+    const first = makeTrending("first", "First Skill", 3, 9000, 71);
+    const second = makeTrending("second", "Second Skill", 17, 8000, 29);
     render(<HomeListingSection initialListing={initialTrending([first, second])} />);
 
     const contentTypeButtons = screen

--- a/src/__tests__/skills-index.claw591.test.tsx
+++ b/src/__tests__/skills-index.claw591.test.tsx
@@ -113,8 +113,8 @@ describe("SkillsIndex", () => {
   it("shows canonical Trending download totals without changing API order", async () => {
     fetchCanonicalTrendingPageMock.mockResolvedValue(
       canonicalPage([
-        makeTrending("first", "First Skill", 17, 9000, 71),
-        makeTrending("second", "Second Skill", 3, 8000, 29),
+        makeTrending("first", "First Skill", 3, 9000, 71),
+        makeTrending("second", "Second Skill", 17, 8000, 29),
       ]),
     );
 


### PR DESCRIPTION
## Summary

- rank native ClawHub Trending candidates by rolling 24-hour downloads before the existing deterministic tie-breakers
- persist the download signal in native candidate pools while keeping pre-v4 pool rows schema-compatible
- bump the canonical ranking version so deployments cannot reuse install-ranked v3 pools
- preserve skills.sh upstream rank, weighted interleave, publisher quota, deduplication, and pagination
- verify the homepage and `/skills` keep the canonical API order even when download and install order conflict

Closes #3419.

## Root cause

#3354 added real native `trending24hDownloads` to rendered canonical cards, but the sortable candidate shape still exposed only installs, bookmarks, and timestamps. The native comparator therefore continued to rank by installs while both surfaces displayed downloads.

## Provenance

- #3270 introduced the combined canonical Trending lanes and interleave.
- #3334 labeled Trending values as downloads.
- #3354 exposed real native 24-hour downloads while retaining install-based ranking.
- #3376 changed homepage skills.sh presentation only.

The mixed-source skills.sh badge/counter presentation is intentionally left unchanged for separate work.

## Validation

- focused canonical/backend/UI regressions: 79 passed
- broader canonical pagination/order regressions: 85 passed
- `bun run ci:static`
- `bun run ci:types-build`
- `bun run ci:packages` (545 tests across package verification)
- `bun run ci:unit`: 5934 passed, 2 skipped; one unrelated scoped plugin redirect test timed out in the full parallel run, then passed 4/4 in isolation

## Proof

[Full before/after browser proof](https://github.com/openclaw/clawhub/pull/3424#issuecomment-5199104552) ran against baseline `6381d789ab1883011639ca8e2aaec53202f0aad5` and candidate `49b8c7971b6050aec9ea1f91d8edb350d7e8dd48` on disposable local Convex deployments in Crabbox/Hetzner.

The canonical fixture deliberately gives `CLAW-590 Native 01` more 24-hour downloads but fewer installs than `CLAW-590 Native 02`. The baseline ranks `Native 02` first; the candidate ranks `Native 01` first on both the homepage and `/skills`. Both captures retain the combined 20-row feed with 12 native and 8 skills.sh entries, preserving the existing upstream order and weighted interleave.
