### PR TITLE
fix: await publish webhook follow-up

### DIFF
--- a/convex/lib/skillPublish.test.ts
+++ b/convex/lib/skillPublish.test.ts
@@ -209,6 +209,201 @@ describe("skillPublish", () => {
     ).rejects.toThrow("storage unavailable");
   });
 
+  it("waits for publish webhook lookup and scheduling before finalization settles", async () => {
+    const previousWebhookUrl = process.env.DISCORD_WEBHOOK_URL;
+    process.env.DISCORD_WEBHOOK_URL = "https://example.invalid/webhook";
+    try {
+      const publishResult = {
+        skillId: "skills:demo",
+        versionId: "skillVersions:demo",
+        embeddingId: "skillEmbeddings:demo",
+      };
+      const webhookLookup = deferred<{
+        skill: {
+          _id: string;
+          slug: string;
+          displayName: string;
+          summary: string;
+          tags: Record<string, unknown>;
+        };
+        owner: { handle: string };
+      }>();
+      const webhookSchedule = deferred<void>();
+      const recordFinalized = vi.fn();
+      const runMutation = vi.fn(async (_ref: unknown, args: Record<string, unknown>) => {
+        if ("claimId" in args && !("result" in args)) {
+          return {
+            status: "claimed",
+            attemptId: "publishAttempts:webhook",
+            skillInsertArgs: {
+              userId: "users:1",
+              slug: "webhook-demo",
+              displayName: "Webhook Demo",
+              version: "1.0.0",
+              embedding: [0, 1, 2],
+            },
+            followup: {
+              slug: "webhook-demo",
+              version: "1.0.0",
+              displayName: "Webhook Demo",
+            },
+          };
+        }
+        if ("version" in args && "embedding" in args) return publishResult;
+        if ("result" in args) {
+          recordFinalized();
+          return {
+            attemptId: "publishAttempts:webhook",
+            status: "finalized",
+            result: args.result,
+          };
+        }
+        throw new Error("unexpected mutation");
+      });
+      const scheduler = {
+        runAfter: vi.fn((_delay: number, _ref: unknown, args: Record<string, unknown>) =>
+          args.event === "skill.publish" ? webhookSchedule.promise : Promise.resolve(),
+        ),
+      };
+      const ctx = {
+        runMutation,
+        runQuery: vi.fn(() => webhookLookup.promise),
+        scheduler,
+      };
+
+      const finalization = finalizeSkillPublishAttempt(
+        ctx as never,
+        "publishAttempts:webhook" as never,
+      );
+      const settled = vi.fn();
+      void finalization.then(settled, settled);
+
+      await vi.waitFor(() => expect(ctx.runQuery).toHaveBeenCalledOnce());
+      expect(settled).not.toHaveBeenCalled();
+
+      webhookLookup.resolve({
+        skill: {
+          _id: "skills:demo",
+          slug: "webhook-demo",
+          displayName: "Webhook Demo",
+          summary: "Webhook scheduling regression coverage.",
+          tags: {},
+        },
+        owner: { handle: "demo" },
+      });
+      await vi.waitFor(() =>
+        expect(scheduler.runAfter).toHaveBeenCalledWith(0, expect.anything(), {
+          event: "skill.publish",
+          skill: expect.objectContaining({ slug: "webhook-demo" }),
+        }),
+      );
+      expect(settled).not.toHaveBeenCalled();
+
+      webhookSchedule.resolve();
+      await expect(finalization).resolves.toEqual(publishResult);
+      expect(recordFinalized).toHaveBeenCalledOnce();
+    } finally {
+      if (previousWebhookUrl === undefined) {
+        delete process.env.DISCORD_WEBHOOK_URL;
+      } else {
+        process.env.DISCORD_WEBHOOK_URL = previousWebhookUrl;
+      }
+    }
+  });
+
+  it.each(["lookup", "schedule"] as const)(
+    "keeps a successful publish finalized when webhook %s fails",
+    async (failure) => {
+      const previousWebhookUrl = process.env.DISCORD_WEBHOOK_URL;
+      process.env.DISCORD_WEBHOOK_URL = "https://example.invalid/webhook";
+      try {
+        const publishResult = {
+          skillId: "skills:demo",
+          versionId: "skillVersions:demo",
+          embeddingId: "skillEmbeddings:demo",
+        };
+        const recordFinalized = vi.fn();
+        const releaseClaim = vi.fn();
+        const runMutation = vi.fn(async (_ref: unknown, args: Record<string, unknown>) => {
+          if ("claimId" in args && !("result" in args) && !("error" in args)) {
+            return {
+              status: "claimed",
+              attemptId: "publishAttempts:webhook-failure",
+              skillInsertArgs: {
+                userId: "users:1",
+                slug: "webhook-demo",
+                displayName: "Webhook Demo",
+                version: "1.0.0",
+                embedding: [0, 1, 2],
+              },
+              followup: {
+                slug: "webhook-demo",
+                version: "1.0.0",
+                displayName: "Webhook Demo",
+              },
+            };
+          }
+          if ("version" in args && "embedding" in args) return publishResult;
+          if ("result" in args) {
+            recordFinalized();
+            return {
+              attemptId: "publishAttempts:webhook-failure",
+              status: "finalized",
+              result: args.result,
+            };
+          }
+          if ("error" in args) {
+            releaseClaim();
+            return {
+              attemptId: "publishAttempts:webhook-failure",
+              status: "ready_to_finalize",
+            };
+          }
+          throw new Error("unexpected mutation");
+        });
+        const scheduler = {
+          runAfter: vi.fn((_delay: number, _ref: unknown, args: Record<string, unknown>) => {
+            if (failure === "schedule" && args.event === "skill.publish") {
+              return Promise.reject(new Error("webhook scheduler unavailable"));
+            }
+            return Promise.resolve();
+          }),
+        };
+        const ctx = {
+          runMutation,
+          runQuery: vi.fn(() => {
+            if (failure === "lookup") {
+              return Promise.reject(new Error("webhook lookup unavailable"));
+            }
+            return Promise.resolve({
+              skill: {
+                _id: "skills:demo",
+                slug: "webhook-demo",
+                displayName: "Webhook Demo",
+                summary: "Webhook failure regression coverage.",
+                tags: {},
+              },
+              owner: { handle: "demo" },
+            });
+          }),
+          scheduler,
+        };
+
+        await expect(
+          finalizeSkillPublishAttempt(ctx as never, "publishAttempts:webhook-failure" as never),
+        ).resolves.toEqual(publishResult);
+        expect(recordFinalized).toHaveBeenCalledOnce();
+        expect(releaseClaim).not.toHaveBeenCalled();
+      } finally {
+        if (previousWebhookUrl === undefined) {
+          delete process.env.DISCORD_WEBHOOK_URL;
+        } else {
+          process.env.DISCORD_WEBHOOK_URL = previousWebhookUrl;
+        }
+      }
+    },
+  );
+
   it("publishes long display names without rewriting the stored label", async () => {
     const displayName = "A".repeat(120);
     const skillMarkdown = `---\ndescription: Long compatibility name.\n---\n# ${displayName}\n`;
@@ -1517,4 +1712,12 @@ function validPng() {
       "base64",
     ),
   );
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
 }

