### PR TITLE
fix(search): prevent rolling usage query timeouts

### DIFF
--- a/convex/lib/canonicalSkillSearchBounds.ts
+++ b/convex/lib/canonicalSkillSearchBounds.ts
@@ -5,5 +5,5 @@ export const CANONICAL_SKILL_SEARCH_BOUNDS = {
   externalCandidateLimitPerIndex: 50,
   externalIndexedReadCount: 6,
   rollingAdoptionDays: 60,
-  rollingUsageBatchSize: 40,
+  rollingUsageBatchSize: 20,
 } as const;

--- a/convex/search.test.ts
+++ b/convex/search.test.ts
@@ -1295,12 +1295,12 @@ describe("search helpers", () => {
       getRollingSkillSearchUsageHandler(
         { db: { query: vi.fn() } },
         {
-          skillIds: Array.from({ length: 41 }, (_, index) => `skills:${index}`),
+          skillIds: Array.from({ length: 21 }, (_, index) => `skills:${index}`),
           startDay: 100,
           endDay: 159,
         },
       ),
-    ).rejects.toThrow("skillIds exceeds 40");
+    ).rejects.toThrow("skillIds exceeds 20");
   });
 
   it("returns one ordered native and external contract with canonical routes and install refs", async () => {
@@ -1367,6 +1367,56 @@ describe("search helpers", () => {
       icon: null,
       sourceIdentity: { lifetimeInstalls: 10_000_000 },
       downloads: 10_000_000,
+    });
+  });
+
+  it("preserves rolling adoption ranking when usage reads require smaller transactions", async () => {
+    generateEmbeddingMock.mockRejectedValueOnce(new Error("embedding unavailable"));
+    const native = Array.from({ length: 100 }, (_, index) => ({
+      skill: makePublicSkill({
+        id: `skills:calendar-${index}`,
+        slug: `calendar-${index}`,
+        displayName: `Calendar ${index}`,
+      }),
+      version: null,
+      ownerHandle: "openclaw",
+      owner: null,
+    }));
+    const runQuery = vi.fn(
+      async (ref: Parameters<typeof getFunctionName>[0], args?: { skillIds?: string[] }) => {
+        switch (getFunctionName(ref)) {
+          case "search:getExactSkillSlugMatch":
+          case "search:lexicalFallbackSkills":
+          case "search:getExternalSkillSearchCandidates":
+            return [];
+          case "search:directPrefixSkillMatches":
+            return native;
+          case "search:getRollingSkillSearchUsage": {
+            const skillIds = args?.skillIds ?? [];
+            if (skillIds.length > 20) {
+              throw new Error("Function execution timed out (maximum duration: 1s)");
+            }
+            return skillIds.map((skillId) => ({
+              skillId,
+              installs: skillId === "skills:calendar-99" ? 10_000 : 1,
+              bookmarks: 0,
+            }));
+          }
+          default:
+            throw new Error(`Unexpected query ${getFunctionName(ref)}`);
+        }
+      },
+    );
+
+    const result = await canonicalSearchSkillsHandler(
+      { runQuery, vectorSearch: vi.fn() },
+      { query: "calendar", limit: 100 },
+    );
+
+    expect(result).toHaveLength(100);
+    expect(result[0]).toMatchObject({
+      id: "clawhub:skills:calendar-99",
+      metrics: { rolling60DayInstalls: 10_000 },
     });
   });
 

