### PR TITLE
fix: resolve skill evals for projected skill pages

### DIFF
--- a/convex/skillEvaluations.ts
+++ b/convex/skillEvaluations.ts
@@ -1,6 +1,7 @@
 import { ConvexError, v } from "convex/values";
 import { internal } from "./_generated/api";
 import type { Doc, Id } from "./_generated/dataModel";
+import type { QueryCtx } from "./_generated/server";
 import { action, internalMutation, internalQuery, mutation, query } from "./functions";
 import { assertAdmin, requireUser } from "./lib/access";
 import { isPublicSkillDoc } from "./lib/globalStats";
@@ -125,11 +126,44 @@ export async function enqueueNvidiaSkillEvaluation(
   return { queued: true as const, runId };
 }
 
+async function resolveEvaluationSkill(
+  ctx: QueryCtx,
+  args: {
+    skillId?: string;
+    sourceRepo?: string;
+    sourcePath?: string;
+  },
+) {
+  const normalizedSkillId = args.skillId ? ctx.db.normalizeId("skills", args.skillId) : null;
+  if (normalizedSkillId) return await ctx.db.get(normalizedSkillId);
+
+  const sourceRepo = args.sourceRepo?.trim().toLowerCase();
+  const sourcePath = args.sourcePath?.trim();
+  if (sourceRepo !== NVIDIA_SKILL_EVALUATION_CONFIG.sourceRepo || !sourcePath) return null;
+
+  const source = await ctx.db
+    .query("githubSkillSources")
+    .withIndex("by_repo", (q) => q.eq("repo", "NVIDIA/skills"))
+    .unique();
+  if (!source) return null;
+
+  const matches = await ctx.db
+    .query("skills")
+    .withIndex("by_github_source", (q) => q.eq("githubSourceId", source._id))
+    .filter((q) => q.eq(q.field("githubPath"), sourcePath))
+    .take(2);
+  return matches.length === 1 ? matches[0] : null;
+}
+
 export const getCurrentForSkill = query({
-  args: { skillId: v.id("skills") },
+  args: {
+    skillId: v.optional(v.string()),
+    sourceRepo: v.optional(v.string()),
+    sourcePath: v.optional(v.string()),
+  },
   handler: async (ctx, args) => {
     try {
-      const skill = await ctx.db.get(args.skillId);
+      const skill = await resolveEvaluationSkill(ctx, args);
       if (
         !isPublicSkillDoc(skill) ||
         skill.installKind !== "github" ||

--- a/src/__tests__/skill-detail-page.test.tsx
+++ b/src/__tests__/skill-detail-page.test.tsx
@@ -395,6 +395,90 @@ describe("SkillDetailPage", () => {
     expect(getDesktopSkillTabs().getByRole("tab", { name: "Evals" })).toBeTruthy();
   });
 
+  it("looks up Evals from the canonical skill when detail data uses a projected id", () => {
+    useQueryMock.mockImplementation((query: unknown, args: unknown) => {
+      if (args === "skip") return undefined;
+      if (getFunctionName(query as never) === "skillEvaluations:getCurrentForSkill") {
+        return {
+          source: {
+            repository: "nvidia/skills",
+            commit: "0a78f333a1d67c837fbf4288efe6488169dc7140",
+            path: "skills/doca-dpa",
+            contentHash: "content-hash",
+          },
+          evaluator: {
+            repository: "NVIDIA/SkillEvaluator",
+            release: "v0.1.0",
+            commit: "4975c97d49e3623eeab739248e52d83c4aa8f582",
+            agent: "codex",
+            agentModel: "gpt-5.6",
+            judgeProvider: "openai",
+            judgeModel: "gpt-5.4",
+            environment: "docker",
+            attempts: 2,
+          },
+          metrics: {
+            sampleCount: 8,
+            overall: { withSkill: 0.9, withoutSkill: 0.6, delta: 0.3 },
+            cases: {
+              withSkillPassed: 4,
+              withSkillTotal: 4,
+              withoutSkillPassed: 2,
+              withoutSkillTotal: 4,
+            },
+            dimensions: [],
+          },
+          completedAt: Date.parse("2026-08-18T00:00:00Z"),
+        };
+      }
+      return undefined;
+    });
+
+    render(
+      <SkillDetailPage
+        slug="doca-dpa"
+        canonicalOwner="nvidia"
+        initialData={{
+          result: {
+            skill: {
+              _id: "canonicalTrendingNativePools:doca-dpa" as Id<"skills">,
+              _creationTime: 0,
+              slug: "doca-dpa",
+              displayName: "DOCA DPA",
+              summary: "Build NVIDIA DOCA DPA applications.",
+              ownerUserId: ownerId,
+              ownerPublisherId,
+              installKind: "github",
+              githubSourceRepo: "NVIDIA/skills",
+              githubPath: "skills/doca-dpa",
+              tags: {},
+              badges: {},
+              stats: { stars: 0, downloads: 0, installs: 0, versions: 0, comments: 0 },
+              createdAt: 0,
+              updatedAt: 0,
+            },
+            owner: null,
+            latestVersion: null,
+            forkOf: null,
+            canonical: null,
+          },
+          readme: null,
+          readmeError: null,
+        }}
+      />,
+    );
+
+    expect(useQueryMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        skillId: "canonicalTrendingNativePools:doca-dpa",
+        sourceRepo: "NVIDIA/skills",
+        sourcePath: "skills/doca-dpa",
+      }),
+    );
+    expect(getDesktopSkillTabs().getByRole("tab", { name: "Evals" })).toBeTruthy();
+  });
+
   it("hides Evals when the current skill version has no completed result", () => {
     render(<SkillDetailPage slug="github-skill" initialData={makeInitialData(true)} />);
 

--- a/src/components/SkillDetailPage.tsx
+++ b/src/components/SkillDetailPage.tsx
@@ -66,6 +66,9 @@ type SkillDetailVersion = NonNullable<NonNullable<SkillBySlugResult>["latestVers
 type GitHubBackedSkillFields = {
   installKind?: "github";
   githubHasSkillCard?: boolean;
+  githubCurrentRepo?: string | null;
+  githubSourceRepo?: string | null;
+  githubPath?: string | null;
   githubScanStatus?: string | null;
 };
 
@@ -260,17 +263,24 @@ export function SkillDetailPage({
   const latestVersionId = latestVersion?._id ?? null;
   const githubBackedFields = skill as GitHubBackedSkillFields | null | undefined;
   const isGitHubBackedSkill = githubBackedFields?.installKind === "github" && !latestVersionId;
+  const skillEvaluationSourceRepo =
+    githubBackedFields?.githubCurrentRepo ?? githubBackedFields?.githubSourceRepo ?? undefined;
+  const skillEvaluationSourcePath = githubBackedFields?.githubPath ?? undefined;
   const skillEvaluationQueries = useMemo(
     () =>
       skill
       ? {
           skillEvaluation: {
             query: api.skillEvaluations.getCurrentForSkill,
-            args: { skillId: skill._id },
+            args: {
+              skillId: skill._id,
+              ...(skillEvaluationSourceRepo ? { sourceRepo: skillEvaluationSourceRepo } : {}),
+              ...(skillEvaluationSourcePath ? { sourcePath: skillEvaluationSourcePath } : {}),
+            },
           },
         }
       : {},
-    [skill?._id],
+    [skill?._id, skillEvaluationSourcePath, skillEvaluationSourceRepo],
   );
   const skillEvaluationResult = useQueries(skillEvaluationQueries).skillEvaluation as
     | SkillEvaluationResult


### PR DESCRIPTION
## Summary
- resolve SkillEvaluator results when a skill detail page is backed by a projected/search row whose `_id` is not a `skills` id
- pass NVIDIA source repo/path from the page to the optional eval query
- keep missing/ambiguous/unavailable eval data fail-soft as `null`, so the Evals tab simply does not render

## Validation
- `bunx convex codegen`
- `bunx vitest run src/__tests__/skill-detail-page.test.tsx --testNamePattern "Evals|evaluation"`
- `bunx tsc -p packages/schema/tsconfig.json --noEmit`
- `bunx tsc -p packages/clawhub/tsconfig.json --noEmit`
- `git diff --check`

## Production note
Live prod currently serves doca-dpa through a projected row id from `canonicalTrendingNativePools`; the browser query was calling `skillEvaluations:getCurrentForSkill` with that projected id, causing Convex argument validation to fail before the handler could return `null`.
