### PR TITLE
fix: keep catalog first-page failures retryable

### DIFF
--- a/src/__tests__/skills-index.test.tsx
+++ b/src/__tests__/skills-index.test.tsx
@@ -1055,28 +1055,32 @@ describe("SkillsIndex", () => {
     async (tab) => {
       searchMock = { tab };
       vi.stubGlobal("IntersectionObserver", undefined);
-      vi.spyOn(console, "error").mockImplementation(() => {});
-      convexHttpMock.query
-        .mockRejectedValueOnce(new Error("temporary failure"))
-        .mockResolvedValueOnce({
-          page: [makeListResult("recovered-skill", "Recovered Skill")],
-          hasMore: false,
-          nextCursor: null,
+      const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      try {
+        convexHttpMock.query
+          .mockRejectedValueOnce(new Error("temporary failure"))
+          .mockResolvedValueOnce({
+            page: [makeListResult("recovered-skill", "Recovered Skill")],
+            hasMore: false,
+            nextCursor: null,
+          });
+
+        render(<SkillsIndex />);
+        await act(async () => {});
+
+        expect(screen.queryByText("No skills found")).toBeNull();
+        expect(screen.getByRole("button", { name: "Load more" })).toBeTruthy();
+
+        await act(async () => {
+          fireEvent.click(screen.getByRole("button", { name: "Load more" }));
         });
 
-      render(<SkillsIndex />);
-      await act(async () => {});
-
-      expect(screen.queryByText("No skills found")).toBeNull();
-      expect(screen.getByRole("button", { name: "Load more" })).toBeTruthy();
-
-      await act(async () => {
-        fireEvent.click(screen.getByRole("button", { name: "Load more" }));
-      });
-
-      expect(convexHttpMock.query).toHaveBeenCalledTimes(2);
-      expect(screen.getByText("Recovered Skill")).toBeTruthy();
-      expect(screen.queryByRole("button", { name: "Load more" })).toBeNull();
+        expect(convexHttpMock.query).toHaveBeenCalledTimes(2);
+        expect(screen.getByText("Recovered Skill")).toBeTruthy();
+        expect(screen.queryByRole("button", { name: "Load more" })).toBeNull();
+      } finally {
+        consoleErrorSpy.mockRestore();
+      }
     },
   );
 

--- a/src/__tests__/skills-index.test.tsx
+++ b/src/__tests__/skills-index.test.tsx
@@ -1050,6 +1050,36 @@ describe("SkillsIndex", () => {
     expect(screen.getByRole("button", { name: "Load more" })).toBeTruthy();
   });
 
+  it.each(["new", "featured", "official"] as const)(
+    "keeps the %s first page retryable after a temporary fetch failure",
+    async (tab) => {
+      searchMock = { tab };
+      vi.stubGlobal("IntersectionObserver", undefined);
+      vi.spyOn(console, "error").mockImplementation(() => {});
+      convexHttpMock.query
+        .mockRejectedValueOnce(new Error("temporary failure"))
+        .mockResolvedValueOnce({
+          page: [makeListResult("recovered-skill", "Recovered Skill")],
+          hasMore: false,
+          nextCursor: null,
+        });
+
+      render(<SkillsIndex />);
+      await act(async () => {});
+
+      expect(screen.queryByText("No skills found")).toBeNull();
+      expect(screen.getByRole("button", { name: "Load more" })).toBeTruthy();
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button", { name: "Load more" }));
+      });
+
+      expect(convexHttpMock.query).toHaveBeenCalledTimes(2);
+      expect(screen.getByText("Recovered Skill")).toBeTruthy();
+      expect(screen.queryByRole("button", { name: "Load more" })).toBeNull();
+    },
+  );
+
   it("keeps loading across empty filtered pages without flashing terminal states", async () => {
     class IntersectionObserverMock {
       observe = vi.fn();

--- a/src/routes/skills/-useSkillsBrowseModel.ts
+++ b/src/routes/skills/-useSkillsBrowseModel.ts
@@ -294,10 +294,10 @@ export function useSkillsBrowseModel({
           setListResults([]);
           setTrendingState("unavailable");
         }
-        // Reset to idle so the user can retry via "Load more"
+        // Keep canonical Trending's dedicated unavailable state; other pages remain retryable.
         setListCursor(pageCursor);
         setListAutoLoadPaused(Boolean(pageCursor));
-        setListStatus(pageCursor ? "idle" : "done");
+        setListStatus(catalogTab === "trending" && !pageCursor ? "done" : "idle");
       }
     },
     [


### PR DESCRIPTION
## Summary

- keep New, Featured, and Official first-page fetch failures retryable
- avoid showing a terminal empty-catalog state before a successful empty response
- preserve Trending's existing unavailable/fallback behavior

## Why

The first request used a null cursor. On rejection, the shared error path set the list to `done`,
which removed **Load more** and presented the catalog as empty. Returning these non-Trending views
to `idle` keeps the existing retry control available without changing successful pagination or
later-page failure behavior.

## Verification

- regression cases: 3/3
- complete `SkillsIndex` suite: 52/52
- Trending control suite: 21/21
- load-more control: 1/1
- `bun run ci:static`
- `bunx tsc --noEmit`
- targeted type-aware oxlint and format checks

The aggregate coverage command did not finish inside a 180-second local timebox, so I am not
claiming that gate; the relevant suites and static gates above completed successfully.

No screenshot is attached because the change concerns a transient rejected-request state and the
regression drives the real rendered controls directly: the retry control remains after failure,
issues a second request, and disappears after recovery.

## AI assistance

AI-assisted implementation and review were used. I reviewed the state transition, can maintain the
change, and independently verified retry, pagination, stale-response, double-click, and Trending
fallback behavior.

## Real behavior proof

The exact live base (`faab45ba`) and PR head (`25db30d2`) were run as real ClawHub applications in
Chromium against the same local Convex deployment and seeded repository fixture. Playwright
intercepted the real first `/api/query` request with HTTP 503 in both lanes.

- Base: rendered the false terminal `No skills found` state with no retry control.
- Candidate: rendered `Load more` after the identical failure.
- Recovery: after removing only the route interception and clicking that real button, the second
  Convex request returned 200 and the seeded skill rendered.

Before/after screenshots, metadata and the full methodology are linked in the durable UI proof
comment below. No DOM, application source, HTML or database row was edited to manufacture the UI.