--- a/convex/search.ts
+++ b/convex/search.ts
@@ -664,8 +664,8 @@ type CanonicalSkillSearchResult = {
 const CANONICAL_NATIVE_CANDIDATE_LIMIT = CANONICAL_SKILL_SEARCH_BOUNDS.nativeCandidateLimit;
 const CANONICAL_RESULT_LIMIT_MAX = CANONICAL_SKILL_SEARCH_BOUNDS.resultLimit;
 const ROLLING_ADOPTION_DAYS = CANONICAL_SKILL_SEARCH_BOUNDS.rollingAdoptionDays;
-// Forty candidates can read at most 2,400 daily rows, leaving headroom below
-// Convex's per-transaction document/byte limits for imported production-shaped data.
+// Twenty candidates read at most 1,200 daily rows. Keep this well below the
+// query CPU ceiling: production-shaped 40-skill batches had intermittent 1s timeouts.
 const ROLLING_USAGE_QUERY_BATCH_SIZE = CANONICAL_SKILL_SEARCH_BOUNDS.rollingUsageBatchSize;
 
 function chunkValues<T>(values: T[], size: number) {

--- a/e2e/clawhub.e2e.test.ts
+++ b/e2e/clawhub.e2e.test.ts
@@ -342,8 +342,9 @@ describe("clawhub e2e", () => {
     const response = await fetchWithTimeout(url.toString(), {
       headers: { Accept: "application/json" },
     });
-    expect(response.ok).toBe(true);
-    const json = (await response.json()) as unknown;
+    const body = await response.text();
+    expect(response.ok, `search failed with ${response.status}: ${body}`).toBe(true);
+    const json = JSON.parse(body) as unknown;
     const parsed = parseArk(ApiV1SearchResponseSchema, json, "API response");
     expect(Array.isArray(parsed.results)).toBe(true);
   });


### PR DESCRIPTION
## Summary

- halve canonical search rolling-usage child transactions from 40 skills (up to 2,400 daily rows) to 20 skills (up to 1,200 rows)
- preserve complete 60-day install/bookmark ranking across all 100 native candidates
- make the production search e2e print HTTP status and body on failure without retrying or weakening detection

## Root cause

The post-merge CI failure on [#3446](https://github.com/openclaw/clawhub/pull/3446) was an intermittent production backend timeout, not a dependency-update regression. `search:searchSkills` split up to 100 native candidates into 40-skill rolling-usage queries and ran them with `Promise.all`. Each child could read 2,400 `skillDailyStats` rows. One child timeout rejected the entire action and propagated through `GET /api/v1/search` as a failed response.

For request `849ed01a583b8ed9`, one child succeeded after reading 2,202 documents in 426 ms; its parallel sibling spent 1,208 ms of user execution time, exceeded Convex's 1-second query limit, and failed at 1,214 ms. The action then failed at `convex/search.ts`, followed by the HTTP action at 5,099 ms. [Exact request chain in Axiom](https://app.axiom.co/openclaw-9pp0/query?initForm=%7B%0A%20%20%22apl%22%3A%20%22%5B%27clawhub%27%5D%20%7C%20where%20%5B%27data.function.request_id%27%5D%20has_cs%20%5C%22849ed01a583b8ed9%5C%22%20%7C%20project%20_time%2C%20%5B%27data.status%27%5D%2C%20%5B%27data.function.path%27%5D%2C%20%5B%27data.function.type%27%5D%2C%20%5B%27data.execution_time_ms%27%5D%2C%20%5B%27data.user_execution_time_ms%27%5D%2C%20%5B%27data.error_message%27%5D%2C%20%5B%27data.usage.database_read_documents%27%5D%2C%20%5B%27data.usage.database_read_bytes%27%5D%20%7C%20order%20by%20_time%20asc%22%2C%0A%20%20%22queryOptions%22%3A%20%7B%0A%20%20%20%20%22quickRange%22%3A%20%222026-08-11T14%3A45%3A00Z..2026-08-11T14%3A55%3A00Z%22%0A%20%20%7D%0A%7D)

Over `2026-08-10T15:00Z..2026-08-11T15:00Z`, `getRollingSkillSearchUsage` had 280,395 executions and 3 one-second timeouts. [24-hour child-query evidence](https://app.axiom.co/openclaw-9pp0/query?initForm=%7B%0A%20%20%22apl%22%3A%20%22%5B%27clawhub%27%5D%20%7C%20where%20_time%20between%20%28datetime%282026-08-10T15%3A00%3A00Z%29%20..%20datetime%282026-08-11T15%3A00%3A00Z%29%29%20%7C%20where%20%5B%27data.function.path%27%5D%20%3D%3D%20%5C%22search%3AgetRollingSkillSearchUsage%5C%22%20%7C%20summarize%20executions%3Dcount%28%29%2C%20failures%3Dcountif%28%5B%27data.status%27%5D%20%3D%3D%20%5C%22failure%5C%22%29%2C%20timeouts%3Dcountif%28%5B%27data.error_message%27%5D%20contains%20%5C%22timed%20out%5C%22%29%2C%20p95_ms%3Dpercentile%28%5B%27data.execution_time_ms%27%5D%2C%2095%29%2C%20p99_ms%3Dpercentile%28%5B%27data.execution_time_ms%27%5D%2C%2099%29%2C%20max_ms%3Dmax%28%5B%27data.execution_time_ms%27%5D%29%22%2C%0A%20%20%22queryOptions%22%3A%20%7B%0A%20%20%20%20%22quickRange%22%3A%20%222026-08-10T15%3A00%3A00Z..2026-08-11T15%3A00%3A00Z%22%0A%20%20%7D%0A%7D)

Provenance: introduced by [#3264](https://github.com/openclaw/clawhub/pull/3264) / `65ea02f4caa19f6c3f240ca0a534240af876fbe7` on 2026-07-25. The intent—bounded 60-day ClawHub adoption tie-breakers—remains unchanged.

## Best-fix verdict

This is the smallest safe correction at the implicated transaction boundary. Serializing unchanged 40-skill batches would retain the same per-query CPU risk. Retrying or dropping usage would mask the failure or violate deterministic 60-day ranking. A materialized rolling-usage digest could remove read amplification but requires a larger migration and synchronization design.

## Regression proof

The new action-level regression deterministically injects the production timeout for usage transactions above 20 skills. It failed before the fix with `Function execution timed out (maximum duration: 1s)`. After the fix it returns all 100 candidates and ranks the high-adoption candidate from the final batch first, proving no candidate or 60-day usage is silently dropped.

## Validation

- `bunx vitest run convex/search.test.ts` — 90 passed
- `bunx vitest run -c vitest.e2e.config.ts e2e/clawhub.e2e.test.ts -t "search endpoint returns a results array"` — 1 passed
- `bun run ci:static`
- `bun run ci:unit` — 6,040 passed, 2 skipped; coverage gate passed
- `bun run ci:types-build`
- `bunx convex codegen` against the configured loopback local Convex runtime; generated bindings unchanged
- autoreview (Codex `gpt-5.6-sol`, high) — clean, no actionable findings

## Residual rollout work

No production deploy was performed. After normal deployment, monitor `search:getRollingSkillSearchUsage` timeout count and `GET /api/v1/search` p95/p99/failure rate. If 20-skill batches still approach the CPU ceiling, follow up with a materialized rolling-usage digest rather than adding retries or weakening the 60-day ranking contract.
