### PR TITLE
fix: default homepage Plugins to Featured

### DIFF
--- a/src/__tests__/home-listing-section.claw591.test.tsx
+++ b/src/__tests__/home-listing-section.claw591.test.tsx
@@ -311,7 +311,9 @@ describe("HomeListingSection", () => {
     render(<HomeListingSection initialListing={initialTrending([], false, "unavailable")} />);
 
     fireEvent.click(screen.getByRole("button", { name: "Plugins" }));
-    expect(screen.getByRole("tab", { name: "New" }).getAttribute("aria-selected")).toBe("true");
+    expect(screen.getByRole("tab", { name: "Featured" }).getAttribute("aria-selected")).toBe(
+      "true",
+    );
 
     fireEvent.click(screen.getByRole("button", { name: "Skills" }));
     expect(screen.getByRole("tab", { name: "Featured" }).getAttribute("aria-selected")).toBe(
@@ -326,12 +328,14 @@ describe("HomeListingSection", () => {
     expect(screen.getByText(/eligible activity in the current 24-hour window/i)).toBeTruthy();
   });
 
-  it("shows Featured, Official, and New for plugins but never plugin Trending", async () => {
+  it("defaults Plugins to Featured, preserves explicit New, and returns to Skills Trending", async () => {
     render(<HomeListingSection initialListing={initialTrending([])} />);
 
     fireEvent.click(screen.getByRole("button", { name: "Plugins" }));
 
-    expect(screen.getByRole("tab", { name: "New" }).getAttribute("aria-selected")).toBe("true");
+    expect(screen.getByRole("tab", { name: "Featured" }).getAttribute("aria-selected")).toBe(
+      "true",
+    );
     expect(screen.getAllByRole("tab").map((tab) => tab.textContent)).toEqual([
       "Featured",
       "Official",
@@ -340,10 +344,23 @@ describe("HomeListingSection", () => {
     expect(screen.queryByRole("tab", { name: "Trending" })).toBeNull();
     expect(screen.queryByRole("tab", { name: "Top" })).toBeNull();
     await waitFor(() =>
+      expect(fetchPluginCatalogMock).toHaveBeenCalledWith(
+        expect.objectContaining({ featured: true }),
+      ),
+    );
+
+    fireEvent.click(screen.getByRole("tab", { name: "New" }));
+    await waitFor(() =>
       expect(convexQueryMock).toHaveBeenCalledWith(
         "packages:listPublicNewPluginsPage",
         expect.any(Object),
       ),
+    );
+    expect(screen.getByRole("tab", { name: "New" }).getAttribute("aria-selected")).toBe("true");
+
+    fireEvent.click(screen.getByRole("button", { name: "Skills" }));
+    expect(screen.getByRole("tab", { name: "Trending" }).getAttribute("aria-selected")).toBe(
+      "true",
     );
   });
 

--- a/src/components/HomeListingSection.tsx
+++ b/src/components/HomeListingSection.tsx
@@ -25,7 +25,6 @@ import { fetchPluginCatalog, type PackageListItem } from "../lib/packageApi";
 import { buildPluginDetailHref } from "../lib/pluginRoutes";
 import { presentationTitle } from "../lib/presentationTitle";
 import { PUBLIC_CATALOG_NAME_PREVIEW_LENGTH, truncateText } from "../lib/truncateText";
-import { MarketplaceIcon } from "./MarketplaceIcon";
 import {
   BrowseControlsDivider,
   BrowseCategorySelect,
@@ -34,6 +33,7 @@ import {
   BrowseSearchTrigger,
   useBrowseSearchDisclosure,
 } from "./BrowseControls";
+import { MarketplaceIcon } from "./MarketplaceIcon";
 import { OfficialBadge } from "./OfficialBadge";
 import { BrowseResultsSkeleton } from "./skeletons/BrowseResultsSkeleton";
 import { Badge } from "./ui/badge";
@@ -567,7 +567,13 @@ export function HomeListingSection({ initialListing = null }: HomeListingSection
     setKind(nextKind);
     setCategorySlug(undefined);
     setTab(
-      nextKind === "skills" ? (canonicalTrendingUnavailable ? "featured" : "trending") : "new",
+      nextKind === "skills"
+        ? canonicalTrendingUnavailable
+          ? "featured"
+          : "trending"
+        : tab === "trending"
+          ? "featured"
+          : tab,
     );
   };
 


### PR DESCRIPTION
Closes #3433

## Summary

- Falls back from the Skills-only `Trending` tab to `Featured` when switching to Plugins.
- Preserves explicitly selected valid Plugins tabs (`Featured`, `Official`, and `New`).
- Preserves the existing Skills default and unavailable-Trending fallback without changing route-level `/plugins` or `/skills` behavior.

## Root cause

#3319 hardened the homepage against an unavailable canonical Trending feed, but its content-type callback always mapped Plugins to `New`. #3418 retained that mapping while restoring the homepage catalog controls. This PR fixes the state transition in the owning homepage component: only the invalid Skills-only `Trending` state falls back to Plugins `Featured`; valid explicit Plugins tabs remain unchanged.

## Tests

- `bunx vitest run src/__tests__/home-listing-section.claw591.test.tsx src/__tests__/home-listing-section.test.tsx src/lib/homeListingData.test.ts` (29 passed)
- `npm_config_cache=/tmp/clawhub-npm-cache-3433 bun run ci:unit` (5,987 passed, 2 skipped)
- `bun run ci:types-build`
- Static format, lint, generated docs, dead-code, and release-workflow pin checks
- `bun run ci:static` reaches the dependency audit, which is blocked by six Mermaid and js-yaml advisories also present on `upstream/main`

## UI proof

Before/after browser proof was captured from real local ClawHub builds at baseline `34350cd16d1783d40fd50d0fb5d267010ccdc2a3` and candidate `6f3075ff97f4f007c951584f88e5f4c195e88d24`, using the repository-owned canonical Trending fixture. It covers desktop and 390px layouts, explicit Plugins `New`, and the return to Skills `Trending`.

[Final-SHA before/after proof](https://github.com/openclaw/clawhub/pull/3434#issuecomment-5209265669)
