### PR TITLE
fix: add year to foundation footer

### DIFF
--- a/src/components/Footer.test.tsx
+++ b/src/components/Footer.test.tsx
@@ -85,6 +85,7 @@ describe("Footer", () => {
     expect(screen.getByRole("link", { name: "Powered by Convex" }).getAttribute("href")).toBe(
       "https://www.convex.dev",
     );
+    expect(screen.getByText("© 2026 OpenClaw Foundation")).toBeTruthy();
   });
 
   it("keeps offscreen imagery lazy and dimensioned", () => {

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -348,7 +348,7 @@ export function Footer() {
         </div>
 
         <div className="footer-v2-bottom">
-          <p className="footer-v2-copy">© OpenClaw Foundation</p>
+          <p className="footer-v2-copy">© 2026 OpenClaw Foundation</p>
           <p className="footer-v2-meta">
             {FOOTER_PLATFORM_LINKS.map((link, index) => (
               <span key={link.label}>


### PR DESCRIPTION
## Summary

- render the footer attribution as `© 2026 OpenClaw Foundation`
- lock the exact visible copy with a footer component regression assertion

## Validation

- `bunx vitest run src/components/Footer.test.tsx`
- `bun run ci:static`
- `bun run ci:unit`
- `bun run ci:types-build`
- `.agents/skills/autoreview/scripts/autoreview --mode local --stream-engine-output`
- real local ClawHub browser verification at desktop, tablet, and mobile widths

