### PR TITLE
fix: restore homepage hero text selection

### DIFF
--- a/src/__tests__/ui-design-contract.test.ts
+++ b/src/__tests__/ui-design-contract.test.ts
@@ -358,6 +358,8 @@ describe("restored UI design contract", () => {
 
     expect(homeSource).toContain('className="home-v2-main oc-app-surface"');
     expect(homeSource).toContain("home-v2-headline oc-hero-title");
+    expect(homeSource).toContain('<span className="home-v2-action-word home-v2-static-headline">');
+    expect(cssRule(css, ".home-v2-headline")).not.toMatch(/(?:cursor: default|user-select: none)/);
     expect(cssRule(css, ".home-v2-static-headline")).toContain("color: var(--oc-accent-primary)");
     expect(css.lastIndexOf(".home-v2-static-headline")).toBeGreaterThan(
       css.lastIndexOf(".home-v2-action-word"),

--- a/src/styles.css
+++ b/src/styles.css
@@ -21492,8 +21492,6 @@ a.search-empty-action {
   justify-content: center;
   text-align: center;
   color: var(--hv2-text);
-  cursor: default;
-  user-select: none;
 }
 .home-v2-headline-clear {
   max-width: 960px;


### PR DESCRIPTION
## What Problem This Solves

The homepage headline renders as static text, but its owning CSS rule explicitly disables text selection and forces the default cursor. As a result, “Claws for your Claws” cannot be selected and copied like ordinary text.

## Proposed Change

- keep the existing static `h1 > span` markup unchanged
- remove `cursor: default` and `user-select: none` from `.home-v2-headline`
- preserve the headline with no link, button, navigation, or click handler
- add a focused UI contract regression covering the static markup and selection CSS

## Evidence

- Root cause: `.home-v2-headline` sets `cursor: default` and `user-select: none`; the later duplicate headline rule does not override either declaration.
- Real local Chromium runs selected exactly `Claws for your Claws` by mouse drag at desktop (1280×900) and mobile (390×844).
- Both runs resolved `userSelect`, `pointerEvents`, and `cursor` to `auto`, stayed on `/`, and confirmed `H1 > SPAN` with zero links and zero buttons.
- `bunx vitest run src/__tests__/ui-design-contract.test.ts` — 19 tests passed.
- `bun run ci:static` — passed.
- `bun run build` — passed.
- [UI proof](https://github.com/openclaw/clawhub/pull/3428#issuecomment-5198893067) — exact-SHA before/after passed in desktop and mobile.

## Scope

Two files, `+2/-2`. No DOM, navigation, copy, or visual styling changes beyond restoring normal text selection.
