### PR TITLE
fix: skill evaluation workers can skip and fail runs

### DIFF
--- a/convex/skillEvaluations.test.ts
+++ b/convex/skillEvaluations.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { failSkillEvaluation, skipSkillEvaluation } from "./skillEvaluations";
+
+type RunMutation = (ref: unknown, args: unknown) => Promise<unknown>;
+
+type WrappedHandler<TArgs, TResult> = {
+  _handler: (ctx: { runMutation: RunMutation }, args: TArgs) => Promise<TResult>;
+};
+
+type TerminalActionArgs = {
+  token: string;
+  runId: string;
+  leaseToken: string;
+};
+
+const skipSkillEvaluationHandler = (
+  skipSkillEvaluation as unknown as WrappedHandler<
+    TerminalActionArgs & { reason: string },
+    { ok: true }
+  >
+)._handler;
+
+const failSkillEvaluationHandler = (
+  failSkillEvaluation as unknown as WrappedHandler<
+    TerminalActionArgs & { error: string },
+    { ok: true; retry: boolean }
+  >
+)._handler;
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("skill evaluation worker terminal actions", () => {
+  it("forwards only internal skip arguments after authenticating the worker", async () => {
+    vi.stubEnv("SECURITY_SCAN_WORKER_TOKEN", "expected-worker-token");
+    const runMutation = vi.fn().mockResolvedValueOnce({ ok: true }).mockResolvedValueOnce({});
+
+    await expect(
+      skipSkillEvaluationHandler(
+        { runMutation },
+        {
+          token: "expected-worker-token",
+          runId: "skillEvaluationRuns:skip",
+          leaseToken: "skip-lease",
+          reason: "not applicable",
+        },
+      ),
+    ).resolves.toEqual({ ok: true });
+    expect(runMutation.mock.calls[0]?.[1]).toEqual({
+      runId: "skillEvaluationRuns:skip",
+      leaseToken: "skip-lease",
+      reason: "not applicable",
+    });
+  });
+
+  it("forwards only internal failure arguments after authenticating the worker", async () => {
+    vi.stubEnv("SECURITY_SCAN_WORKER_TOKEN", "expected-worker-token");
+    const runMutation = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, retry: false })
+      .mockResolvedValueOnce({});
+
+    await expect(
+      failSkillEvaluationHandler(
+        { runMutation },
+        {
+          token: "expected-worker-token",
+          runId: "skillEvaluationRuns:fail",
+          leaseToken: "fail-lease",
+          error: "synthetic worker failure",
+        },
+      ),
+    ).resolves.toEqual({ ok: true, retry: false });
+    expect(runMutation.mock.calls[0]?.[1]).toEqual({
+      runId: "skillEvaluationRuns:fail",
+      leaseToken: "fail-lease",
+      error: "synthetic worker failure",
+    });
+  });
+
+  it.each([
+    {
+      name: "skip",
+      invoke: (runMutation: RunMutation) =>
+        skipSkillEvaluationHandler(
+          { runMutation },
+          {
+            token: "invalid-worker-token",
+            runId: "skillEvaluationRuns:skip",
+            leaseToken: "skip-lease",
+            reason: "not applicable",
+          },
+        ),
+    },
+    {
+      name: "fail",
+      invoke: (runMutation: RunMutation) =>
+        failSkillEvaluationHandler(
+          { runMutation },
+          {
+            token: "invalid-worker-token",
+            runId: "skillEvaluationRuns:fail",
+            leaseToken: "fail-lease",
+            error: "synthetic worker failure",
+          },
+        ),
+    },
+  ])("rejects an invalid external token before the $name mutation", async ({ invoke }) => {
+    vi.stubEnv("SECURITY_SCAN_WORKER_TOKEN", "expected-worker-token");
+    const runMutation = vi.fn(async () => undefined);
+
+    await expect(invoke(runMutation)).rejects.toThrow("Unauthorized");
+    expect(runMutation).not.toHaveBeenCalled();
+  });
+});

--- a/convex/skillEvaluations.ts
+++ b/convex/skillEvaluations.ts
@@ -471,7 +471,11 @@ export const skipSkillEvaluation = action({
     const result = await runMutationRef<{ ok: true }>(
       ctx,
       internalRefs.skillEvaluations.skipSkillEvaluationInternal,
-      args,
+      {
+        runId: args.runId,
+        leaseToken: args.leaseToken,
+        reason: args.reason,
+      },
     );
     await requestNextSkillEvaluationDispatch(ctx);
     return result;
@@ -490,7 +494,11 @@ export const failSkillEvaluation = action({
     const result = await runMutationRef<{ ok: true; retry: boolean }>(
       ctx,
       internalRefs.skillEvaluations.failSkillEvaluationInternal,
-      args,
+      {
+        runId: args.runId,
+        leaseToken: args.leaseToken,
+        error: args.error,
+      },
     );
     await requestNextSkillEvaluationDispatch(ctx);
     return result;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where skill-evaluation workers could complete successful runs but could not skip or fail running evaluations. The public terminal actions authenticated correctly, then Convex rejected their internal mutation calls because the external worker token was forwarded as an undeclared argument.

## Why This Change Was Made

After authenticating the worker, the skip and fail actions now construct validator-approved internal arguments explicitly, matching the existing complete action. The external worker-auth boundary and internal lease checks are unchanged.

## User Impact

Evaluation workers can terminalize skipped and failed runs again instead of leaving them stuck in the running state. Impact: **3/5**.

## Evidence

Redacted Axiom evidence from dataset `clawhub`:

- Current window: `2026-08-19T15:09:30Z` to `2026-08-20T15:02:05Z`.
- 95 skill-evaluation runs produced the same terminal-action validator failure family across the public and internal skip/fail paths.
- The equal baseline window showed 30 failures per affected path.
- No tokens, run IDs, PII, or raw event samples are included.

TDD proof:

- Red: `bunx vitest run convex/skillEvaluations.test.ts` failed both forwarding tests because the internal argument object contained `token`; invalid-token tests already passed.
- Green: `bunx vitest run convex/skillEvaluations.test.ts convex/skillEvaluations.runtime.test.ts` (13 passed).
- Tests assert both skip and fail internal mutations receive only `runId`, `leaseToken`, and `reason`/`error`, while invalid external tokens are rejected before any mutation call.

Validation:

- `bun run ci:static`
- `bun run ci:unit` (6160 passed, 3 skipped)
- `bun run ci:types-build`
- `.agents/skills/autoreview/scripts/autoreview --mode local ...` (clean; no accepted/actionable findings)

A local-only `bunx convex dev --once` push was attempted twice against `anonymous:anonymous-agent` at `127.0.0.1`; both attempts were blocked by an unrelated existing `ExportInProgress`. No dev-cloud or production deployment was attempted.
