### PR TITLE
fix: gate skill evaluation tab query

### DIFF
--- a/src/components/SkillDetailPage.tsx
+++ b/src/components/SkillDetailPage.tsx
@@ -20,6 +20,7 @@ import {
 import { getSkillCategoriesForSkill, getSkillCategoryForSkill } from "../lib/categories";
 import { getUserFacingConvexError } from "../lib/convexError";
 import { buildSkillSecurityAuditHref } from "../lib/ownerRoute";
+import { getRuntimeEnv } from "../lib/runtimeEnv";
 import { canManageSkill, isModerator } from "../lib/roles";
 import { skillCardLoadKey } from "../lib/skillCards";
 import type { SkillBySlugResult, SkillPageInitialData } from "../lib/skillPage";
@@ -260,9 +261,10 @@ export function SkillDetailPage({
   const latestVersionId = latestVersion?._id ?? null;
   const githubBackedFields = skill as GitHubBackedSkillFields | null | undefined;
   const isGitHubBackedSkill = githubBackedFields?.installKind === "github" && !latestVersionId;
+  const skillEvaluationUiEnabled = getRuntimeEnv("VITE_ENABLE_SKILL_EVALUATIONS") === "1";
   const skillEvaluation = useQuery(
     api.skillEvaluations.getCurrentForSkill,
-    skill ? { skillId: skill._id } : "skip",
+    skillEvaluationUiEnabled && skill ? { skillId: skill._id } : "skip",
   ) as SkillEvaluationResult | null | undefined;
   const modInfo = result?.moderationInfo ?? null;
   const relatedCategory = useMemo(() => (skill ? getSkillCategoryForSkill(skill) : null), [skill]);


### PR DESCRIPTION
## Summary
- gate the skill evaluation tab query behind `VITE_ENABLE_SKILL_EVALUATIONS=1`
- restores skill detail pages when production Convex cannot serve `skillEvaluations:getCurrentForSkill` yet

## Validation
- `git diff --check`

## Incident note
Production skill detail pages are currently crashing after hydration on the evaluation query, so this PR intentionally disables the frontend query by default while preserving the merged backend/evaluator code for a proper rollout follow-up.

Tests intentionally not awaited per maintainer incident instruction.