### PR TITLE
fix: caller metadata with a line break can no longer inject workflow commands into package publish logs

### DIFF
--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -363,6 +363,15 @@ jobs:
           from urllib.parse import quote, urlparse
           from urllib.request import Request, urlopen
 
+          def quote_for_log(part):
+              # shlex.quote is shell quoting, not output escaping: it wraps a value holding a
+              # line break in single quotes and leaves the break itself intact. One newline in
+              # a caller's metadata would then open a second log line, which the runner reads
+              # as a ::workflow-command. json.dumps escapes every control character, so one
+              # publish stays one line however the caller fills changelog, categories or topics.
+              quoted = shlex.quote(part)
+              return quoted if quoted.isprintable() else json.dumps(part)
+
           def split_ref_path(value):
               if not value:
                   return "", ""
@@ -572,7 +581,9 @@ jobs:
           shell_line = " ".join(shlex.quote(part) for part in cmd)
           path.write_text("#!/usr/bin/env bash\nset -euo pipefail\n" + shell_line + "\n", encoding="utf-8")
           path.chmod(0o755)
-          print(shell_line)
+          # Log-only: the file above is what a maintainer re-runs, so it keeps plain shell
+          # quoting. This echo does not, because the runner parses each stdout line.
+          print(" ".join(quote_for_log(part) for part in cmd))
 
           def write_output(fh, name, value):
               delimiter = f"ghadelimiter_{uuid.uuid4().hex}"

--- a/src/__tests__/package-publish-workflow.test.ts
+++ b/src/__tests__/package-publish-workflow.test.ts
@@ -232,4 +232,23 @@ describe("package publish workflow", () => {
       expect(resolveStep?.run).toContain(`elif ${clearName}:\n    cmd += ["--${name}", ""]`);
     }
   });
+
+  it("keeps a metadata value carrying CR or LF from opening a second log line", () => {
+    const workflow = readFileSync(resolve(".github/workflows/package-publish.yml"), "utf8");
+
+    // shlex.quote is shell quoting, not output escaping: it wraps a value in single quotes
+    // and leaves an embedded line break intact, so a changelog, categories or topics value
+    // carrying one would reach the runner as its own ::workflow-command line.
+    expect(workflow).toContain(
+      [
+        "              quoted = shlex.quote(part)",
+        "              return quoted if quoted.isprintable() else json.dumps(part)",
+      ].join("\n"),
+    );
+    expect(workflow).toContain('print(" ".join(quote_for_log(part) for part in cmd))');
+    expect(workflow).not.toContain("print(shell_line)");
+
+    // The re-runnable .sh file is a real shell script, so it keeps plain shell quoting.
+    expect(workflow).toContain('shell_line = " ".join(shlex.quote(part) for part in cmd)');
+  });
 });


### PR DESCRIPTION
Related: #3414

## What Problem This Solves

A repository that publishes packages through the reusable `package-publish.yml` workflow can pass a
`changelog`, `categories` or `topics` value. If that value contains a line break, the workflow's own
run log stops being one line and the GitHub Actions runner executes the remainder as a workflow
command: the caller can set an annotation, and the same channel reaches `::error`, `::warning`,
`::add-mask` and `::stop-commands`.

The values are caller-controlled `workflow_call` inputs, so anything that composes this workflow —
a matrix job, a release automation, a downstream repository passing a changelog straight from a tag
message or a PR body — can carry a newline into the log without anyone intending it.

## Why This Change Was Made

The resolve step builds a shell line and both writes it to a re-runnable `.sh` file and echoes it:

```python
shell_line = " ".join(shlex.quote(part) for part in cmd)
path.write_text("#!/usr/bin/env bash\nset -euo pipefail\n" + shell_line + "\n", encoding="utf-8")
path.chmod(0o755)
print(shell_line)
```

`shlex.quote` is shell quoting, not output escaping. Given `"a\n::notice::x"` it returns
`'a\n::notice::x'` — single quotes around a line break that is still a line break. That is correct
for the `.sh` file, where a shell reads the quotes, and wrong for the echo, where the runner reads
each stdout line on its own.

So the file keeps `shell_line` untouched and only the echo changes, through a `quote_for_log`
helper that falls back to `json.dumps` when the shell-quoted form is not printable:

```python
quoted = shlex.quote(part)
return quoted if quoted.isprintable() else json.dumps(part)
```

Two choices inside that:

1. **`str.isprintable()`, not an explicit `\r\n` check.** It is false for every C0/C1 control
   character and for the Unicode line and paragraph separators, so nothing has to enumerate the
   characters that can split a line. `--changelog 'Adds 日本語 notes'` is printable and stays on the
   readable, copy-pasteable `shlex.quote` path; only a value that cannot be printed as one line is
   escaped.
