### PR TITLE
fix: allow republishing hard-deleted packages

### DIFF
--- a/convex/publishAttempts.test.ts
+++ b/convex/publishAttempts.test.ts
@@ -71,7 +71,10 @@ const findExistingPublishAttemptForArtifactHandler = (
   }
 )._handler;
 
-function makeAttemptLookupCtx(attempts: Array<Record<string, unknown>>) {
+function makeAttemptLookupCtx(
+  attempts: Array<Record<string, unknown>>,
+  options: { missingIds?: string[] } = {},
+) {
   let requestedStatus = "";
   const indexQuery = {
     eq: vi.fn((field: string, value: unknown) => {
@@ -81,6 +84,7 @@ function makeAttemptLookupCtx(attempts: Array<Record<string, unknown>>) {
   };
   return {
     db: {
+      get: vi.fn(async (id: string) => (options.missingIds?.includes(id) ? null : { _id: id })),
       query: vi.fn(() => ({
         withIndex: vi.fn(
           (_indexName: string, buildQuery: (query: typeof indexQuery) => unknown) => {
@@ -181,6 +185,35 @@ describe("publishAttempts", () => {
       status: "blocked",
       reusable: false,
     });
+  });
+
+  it("does not reserve a package version for a hard-deleted publish target", async () => {
+    const attempt = {
+      _id: "publishAttempts:orphaned",
+      kind: "package",
+      status: "finalized",
+      userId: "users:owner",
+      ownerUserId: "users:owner",
+      ownerPublisherId: "publishers:deleted",
+      packageId: "packages:deleted",
+      packageReleaseId: "packageReleases:deleted",
+      slug: "@example/deleted-plugin",
+      version: "1.0.0",
+      artifactFingerprint: "old-fingerprint",
+    };
+
+    await expect(
+      findExistingPublishAttemptForArtifactHandler(
+        makeAttemptLookupCtx([attempt], {
+          missingIds: ["packages:deleted", "packageReleases:deleted"],
+        }),
+        {
+          kind: "package",
+          slug: "@example/deleted-plugin",
+          version: "1.0.0",
+        },
+      ),
+    ).resolves.toBeNull();
   });
 
   it("returns the stored package artifact digest while publication is pending", async () => {

--- a/convex/publishAttempts.ts
+++ b/convex/publishAttempts.ts
@@ -1,7 +1,7 @@
 import { ConvexError, v } from "convex/values";
 import { internal } from "./_generated/api";
 import type { Doc, Id } from "./_generated/dataModel";
-import type { MutationCtx } from "./_generated/server";
+import type { MutationCtx, QueryCtx } from "./_generated/server";
 import { action, internalAction, internalMutation, internalQuery } from "./functions";
 import { finalizeSkillPublishAttempt } from "./lib/skillPublish";
 import { requestPublishAttemptDispatch } from "./publishAttemptDispatch";
@@ -283,6 +283,20 @@ function isTerminalRetriableAttemptStatus(status: string) {
   return status === "blocked" || status === "failed" || status === "expired";
 }
 
+async function isOrphanedPackagePublishAttempt(
+  ctx: Pick<QueryCtx, "db">,
+  attempt: Doc<"publishAttempts">,
+) {
+  if (attempt.kind !== "package" || !attempt.packageId || !attempt.packageReleaseId) {
+    return false;
+  }
+  const [pkg, release] = await Promise.all([
+    ctx.db.get(attempt.packageId),
+    ctx.db.get(attempt.packageReleaseId),
+  ]);
+  return !pkg || !release;
+}
+
 export const findExistingPublishAttemptForArtifactInternal = internalQuery({
   args: {
     kind: v.union(v.literal("skill"), v.literal("package")),
@@ -306,29 +320,34 @@ export const findExistingPublishAttemptForArtifactInternal = internalQuery({
         )
         .order("desc")
         .take(25);
-      const match = attempts.find((attempt) => {
+      for (const match of attempts) {
+        let matchesLookup: boolean;
         if (args.kind === "package") {
-          if (args.artifactFingerprint === undefined) return true;
-          if (attempt.artifactFingerprint !== args.artifactFingerprint) return false;
-          if (args.ownerPublisherId !== undefined) {
-            return (
-              attempt.ownerPublisherId === args.ownerPublisherId &&
-              attempt.userId === args.userId &&
-              attempt.ownerUserId === args.ownerUserId
-            );
+          if (args.artifactFingerprint === undefined) {
+            matchesLookup = true;
+          } else if (match.artifactFingerprint !== args.artifactFingerprint) {
+            matchesLookup = false;
+          } else if (args.ownerPublisherId !== undefined) {
+            matchesLookup =
+              match.ownerPublisherId === args.ownerPublisherId &&
+              match.userId === args.userId &&
+              match.ownerUserId === args.ownerUserId;
+          } else {
+            matchesLookup =
+              match.ownerPublisherId === undefined &&
+              match.userId === args.userId &&
+              match.ownerUserId === args.ownerUserId;
           }
-          return (
-            attempt.ownerPublisherId === undefined &&
-            attempt.userId === args.userId &&
-            attempt.ownerUserId === args.ownerUserId
-          );
+        } else if (args.ownerPublisherId !== undefined) {
+          matchesLookup = match.ownerPublisherId === args.ownerPublisherId;
+        } else {
+          matchesLookup = match.ownerPublisherId === undefined && match.userId === args.userId;
         }
-        if (args.ownerPublisherId !== undefined) {
-          return attempt.ownerPublisherId === args.ownerPublisherId;
-        }
-        return attempt.ownerPublisherId === undefined && attempt.userId === args.userId;
-      });
-      if (match) {
+
+        if (!matchesLookup) continue;
+        // Hard deletion removes the package and release but intentionally retains audit attempts.
+        // Those audit rows must not reserve the deleted package version forever.
+        if (await isOrphanedPackagePublishAttempt(ctx, match)) continue;
         return {
           attemptId: match._id,
           status: match.status,

--- a/specs/security-moderation.md
+++ b/specs/security-moderation.md
@@ -312,9 +312,12 @@ See also: [acceptable-usage.md](./acceptable-usage.md) for the marketplace polic
 - A Claw staged-attempt key binds actor, owner, normalized package name,
   version, and verified tarball digest. Only that exact tuple may reuse an
   active pending attempt or active published release. Different artifacts or
-  owners and terminal, deleted, blocked, quarantined, revoked, or malicious
-  state must preserve the version conflict rather than being reused or
-  discarded.
+  owners and terminal, soft-deleted, blocked, quarantined, revoked, or
+  malicious state whose target still exists must preserve the version conflict
+  rather than being reused or discarded. Hard deletion removes package and
+  release rows but retains the publish attempt as audit history; an attempt
+  whose referenced package or release no longer exists is audit-only and must
+  neither reserve that package version nor be reused.
 - Claw pending and final publication responses expose the verified artifact
   SHA-256. Polling must preserve the same digest, and the package artifact
   download must serve the exact stored tarball bytes whose SHA-256 matches that


### PR DESCRIPTION
## Summary

- ignore package publish attempts whose referenced package or release was hard-deleted
- retain the audit attempt while allowing the deleted package version to be published again
- add a regression test for the exact orphaned-attempt lookup

## Root cause

Hard-deleting a publisher removes its packages and releases but retains publish-attempt audit rows. The version-conflict lookup treated those orphaned rows as live reservations, so a recreated publisher could not republish the same version.

## Validation

- `bunx vitest run convex/publishAttempts.test.ts`
- `bun run ci:static`
- `bun run ci:unit`
- `bun run ci:types-build`
- local Convex function push with `bunx convex dev --once`
- autoreview: clean, no actionable findings
