### PR TITLE
fix: restore skill eval tab safely

### DIFF
--- a/convex/skillEvaluations.ts
+++ b/convex/skillEvaluations.ts
@@ -128,47 +128,52 @@ export async function enqueueNvidiaSkillEvaluation(
 export const getCurrentForSkill = query({
   args: { skillId: v.id("skills") },
   handler: async (ctx, args) => {
-    const skill = await ctx.db.get(args.skillId);
-    if (
-      !isPublicSkillDoc(skill) ||
-      skill.installKind !== "github" ||
-      skill.githubCurrentStatus !== "present" ||
-      skill.githubCurrentRepo?.trim().toLowerCase() !== NVIDIA_SKILL_EVALUATION_CONFIG.sourceRepo ||
-      !skill.githubCurrentContentHash
-    ) {
+    try {
+      const skill = await ctx.db.get(args.skillId);
+      if (
+        !isPublicSkillDoc(skill) ||
+        skill.installKind !== "github" ||
+        skill.githubCurrentStatus !== "present" ||
+        skill.githubCurrentRepo?.trim().toLowerCase() !==
+          NVIDIA_SKILL_EVALUATION_CONFIG.sourceRepo ||
+        !skill.githubCurrentContentHash
+      ) {
+        return null;
+      }
+      const run = await ctx.db
+        .query("skillEvaluationRuns")
+        .withIndex("by_skill_content_hash_config_key", (q) =>
+          q
+            .eq("skillId", skill._id)
+            .eq("contentHash", skill.githubCurrentContentHash as string)
+            .eq("configKey", NVIDIA_SKILL_EVALUATION_CONFIG_KEY),
+        )
+        .unique();
+      if (run?.status !== "succeeded" || !run.metrics || !run.completedAt) return null;
+      return {
+        source: {
+          repository: run.sourceRepo,
+          commit: run.sourceCommit,
+          path: run.sourcePath,
+          contentHash: run.contentHash,
+        },
+        evaluator: {
+          repository: run.evaluatorRepository,
+          release: run.evaluatorRelease,
+          commit: run.evaluatorCommit,
+          agent: run.agent,
+          agentModel: run.agentModel,
+          judgeProvider: run.judgeProvider,
+          judgeModel: run.judgeModel,
+          environment: run.environment,
+          attempts: run.attemptsPerCase,
+        },
+        metrics: run.metrics,
+        completedAt: run.completedAt,
+      };
+    } catch {
       return null;
     }
-    const run = await ctx.db
-      .query("skillEvaluationRuns")
-      .withIndex("by_skill_content_hash_config_key", (q) =>
-        q
-          .eq("skillId", skill._id)
-          .eq("contentHash", skill.githubCurrentContentHash as string)
-          .eq("configKey", NVIDIA_SKILL_EVALUATION_CONFIG_KEY),
-      )
-      .unique();
-    if (run?.status !== "succeeded" || !run.metrics || !run.completedAt) return null;
-    return {
-      source: {
-        repository: run.sourceRepo,
-        commit: run.sourceCommit,
-        path: run.sourcePath,
-        contentHash: run.contentHash,
-      },
-      evaluator: {
-        repository: run.evaluatorRepository,
-        release: run.evaluatorRelease,
-        commit: run.evaluatorCommit,
-        agent: run.agent,
-        agentModel: run.agentModel,
-        judgeProvider: run.judgeProvider,
-        judgeModel: run.judgeModel,
-        environment: run.environment,
-        attempts: run.attemptsPerCase,
-      },
-      metrics: run.metrics,
-      completedAt: run.completedAt,
-    };
   },
 });
 

--- a/src/__tests__/skill-detail-page.test.tsx
+++ b/src/__tests__/skill-detail-page.test.tsx
@@ -38,6 +38,11 @@ vi.mock("@convex-dev/auth/react", () => ({
 }));
 
 const useQueryMock = vi.fn();
+const useQueriesMock = vi.fn((queries: Record<string, { query: unknown; args: unknown }>) =>
+  Object.fromEntries(
+    Object.entries(queries).map(([key, value]) => [key, useQueryMock(value.query, value.args)]),
+  ),
+);
 const useMutationMock = vi.fn();
 const convexQueryMock = vi.fn();
 const convexClientMock = { query: convexQueryMock };
@@ -51,6 +56,8 @@ vi.mock("convex/react", () => ({
   ConvexReactClient: class {},
   useConvex: () => convexClientMock,
   useQuery: (...args: unknown[]) => useQueryMock(...args),
+  useQueries: (queries: Record<string, { query: unknown; args: unknown }>) =>
+    useQueriesMock(queries),
   useMutation: (...args: unknown[]) => useMutationMock(...args),
   usePaginatedQuery: () => ({
     results: [],
@@ -129,6 +136,7 @@ describe("SkillDetailPage", () => {
   beforeEach(() => {
     window.location.hash = "";
     useQueryMock.mockReset();
+    useQueriesMock.mockClear();
     useMutationMock.mockReset();
     convexQueryMock.mockReset();
     getReadmeMock.mockReset();
@@ -391,6 +399,15 @@ describe("SkillDetailPage", () => {
     render(<SkillDetailPage slug="github-skill" initialData={makeInitialData(true)} />);
 
     expect(getDesktopSkillTabs().queryByRole("tab", { name: "Evals" })).toBeNull();
+  });
+
+  it("hides Evals when the optional evaluation query fails", () => {
+    useQueriesMock.mockReturnValueOnce({ skillEvaluation: new Error("evaluation unavailable") });
+
+    render(<SkillDetailPage slug="github-skill" initialData={makeInitialData(true)} />);
+
+    expect(getDesktopSkillTabs().queryByRole("tab", { name: "Evals" })).toBeNull();
+    expect(screen.queryByText("Something went wrong")).toBeNull();
   });
 
   it("opens an evaluation deep link after its result finishes loading", async () => {

--- a/src/components/SkillDetailPage.tsx
+++ b/src/components/SkillDetailPage.tsx
@@ -5,7 +5,7 @@ import {
   resolveSkillCategories,
   type ClawdisSkillMetadata,
 } from "clawhub-schema";
-import { useAction, useMutation, useQuery } from "convex/react";
+import { useAction, useMutation, useQueries, useQuery } from "convex/react";
 import { ArrowLeft, TriangleAlert, Upload } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
@@ -20,7 +20,6 @@ import {
 import { getSkillCategoriesForSkill, getSkillCategoryForSkill } from "../lib/categories";
 import { getUserFacingConvexError } from "../lib/convexError";
 import { buildSkillSecurityAuditHref } from "../lib/ownerRoute";
-import { getRuntimeEnv } from "../lib/runtimeEnv";
 import { canManageSkill, isModerator } from "../lib/roles";
 import { skillCardLoadKey } from "../lib/skillCards";
 import type { SkillBySlugResult, SkillPageInitialData } from "../lib/skillPage";
@@ -261,11 +260,17 @@ export function SkillDetailPage({
   const latestVersionId = latestVersion?._id ?? null;
   const githubBackedFields = skill as GitHubBackedSkillFields | null | undefined;
   const isGitHubBackedSkill = githubBackedFields?.installKind === "github" && !latestVersionId;
-  const skillEvaluationUiEnabled = getRuntimeEnv("VITE_ENABLE_SKILL_EVALUATIONS") === "1";
-  const skillEvaluation = useQuery(
-    api.skillEvaluations.getCurrentForSkill,
-    skillEvaluationUiEnabled && skill ? { skillId: skill._id } : "skip",
-  ) as SkillEvaluationResult | null | undefined;
+  const skillEvaluationResult = useQueries(
+    skill
+      ? {
+          skillEvaluation: {
+            query: api.skillEvaluations.getCurrentForSkill,
+            args: { skillId: skill._id },
+          },
+        }
+      : {},
+  ).skillEvaluation as SkillEvaluationResult | null | Error | undefined;
+  const skillEvaluation = skillEvaluationResult instanceof Error ? null : skillEvaluationResult;
   const modInfo = result?.moderationInfo ?? null;
   const relatedCategory = useMemo(() => (skill ? getSkillCategoryForSkill(skill) : null), [skill]);
   const relatedCategories = useMemo(


### PR DESCRIPTION
## Summary
- restore the Evals tab query by removing the emergency frontend kill switch
- make the optional evaluation query fail soft in the skill page
- make `skillEvaluations:getCurrentForSkill` return `null` when evaluation storage is unavailable

## Validation
- `git diff --check`
- `bunx vitest run src/__tests__/skill-detail-page.test.tsx --testNamePattern "Evals|evaluation"`
- production Convex query for `doca-dpa` returns the completed eval result

## Incident note
The backfill result exists in production. The tab was hidden only because the emergency hotfix disabled the frontend query by default.