2. **`json.dumps`, not a blanket `repr`.** `ensure_ascii` defaults to true, so the fallback output
   is ASCII-only and cannot smuggle a separator back in.

This is the same fix as #3414 on the skill workflow, where the finding was raised. I noticed the
package side while writing that one; it has the same shape because the two workflows forward the
same three caller-controlled inputs.

## User Impact

Callers of the reusable package publish workflow can no longer influence the runner through
metadata inputs, intentionally or by accident. Nothing else changes: the executed command is a
`subprocess.run` argument list and is untouched, the generated `.sh` file is byte-identical, and a
metadata value with no control characters logs exactly as it did before.

## Evidence

**Real behavior.** Two jobs in one dispatch, same multi-line `changelog`, differing only in the
pinned ClawHub SHA — `82313c2b` (current `main`) and `25aec929` (this branch's head). Both hardcode
`dry_run: true` and pass no `secrets:`
([run 31409524372](https://github.com/Yigtwxx/clawhub-skill-metadata-proof/actions/runs/31409524372),
[workflow source](https://github.com/Yigtwxx/clawhub-skill-metadata-proof/blob/main/.github/workflows/proof-package-newline.yml)):

```yaml
changelog: |-
  Line one of the changelog value.
  ::notice title=INJECTED::this line came from a changelog input
```

[before-fix](https://github.com/Yigtwxx/clawhub-skill-metadata-proof/actions/runs/31409524372/job/93523961368)
— the echo breaks in two and the runner consumes the second line:

```
bun ... package publish Yigtwxx/clawhub-skill-metadata-proof@15655db6 ... --dry-run --json --tags latest --changelog 'Line one of the changelog value.
##[notice]this line came from a changelog input' --source-ref refs/heads/main
```

[after-fix](https://github.com/Yigtwxx/clawhub-skill-metadata-proof/actions/runs/31409524372/job/93523961426)
— one line, and the payload is inert text:

```
bun ... package publish Yigtwxx/clawhub-skill-metadata-proof@15655db6 ... --dry-run --json --tags latest --changelog "Line one of the changelog value.\n::notice title=INJECTED::this line came from a changelog input" --source-ref refs/heads/main
```

The check-run annotations are the unambiguous half, because a line the runner accepts as a command
is removed from the log rather than printed:

```
$ gh api repos/.../check-runs/93523961368/annotations   # before-fix
failure   -          Process completed with exit code 1.
warning   -          Plugin Inspector skipped because ... is not a plugin root.
notice    INJECTED   this line came from a changelog input' --source-ref refs/heads/main

$ gh api repos/.../check-runs/93523961426/annotations   # after-fix
failure   -          Process completed with exit code 1.
warning   -          Plugin Inspector skipped because ... is not a plugin root.
```

The injected annotation carries the tail of the real command, which is what the runner swallowed.

**Both jobs end red, and that is expected.** The step under test, `Resolve publish command`, is
green in both; the caller repository holds no ClawPack package, so both jobs then stop at
`Run package publish` with the identical `exit code 1` and the identical plugin-inspector warning
above. Those two annotations appear on both sides and cancel out; the `INJECTED` one does not.

One thing worth a maintainer's eye, which the fix does not and cannot address: the raw second line
is *also* in both jobs' logs before the resolve step runs, in the runner's own `##[group] Inputs`
echo of the reusable-workflow inputs and in the `env:` block printed above each step. Those are the
runner writing its own log rather than step stdout, so they are never parsed — the after-fix job
having no `INJECTED` annotation is the proof of that. A multi-line input stays visible in logs
either way; what this fix removes is the part where it becomes executable.

**Tests.** `src/__tests__/package-publish-workflow.test.ts` gains a case that pins the helper
itself, that the echo goes through it, and that `shell_line` keeps plain shell quoting for the `.sh`
file:

```
bunx vitest run src/__tests__/package-publish-workflow.test.ts scripts/security/package-publish-workflow.test.ts
  7 passed (7)
```

Negative control: restoring only `.github/workflows/package-publish.yml` from `main` gives
`1 failed | 5 passed`, so the test fails without the fix. The test pins the fallback rather than
only the absence of the old call, so replacing `quote_for_log` with anything that leaves a control
character intact fails it.

All seven embedded Python blocks in the workflow were extracted from the file and parsed with
`ast.parse`; all seven are syntactically valid, including the 243-line block this touches.

```
bunx oxfmt --check src/__tests__/package-publish-workflow.test.ts    All matched files use the correct format.
```

**Pre-existing CI failure, unrelated to this branch.** `pr-gates` currently fails at `bun audit` on
`main` itself and therefore on every open PR; #3446 fixes that separately. It is not caused by this
diff.

Screenshots: N/A, workflow change with no UI surface.
