### PR TITLE
chore: prioritize doca eval backfill

### DIFF
--- a/convex/skillEvaluations.ts
+++ b/convex/skillEvaluations.ts
@@ -542,6 +542,28 @@ export const startNvidiaSkillEvaluationBackfill = mutation({
   },
 });
 
+export const prioritizeDocaDpaSkillEvaluation = mutation({
+  args: {
+    confirm: v.literal("prioritize-doca-dpa-skill-evaluation"),
+    sourcePath: v.literal("skills/doca-dpa"),
+  },
+  handler: async (ctx, args) => {
+    const now = Date.now();
+    const rows = await ctx.db
+      .query("skillEvaluationRuns")
+      .withIndex("by_status_source_next_run_at", (q) =>
+        q.eq("status", "queued").eq("source", "backfill"),
+      )
+      .order("asc")
+      .filter((q) => q.eq(q.field("sourcePath"), args.sourcePath))
+      .take(2);
+    if (rows.length !== 1) return { prioritized: false as const, reason: "not-unique" as const };
+    await ctx.db.patch(rows[0]._id, { nextRunAt: 0, updatedAt: now });
+    await requestSkillEvaluationDispatch(ctx);
+    return { prioritized: true as const, runId: rows[0]._id };
+  },
+});
+
 export const backfillNvidiaSkillEvaluationsPageInternal = internalMutation({
   args: {
     sourceId: v.id("githubSkillSources"),

--- a/src/components/SkillDetailPage.tsx
+++ b/src/components/SkillDetailPage.tsx
@@ -269,17 +269,17 @@ export function SkillDetailPage({
   const skillEvaluationQueries = useMemo(
     () =>
       skill
-      ? {
-          skillEvaluation: {
-            query: api.skillEvaluations.getCurrentForSkill,
-            args: {
-              skillId: skill._id,
-              ...(skillEvaluationSourceRepo ? { sourceRepo: skillEvaluationSourceRepo } : {}),
-              ...(skillEvaluationSourcePath ? { sourcePath: skillEvaluationSourcePath } : {}),
+        ? {
+            skillEvaluation: {
+              query: api.skillEvaluations.getCurrentForSkill,
+              args: {
+                skillId: skill._id,
+                ...(skillEvaluationSourceRepo ? { sourceRepo: skillEvaluationSourceRepo } : {}),
+                ...(skillEvaluationSourcePath ? { sourcePath: skillEvaluationSourcePath } : {}),
+              },
             },
-          },
-        }
-      : {},
+          }
+        : {},
     [skill?._id, skillEvaluationSourcePath, skillEvaluationSourceRepo],
   );
   const skillEvaluationResult = useQueries(skillEvaluationQueries).skillEvaluation as


### PR DESCRIPTION
## Summary
- add a temporary exact-path maintenance mutation to move the queued `skills/doca-dpa` NVIDIA eval run to the front of the backfill queue
- does not create or alter evaluation results; it only updates `nextRunAt` for the unique queued doca-dpa run and requests worker dispatch

## Validation
- `bunx convex codegen`
- `bun run format -- convex/skillEvaluations.ts`
- `bun run ci:static`
- `bunx tsc -p packages/schema/tsconfig.json --noEmit`
- `bunx tsc -p packages/clawhub/tsconfig.json --noEmit`
- `git diff --check`

## Follow-up
- Remove this exact-path prioritizer after prod doca-dpa evaluation is completed and visible.
