### PR TITLE
fix: filter skills.sh route query params

### DIFF
--- a/src/__tests__/skills-sh-route.test.ts
+++ b/src/__tests__/skills-sh-route.test.ts
@@ -22,15 +22,32 @@ async function loadRoute() {
   };
 }
 
-async function runLoader() {
+async function runLoader(params = { owner: "patrick-erichsen", repo: "skills", slug: "html" }) {
   const route = await loadRoute();
   try {
-    return await route.__config.loader({
-      params: { owner: "patrick-erichsen", repo: "skills", slug: "html" },
-    });
+    return await route.__config.loader({ params });
   } catch (error) {
     return error;
   }
+}
+
+async function getFuzzyMatchParams() {
+  const { createMemoryHistory, createRootRoute, createRoute, createRouter } =
+    await vi.importActual<typeof import("@tanstack/react-router")>("@tanstack/react-router");
+  const rootRoute = createRootRoute();
+  const detailRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/skills-sh/$owner/$repo/$slug",
+  });
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([detailRoute]),
+    history: createMemoryHistory({ initialEntries: ["/"] }),
+  });
+  const match = router
+    .matchRoutes("/skills-sh/patrick-erichsen/skills/html/extra")
+    .find((candidate) => candidate.routeId === "/skills-sh/$owner/$repo/$slug");
+  if (!match) throw new Error("Expected TanStack Router to fuzzy-match the skills.sh detail route");
+  return match.params;
 }
 
 describe("skills.sh detail route", () => {
@@ -41,6 +58,25 @@ describe("skills.sh detail route", () => {
     queryMock.mockResolvedValue({ kind: "external", entry });
 
     expect(await runLoader()).toEqual(entry);
+    expect(queryMock.mock.calls[0]?.[1]).toEqual({
+      owner: "patrick-erichsen",
+      repo: "skills",
+      slug: "html",
+    });
+  });
+
+  it("omits TanStack fuzzy-match metadata from the Convex query", async () => {
+    const entry = { displayName: "HTML Artifact Chooser" };
+    queryMock.mockResolvedValue({ kind: "external", entry });
+    const params = await getFuzzyMatchParams();
+
+    expect(params).toEqual({
+      owner: "patrick-erichsen",
+      repo: "skills",
+      slug: "html",
+      "**": "extra",
+    });
+    expect(await runLoader(params)).toEqual(entry);
     expect(queryMock.mock.calls[0]?.[1]).toEqual({
       owner: "patrick-erichsen",
       repo: "skills",

--- a/src/routes/skills-sh/$owner/$repo/$slug.tsx
+++ b/src/routes/skills-sh/$owner/$repo/$slug.tsx
@@ -5,7 +5,11 @@ import { convexHttp } from "../../../../convex/client";
 
 export const Route = createFileRoute("/skills-sh/$owner/$repo/$slug")({
   loader: async ({ params }) => {
-    const result = await convexHttp.query(api.skillsShMirrorPublic.getByRoute, params);
+    const result = await convexHttp.query(api.skillsShMirrorPublic.getByRoute, {
+      owner: params.owner,
+      repo: params.repo,
+      slug: params.slug,
+    });
     if (!result) throw notFound();
     if (result.kind === "redirect") throw redirect({ href: result.canonicalRoute });
     return result.entry;


### PR DESCRIPTION
## Summary

- pass only `owner`, `repo`, and `slug` from the skills.sh detail loader to the strict Convex query validator
- add a regression test using TanStack Router's real fuzzy-match output, including its `**` leftover-path metadata

## Root cause

TanStack Router fuzzy-matches an overlong path such as `/skills-sh/patrick-erichsen/skills/html/extra` to the detail route and adds `"**": "extra"` to the route params while marking the navigation as a global 404. The loader forwarded that entire framework-owned object to `skillsShMirrorPublic:getByRoute`, whose strict validator accepts only `owner`, `repo`, and `slug`, causing `ArgumentValidationError` before the query handler ran.

## Production evidence

Axiom dataset `clawhub`, window `2026-08-07T15:00:00Z` to `2026-08-10T15:01:20.358Z`:

- 1,534 `skillsShMirrorPublic:getByRoute` failures with extra field `**`
- 10.78% route failure rate (`1,534 / 14,223`), up from 5.06% (`413 / 8,151`) in the equal preceding baseline

## Validation

- red: `bunx vitest run src/__tests__/skills-sh-route.test.ts` failed because the Convex query received `**`
- green: `bunx vitest run src/__tests__/skills-sh-route.test.ts --maxWorkers=1 --testTimeout=60000` (4 passed)
- `bun run format:check`
- `bun run lint`
- `bun run deadcode:ci`
- `bun run llms:check`
- `bun run check:release-workflow-action-pins`
- `bun run ci:types-build`
- `.agents/skills/autoreview/scripts/autoreview --mode local --parallel-tests 'bun run ci:unit' ...` reported no accepted/actionable findings

### Local gate caveats

- `bun run ci:static` stopped at `bun audit` on eight current dependency advisories before formatting/lint; all remaining static components passed when run directly.
- The first `bun run ci:unit` attempt completed 6,018 tests with two unrelated 15-second timeouts; both files then passed together (8/8 in 3.74s). Later retries became host-resource-limited with unrelated worker-start/timeouts. Fresh PR CI should provide the authoritative full-suite result.
