### PR TITLE
fix: show current NVIDIA evals from source-backed skills

### DIFF
--- a/convex/skillEvaluations.runtime.test.ts
+++ b/convex/skillEvaluations.runtime.test.ts
@@ -158,6 +158,50 @@ describe("skill evaluation runtime queue", () => {
     await expect(t.query(api.skillEvaluations.getCurrentForSkill, { skillId })).resolves.toBeNull();
   });
 
+  it("publishes current results for skills whose repo comes from the GitHub source row", async () => {
+    const t = convexTest(schema, modules);
+    const contentHash = "hash-v1";
+    const skillId = await insertNvidiaSkill(t, { hash: contentHash, slug: "doca-dpa" });
+    await t.run(async (ctx) => {
+      const sourceId = await ctx.db.insert("githubSkillSources", {
+        repo: "NVIDIA/skills",
+        createdAt: 1,
+        updatedAt: 1,
+      });
+      await ctx.db.patch(skillId, {
+        githubCurrentRepo: undefined,
+        githubSourceId: sourceId,
+      });
+      await ctx.db.insert("skillEvaluationRuns", {
+        ...evaluationRow({ skillId, contentHash, scanStatus: "suspicious", source: "backfill" }),
+        status: "succeeded",
+        metrics: {
+          sampleCount: 8,
+          overall: { withSkill: 0.9, withoutSkill: 0.6, delta: 0.3 },
+          cases: {
+            withSkillPassed: 4,
+            withSkillTotal: 4,
+            withoutSkillPassed: 2,
+            withoutSkillTotal: 4,
+          },
+          dimensions: [{ id: "correctness", withSkill: 0.9, withoutSkill: 0.6, delta: 0.3 }],
+        },
+        completedAt: 100,
+      });
+    });
+
+    await expect(
+      t.query(api.skillEvaluations.getCurrentForSkill, {
+        skillId,
+        sourceRepo: "NVIDIA/skills",
+        sourcePath: "skills/doca-dpa",
+      }),
+    ).resolves.toMatchObject({
+      source: { repository: "nvidia/skills", path: "skills/demo" },
+      metrics: { overall: { delta: 0.3 } },
+    });
+  });
+
   it("does not publish results for a skill hidden from public view", async () => {
     const t = convexTest(schema, modules);
     const contentHash = "hash-v1";

--- a/convex/skillEvaluations.ts
+++ b/convex/skillEvaluations.ts
@@ -164,12 +164,13 @@ export const getCurrentForSkill = query({
   handler: async (ctx, args) => {
     try {
       const skill = await resolveEvaluationSkill(ctx, args);
+      const source = skill?.githubSourceId ? await ctx.db.get(skill.githubSourceId) : null;
+      const skillSourceRepo = (skill?.githubCurrentRepo ?? source?.repo)?.trim().toLowerCase();
       if (
         !isPublicSkillDoc(skill) ||
         skill.installKind !== "github" ||
         skill.githubCurrentStatus !== "present" ||
-        skill.githubCurrentRepo?.trim().toLowerCase() !==
-          NVIDIA_SKILL_EVALUATION_CONFIG.sourceRepo ||
+        skillSourceRepo !== NVIDIA_SKILL_EVALUATION_CONFIG.sourceRepo ||
         !skill.githubCurrentContentHash
       ) {
         return null;


### PR DESCRIPTION
## Summary
- resolve the Evals tab query through `githubSkillSources.repo` when a skill does not carry `githubCurrentRepo`
- keep the public query fail-soft: unavailable or non-current eval data returns `null`, so the tab stays hidden instead of throwing
- add a regression test for completed evals on source-backed NVIDIA skills

## Validation
- `env PATH="/Users/patrickerichsen/.bun/bin:$PATH" bunx convex codegen`
- `env PATH="/Users/patrickerichsen/.bun/bin:$PATH" bun run format -- convex/skillEvaluations.ts convex/skillEvaluations.runtime.test.ts`
- `env PATH="/Users/patrickerichsen/.bun/bin:$PATH" bunx vitest run convex/skillEvaluations.runtime.test.ts --testNamePattern "current results|completed result|repo comes"`
- `env PATH="/Users/patrickerichsen/.bun/bin:$PATH" bunx tsc --noEmit`
- `env PATH="/Users/patrickerichsen/.bun/bin:$PATH" bun run ci:static`
- `git diff --check`