--- a/convex/lib/skillPublish.ts
+++ b/convex/lib/skillPublish.ts
@@ -907,12 +907,16 @@ async function scheduleSkillPublishFollowups(
   );
 
   if (!followup.skipWebhook && getWebhookConfig().url) {
-    void schedulePublishWebhook(ctx, {
-      slug: followup.slug,
-      version: followup.version,
-      displayName: followup.displayName,
-      ownerHandle: followup.ownerHandle,
-    });
+    try {
+      await schedulePublishWebhook(ctx, {
+        slug: followup.slug,
+        version: followup.version,
+        displayName: followup.displayName,
+        ownerHandle: followup.ownerHandle,
+      });
+    } catch {
+      // Publication has committed; the Discord notification is best-effort.
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

- await publish-webhook lookup and scheduling so the Convex action does not return with live query or scheduler operations
- contain failures at the optional Discord follow-up boundary so an already-successful publication remains finalized
- add regressions covering unsettled lookup/scheduling plus non-fatal lookup and scheduler rejection

## Production evidence

Axiom dataset `clawhub` showed 631 `Convex UnawaitedOperations` warnings across 631 publish-completion requests from `2026-08-19T15:09:30Z` to `2026-08-20T15:02:05Z`: 489 query and 142 schedule warnings. The equal preceding window had 441 warnings (360 query, 81 schedule), so the current window increased 43%.

Current `origin/main` detached `schedulePublishWebhook(...)` even though that helper awaits a skill query and then a scheduler call. A focused deferred-promise test failed on the base because finalization settled before the webhook query resolved, directly supporting that source mechanism.

Impact: **2/5**. Publication data remains committed, but Discord dispatch is nondeterministic and every affected request emits runtime warnings. The fix is limited to awaiting and containing the optional follow-up.

PR #3401 remains separate publication-recovery scope and is not modified or duplicated here.

## Validation

- `bunx vitest run convex/lib/skillPublish.test.ts -t "waits for publish webhook lookup and scheduling before finalization settles"` (red on base, green after fix)
- `bunx vitest run convex/lib/skillPublish.test.ts -t "keeps a successful publish finalized when webhook"` (red after await-only slice, green after containment)
- `bunx vitest run convex/lib/skillPublish.test.ts` (29 passed)
- `bun run ci:static`
- `bun run ci:unit` (466 files passed, 6,159 tests passed, 3 skipped)
- `bun run ci:types-build`
- `.agents/skills/autoreview/scripts/autoreview --mode local --stream-engine-output` (clean, no actionable findings)

No production, deployment, monitor, or observability state was mutated.
