### PR TITLE
chore: format skill eval query

### DIFF
--- a/src/components/SkillDetailPage.tsx
+++ b/src/components/SkillDetailPage.tsx
@@ -269,17 +269,17 @@ export function SkillDetailPage({
   const skillEvaluationQueries = useMemo(
     () =>
       skill
-      ? {
-          skillEvaluation: {
-            query: api.skillEvaluations.getCurrentForSkill,
-            args: {
-              skillId: skill._id,
-              ...(skillEvaluationSourceRepo ? { sourceRepo: skillEvaluationSourceRepo } : {}),
-              ...(skillEvaluationSourcePath ? { sourcePath: skillEvaluationSourcePath } : {}),
+        ? {
+            skillEvaluation: {
+              query: api.skillEvaluations.getCurrentForSkill,
+              args: {
+                skillId: skill._id,
+                ...(skillEvaluationSourceRepo ? { sourceRepo: skillEvaluationSourceRepo } : {}),
+                ...(skillEvaluationSourcePath ? { sourcePath: skillEvaluationSourcePath } : {}),
+              },
             },
-          },
-        }
-      : {},
+          }
+        : {},
     [skill?._id, skillEvaluationSourcePath, skillEvaluationSourceRepo],
   );
   const skillEvaluationResult = useQueries(skillEvaluationQueries).skillEvaluation as


### PR DESCRIPTION
## Summary
- format the SkillDetailPage eval query expression that landed in #3485

## Validation
- `bun run ci:static`
- `bunx vitest run src/__tests__/skill-detail-page.test.tsx --testNamePattern "Evals|evaluation"`
- `bunx tsc -p packages/schema/tsconfig.json --noEmit`
- `bunx tsc -p packages/clawhub/tsconfig.json --noEmit`
- `git diff --check`
