### PR TITLE
fix(web): simplify official publisher activity

### DIFF
--- a/src/__tests__/official-route.test.tsx
+++ b/src/__tests__/official-route.test.tsx
@@ -39,6 +39,7 @@ vi.mock("../components/PublisherListItem", () => ({
   PublisherListItem: (props: {
     publisher: { _id: string };
     showOfficialBadge?: boolean;
+    showPublishedRail?: boolean;
     variant?: string;
   }) => {
     publisherListItemMock(props);
@@ -152,6 +153,7 @@ describe("official route", () => {
     expect(publisherListItemMock).toHaveBeenCalledWith(
       expect.objectContaining({
         showOfficialBadge: false,
+        showPublishedRail: false,
         variant: "list",
       }),
     );

--- a/src/components/PublisherListItem.test.tsx
+++ b/src/components/PublisherListItem.test.tsx
@@ -39,6 +39,26 @@ describe("PublisherListItem", () => {
     expect(screen.queryByText("34")).toBeNull();
   });
 
+  it("renders plain activity without grouped item icons", () => {
+    const publisher = makePublisher();
+    publisher.publishedItems = [
+      { kind: "skill", displayName: "Example Skill", slug: "example-skill" } as never,
+    ];
+
+    const { container } = render(
+      <PublisherListItem publisher={publisher} showPublishedRail={false} />,
+    );
+
+    expect(container.querySelector(".publisher-published-rail")).toBeNull();
+    expect(container.querySelector(".publisher-card-main > .marketplace-icon")).toBeTruthy();
+    expect(container.querySelector(".publisher-card-stat.is-primary svg")).toBeTruthy();
+    expect(screen.getByText("2")).toBeTruthy();
+    expect(screen.getByText("published")).toBeTruthy();
+    expect(screen.getByText("12")).toBeTruthy();
+    expect(screen.getByText("downloads")).toBeTruthy();
+    expect(container.querySelector(".publisher-card-stat-separator")?.textContent).toBe("·");
+  });
+
   it("renders legacy preview metrics as downloads", () => {
     const publisher = makePublisher();
     publisher.publishedItems = [

--- a/src/components/PublisherListItem.tsx
+++ b/src/components/PublisherListItem.tsx
@@ -15,6 +15,7 @@ import { OfficialBadge } from "./OfficialBadge";
 type PublisherListItemProps = {
   publisher: PublicPublisherListItem;
   showOfficialBadge?: boolean;
+  showPublishedRail?: boolean;
   variant?: "list" | "grid" | "highlight";
 };
 
@@ -38,6 +39,7 @@ function PublishedRail({ items }: { items: PublicPublisherPublishedItem[] }) {
 export function PublisherListItem({
   publisher,
   showOfficialBadge = true,
+  showPublishedRail = true,
   variant = "list",
 }: PublisherListItemProps) {
   const handle = publisher.handle.trim();
@@ -98,12 +100,17 @@ export function PublisherListItem({
         </div>
       </div>
       {summaryInMain ? null : <p className="publisher-card-summary">{truncateText(summary, 80)}</p>}
-      <div className="publisher-card-stats">
+      <div className={`publisher-card-stats${showPublishedRail ? "" : " is-plain"}`}>
         <span className="publisher-card-stat">
-          <PublishedRail items={publisher.publishedItems} />
+          {showPublishedRail ? <PublishedRail items={publisher.publishedItems} /> : null}
           <strong>{formatCompactStat(publishedCount)}</strong>
           published
         </span>
+        {showPublishedRail ? null : (
+          <span className="publisher-card-stat-separator" aria-hidden="true">
+            ·
+          </span>
+        )}
         <span className="publisher-card-stat is-primary">
           <Download size={14} aria-hidden="true" />
           <strong>{formatCompactStat(publisher.stats.downloads)}</strong>

--- a/src/routes/official/index.tsx
+++ b/src/routes/official/index.tsx
@@ -257,6 +257,7 @@ function OfficialIndex() {
                     publisher={publisher}
                     variant="list"
                     showOfficialBadge={false}
+                    showPublishedRail={false}
                   />
                 ))}
               </div>

--- a/src/styles.css
+++ b/src/styles.css
@@ -18031,6 +18031,19 @@ a.agentic-risk-finding-title:focus-visible {
   color: var(--oc-text-muted);
 }
 
+.publisher-card-list .publisher-card-stats.is-plain {
+  display: flex;
+  gap: var(--oc-space-2);
+}
+
+.publisher-card-list .publisher-card-stats.is-plain .publisher-card-stat.is-primary::before {
+  content: none;
+}
+
+.publisher-card-stat-separator {
+  color: var(--oc-text-muted);
+}
+
 .publisher-card-stat svg {
   color: color-mix(in srgb, var(--ink-soft) 76%, var(--bg));
 }
@@ -18240,8 +18253,16 @@ a.agentic-risk-finding-title:focus-visible {
     text-align: right;
   }
 
+  .publisher-card-stats.is-plain {
+    display: grid;
+  }
+
   .publisher-card-list .publisher-card-stat.is-primary::before {
     content: none;
+  }
+
+  .publisher-card-stat-separator {
+    display: none;
   }
 
   .publisher-published-rail {


### PR DESCRIPTION
Closes #3421

## Summary

- removes the grouped package/plugin rail from `/official` publisher activity rows
- preserves publisher logos, published/download counts, and the established download glyph
- renders the middle dot as an explicit separator with one symmetric Carapace spacing token
- leaves search and other publisher listings unchanged

## Root cause

`PublisherListItem` always rendered `PublishedRail` before the published count. List rows then placed the two metric groups in a 20px grid gap while adding another 6px right margin to a generated separator, producing redundant decoration and asymmetric spacing.

## Provenance

The grouped rail and separator layout were introduced in #2087 by commit `8bd7be9d` on May 9, 2026. The download glyph came from the separate commit `379c1871` on June 22, 2026, so this PR intentionally preserves it.

## Tests

- `bun run test -- src/components/PublisherListItem.test.tsx src/__tests__/official-route.test.tsx` — 11 passed
- `bun run ci:static` — passed
- `bun run build` — passed
- `bun run ci:unit` — 5,929 passed; one unrelated sandbox failure because `npm pack` could not write `~/.npm/_logs`
- `bun run test -- scripts/claws-feed-openclaw-e2e.test.ts` outside the filesystem sandbox — 7 passed, 1 skipped

## Proof

Real built ClawHub baseline and candidate instances were checked at 1440×900 and 390×844 against the local Convex fixture. The repository `proof:ui` command was also attempted, but remote provisioning stopped before capture because this environment has no `HCLOUD_TOKEN` or `HETZNER_TOKEN`. The local before/after screenshots are published in the proof comment below.

## Scope

This PR does not change sorting, queries, counts, organization identity, responsive behavior, copy, or other listings. It adds no shared abstraction and uses the installed Carapace spacing contract.
