### PR TITLE
fix: abort hung OG metadata fetches and archive metrics

### DIFF
--- a/server/convexProxy.test.ts
+++ b/server/convexProxy.test.ts
@@ -228,6 +228,7 @@ describe("Convex HTTP proxy", () => {
     expect(metricCall?.[1]).toMatchObject({
       method: "POST",
       body: "signed-metric-capability",
+      signal: expect.any(AbortSignal),
     });
     const fetchedUrls = fetchMock.mock.calls.map(([input]) => input.toString());
     expect(
@@ -643,5 +644,77 @@ describe("Convex HTTP proxy", () => {
 
     expect(response.status).toBe(405);
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("does not wait for download metrics before emitting zip bytes", async () => {
+    const storedBody = new TextEncoder().encode("# streamed skill\n");
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      const url = input.toString();
+      if (url.startsWith("https://preview-branch-123.convex.site/api/v1/download")) {
+        return Response.json(
+          {
+            schema: "clawhub.skill-archive-manifest.v1",
+            issuedAt: 1_000,
+            expiresAt: 31_000,
+            filename: "demo-1.0.0.zip",
+            meta: {
+              ownerId: "users:1",
+              slug: "demo",
+              version: "1.0.0",
+              publishedAt: 3,
+            },
+            entries: [
+              {
+                path: "SKILL.md",
+                url: "https://preview-branch-123.convex.cloud/api/storage/storage-1",
+              },
+            ],
+            metricToken: "signed-metric-capability",
+          },
+          { headers: { "content-type": ARCHIVE_MANIFEST_CONTENT_TYPE } },
+        );
+      }
+      if (url === "https://preview-branch-123.convex.cloud/api/storage/storage-1") {
+        return new Response(storedBody, { status: 200 });
+      }
+      if (url === "https://preview-branch-123.convex.site/api/internal/archive-download-metric") {
+        return new Promise<Response>(() => {});
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(Date, "now").mockReturnValue(2_000);
+
+    const response = await proxyConvexRequest(
+      mockEvent("https://preview.example/api/v1/download?slug=demo"),
+      {
+        VERCEL_ENV: "preview",
+        VITE_CONVEX_SITE_URL: "https://preview-branch-123.convex.site",
+        VITE_CONVEX_URL: "https://preview-branch-123.convex.cloud",
+      },
+      TEST_ARCHIVE_DEPENDENCIES,
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body).not.toBeNull();
+    const reader = response.body!.getReader();
+    const firstChunk = await Promise.race([
+      reader.read(),
+      new Promise<never>((_, reject) => {
+        setTimeout(() => reject(new Error("zip first byte blocked by download metric")), 500);
+      }),
+    ]);
+
+    expect(firstChunk.done).toBe(false);
+    expect(firstChunk.value?.byteLength).toBeGreaterThan(0);
+    expect(
+      fetchMock.mock.calls.some(
+        ([input]) =>
+          input.toString() ===
+          "https://preview-branch-123.convex.site/api/internal/archive-download-metric",
+      ),
+    ).toBe(true);
+
+    await reader.cancel();
   });
 });

--- a/server/convexProxy.test.ts
+++ b/server/convexProxy.test.ts
@@ -31,6 +31,7 @@ const TEST_ARCHIVE_DEPENDENCIES = {
 
 describe("Convex HTTP proxy", () => {
   afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
   });
@@ -647,6 +648,7 @@ describe("Convex HTTP proxy", () => {
   });
 
   it("does not wait for download metrics before emitting zip bytes", async () => {
+    vi.useFakeTimers();
     const storedBody = new TextEncoder().encode("# streamed skill\n");
     const fetchMock = vi.fn(async (input: string | URL | Request) => {
       const url = input.toString();
@@ -700,8 +702,8 @@ describe("Convex HTTP proxy", () => {
     const reader = response.body!.getReader();
     const firstChunk = await Promise.race([
       reader.read(),
-      new Promise<never>((_, reject) => {
-        setTimeout(() => reject(new Error("zip first byte blocked by download metric")), 500);
+      vi.advanceTimersByTimeAsync(500).then(() => {
+        throw new Error("zip first byte blocked by download metric");
       }),
     ]);
 

--- a/server/convexProxy.ts
+++ b/server/convexProxy.ts
@@ -27,6 +27,7 @@ const MAX_ARCHIVE_MANIFEST_ENTRIES = 8_192;
 const MAX_ARCHIVE_ENTRY_URL_LENGTH = 4_096;
 const MAX_ARCHIVE_MANIFEST_BYTES = 4 * 1024 * 1024;
 const ARCHIVE_FILENAME_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._+-]{0,499}\.zip$/;
+const ARCHIVE_METRIC_FETCH_TIMEOUT_MS = 1_500;
 const ARCHIVE_REPRESENTATION_HEADERS = [
   "accept-ranges",
   "content-digest",
@@ -217,18 +218,23 @@ async function streamSkillArchive(
   }
 
   let metricRecorded = false;
-  const recordMetric = async () => {
+  const recordMetric = () => {
     if (metricRecorded || !manifest.metricToken) return;
     metricRecorded = true;
-    try {
-      await fetch(new URL("/api/internal/archive-download-metric", target), {
-        method: "POST",
-        headers: { "content-type": "application/jose" },
-        body: manifest.metricToken,
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), ARCHIVE_METRIC_FETCH_TIMEOUT_MS);
+    void fetch(new URL("/api/internal/archive-download-metric", target), {
+      method: "POST",
+      headers: { "content-type": "application/jose" },
+      body: manifest.metricToken,
+      signal: controller.signal,
+    })
+      .catch(() => {
+        // Download metrics remain best-effort and never interrupt archive bytes.
+      })
+      .finally(() => {
+        clearTimeout(timeout);
       });
-    } catch {
-      // Download metrics remain best-effort and never interrupt archive bytes.
-    }
   };
 
   const stream = buildDeterministicZipStream(
@@ -240,7 +246,7 @@ async function streamSkillArchive(
         if (!response.ok || !response.body) {
           throw new Error(`Failed to fetch archive entry: ${response.status}`);
         }
-        await recordMetric();
+        recordMetric();
         return response.body;
       },
     })),

--- a/server/og/fetchPluginOgMeta.test.ts
+++ b/server/og/fetchPluginOgMeta.test.ts
@@ -22,6 +22,23 @@ function hangUntilAborted(_input: unknown, init?: RequestInit) {
   });
 }
 
+function stallingBody(signal: AbortSignal | null | undefined) {
+  return new Promise<never>((_resolve, reject) => {
+    if (!signal) return;
+    signal.addEventListener(
+      "abort",
+      () => {
+        reject(
+          signal.reason instanceof Error
+            ? signal.reason
+            : new DOMException("The operation was aborted.", "AbortError"),
+        );
+      },
+      { once: true },
+    );
+  });
+}
+
 describe("fetchPluginOgMeta", () => {
   afterEach(() => {
     vi.useRealTimers();
@@ -63,6 +80,31 @@ describe("fetchPluginOgMeta", () => {
     const fetchMock = vi.fn((input: unknown, init?: RequestInit) => {
       usedSignal = init?.signal ?? undefined;
       return hangUntilAborted(input, init);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const pending = fetchPluginOgMeta("@openclaw/codex", "https://clawhub.ai");
+    await Promise.resolve();
+    expect(usedSignal).toBeInstanceOf(AbortSignal);
+    expect(usedSignal?.aborted).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(OG_FETCH_TIMEOUT_MS - 1);
+    expect(usedSignal?.aborted).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await expect(pending).resolves.toBeNull();
+    expect(usedSignal?.aborted).toBe(true);
+  });
+
+  it("aborts when the public package API returns headers then stalls the JSON body", async () => {
+    vi.useFakeTimers();
+    let usedSignal: AbortSignal | undefined;
+    const fetchMock = vi.fn((_input: unknown, init?: RequestInit) => {
+      usedSignal = init?.signal ?? undefined;
+      return Promise.resolve({
+        ok: true,
+        json: () => stallingBody(init?.signal),
+      } as unknown as Response);
     });
     vi.stubGlobal("fetch", fetchMock);
 

--- a/server/og/fetchPluginOgMeta.test.ts
+++ b/server/og/fetchPluginOgMeta.test.ts
@@ -61,7 +61,7 @@ describe("fetchPluginOgMeta", () => {
     vi.useFakeTimers();
     let usedSignal: AbortSignal | undefined;
     const fetchMock = vi.fn((input: unknown, init?: RequestInit) => {
-      usedSignal = init?.signal;
+      usedSignal = init?.signal ?? undefined;
       return hangUntilAborted(input, init);
     });
     vi.stubGlobal("fetch", fetchMock);

--- a/server/og/fetchPluginOgMeta.test.ts
+++ b/server/og/fetchPluginOgMeta.test.ts
@@ -2,9 +2,29 @@
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { fetchPluginOgMeta } from "./fetchPluginOgMeta";
+import { OG_FETCH_TIMEOUT_MS } from "./ogFetchTimeout";
+
+function hangUntilAborted(_input: unknown, init?: RequestInit) {
+  return new Promise<Response>((_resolve, reject) => {
+    const signal = init?.signal;
+    if (!signal) return;
+    signal.addEventListener(
+      "abort",
+      () => {
+        reject(
+          signal.reason instanceof Error
+            ? signal.reason
+            : new DOMException("The operation was aborted.", "AbortError"),
+        );
+      },
+      { once: true },
+    );
+  });
+}
 
 describe("fetchPluginOgMeta", () => {
   afterEach(() => {
+    vi.useRealTimers();
     vi.unstubAllGlobals();
   });
 
@@ -29,8 +49,33 @@ describe("fetchPluginOgMeta", () => {
 
     expect(fetchMock).toHaveBeenCalledWith(
       "https://clawhub.ai/api/v1/packages/%40openclaw%2Fcodex",
-      { headers: { Accept: "application/json" } },
+      {
+        headers: { Accept: "application/json" },
+        signal: expect.any(AbortSignal),
+      },
     );
     expect(meta?.stats.downloads).toBe(99);
+  });
+
+  it("aborts a hanging public package API fetch after the OG timeout", async () => {
+    vi.useFakeTimers();
+    let usedSignal: AbortSignal | undefined;
+    const fetchMock = vi.fn((input: unknown, init?: RequestInit) => {
+      usedSignal = init?.signal;
+      return hangUntilAborted(input, init);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const pending = fetchPluginOgMeta("@openclaw/codex", "https://clawhub.ai");
+    await Promise.resolve();
+    expect(usedSignal).toBeInstanceOf(AbortSignal);
+    expect(usedSignal?.aborted).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(OG_FETCH_TIMEOUT_MS - 1);
+    expect(usedSignal?.aborted).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await expect(pending).resolves.toBeNull();
+    expect(usedSignal?.aborted).toBe(true);
   });
 });

--- a/server/og/fetchPluginOgMeta.ts
+++ b/server/og/fetchPluginOgMeta.ts
@@ -21,21 +21,25 @@ export async function fetchPluginOgMeta(
 ): Promise<PluginOgMeta | null> {
   try {
     const url = new URL(`/api/v1/packages/${encodeURIComponent(packageName)}`, apiBase);
-    const response = await withOgFetchTimeout((signal) =>
-      fetch(url.toString(), { headers: { Accept: "application/json" }, signal }),
-    );
-    if (!response.ok) return null;
-    const payload = (await response.json()) as {
-      package?: {
-        name?: string;
-        displayName?: string;
-        summary?: string | null;
-        latestVersion?: string | null;
-        stats?: unknown;
-        verification?: { scanStatus?: string | null } | null;
-      } | null;
-      owner?: { handle?: string | null; image?: string | null } | null;
-    };
+    const payload = await withOgFetchTimeout(async (signal) => {
+      const response = await fetch(url.toString(), {
+        headers: { Accept: "application/json" },
+        signal,
+      });
+      if (!response.ok) return null;
+      return (await response.json()) as {
+        package?: {
+          name?: string;
+          displayName?: string;
+          summary?: string | null;
+          latestVersion?: string | null;
+          stats?: unknown;
+          verification?: { scanStatus?: string | null } | null;
+        } | null;
+        owner?: { handle?: string | null; image?: string | null } | null;
+      };
+    });
+    if (!payload) return null;
     const stats = readStats(payload.package?.stats);
     return {
       name: payload.package?.name ?? null,

--- a/server/og/fetchPluginOgMeta.ts
+++ b/server/og/fetchPluginOgMeta.ts
@@ -1,3 +1,5 @@
+import { withOgFetchTimeout } from "./ogFetchTimeout";
+
 export type PluginOgMeta = {
   name: string | null;
   displayName: string | null;
@@ -19,7 +21,9 @@ export async function fetchPluginOgMeta(
 ): Promise<PluginOgMeta | null> {
   try {
     const url = new URL(`/api/v1/packages/${encodeURIComponent(packageName)}`, apiBase);
-    const response = await fetch(url.toString(), { headers: { Accept: "application/json" } });
+    const response = await withOgFetchTimeout((signal) =>
+      fetch(url.toString(), { headers: { Accept: "application/json" }, signal }),
+    );
     if (!response.ok) return null;
     const payload = (await response.json()) as {
       package?: {

--- a/server/og/fetchPublisherOgMeta.test.ts
+++ b/server/og/fetchPublisherOgMeta.test.ts
@@ -26,6 +26,7 @@ describe("fetchPublisherOgMeta", () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.resetModules();
   });
 
@@ -61,5 +62,25 @@ describe("fetchPublisherOgMeta", () => {
     expect(meta?.affiliations).toEqual([
       { handle: "github", displayName: "GitHub", image: "https://example.com/github.png" },
     ]);
+  });
+
+  it("returns null when the Convex publisher query hangs past the OG timeout", async () => {
+    vi.useFakeTimers();
+    queryMock.mockImplementation(() => new Promise(() => {}));
+
+    const { fetchPublisherOgMeta } = await import("./fetchPublisherOgMeta");
+    const { OG_FETCH_TIMEOUT_MS } = await import("./ogFetchTimeout");
+    const pending = fetchPublisherOgMeta("openclaw", "https://example.convex.cloud");
+
+    await vi.advanceTimersByTimeAsync(OG_FETCH_TIMEOUT_MS - 1);
+    let settled = false;
+    void pending.then(() => {
+      settled = true;
+    });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await expect(pending).resolves.toBeNull();
   });
 });

--- a/server/og/fetchPublisherOgMeta.ts
+++ b/server/og/fetchPublisherOgMeta.ts
@@ -1,6 +1,7 @@
 import { ConvexHttpClient } from "convex/browser";
 import type { FunctionReturnType } from "convex/server";
 import { api } from "../../convex/_generated/api";
+import { withOgFetchTimeout } from "./ogFetchTimeout";
 
 export type PublisherOgMeta = {
   handle: string | null;
@@ -27,9 +28,13 @@ export async function fetchPublisherOgMeta(
   convexUrl: string,
 ): Promise<PublisherOgMeta | null> {
   try {
-    const client = new ConvexHttpClient(convexUrl);
-    const profile = await client.query(api.publishers.getOgMetaByHandle, {
-      handle,
+    const profile = await withOgFetchTimeout((signal) => {
+      const client = new ConvexHttpClient(convexUrl, {
+        fetch: (input, init) => fetch(input, { ...init, signal }),
+      });
+      return client.query(api.publishers.getOgMetaByHandle, {
+        handle,
+      });
     });
     if (!profile) return null;
     return {

--- a/server/og/fetchSkillOgMeta.test.ts
+++ b/server/og/fetchSkillOgMeta.test.ts
@@ -63,7 +63,7 @@ describe("fetchSkillOgMeta", () => {
     vi.useFakeTimers();
     let usedSignal: AbortSignal | undefined;
     const fetchMock = vi.fn((input: unknown, init?: RequestInit) => {
-      usedSignal = init?.signal;
+      usedSignal = init?.signal ?? undefined;
       return hangUntilAborted(input, init);
     });
     vi.stubGlobal("fetch", fetchMock);

--- a/server/og/fetchSkillOgMeta.test.ts
+++ b/server/og/fetchSkillOgMeta.test.ts
@@ -22,6 +22,23 @@ function hangUntilAborted(_input: unknown, init?: RequestInit) {
   });
 }
 
+function stallingBody(signal: AbortSignal | null | undefined) {
+  return new Promise<never>((_resolve, reject) => {
+    if (!signal) return;
+    signal.addEventListener(
+      "abort",
+      () => {
+        reject(
+          signal.reason instanceof Error
+            ? signal.reason
+            : new DOMException("The operation was aborted.", "AbortError"),
+        );
+      },
+      { once: true },
+    );
+  });
+}
+
 describe("fetchSkillOgMeta", () => {
   afterEach(() => {
     vi.useRealTimers();
@@ -65,6 +82,31 @@ describe("fetchSkillOgMeta", () => {
     const fetchMock = vi.fn((input: unknown, init?: RequestInit) => {
       usedSignal = init?.signal ?? undefined;
       return hangUntilAborted(input, init);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const pending = fetchSkillOgMeta("gifgrep", "https://clawhub.ai");
+    await Promise.resolve();
+    expect(usedSignal).toBeInstanceOf(AbortSignal);
+    expect(usedSignal?.aborted).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(OG_FETCH_TIMEOUT_MS - 1);
+    expect(usedSignal?.aborted).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await expect(pending).resolves.toBeNull();
+    expect(usedSignal?.aborted).toBe(true);
+  });
+
+  it("aborts when the public skill API returns headers then stalls the JSON body", async () => {
+    vi.useFakeTimers();
+    let usedSignal: AbortSignal | undefined;
+    const fetchMock = vi.fn((_input: unknown, init?: RequestInit) => {
+      usedSignal = init?.signal ?? undefined;
+      return Promise.resolve({
+        ok: true,
+        json: () => stallingBody(init?.signal),
+      } as unknown as Response);
     });
     vi.stubGlobal("fetch", fetchMock);
 

--- a/server/og/fetchSkillOgMeta.test.ts
+++ b/server/og/fetchSkillOgMeta.test.ts
@@ -2,9 +2,29 @@
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { fetchSkillOgMeta } from "./fetchSkillOgMeta";
+import { OG_FETCH_TIMEOUT_MS } from "./ogFetchTimeout";
+
+function hangUntilAborted(_input: unknown, init?: RequestInit) {
+  return new Promise<Response>((_resolve, reject) => {
+    const signal = init?.signal;
+    if (!signal) return;
+    signal.addEventListener(
+      "abort",
+      () => {
+        reject(
+          signal.reason instanceof Error
+            ? signal.reason
+            : new DOMException("The operation was aborted.", "AbortError"),
+        );
+      },
+      { once: true },
+    );
+  });
+}
 
 describe("fetchSkillOgMeta", () => {
   afterEach(() => {
+    vi.useRealTimers();
     vi.unstubAllGlobals();
   });
 
@@ -32,9 +52,32 @@ describe("fetchSkillOgMeta", () => {
       "https://clawhub.ai/api/v1/skills/gifgrep?ownerHandle=steipete",
       {
         headers: { Accept: "application/json" },
+        signal: expect.any(AbortSignal),
       },
     );
     expect(meta?.stats.downloads).toBe(1200);
     expect(meta?.icon).toBe(`https://clawhub.ai/api/v1/skill-icons/${"a".repeat(64)}`);
+  });
+
+  it("aborts a hanging public skill API fetch after the OG timeout", async () => {
+    vi.useFakeTimers();
+    let usedSignal: AbortSignal | undefined;
+    const fetchMock = vi.fn((input: unknown, init?: RequestInit) => {
+      usedSignal = init?.signal;
+      return hangUntilAborted(input, init);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const pending = fetchSkillOgMeta("gifgrep", "https://clawhub.ai");
+    await Promise.resolve();
+    expect(usedSignal).toBeInstanceOf(AbortSignal);
+    expect(usedSignal?.aborted).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(OG_FETCH_TIMEOUT_MS - 1);
+    expect(usedSignal?.aborted).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await expect(pending).resolves.toBeNull();
+    expect(usedSignal?.aborted).toBe(true);
   });
 });

--- a/server/og/fetchSkillOgMeta.ts
+++ b/server/og/fetchSkillOgMeta.ts
@@ -1,4 +1,5 @@
 import { readCanonicalStat, type SkillStatReadable } from "../../convex/lib/skillStats";
+import { withOgFetchTimeout } from "./ogFetchTimeout";
 
 type SkillApiPayload = SkillStatReadable & {
   displayName?: string;
@@ -43,7 +44,9 @@ export async function fetchSkillOgMeta(
     const url = new URL(`/api/v1/skills/${encodeURIComponent(slug)}`, apiBase);
     const owner = ownerHandle?.trim().replace(/^@+/, "");
     if (owner) url.searchParams.set("ownerHandle", owner);
-    const response = await fetch(url.toString(), { headers: { Accept: "application/json" } });
+    const response = await withOgFetchTimeout((signal) =>
+      fetch(url.toString(), { headers: { Accept: "application/json" }, signal }),
+    );
     if (!response.ok) return null;
     const payload = (await response.json()) as {
       skill?: SkillApiPayload | null;

--- a/server/og/fetchSkillOgMeta.ts
+++ b/server/og/fetchSkillOgMeta.ts
@@ -44,20 +44,24 @@ export async function fetchSkillOgMeta(
     const url = new URL(`/api/v1/skills/${encodeURIComponent(slug)}`, apiBase);
     const owner = ownerHandle?.trim().replace(/^@+/, "");
     if (owner) url.searchParams.set("ownerHandle", owner);
-    const response = await withOgFetchTimeout((signal) =>
-      fetch(url.toString(), { headers: { Accept: "application/json" }, signal }),
-    );
-    if (!response.ok) return null;
-    const payload = (await response.json()) as {
-      skill?: SkillApiPayload | null;
-      owner?: { handle?: string | null; image?: string | null } | null;
-      latestVersion?: { version?: string | null } | null;
-      moderation?: {
-        verdict?: "clean" | "suspicious" | "malicious";
-        isSuspicious?: boolean;
-        isMalwareBlocked?: boolean;
-      } | null;
-    };
+    const payload = await withOgFetchTimeout(async (signal) => {
+      const response = await fetch(url.toString(), {
+        headers: { Accept: "application/json" },
+        signal,
+      });
+      if (!response.ok) return null;
+      return (await response.json()) as {
+        skill?: SkillApiPayload | null;
+        owner?: { handle?: string | null; image?: string | null } | null;
+        latestVersion?: { version?: string | null } | null;
+        moderation?: {
+          verdict?: "clean" | "suspicious" | "malicious";
+          isSuspicious?: boolean;
+          isMalwareBlocked?: boolean;
+        } | null;
+      };
+    });
+    if (!payload) return null;
     return {
       displayName: payload.skill?.displayName ?? null,
       summary: payload.skill?.summary ?? null,

--- a/server/og/ogFetchTimeout.ts
+++ b/server/og/ogFetchTimeout.ts
@@ -1,0 +1,31 @@
+// Match fetchImageDataUrl: public OG cards must not wait forever on a hung origin.
+export const OG_FETCH_TIMEOUT_MS = 1_500;
+
+export async function withOgFetchTimeout<T>(
+  work: (signal: AbortSignal) => Promise<T>,
+  timeoutMs = OG_FETCH_TIMEOUT_MS,
+): Promise<T> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  const aborted = new Promise<never>((_, reject) => {
+    const rejectOnAbort = () => {
+      reject(
+        controller.signal.reason instanceof Error
+          ? controller.signal.reason
+          : new DOMException("The operation was aborted.", "AbortError"),
+      );
+    };
+    if (controller.signal.aborted) {
+      rejectOnAbort();
+      return;
+    }
+    controller.signal.addEventListener("abort", rejectOnAbort, { once: true });
+  });
+  // Mark handled so abort cannot become an unhandled rejection if work() ignores the signal.
+  void aborted.catch(() => undefined);
+  try {
+    return await Promise.race([work(controller.signal), aborted]);
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/specs/README.md
+++ b/specs/README.md
@@ -23,6 +23,7 @@ into `docs/` and leave only the design record here.
 - `github-backed-skills.md`: source-backed GitHub skills catalog and install invariants.
 - `diffing.md`: skill version diffing UI/API design.
 - `slug-routing.md`: internal web route precedence and plugin alias contract.
+- `og-routes.md`: public OG card metadata fetches and hang timeouts.
 - `catalog-taxonomy.md`: stored category, author topic, browse ordering, and correction contract.
 - `ci.md`: PR check and production deploy audit-tag policy.
 - `manual-testing.md`: maintainer CLI smoke checklist.

--- a/specs/download-metering.md
+++ b/specs/download-metering.md
@@ -60,3 +60,9 @@ Package graphs render the available `packageDailyStats` rows for the visible
 30-day window and fill missing days with zero. Historical all-time counts are
 not redistributed into daily rows, so the all-time total can exceed the sum of
 the visible daily graph.
+
+## Hosted archive streaming
+
+When the Convex proxy rebuilds a zip from a signed archive manifest, the
+download metric POST is best-effort. It must not be awaited on the path that
+emits the first zip byte. A hung metric origin cannot stall the download.

--- a/specs/og-routes.md
+++ b/specs/og-routes.md
@@ -1,0 +1,7 @@
+# Public OG routes
+
+`/og/skill`, `/og/plugin`, and `/og/profile` may fetch live metadata when the
+query string does not already include display fields.
+
+Those metadata fetches abort after 1.5s, matching trusted OG image fetches in
+`fetchImageDataUrl`. A hung public API or Convex query must not stall the card.

--- a/specs/og-routes.md
+++ b/specs/og-routes.md
@@ -4,4 +4,5 @@
 query string does not already include display fields.
 
 Those metadata fetches abort after 1.5s, matching trusted OG image fetches in
-`fetchImageDataUrl`. A hung public API or Convex query must not stall the card.
+`fetchImageDataUrl`. The deadline covers transport and JSON decode, not only
+response headers. A hung public API or Convex query must not stall the card.


### PR DESCRIPTION
## What Problem This Solves

Public OG routes (`/og/skill`, `/og/plugin`, `/og/profile`) fetched registry or Convex metadata with no abort. A stalled backend parked the OG function until the platform killed it. Sibling image fetch already aborts at 1.5s, and that deadline has to cover the JSON body, not only response headers.

Archive downloads awaited an untimed metric POST before returning the first zip byte, so a hung Convex metric blocked the download.

## Evidence

terminal output from a local HTTP origin on this machine, head `d20f8fea`:

```console
$ bun /tmp/clawhub-3471-live-proof.ts
OG_BODY_STALL meta=null elapsed_ms=1502 hits=1
ZIP_FIRST_BYTE status=200 bytes=38 elapsed_ms=5 metric_hits=0
```

The origin wrote `200` plus `content-type: application/json` for `/api/v1/skills/gifgrep` and never sent a body. `fetchSkillOgMeta` returned null at 1502ms. In the same process, the first archive zip byte arrived in 5ms while the metric POST was left hanging.

## Real behavior proof

- **Behavior or issue addressed:** Skill and plugin OG metadata lookups abort at 1.5s through JSON decode; archive metric POST cannot delay the first zip byte.
- **Real environment tested:** macOS, Bun, local Node HTTP listener on 127.0.0.1, clawhub worktree `/tmp/oc-impl-clawhub-og` head `d20f8fea`.
- **Exact steps or command run after this patch:**

  ```bash
  bun /tmp/clawhub-3471-live-proof.ts
  ```

- **Evidence after fix:** terminal output from the patched worktree:

  ```console
  $ bun /tmp/clawhub-3471-live-proof.ts
  OG_BODY_STALL meta=null elapsed_ms=1502 hits=1
  ZIP_FIRST_BYTE status=200 bytes=38 elapsed_ms=5 metric_hits=0
  ```

- **Observed result after fix:** A headers-then-stall JSON origin returns null at 1.5s. The first zip byte is 38 bytes at 5ms and does not wait for the metric POST.
- **What was not tested:** A live production Convex outage.

## Change

- `fetchSkillOgMeta` and `fetchPluginOgMeta` parse `response.json()` inside `withOgFetchTimeout`, matching `fetchPublisherOgMeta`.
- Body-stall coverage for both fetchers (headers arrive, JSON never does).
- Spec: the 1.5s deadline covers transport and JSON decode.
