### PR TITLE
fix(api): skip duplicate plugin export paths

### DIFF
--- a/convex/httpApiV1.handlers.test.ts
+++ b/convex/httpApiV1.handlers.test.ts
@@ -1010,6 +1010,105 @@ describe("httpApiV1 handlers", () => {
     ]);
   });
 
+  it("skills export logs build failures without authorization token material", async () => {
+    vi.mocked(requireApiTokenUser).mockResolvedValue({
+      userId: "users:actor",
+      user: { _id: "users:actor", role: "user" },
+    } as never);
+    vi.mocked(getOptionalApiTokenUser).mockResolvedValue({
+      userId: "users:actor",
+      user: { _id: "users:actor", role: "user" },
+    } as never);
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    const runQuery = vi.fn(async (_query: unknown, args: Record<string, unknown>) => {
+      if ("startDate" in args) {
+        return {
+          page: [
+            {
+              skillId: "skills:first",
+              slug: "demo",
+              displayName: "First Demo",
+              latestVersionId: "skillVersions:first",
+              createdAt: 1,
+              updatedAt: 2,
+              stats: {},
+              ownerUserId: "users:alice",
+              ownerHandle: "alice",
+              ownerDisplayName: "Alice",
+            },
+            {
+              skillId: "skills:second",
+              slug: "demo",
+              displayName: "Second Demo",
+              latestVersionId: "skillVersions:second",
+              createdAt: 1,
+              updatedAt: 3,
+              stats: {},
+              ownerUserId: "users:alice",
+              ownerHandle: "alice",
+              ownerDisplayName: "Alice",
+            },
+          ],
+          nextCursor: null,
+          hasMore: false,
+        };
+      }
+      if (args.versionId === "skillVersions:first") {
+        return {
+          skillId: "skills:first",
+          version: "1.0.0",
+          files: [{ storageId: "storage:first", path: "SKILL.md" }],
+        };
+      }
+      if (args.versionId === "skillVersions:second") {
+        return {
+          skillId: "skills:second",
+          version: "1.0.0",
+          files: [{ storageId: "storage:second", path: "SKILL.md" }],
+        };
+      }
+      return null;
+    });
+
+    try {
+      await expect(
+        __handlers.exportSkillsV1Handler(
+          makeCtx({
+            runQuery,
+            storage: { get: vi.fn(async (storageId: string) => new Blob([storageId])) },
+          }),
+          new Request("https://example.com/api/v1/skills/export?startDate=1&endDate=5", {
+            headers: { authorization: "Bearer user-token" },
+          }),
+        ),
+      ).rejects.toThrow(/Duplicate ZIP path/);
+
+      expect(consoleError).toHaveBeenCalledWith(
+        "skills_export_failed",
+        expect.objectContaining({
+          phase: "build_zip",
+          startDate: 1,
+          endDate: 5,
+          limit: 250,
+          cursorPresent: false,
+          pageLength: 2,
+          versionCount: 2,
+          blobTaskCount: 2,
+          blobCount: 2,
+          totalExportBytes: 27,
+          zipEntryCount: 4,
+          manifestCount: 2,
+          exportErrorCount: 0,
+          errorName: "Error",
+        }),
+      );
+      expect(JSON.stringify(consoleError.mock.calls)).not.toContain("user-token");
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
   it("plugins export defaults to both plugin families with the proven 250 item page limit", async () => {
     vi.mocked(requireApiTokenUser).mockResolvedValue({
       userId: "users:actor",
@@ -1202,6 +1301,100 @@ describe("httpApiV1 handlers", () => {
       "_manifest.json",
       "bundle-plugin/demo-bundle/openclaw.bundle.json",
       "code-plugin/@scope/demo-plugin/package.json",
+    ]);
+  });
+
+  it("plugins export skips duplicate legacy release paths and preserves the first file", async () => {
+    vi.mocked(requireApiTokenUser).mockResolvedValue({
+      userId: "users:actor",
+      user: { _id: "users:actor", role: "user" },
+    } as never);
+    vi.mocked(getOptionalApiTokenUser).mockResolvedValue({
+      userId: "users:actor",
+      user: { _id: "users:actor", role: "user" },
+    } as never);
+
+    const runQuery = vi.fn(async (_query: unknown, args: Record<string, unknown>) => {
+      if ("startDate" in args) {
+        return {
+          page: [
+            {
+              packageId: "packages:bundle",
+              name: "demo-bundle",
+              displayName: "Demo Bundle",
+              family: "bundle-plugin",
+              latestReleaseId: "packageReleases:bundle",
+              latestVersion: "1.0.0",
+              createdAt: 1,
+              updatedAt: 2,
+              stats: { downloads: 0, installs: 0, stars: 0, versions: 1 },
+              ownerUserId: "users:alice",
+              ownerHandle: "alice",
+              ownerDisplayName: "Alice",
+            },
+          ],
+          nextCursor: null,
+          hasMore: false,
+        };
+      }
+      if (args.releaseId === "packageReleases:bundle") {
+        return {
+          packageId: "packages:bundle",
+          version: "1.0.0",
+          changelog: "Legacy bundle",
+          createdAt: 2,
+          files: [
+            {
+              storageId: "storage:first",
+              path: "plugins/humanizer/_skillhub_meta.json",
+              size: 13,
+              sha256: "sha-first",
+              contentType: "application/json",
+            },
+            {
+              storageId: "storage:second",
+              path: "plugins/humanizer/_skillhub_meta.json",
+              size: 14,
+              sha256: "sha-second",
+              contentType: "application/json",
+            },
+          ],
+          artifactKind: "legacy-zip",
+          softDeletedAt: undefined,
+        };
+      }
+      return null;
+    });
+    const storageGet = vi.fn(async (storageId: string) => new Blob([storageId]));
+
+    const response = await __handlers.exportPluginsV1Handler(
+      makeCtx({ runQuery, storage: { get: storageGet } }),
+      new Request("https://example.com/api/v1/plugins/export?startDate=1&endDate=5", {
+        headers: { authorization: "Bearer user-token" },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("X-Total-Returned")).toBe("1");
+    expect(response.headers.get("X-Export-Errors")).toBe("1");
+    expect(storageGet).toHaveBeenCalledTimes(1);
+    expect(storageGet).toHaveBeenCalledWith("storage:first");
+
+    const zipEntries = unzipSync(new Uint8Array(await response.arrayBuffer()));
+    expect(
+      new TextDecoder().decode(
+        zipEntries["bundle-plugin/demo-bundle/plugins/humanizer/_skillhub_meta.json"],
+      ),
+    ).toBe("storage:first");
+    expect(JSON.parse(new TextDecoder().decode(zipEntries["_errors.json"]))).toEqual([
+      {
+        package: "demo-bundle",
+        error:
+          'duplicate archive path skipped: "bundle-plugin/demo-bundle/plugins/humanizer/_skillhub_meta.json"',
+      },
+    ]);
+    expect(JSON.parse(new TextDecoder().decode(zipEntries["_manifest.json"]))).toEqual([
+      expect.objectContaining({ packageName: "demo-bundle", fileCount: 1 }),
     ]);
   });
 

--- a/convex/httpApiV1/packagesV1.ts
+++ b/convex/httpApiV1/packagesV1.ts
@@ -2200,7 +2200,12 @@ export async function exportPluginsV1Handler(ctx: ActionCtx, request: Request) {
       () => null,
     );
 
-    type BlobTask = { digestIndex: number; fileIndex: number; storageId: Id<"_storage"> };
+    type BlobTask = {
+      digestIndex: number;
+      fileIndex: number;
+      storageId: Id<"_storage">;
+      archivePath: string;
+    };
     const blobTasks: BlobTask[] = [];
 
     logContext.phase = "plan_blobs";
@@ -2253,6 +2258,9 @@ export async function exportPluginsV1Handler(ctx: ActionCtx, request: Request) {
       }
       exportableReleases[i] = release;
 
+      const exportRoot = pluginExportRoot(digest);
+      const archivePaths = new Set<string>();
+
       for (let j = 0; j < release.files.length; j++) {
         if (blobTasks.length >= MAX_PLUGIN_EXPORT_FILE_COUNT) {
           exportErrors.push({
@@ -2261,10 +2269,20 @@ export async function exportPluginsV1Handler(ctx: ActionCtx, request: Request) {
           });
           break;
         }
+        const archivePath = `${exportRoot}/${release.files[j].path}`;
+        if (archivePaths.has(archivePath)) {
+          exportErrors.push({
+            package: digest.name,
+            error: `duplicate archive path skipped: "${archivePath}"`,
+          });
+          continue;
+        }
+        archivePaths.add(archivePath);
         blobTasks.push({
           digestIndex: i,
           fileIndex: j,
           storageId: release.files[j].storageId,
+          archivePath,
         });
       }
     }
@@ -2286,13 +2304,19 @@ export async function exportPluginsV1Handler(ctx: ActionCtx, request: Request) {
     > = [];
     let totalExportBytes = 0;
 
-    const blobsByDigest = new Map<number, Map<number, Blob | null>>();
+    const blobsByDigest = new Map<
+      number,
+      Map<number, { blob: Blob | null; archivePath: string }>
+    >();
     for (let k = 0; k < blobTasks.length; k++) {
       const task = blobTasks[k];
       if (!blobsByDigest.has(task.digestIndex)) {
         blobsByDigest.set(task.digestIndex, new Map());
       }
-      blobsByDigest.get(task.digestIndex)!.set(task.fileIndex, blobs[k]);
+      blobsByDigest.get(task.digestIndex)!.set(task.fileIndex, {
+        blob: blobs[k],
+        archivePath: task.archivePath,
+      });
     }
 
     logContext.phase = "assemble_entries";
@@ -2317,8 +2341,9 @@ export async function exportPluginsV1Handler(ctx: ActionCtx, request: Request) {
           continue;
         }
 
-        const blob = digestBlobs.get(j);
-        if (!blob) {
+        const plannedFile = digestBlobs.get(j);
+        if (!plannedFile) continue;
+        if (!plannedFile.blob) {
           exportErrors.push({
             package: digest.name,
             error: `blob not found for file "${filePath}" (storageId: ${release.files[j].storageId})`,
@@ -2326,7 +2351,7 @@ export async function exportPluginsV1Handler(ctx: ActionCtx, request: Request) {
           continue;
         }
 
-        const buffer = new Uint8Array(await blob.arrayBuffer());
+        const buffer = new Uint8Array(await plannedFile.blob.arrayBuffer());
         if (totalExportBytes + buffer.byteLength > MAX_PLUGIN_EXPORT_TOTAL_BYTES) {
           exportErrors.push({
             package: digest.name,
@@ -2335,7 +2360,7 @@ export async function exportPluginsV1Handler(ctx: ActionCtx, request: Request) {
           continue;
         }
         totalExportBytes += buffer.byteLength;
-        zipEntries.push({ path: `${exportRoot}/${filePath}`, bytes: buffer });
+        zipEntries.push({ path: plannedFile.archivePath, bytes: buffer });
         fileCount++;
       }
 


### PR DESCRIPTION
## Summary

- skip duplicate legacy plugin release paths during export planning
- preserve the first file, avoid redundant Blob reads, and record skipped duplicates in `_errors.json`
- restore standalone coverage for `skills_export_failed` context and bearer-token redaction

Follow-up to the sibling-path review on #3474:
https://github.com/openclaw/clawhub/pull/3474#pullrequestreview-4953905557

## Root cause

Plugin exports still planned and fetched every legacy release file, then discovered duplicate archive paths only when `buildMergedExportZip` rejected the completed entry list. This mirrors the skills failure repaired in #3474. The plugin export path was introduced in #2547.

The fix applies the existing skills invariant at the planning boundary: the first archive path wins, later duplicates become explicit export errors, and duplicate Blobs are never fetched. The ZIP builder remains strict for other callers.

## Validation

- TDD negative control: plugin duplicate-path regression threw `Duplicate ZIP path detected` before the fix
- `bunx vitest run convex/httpApiV1.handlers.test.ts` - 433 passed
- `bun run ci:static` - passed
- `bun run ci:unit` - 6,101 passed, 3 skipped on the exact rebased head
- `bun run ci:packages` - passed
- `bun run ci:types-build` - passed
- `GITHUB_TOKEN=<redacted> bun run ci:e2e-http` - passed
- autoreview against `origin/main` - clean, no actionable findings, 0.94

The unauthenticated HTTP gate initially hit a transient GitHub archive download timeout in an unrelated package dry-run test. That test passed alone, the complete clean-main gate passed, and the complete candidate gate passed with the CLI's supported `GITHUB_TOKEN` path.

## Scope

This does not change the ZIP builder or address the separate bulk-export OOM architecture.
