### PR TITLE
fix: skill diffs stop crashing in dark mode

### DIFF
--- a/src/components/SkillDiffCard.test.tsx
+++ b/src/components/SkillDiffCard.test.tsx
@@ -1,13 +1,19 @@
 /* @vitest-environment jsdom */
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { useEffect } from "react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Doc, Id } from "../../convex/_generated/dataModel";
 import { SkillDiffCard } from "./SkillDiffCard";
 
 const getFilePreviewMock = vi.fn();
 let diffEditorMounts = 0;
 let diffEditorUnmounts = 0;
+let monacoMock: {
+  editor: {
+    defineTheme: ReturnType<typeof vi.fn>;
+    setTheme: ReturnType<typeof vi.fn>;
+  };
+} | null = null;
 
 vi.mock("convex/react", () => ({
   useAction: () => getFilePreviewMock,
@@ -23,9 +29,12 @@ vi.mock("@monaco-editor/react", () => ({
     options,
   }: {
     className?: string;
-    options?: { renderSideBySide?: boolean; useInlineViewWhenSpaceIsLimited?: boolean };
+    options?: {
+      renderSideBySide?: boolean;
+      useInlineViewWhenSpaceIsLimited?: boolean;
+    };
   }) => <MockDiffEditor className={className} options={options} />,
-  useMonaco: () => null,
+  useMonaco: () => monacoMock,
 }));
 
 function MockDiffEditor({
@@ -33,7 +42,10 @@ function MockDiffEditor({
   options,
 }: {
   className?: string;
-  options?: { renderSideBySide?: boolean; useInlineViewWhenSpaceIsLimited?: boolean };
+  options?: {
+    renderSideBySide?: boolean;
+    useInlineViewWhenSpaceIsLimited?: boolean;
+  };
 }) {
   useEffect(() => {
     diffEditorMounts += 1;
@@ -91,6 +103,49 @@ describe("SkillDiffCard", () => {
     getFilePreviewMock.mockResolvedValue({ text: "content" });
     diffEditorMounts = 0;
     diffEditorUnmounts = 0;
+    monacoMock = null;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    document.documentElement.removeAttribute("data-theme-resolved");
+  });
+
+  it("does not pass modern CSS colors to Monaco", async () => {
+    installMatchMedia(false);
+    const defineTheme = vi.fn();
+    monacoMock = {
+      editor: {
+        defineTheme,
+        setTheme: vi.fn(),
+      },
+    };
+    document.documentElement.setAttribute("data-theme-resolved", "dark");
+    vi.spyOn(window, "getComputedStyle").mockReturnValue({
+      getPropertyValue: () => "lab(70% 0 0)",
+    } as CSSStyleDeclaration);
+
+    render(
+      <SkillDiffCard
+        skill={skill}
+        versions={[
+          makeVersion("skillVersions:1", "1.0.1"),
+          makeVersion("skillVersions:2", "1.0.2"),
+        ]}
+      />,
+    );
+
+    await waitFor(() => expect(defineTheme).toHaveBeenCalled());
+    const theme = defineTheme.mock.calls[0]?.[1] as {
+      rules: Array<{ foreground: string }>;
+      colors: Record<string, string>;
+    };
+    expect(theme.rules.map((rule) => rule.foreground)).toEqual(["#f4f4f5", "#a1a1aa"]);
+    expect(
+      [...theme.rules.map((rule) => rule.foreground), ...Object.values(theme.colors)].filter(
+        (color) => /^(?:lab|lch|oklab|oklch|color|color-mix)\(/i.test(color),
+      ),
+    ).toEqual([]);
   });
 
   it("defaults to inline mode on narrow screens", async () => {

--- a/src/components/SkillDiffCard.tsx
+++ b/src/components/SkillDiffCard.tsx
@@ -744,28 +744,44 @@ function buildDiffOptions(
 
 function applyMonacoTheme(monaco: NonNullable<ReturnType<typeof useMonaco>>) {
   const styles = getComputedStyle(document.documentElement);
-  const surface = normalizeHex(styles.getPropertyValue("--oc-bg-elevated").trim() || "#ffffff");
-  const surfaceMuted = styles.getPropertyValue("--oc-bg-surface").trim() || "#f6f1ec";
-  const ink = styles.getPropertyValue("--oc-text-primary").trim() || "#1d1a17";
-  const inkSoft = styles.getPropertyValue("--oc-text-secondary").trim() || "#4c463f";
-  const line = styles.getPropertyValue("--oc-border-subtle").trim() || "rgba(29, 26, 23, 0.12)";
-  const accent = styles.getPropertyValue("--oc-accent-primary").trim() || "#e65c46";
-  const seafoam = styles.getPropertyValue("--oc-accent-secondary").trim() || "#2bc6a4";
-  const diffAdded = styles.getPropertyValue("--oc-diff-added").trim() || "#9bb955";
-  const diffAddedStrong = styles.getPropertyValue("--oc-diff-added-strong").trim() || seafoam;
-  const diffRemoved = styles.getPropertyValue("--oc-diff-removed").trim() || "#e47866";
-  const diffRemovedStrong = styles.getPropertyValue("--oc-diff-removed-strong").trim() || accent;
-  const diffDiagonal = toMonacoColor(
-    styles.getPropertyValue("--diff-diagonal").trim() || "#22222233",
-  );
-  const diffBorder = toMonacoColor(styles.getPropertyValue("--diff-border").trim() || line);
-  const lineNumber =
+  const isDark = isDarkThemeResolved();
+  const fallback = isDark
+    ? {
+        surface: "#18181b",
+        surfaceMuted: "#101012",
+        ink: "#f4f4f5",
+        inkSoft: "#a1a1aa",
+        line: "#ffffff1a",
+      }
+    : {
+        surface: "#ffffff",
+        surfaceMuted: "#f6f1ec",
+        ink: "#1d1a17",
+        inkSoft: "#4c463f",
+        line: "#1d1a171f",
+      };
+  const readColor = (name: string, fallbackColor: string) =>
+    toMonacoColor(styles.getPropertyValue(name).trim(), fallbackColor);
+  const surface = readColor("--oc-bg-elevated", fallback.surface);
+  const surfaceMuted = readColor("--oc-bg-surface", fallback.surfaceMuted);
+  const ink = readColor("--oc-text-primary", fallback.ink);
+  const inkSoft = readColor("--oc-text-secondary", fallback.inkSoft);
+  const line = readColor("--oc-border-subtle", fallback.line);
+  const accent = readColor("--oc-accent-primary", "#e65c46");
+  const seafoam = readColor("--oc-accent-secondary", "#2bc6a4");
+  const diffAdded = readColor("--oc-diff-added", "#9bb955");
+  const diffAddedStrong = readColor("--oc-diff-added-strong", seafoam);
+  const diffRemoved = readColor("--oc-diff-removed", "#e47866");
+  const diffRemovedStrong = readColor("--oc-diff-removed-strong", accent);
+  const diffDiagonal = readColor("--diff-diagonal", "#22222233");
+  const diffBorder = readColor("--diff-border", line);
+  const lineNumber = toMonacoColor(
     styles.getPropertyValue("--diff-line-number").trim() ||
-    styles.getPropertyValue("--ink-soft").trim() ||
-    "#4c463f";
+      styles.getPropertyValue("--ink-soft").trim(),
+    fallback.inkSoft,
+  );
   const background = surface;
   const gutter = surfaceMuted;
-  const isDark = isDarkThemeResolved();
   const base = isDark ? "vs-dark" : "vs";
 
   const diffInserted = withAlpha(diffAdded, isDark ? 0.26 : 0.14);
@@ -781,8 +797,8 @@ function applyMonacoTheme(monaco: NonNullable<ReturnType<typeof useMonaco>>) {
     base,
     inherit: true,
     rules: [
-      { token: "", foreground: normalizeHex(ink) },
-      { token: "comment", foreground: normalizeHex(inkSoft) },
+      { token: "", foreground: ink },
+      { token: "comment", foreground: inkSoft },
     ],
     colors: {
       "editor.background": background,
@@ -821,11 +837,14 @@ function normalizeHex(value: string) {
   if (value.length === 4) {
     return `#${value[1]}${value[1]}${value[2]}${value[2]}${value[3]}${value[3]}`;
   }
+  if (value.length === 5) {
+    return `#${value[1]}${value[1]}${value[2]}${value[2]}${value[3]}${value[3]}${value[4]}${value[4]}`;
+  }
   return value;
 }
 
 function toRgba(color: string, alpha: number) {
-  const hex = normalizeHex(color).replace("#", "");
+  const hex = normalizeHex(color).replace("#", "").slice(0, 6);
   if (hex.length !== 6) return color;
   const r = Number.parseInt(hex.slice(0, 2), 16);
   const g = Number.parseInt(hex.slice(2, 4), 16);
@@ -836,7 +855,7 @@ function toRgba(color: string, alpha: number) {
 function withAlpha(color: string, alpha: number) {
   const hex = normalizeHex(color);
   if (!hex.startsWith("#")) return color;
-  const value = hex.slice(1);
+  const value = hex.slice(1, 7);
   if (value.length !== 6) return color;
   const channel = Math.round(alpha * 255)
     .toString(16)
@@ -844,20 +863,25 @@ function withAlpha(color: string, alpha: number) {
   return `#${value}${channel}`;
 }
 
-function toMonacoColor(color: string) {
+function toMonacoColor(color: string, fallback: string) {
   const trimmed = color.trim();
-  if (trimmed.startsWith("#")) return trimmed;
+  const hex = normalizeHex(trimmed);
+  if (/^#[0-9a-f]{6}(?:[0-9a-f]{2})?$/i.test(hex)) return hex;
   const rgbaMatch = /^rgba?\(([^)]+)\)$/i.exec(trimmed);
-  if (!rgbaMatch) return trimmed;
+  if (!rgbaMatch) return normalizeHex(fallback);
   const parts = rgbaMatch[1].split(",").map((part) => part.trim());
-  if (parts.length < 3) return trimmed;
+  if (parts.length < 3) return normalizeHex(fallback);
   const [r, g, b] = parts.map((part) => Number.parseFloat(part));
   const alpha = parts.length >= 4 ? Number.parseFloat(parts[3]) : 1;
-  if ([r, g, b, alpha].some((value) => Number.isNaN(value))) return trimmed;
-  const channel = Math.round(alpha * 255)
+  if ([r, g, b, alpha].some((value) => !Number.isFinite(value))) return normalizeHex(fallback);
+  const channel = Math.round(Math.min(1, Math.max(0, alpha)) * 255)
     .toString(16)
     .padStart(2, "0");
   return `#${[r, g, b]
-    .map((value) => Math.round(value).toString(16).padStart(2, "0"))
+    .map((value) =>
+      Math.round(Math.min(255, Math.max(0, value)))
+        .toString(16)
+        .padStart(2, "0"),
+    )
     .join("")}${channel}`;
 }


### PR DESCRIPTION
Closes #3440

## What Problem This Solves

Fixes an issue where users opening a skill diff in dark mode could see the page crash when the browser resolved theme tokens to modern CSS `lab(...)` colors.

## Why This Change Was Made

Normalizes every CSS-derived color at the Monaco theme boundary and uses theme-appropriate hex fallbacks for color syntaxes Monaco cannot parse. Existing hex and `rgb`/`rgba` values remain supported, including alpha channels and clamped channel values.

## User Impact

Skill diffs now remain usable in dark mode across browsers that expose computed theme colors using modern CSS color functions.

## Evidence

Before the fix, the focused regression captured `lab(98.26% 0 0)` and `lab(70% 0 0)` in the Monaco token rules and failed. After the fix, the same dark-theme setup receives `#f4f4f5` and `#a1a1aa`, and no modern CSS color function reaches the Monaco theme payload.

Validation:

```text
bunx vitest run src/components/SkillDiffCard.test.tsx
bun run ci:unit
bunx vitest run scripts/claws-feed-openclaw-e2e.test.ts
bun run format:check
bun run lint
bun run llms:check
bun run deadcode:ci
bun run check:release-workflow-action-pins
bun run ci:types-build
```

The focused suite passed 5 tests. The complete unit run passed 6,013 tests with 9 skipped; its loopback-restricted feed suite also passed separately with 7 tests and 1 skip. Formatting, linting, dead-code analysis, type checks, and the production build passed.

Real browser proof on the PR head used the public development Convex backend and opened `http://localhost:3003/ivangdavila/skills/word-docx#diff` in dark mode. The browser reported:

```text
data-theme=dark
data-theme-resolved=dark
--oc-text-primary=oklch(0.985 0 0)
--oc-text-secondary=oklch(0.87 0 0)
--oc-bg-elevated=oklch(0.205 0 0)
monaco-diff-editor count=1
monaco-editor count=3
error-boundary visible=false
console errors=[]
```

The rendered Diff tab showed `previous (v1.0.1)` to `latest (v1.0.2)`, `SKILL.md`, `1 of 2 files`, `+100/-60`, and the changed source lines inside Monaco. This exercises the original failure boundary with real browser-computed modern CSS colors rather than mocked values.

`bun run ci:static` currently stops at the dependency audit because the unchanged lockfile reports existing advisories in DOMPurify, Mermaid, Nano ID, and js-yaml. All remaining static subchecks listed above pass.

Disclosure: AI was used to understand the codebase and review the fix.
