### PR TITLE
fix: stabilize skill eval query request

### DIFF
--- a/src/components/SkillDetailPage.tsx
+++ b/src/components/SkillDetailPage.tsx
@@ -260,8 +260,9 @@ export function SkillDetailPage({
   const latestVersionId = latestVersion?._id ?? null;
   const githubBackedFields = skill as GitHubBackedSkillFields | null | undefined;
   const isGitHubBackedSkill = githubBackedFields?.installKind === "github" && !latestVersionId;
-  const skillEvaluationResult = useQueries(
-    skill
+  const skillEvaluationQueries = useMemo(
+    () =>
+      skill
       ? {
           skillEvaluation: {
             query: api.skillEvaluations.getCurrentForSkill,
@@ -269,7 +270,13 @@ export function SkillDetailPage({
           },
         }
       : {},
-  ).skillEvaluation as SkillEvaluationResult | null | Error | undefined;
+    [skill?._id],
+  );
+  const skillEvaluationResult = useQueries(skillEvaluationQueries).skillEvaluation as
+    | SkillEvaluationResult
+    | null
+    | Error
+    | undefined;
   const skillEvaluation = skillEvaluationResult instanceof Error ? null : skillEvaluationResult;
   const modInfo = result?.moderationInfo ?? null;
   const relatedCategory = useMemo(() => (skill ? getSkillCategoryForSkill(skill) : null), [skill]);


### PR DESCRIPTION
## Summary
- memoize the optional skill evaluation `useQueries` request
- prevents the restored Evals tab query from triggering a render loop while preserving fail-soft query behavior

## Validation
- `git diff --check`
- `bunx vitest run src/__tests__/skill-detail-page.test.tsx --testNamePattern "Evals|evaluation"`

## Incident note
Production showed React minified error #301 after the restore deploy because the `useQueries` request object was recreated on every render.