### PR TITLE
chore: remove stale ClawHub code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -56,22 +56,22 @@
 /convex/lib/webhooks.ts @openclaw/openclaw-secops @Patrick-Erichsen
 
 # Frontend auth, admin, publish, upload, and security-review surfaces.
-/src/lib/packageApi.ts @openclaw/openclaw-secops @BunsDev
-/src/lib/packageUpload.ts @openclaw/openclaw-secops @BunsDev
-/src/lib/roles.ts @openclaw/openclaw-secops @BunsDev
-/src/lib/uploadFiles.ts @openclaw/openclaw-secops @BunsDev
-/src/lib/uploadUtils.ts @openclaw/openclaw-secops @BunsDev
-/src/routes/admin.tsx @openclaw/openclaw-secops @BunsDev
-/src/routes/cli/auth.tsx @openclaw/openclaw-secops @BunsDev
-/src/routes/packages/new.tsx @openclaw/openclaw-secops @BunsDev
-/src/routes/plugins/publish.tsx @openclaw/openclaw-secops @BunsDev
-/src/routes/publish-plugin.tsx @openclaw/openclaw-secops @BunsDev
-/src/routes/publish-skill.tsx @openclaw/openclaw-secops @BunsDev
-/src/routes/skills/publish.tsx @openclaw/openclaw-secops @BunsDev
-/src/routes/upload.tsx @openclaw/openclaw-secops @BunsDev
-/src/routes/upload/ @openclaw/openclaw-secops @BunsDev
-/src/routes/$owner/$slug/security/ @openclaw/openclaw-secops @BunsDev
-/src/routes/plugins/$name/security/ @openclaw/openclaw-secops @BunsDev
+/src/lib/packageApi.ts @openclaw/openclaw-secops
+/src/lib/packageUpload.ts @openclaw/openclaw-secops
+/src/lib/roles.ts @openclaw/openclaw-secops
+/src/lib/uploadFiles.ts @openclaw/openclaw-secops
+/src/lib/uploadUtils.ts @openclaw/openclaw-secops
+/src/routes/admin.tsx @openclaw/openclaw-secops
+/src/routes/cli/auth.tsx @openclaw/openclaw-secops
+/src/routes/packages/new.tsx @openclaw/openclaw-secops
+/src/routes/plugins/publish.tsx @openclaw/openclaw-secops
+/src/routes/publish-plugin.tsx @openclaw/openclaw-secops
+/src/routes/publish-skill.tsx @openclaw/openclaw-secops
+/src/routes/skills/publish.tsx @openclaw/openclaw-secops
+/src/routes/upload.tsx @openclaw/openclaw-secops
+/src/routes/upload/ @openclaw/openclaw-secops
+/src/routes/$owner/$slug/security/ @openclaw/openclaw-secops
+/src/routes/plugins/$name/security/ @openclaw/openclaw-secops
 
 # CLI auth, admin, publishing, ownership, and package-contract surfaces.
 /packages/clawhub/src/browserAuth.ts @openclaw/openclaw-secops @Patrick-Erichsen


### PR DESCRIPTION
## What Problem This Solves

Resolves a repository governance problem where GitHub reports 16 invalid CODEOWNERS entries because `@BunsDev` has read access rather than the write access required for code owners.

## Why This Change Was Made

Removes only the 16 stale `@BunsDev` owner tokens from frontend package, upload, admin, publish, and security routes. `@openclaw/openclaw-secops` remains on every affected entry, and `BunsDev` keeps repository read access.

## User Impact

No user-visible product impact. Maintainers regain a valid CODEOWNERS file without changing repository access.

## Evidence

- GitHub CODEOWNERS errors on `main` before the change: 16
- GitHub CODEOWNERS errors on exact branch head `2e876ebf0a11096e3e14edbde22c4873131b9a0b`: 0
- `BunsDev` repository permission after the change: `read`
- `bun run ci:static`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` (clean; no accepted/actionable findings)
- `git diff --check`
- Scope check: one changed file, 16 removed owner tokens, all 16 affected entries still owned by `@openclaw/openclaw-secops`

AI assistance: Codex assisted with the scoped edit and validation; the maintainer reviewed the exact diff and evidence.
