### PR TITLE
fix(api): skip duplicate skill export paths

### DIFF
--- a/convex/httpApiV1.handlers.test.ts
+++ b/convex/httpApiV1.handlers.test.ts
@@ -942,7 +942,7 @@ describe("httpApiV1 handlers", () => {
     expect(Object.keys(zipEntries).some((path) => path.endsWith("/SKILL.md"))).toBe(false);
   });
 
-  it("skills export logs generation failure context", async () => {
+  it("skills export skips duplicate legacy file paths without failing the page", async () => {
     vi.mocked(requireApiTokenUser).mockResolvedValue({
       userId: "users:actor",
       user: { _id: "users:actor", role: "user" },
@@ -951,8 +951,6 @@ describe("httpApiV1 handlers", () => {
       userId: "users:actor",
       user: { _id: "users:actor", role: "user" },
     } as never);
-    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
-
     const runQuery = vi.fn(async (_query: unknown, args: Record<string, unknown>) => {
       if ("startDate" in args) {
         return {
@@ -979,50 +977,37 @@ describe("httpApiV1 handlers", () => {
           skillId: "skills:demo",
           version: "1.0.0",
           files: [
-            { storageId: "storage:one", path: "SKILL.md" },
-            { storageId: "storage:two", path: "SKILL.md" },
+            { storageId: "storage:one", path: "skills/humanizer/_skillhub_meta.json" },
+            { storageId: "storage:two", path: "skills/humanizer/_skillhub_meta.json" },
           ],
         };
       }
       return null;
     });
 
-    try {
-      await expect(
-        __handlers.exportSkillsV1Handler(
-          makeCtx({
-            runQuery,
-            storage: { get: vi.fn(async () => new Blob(["content"])) },
-          }),
-          new Request("https://example.com/api/v1/skills/export?startDate=1&endDate=5", {
-            headers: { authorization: "Bearer user-token" },
-          }),
-        ),
-      ).rejects.toThrow(/Duplicate ZIP path/);
+    const storageGet = vi.fn(async (storageId: string) => new Blob([storageId]));
+    const response = await __handlers.exportSkillsV1Handler(
+      makeCtx({ runQuery, storage: { get: storageGet } }),
+      new Request("https://example.com/api/v1/skills/export?startDate=1&endDate=5", {
+        headers: { authorization: "Bearer user-token" },
+      }),
+    );
 
-      expect(consoleError).toHaveBeenCalledWith(
-        "skills_export_failed",
-        expect.objectContaining({
-          phase: "build_zip",
-          startDate: 1,
-          endDate: 5,
-          limit: 250,
-          cursorPresent: false,
-          pageLength: 1,
-          versionCount: 1,
-          blobTaskCount: 2,
-          blobCount: 2,
-          zipEntryCount: 3,
-          manifestCount: 1,
-          exportErrorCount: 0,
-          totalExportBytes: 14,
-          errorName: "Error",
-        }),
-      );
-      expect(JSON.stringify(consoleError.mock.calls)).not.toContain("user-token");
-    } finally {
-      consoleError.mockRestore();
-    }
+    expect(response.status).toBe(200);
+    expect(response.headers.get("X-Export-Errors")).toBe("1");
+    expect(storageGet).toHaveBeenCalledTimes(1);
+    expect(storageGet).toHaveBeenCalledWith("storage:one");
+
+    const zipEntries = unzipSync(new Uint8Array(await response.arrayBuffer()));
+    expect(
+      new TextDecoder().decode(zipEntries["alice/demo/skills/humanizer/_skillhub_meta.json"]),
+    ).toBe("storage:one");
+    expect(JSON.parse(new TextDecoder().decode(zipEntries["_errors.json"]))).toEqual([
+      {
+        slug: "demo",
+        error: 'duplicate archive path skipped: "alice/demo/skills/humanizer/_skillhub_meta.json"',
+      },
+    ]);
   });
 
   it("plugins export defaults to both plugin families with the proven 250 item page limit", async () => {

--- a/convex/httpApiV1/skillsV1.ts
+++ b/convex/httpApiV1/skillsV1.ts
@@ -3893,7 +3893,12 @@ export async function exportSkillsV1Handler(ctx: ActionCtx, request: Request) {
       () => null,
     );
 
-    type BlobTask = { digestIndex: number; fileIndex: number; storageId: Id<"_storage"> };
+    type BlobTask = {
+      digestIndex: number;
+      fileIndex: number;
+      storageId: Id<"_storage">;
+      archivePath: string;
+    };
     const blobTasks: BlobTask[] = [];
 
     logContext.phase = "plan_blobs";
@@ -3959,6 +3964,11 @@ export async function exportSkillsV1Handler(ctx: ActionCtx, request: Request) {
         continue;
       }
 
+      const publisherSegment = getExportPublisherSegment(digest);
+      if (!publisherSegment) continue;
+      const exportRoot = `${publisherSegment}/${digest.slug}`;
+      const archivePaths = new Set([`${exportRoot}/_export_skill_meta.json`]);
+
       for (let j = 0; j < version.files.length; j++) {
         if (blobTasks.length >= MAX_EXPORT_FILE_COUNT) {
           exportErrors.push({
@@ -3967,10 +3977,20 @@ export async function exportSkillsV1Handler(ctx: ActionCtx, request: Request) {
           });
           break;
         }
+        const archivePath = `${exportRoot}/${version.files[j].path}`;
+        if (archivePaths.has(archivePath)) {
+          exportErrors.push({
+            slug: digest.slug,
+            error: `duplicate archive path skipped: "${archivePath}"`,
+          });
+          continue;
+        }
+        archivePaths.add(archivePath);
         blobTasks.push({
           digestIndex: i,
           fileIndex: j,
           storageId: version.files[j].storageId,
+          archivePath,
         });
       }
     }
@@ -3985,13 +4005,19 @@ export async function exportSkillsV1Handler(ctx: ActionCtx, request: Request) {
     const manifest: MergedExportManifestEntry[] = [];
     let totalExportBytes = 0;
 
-    const blobsByDigest = new Map<number, Map<number, Blob | null>>();
+    const blobsByDigest = new Map<
+      number,
+      Map<number, { blob: Blob | null; archivePath: string }>
+    >();
     for (let k = 0; k < blobTasks.length; k++) {
       const task = blobTasks[k];
       if (!blobsByDigest.has(task.digestIndex)) {
         blobsByDigest.set(task.digestIndex, new Map());
       }
-      blobsByDigest.get(task.digestIndex)!.set(task.fileIndex, blobs[k]);
+      blobsByDigest.get(task.digestIndex)!.set(task.fileIndex, {
+        blob: blobs[k],
+        archivePath: task.archivePath,
+      });
     }
 
     logContext.phase = "assemble_entries";
@@ -4059,8 +4085,9 @@ export async function exportSkillsV1Handler(ctx: ActionCtx, request: Request) {
           continue;
         }
 
-        const blob = digestBlobs.get(j);
-        if (!blob) {
+        const plannedFile = digestBlobs.get(j);
+        if (!plannedFile) continue;
+        if (!plannedFile.blob) {
           exportErrors.push({
             slug: digest.slug,
             error: `blob not found for file "${filePath}" (storageId: ${version.files[j].storageId})`,
@@ -4068,7 +4095,7 @@ export async function exportSkillsV1Handler(ctx: ActionCtx, request: Request) {
           continue;
         }
 
-        const buffer = new Uint8Array(await blob.arrayBuffer());
+        const buffer = new Uint8Array(await plannedFile.blob.arrayBuffer());
         if (totalExportBytes + buffer.byteLength > MAX_EXPORT_TOTAL_BYTES) {
           exportErrors.push({
             slug: digest.slug,
@@ -4077,7 +4104,7 @@ export async function exportSkillsV1Handler(ctx: ActionCtx, request: Request) {
           continue;
         }
         totalExportBytes += buffer.byteLength;
-        zipEntries.push({ path: `${exportRoot}/${filePath}`, bytes: buffer });
+        zipEntries.push({ path: plannedFile.archivePath, bytes: buffer });
         fileCount++;
       }
 


### PR DESCRIPTION
## Summary

- reject duplicate legacy archive paths while planning a skill export
- keep the first file, avoid fetching the duplicate Blob, and record the skipped path in `_errors.json`
- preserve the successful export response and `X-Export-Errors` signal

## Production evidence

Axiom window `2026-08-14T15:01:51.298Z` to `2026-08-17T15:08:28.591Z` recorded 640 duplicate ZIP-path failures, up from 267 in the equal preceding baseline. One observed collision was `skills/humanizer/_skillhub_meta.json`.

## Validation

- focused TDD regression: red before the fix, green after
- `convex/httpApiV1.handlers.test.ts`: 431/431 passed
- `bunx tsc --noEmit`: passed
- `bun run ci:static`: passed
- `bun run ci:unit`: 6,092 passed, 3 skipped; one unrelated UI timeout reran green
- `bun run ci:types-build`: passed
- autoreview: clean, no accepted/actionable findings

## Residual risk

This intentionally does not address the separate export OOM class (1,886 failures in the current window). That requires extending the Nitro signed-manifest streaming architecture to bulk exports and belongs in a separate repair.
