### PR TITLE
fix(api): stream bulk skill exports

### DIFF
--- a/convex/httpApiV1.handlers.test.ts
+++ b/convex/httpApiV1.handlers.test.ts
@@ -864,6 +864,91 @@ describe("httpApiV1 handlers", () => {
     });
   });
 
+  it("skills export reports archive paths that exceed the signed byte budget", async () => {
+    vi.stubEnv("CLAWHUB_PREVIEW", "1");
+    vi.mocked(requireApiTokenUser).mockResolvedValue({
+      userId: "users:actor",
+      user: { _id: "users:actor", role: "user" },
+    } as never);
+    vi.mocked(getOptionalApiTokenUser).mockResolvedValue({
+      userId: "users:actor",
+      user: { _id: "users:actor", role: "user" },
+    } as never);
+    const longUnicodePath = `${"界".repeat(490)}.md`;
+    const runQuery = vi.fn(async (_query: unknown, args: Record<string, unknown>) => {
+      if ("startDate" in args) {
+        return {
+          page: [
+            {
+              skillId: "skills:demo",
+              slug: "demo",
+              displayName: "Demo",
+              latestVersionId: "skillVersions:demo",
+              createdAt: 1,
+              updatedAt: 2,
+              stats: {},
+              ownerUserId: "users:alice",
+              ownerHandle: "alice",
+            },
+          ],
+          nextCursor: null,
+          hasMore: false,
+        };
+      }
+      if (args.versionId === "skillVersions:demo") {
+        return {
+          skillId: "skills:demo",
+          version: "1.0.0",
+          files: [
+            {
+              storageId: "storage:demo",
+              path: longUnicodePath,
+              size: 1,
+              sha256: "a".repeat(64),
+            },
+          ],
+        };
+      }
+      return null;
+    });
+    const storageGetUrl = vi.fn(
+      async () => "https://preview-branch-123.convex.cloud/api/storage/storage-demo",
+    );
+
+    const response = await __handlers.exportSkillsV1Handler(
+      makeCtx({ runQuery, storage: { get: vi.fn(), getUrl: storageGetUrl } }),
+      new Request(
+        "https://preview-branch-123.convex.site/api/v1/skills/export?startDate=1&endDate=5",
+        {
+          headers: {
+            authorization: "Bearer user-token",
+            "x-clawhub-archive-manifest": "v1",
+            "x-clawhub-vercel-oidc-token": "vercel-oidc",
+          },
+        },
+      ),
+      {
+        verifyArchiveRequester: vi.fn(async () => undefined),
+        signArchiveManifest: vi.fn(async (manifest: unknown) => JSON.stringify(manifest)),
+      },
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("X-Export-Errors")).toBe("1");
+    expect(storageGetUrl).not.toHaveBeenCalled();
+    const manifest = JSON.parse(await response.text());
+    expect(manifest.entries).toEqual([
+      expect.objectContaining({ kind: "inline", path: "_errors.json" }),
+    ]);
+    expect(JSON.parse(manifest.entries[0].text)).toEqual([
+      {
+        slug: "demo",
+        error: "archive path exceeds signed manifest byte limit (file index 0)",
+      },
+    ]);
+    expect(manifest.exportManifest).toEqual([]);
+  });
+
   it("skills export includes GitHub-backed skills as public GitHub handoff descriptors", async () => {
     vi.mocked(requireApiTokenUser).mockResolvedValue({
       userId: "users:actor",

--- a/convex/httpApiV1.handlers.test.ts
+++ b/convex/httpApiV1.handlers.test.ts
@@ -617,6 +617,28 @@ describe("httpApiV1 handlers", () => {
     );
   });
 
+  it("skills export does not expose storage manifests to direct clients", async () => {
+    vi.mocked(requireApiTokenUser).mockResolvedValue({
+      userId: "users:actor",
+      user: { _id: "users:actor", role: "user" },
+    } as never);
+    const runQuery = vi.fn();
+
+    const response = await __handlers.exportSkillsV1Handler(
+      makeCtx({ runQuery }),
+      new Request("https://example.com/api/v1/skills/export?startDate=1&endDate=2", {
+        headers: {
+          authorization: "Bearer user-token",
+          "x-clawhub-archive-manifest": "v1",
+        },
+      }),
+    );
+
+    expect(response.status).toBe(401);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(runQuery).not.toHaveBeenCalled();
+  });
+
   it("skills export preserves pagination headers for empty filtered pages", async () => {
     vi.mocked(requireApiTokenUser).mockResolvedValue({
       userId: "users:actor",
@@ -728,6 +750,118 @@ describe("httpApiV1 handlers", () => {
       "bob/demo/SKILL.md",
       "bob/demo/_export_skill_meta.json",
     ]);
+  });
+
+  it("skills export hands Nitro a signed storage manifest without loading Blob bodies", async () => {
+    vi.stubEnv("CLAWHUB_PREVIEW", "1");
+    vi.mocked(requireApiTokenUser).mockResolvedValue({
+      userId: "users:actor",
+      user: { _id: "users:actor", role: "user" },
+    } as never);
+    vi.mocked(getOptionalApiTokenUser).mockResolvedValue({
+      userId: "users:actor",
+      user: { _id: "users:actor", role: "user" },
+    } as never);
+    const runQuery = vi.fn(async (_query: unknown, args: Record<string, unknown>) => {
+      if ("startDate" in args) {
+        return {
+          page: [
+            {
+              skillId: "skills:demo",
+              slug: "demo",
+              displayName: "Demo",
+              latestVersionId: "skillVersions:demo",
+              createdAt: 1,
+              updatedAt: 2,
+              stats: { downloads: 4 },
+              ownerUserId: "users:alice",
+              ownerHandle: "alice",
+              ownerDisplayName: "Alice",
+            },
+          ],
+          nextCursor: "next-page",
+          hasMore: true,
+        };
+      }
+      if (args.versionId === "skillVersions:demo") {
+        return {
+          skillId: "skills:demo",
+          version: "1.0.0",
+          files: [
+            {
+              storageId: "storage:demo",
+              path: "SKILL.md",
+              size: 64 * 1024 * 1024,
+              sha256: "a".repeat(64),
+            },
+          ],
+        };
+      }
+      return null;
+    });
+    const storageGet = vi.fn();
+    const storageGetUrl = vi.fn(
+      async () => "https://preview-branch-123.convex.cloud/api/storage/storage-demo",
+    );
+    const verifyArchiveRequester = vi.fn(async () => undefined);
+    const signArchiveManifest = vi.fn(async (manifest: unknown) => JSON.stringify(manifest));
+
+    const response = await __handlers.exportSkillsV1Handler(
+      makeCtx({
+        runQuery,
+        storage: { get: storageGet, getUrl: storageGetUrl },
+      }),
+      new Request(
+        "https://preview-branch-123.convex.site/api/v1/skills/export?startDate=1&endDate=5",
+        {
+          headers: {
+            authorization: "Bearer user-token",
+            "x-clawhub-archive-manifest": "v1",
+            "x-clawhub-vercel-oidc-token": "vercel-oidc",
+          },
+        },
+      ),
+      { verifyArchiveRequester, signArchiveManifest },
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe(
+      "application/vnd.clawhub.skill-archive-manifest+jws",
+    );
+    expect(response.headers.get("X-Next-Cursor")).toBe("next-page");
+    expect(response.headers.get("X-Has-More")).toBe("true");
+    expect(response.headers.get("X-Total-Returned")).toBe("1");
+    expect(response.headers.get("X-Export-Errors")).toBe("0");
+    expect(storageGet).not.toHaveBeenCalled();
+    expect(storageGetUrl).toHaveBeenCalledWith("storage:demo");
+    expect(verifyArchiveRequester).toHaveBeenCalledWith("vercel-oidc", "preview");
+    const manifest = JSON.parse(await response.text());
+    expect(manifest).toMatchObject({
+      schema: "clawhub.skill-export-archive-manifest.v1",
+      issuer: "https://preview-branch-123.convex.site",
+      filename: "skills-export-1-5.zip",
+      entries: [
+        {
+          kind: "storage",
+          path: "alice/demo/SKILL.md",
+          url: "https://preview-branch-123.convex.cloud/api/storage/storage-demo",
+          size: 64 * 1024 * 1024,
+          sha256: "a".repeat(64),
+        },
+        {
+          kind: "inline",
+          path: "alice/demo/_export_skill_meta.json",
+        },
+      ],
+      exportManifest: [
+        expect.objectContaining({
+          publisher: "alice",
+          slug: "demo",
+          sourceRef: "public-clawhub",
+          fileCount: 1,
+        }),
+      ],
+    });
   });
 
   it("skills export includes GitHub-backed skills as public GitHub handoff descriptors", async () => {

--- a/convex/httpApiV1/skillsV1.ts
+++ b/convex/httpApiV1/skillsV1.ts
@@ -21,7 +21,20 @@ import { api, internal } from "../_generated/api";
 import type { Doc, Id } from "../_generated/dataModel";
 import type { ActionCtx } from "../_generated/server";
 import { getOptionalApiTokenUserId, requireApiTokenUser } from "../lib/apiTokenAuth";
+import {
+  ARCHIVE_MANIFEST_AUDIENCE,
+  ARCHIVE_MANIFEST_CONTENT_TYPE,
+  ARCHIVE_MANIFEST_JWS_TYPE,
+  signArchivePayload,
+  type SkillExportArchiveManifest,
+} from "../lib/archiveManifest";
 import { serializeCanonicalSkillSearchResults } from "../lib/canonicalSkillSearchResponse";
+import {
+  ARCHIVE_REQUEST_IDENTITY_HEADER,
+  expectedVercelEnvironmentForConvexSite,
+  type ClawHubVercelEnvironment,
+  verifyClawHubVercelOidcToken,
+} from "../lib/clawhubVercelOidc";
 import {
   buildGitHubSkillHandoffDescriptor,
   getGitHubHandoffBlock,
@@ -95,7 +108,25 @@ const MAX_EXPORT_FILE_COUNT = 10_000;
 const MAX_EXPORT_PAGE_LIMIT = 250;
 const DEFAULT_EXPORT_PAGE_LIMIT = 250;
 const MAX_EXPORT_TOTAL_BYTES = 256 * 1024 * 1024;
+const ARCHIVE_MANIFEST_REQUEST_HEADER = "x-clawhub-archive-manifest";
+const ARCHIVE_MANIFEST_TTL_MS = 30_000;
+// Covers the 10,000-file export contract (including long paths and JWS
+// expansion) while keeping the trusted Nitro handoff materially bounded.
+const MAX_ARCHIVE_MANIFEST_BYTES = 16 * 1024 * 1024;
 const MAX_SECURITY_VERDICT_ITEMS = 100;
+
+type SkillsExportDependencies = {
+  verifyArchiveRequester: (
+    token: string,
+    expectedEnvironment: ClawHubVercelEnvironment,
+  ) => Promise<unknown>;
+  signArchiveManifest: (manifest: SkillExportArchiveManifest) => Promise<string>;
+};
+
+const DEFAULT_SKILLS_EXPORT_DEPENDENCIES: SkillsExportDependencies = {
+  verifyArchiveRequester: verifyClawHubVercelOidcToken,
+  signArchiveManifest: (manifest) => signArchivePayload(manifest, ARCHIVE_MANIFEST_JWS_TYPE),
+};
 
 async function readRequestBodyWithinLimit(request: Request, maxBytes: number) {
   if (!request.body) return new Uint8Array();
@@ -3729,6 +3760,7 @@ type SkillsExportPhase =
   | "build_empty_zip"
   | "load_versions"
   | "plan_blobs"
+  | "load_blob_urls"
   | "load_blobs"
   | "assemble_entries"
   | "build_zip";
@@ -3760,11 +3792,27 @@ function logSkillsExportFailure(context: SkillsExportLogContext, error: unknown)
   });
 }
 
-export async function exportSkillsV1Handler(ctx: ActionCtx, request: Request) {
+export async function exportSkillsV1Handler(
+  ctx: ActionCtx,
+  request: Request,
+  dependencies: SkillsExportDependencies = DEFAULT_SKILLS_EXPORT_DEPENDENCIES,
+) {
   try {
     await requireApiTokenUser(ctx, request);
   } catch (err) {
     return text(err instanceof Error ? err.message : "Unauthorized", 401);
+  }
+
+  const manifestRequested = request.headers.get(ARCHIVE_MANIFEST_REQUEST_HEADER) === "v1";
+  if (manifestRequested) {
+    const token = request.headers.get(ARCHIVE_REQUEST_IDENTITY_HEADER)?.trim();
+    const expectedEnvironment = expectedVercelEnvironmentForConvexSite(request.url);
+    if (!token || !expectedEnvironment) return unauthorizedSkillsExportManifestResponse();
+    try {
+      await dependencies.verifyArchiveRequester(token, expectedEnvironment);
+    } catch {
+      return unauthorizedSkillsExportManifestResponse();
+    }
   }
 
   const rate = await applyRateLimit(ctx, request, "export");
@@ -3847,12 +3895,29 @@ export async function exportSkillsV1Handler(ctx: ActionCtx, request: Request) {
   if (result.page.length === 0) {
     try {
       logContext.phase = "build_empty_zip";
+      const filename = `skills-export-${startDate}-${endDate}-empty.zip`;
+      if (manifestRequested) {
+        return await buildSignedSkillsExportManifestResponse(
+          request,
+          dependencies,
+          filename,
+          [],
+          [],
+          mergeHeaders(rate.headers, {
+            "X-Next-Cursor": result.nextCursor ?? "",
+            "X-Has-More": String(result.hasMore),
+            "X-Total-Returned": "0",
+            "X-Date-Range": `${startDate}-${endDate}`,
+            "X-Export-Errors": "0",
+          }),
+        );
+      }
       const emptyZip = buildMergedExportZip([], []);
       return new Response(emptyZip as unknown as BodyInit, {
         status: 200,
         headers: mergeHeaders(rate.headers, {
           "Content-Type": "application/zip",
-          "Content-Disposition": `attachment; filename="skills-export-${startDate}-${endDate}-empty.zip"`,
+          "Content-Disposition": `attachment; filename="${filename}"`,
           "X-Next-Cursor": result.nextCursor ?? "",
           "X-Has-More": String(result.hasMore),
           "X-Total-Returned": "0",
@@ -3898,6 +3963,8 @@ export async function exportSkillsV1Handler(ctx: ActionCtx, request: Request) {
       fileIndex: number;
       storageId: Id<"_storage">;
       archivePath: string;
+      size: number;
+      sha256: string;
     };
     const blobTasks: BlobTask[] = [];
 
@@ -3991,23 +4058,40 @@ export async function exportSkillsV1Handler(ctx: ActionCtx, request: Request) {
           fileIndex: j,
           storageId: version.files[j].storageId,
           archivePath,
+          size: version.files[j].size,
+          sha256: version.files[j].sha256,
         });
       }
     }
     logContext.blobTaskCount = blobTasks.length;
     logContext.exportErrorCount = exportErrors.length;
 
-    logContext.phase = "load_blobs";
-    const blobs = await chunkedParallel(blobTasks, 50, (task) => ctx.storage.get(task.storageId));
+    logContext.phase = manifestRequested ? "load_blob_urls" : "load_blobs";
+    const blobs = await chunkedParallel(blobTasks, 50, async (task) =>
+      manifestRequested
+        ? { kind: "storage" as const, url: await ctx.storage.getUrl(task.storageId) }
+        : { kind: "blob" as const, blob: await ctx.storage.get(task.storageId) },
+    );
     logContext.blobCount = blobs.length;
 
-    const zipEntries: Array<{ path: string; bytes: Uint8Array }> = [];
+    type PreparedExportEntry =
+      | { path: string; bytes: Uint8Array }
+      | { path: string; url: string; size: number; sha256: string };
+    const zipEntries: PreparedExportEntry[] = [];
     const manifest: MergedExportManifestEntry[] = [];
     let totalExportBytes = 0;
 
     const blobsByDigest = new Map<
       number,
-      Map<number, { blob: Blob | null; archivePath: string }>
+      Map<
+        number,
+        {
+          source: { kind: "blob"; blob: Blob | null } | { kind: "storage"; url: string | null };
+          archivePath: string;
+          size: number;
+          sha256: string;
+        }
+      >
     >();
     for (let k = 0; k < blobTasks.length; k++) {
       const task = blobTasks[k];
@@ -4015,8 +4099,10 @@ export async function exportSkillsV1Handler(ctx: ActionCtx, request: Request) {
         blobsByDigest.set(task.digestIndex, new Map());
       }
       blobsByDigest.get(task.digestIndex)!.set(task.fileIndex, {
-        blob: blobs[k],
+        source: blobs[k],
         archivePath: task.archivePath,
+        size: task.size,
+        sha256: task.sha256,
       });
     }
 
@@ -4087,7 +4173,11 @@ export async function exportSkillsV1Handler(ctx: ActionCtx, request: Request) {
 
         const plannedFile = digestBlobs.get(j);
         if (!plannedFile) continue;
-        if (!plannedFile.blob) {
+        const sourceAvailable =
+          plannedFile.source.kind === "storage"
+            ? Boolean(plannedFile.source.url)
+            : Boolean(plannedFile.source.blob);
+        if (!sourceAvailable) {
           exportErrors.push({
             slug: digest.slug,
             error: `blob not found for file "${filePath}" (storageId: ${version.files[j].storageId})`,
@@ -4095,16 +4185,29 @@ export async function exportSkillsV1Handler(ctx: ActionCtx, request: Request) {
           continue;
         }
 
-        const buffer = new Uint8Array(await plannedFile.blob.arrayBuffer());
-        if (totalExportBytes + buffer.byteLength > MAX_EXPORT_TOTAL_BYTES) {
+        const fileBytes =
+          plannedFile.source.kind === "storage" ? plannedFile.size : plannedFile.source.blob!.size;
+        if (totalExportBytes + fileBytes > MAX_EXPORT_TOTAL_BYTES) {
           exportErrors.push({
             slug: digest.slug,
             error: `byte cap exceeded (${MAX_EXPORT_TOTAL_BYTES}) at file "${filePath}"`,
           });
           continue;
         }
-        totalExportBytes += buffer.byteLength;
-        zipEntries.push({ path: plannedFile.archivePath, bytes: buffer });
+        totalExportBytes += fileBytes;
+        if (plannedFile.source.kind === "storage") {
+          zipEntries.push({
+            path: plannedFile.archivePath,
+            url: plannedFile.source.url!,
+            size: plannedFile.size,
+            sha256: plannedFile.sha256,
+          });
+        } else {
+          zipEntries.push({
+            path: plannedFile.archivePath,
+            bytes: new Uint8Array(await plannedFile.source.blob!.arrayBuffer()),
+          });
+        }
         fileCount++;
       }
 
@@ -4142,13 +4245,33 @@ export async function exportSkillsV1Handler(ctx: ActionCtx, request: Request) {
     logContext.totalExportBytes = totalExportBytes;
 
     logContext.phase = "build_zip";
-    const zipBytes = buildMergedExportZip(zipEntries, manifest);
+    const filename = `skills-export-${startDate}-${endDate}.zip`;
+    if (manifestRequested) {
+      return await buildSignedSkillsExportManifestResponse(
+        request,
+        dependencies,
+        filename,
+        zipEntries,
+        manifest,
+        mergeHeaders(rate.headers, {
+          "X-Next-Cursor": result.nextCursor ?? "",
+          "X-Has-More": String(result.hasMore),
+          "X-Total-Returned": String(manifest.length),
+          "X-Date-Range": `${startDate}-${endDate}`,
+          "X-Export-Errors": String(exportErrors.length),
+        }),
+      );
+    }
+    const zipBytes = buildMergedExportZip(
+      zipEntries.filter((entry): entry is { path: string; bytes: Uint8Array } => "bytes" in entry),
+      manifest,
+    );
 
     return new Response(zipBytes as unknown as BodyInit, {
       status: 200,
       headers: mergeHeaders(rate.headers, {
         "Content-Type": "application/zip",
-        "Content-Disposition": `attachment; filename="skills-export-${startDate}-${endDate}.zip"`,
+        "Content-Disposition": `attachment; filename="${filename}"`,
         "X-Next-Cursor": result.nextCursor ?? "",
         "X-Has-More": String(result.hasMore),
         "X-Total-Returned": String(manifest.length),
@@ -4160,6 +4283,65 @@ export async function exportSkillsV1Handler(ctx: ActionCtx, request: Request) {
     logSkillsExportFailure(logContext, err);
     throw err;
   }
+}
+
+function unauthorizedSkillsExportManifestResponse() {
+  return new Response("Unauthorized archive manifest request", {
+    status: 401,
+    headers: { "Cache-Control": "no-store" },
+  });
+}
+
+async function buildSignedSkillsExportManifestResponse(
+  request: Request,
+  dependencies: SkillsExportDependencies,
+  filename: string,
+  entries: Array<
+    | { path: string; bytes: Uint8Array }
+    | { path: string; url: string; size: number; sha256: string }
+  >,
+  exportManifest: MergedExportManifestEntry[],
+  headers: HeadersInit,
+) {
+  const issuedAt = Date.now();
+  const manifest: SkillExportArchiveManifest = {
+    schema: "clawhub.skill-export-archive-manifest.v1",
+    issuer: new URL(request.url).origin,
+    audience: ARCHIVE_MANIFEST_AUDIENCE,
+    issuedAt,
+    expiresAt: issuedAt + ARCHIVE_MANIFEST_TTL_MS,
+    filename,
+    entries: entries.map((entry) =>
+      "bytes" in entry
+        ? {
+            kind: "inline" as const,
+            path: entry.path,
+            text: new TextDecoder().decode(entry.bytes),
+          }
+        : {
+            kind: "storage" as const,
+            path: entry.path,
+            url: entry.url,
+            size: entry.size,
+            sha256: entry.sha256,
+          },
+    ),
+    exportManifest,
+  };
+  const signedManifest = await dependencies.signArchiveManifest(manifest);
+  if (new TextEncoder().encode(signedManifest).byteLength > MAX_ARCHIVE_MANIFEST_BYTES) {
+    return new Response("Skill export archive manifest is too large", {
+      status: 413,
+      headers,
+    });
+  }
+  return new Response(signedManifest, {
+    status: 200,
+    headers: mergeHeaders(headers, {
+      "Content-Type": ARCHIVE_MANIFEST_CONTENT_TYPE,
+      "Cache-Control": "private, no-store",
+    }),
+  });
 }
 
 function getExportPublisherSegment(digest: {

--- a/convex/httpApiV1/skillsV1.ts
+++ b/convex/httpApiV1/skillsV1.ts
@@ -72,6 +72,7 @@ import {
   buildDeterministicZip,
   buildMergedExportZip,
   type MergedExportManifestEntry,
+  validateExportArchivePath,
   validateSlug,
   validateFilePath,
 } from "../lib/skillZip";
@@ -4045,6 +4046,13 @@ export async function exportSkillsV1Handler(
           break;
         }
         const archivePath = `${exportRoot}/${version.files[j].path}`;
+        if (!validateExportArchivePath(archivePath)) {
+          exportErrors.push({
+            slug: digest.slug,
+            error: `archive path exceeds signed manifest byte limit (file index ${j})`,
+          });
+          continue;
+        }
         if (archivePaths.has(archivePath)) {
           exportErrors.push({
             slug: digest.slug,

--- a/convex/lib/archiveManifest.test.ts
+++ b/convex/lib/archiveManifest.test.ts
@@ -1,0 +1,51 @@
+/* @vitest-environment node */
+
+import { exportPKCS8, generateKeyPair } from "jose";
+import { expect, it } from "vitest";
+import {
+  ARCHIVE_MANIFEST_AUDIENCE,
+  ARCHIVE_MANIFEST_JWS_TYPE,
+  signArchivePayload,
+  type SkillExportArchiveManifest,
+} from "./archiveManifest";
+
+it("keeps the 10,000-file signed export contract inside the Nitro handoff budget", async () => {
+  const entries = Array.from({ length: 10_000 }, (_, index) => {
+    const prefix = `alice/demo/${index}-`;
+    return {
+      kind: "storage" as const,
+      path: `${prefix}${"x".repeat(900 - prefix.length)}`,
+      url: `https://preview-branch-123.convex.cloud/api/storage/storage-${index}`,
+      size: 0,
+      sha256: "a".repeat(64),
+    };
+  });
+  const manifest: SkillExportArchiveManifest = {
+    schema: "clawhub.skill-export-archive-manifest.v1",
+    issuer: "https://preview-branch-123.convex.site",
+    audience: ARCHIVE_MANIFEST_AUDIENCE,
+    issuedAt: 1_000,
+    expiresAt: 31_000,
+    filename: "skills-export-1-5.zip",
+    entries,
+    exportManifest: [
+      {
+        publisher: "alice",
+        slug: "demo",
+        sourceRef: "public-clawhub",
+        version: "1.0.0",
+        displayName: "Demo",
+        createdAt: 1,
+        updatedAt: 2,
+        stats: {},
+        fileCount: entries.length,
+      },
+    ],
+  };
+  const keyPair = await generateKeyPair("RS256", { extractable: true });
+  const privateKey = await exportPKCS8(keyPair.privateKey);
+
+  const token = await signArchivePayload(manifest, ARCHIVE_MANIFEST_JWS_TYPE, privateKey);
+
+  expect(new TextEncoder().encode(token).byteLength).toBeLessThanOrEqual(16 * 1024 * 1024);
+});

--- a/convex/lib/archiveManifest.ts
+++ b/convex/lib/archiveManifest.ts
@@ -1,4 +1,5 @@
 import { CompactSign, compactVerify, createLocalJWKSet, importPKCS8 } from "jose";
+import type { MergedExportManifestEntry } from "./skillZip";
 
 export const ARCHIVE_MANIFEST_CONTENT_TYPE = "application/vnd.clawhub.skill-archive-manifest+jws";
 export const ARCHIVE_MANIFEST_AUDIENCE = "clawhub.nitro-skill-archive";
@@ -31,6 +32,31 @@ export type SkillArchiveManifest = {
   metricToken?: string;
 };
 
+export type SkillExportArchiveManifestEntry =
+  | {
+      kind: "storage";
+      path: string;
+      url: string;
+      size: number;
+      sha256: string;
+    }
+  | {
+      kind: "inline";
+      path: string;
+      text: string;
+    };
+
+export type SkillExportArchiveManifest = {
+  schema: "clawhub.skill-export-archive-manifest.v1";
+  issuer: string;
+  audience: typeof ARCHIVE_MANIFEST_AUDIENCE;
+  issuedAt: number;
+  expiresAt: number;
+  filename: string;
+  entries: SkillExportArchiveManifestEntry[];
+  exportManifest: MergedExportManifestEntry[];
+};
+
 export type ArchiveMetricPayload = {
   schema: "clawhub.archive-download-metric.v1";
   issuer: string;
@@ -41,7 +67,7 @@ export type ArchiveMetricPayload = {
 };
 
 export async function signArchivePayload(
-  payload: SkillArchiveManifest | ArchiveMetricPayload,
+  payload: SkillArchiveManifest | SkillExportArchiveManifest | ArchiveMetricPayload,
   type: typeof ARCHIVE_MANIFEST_JWS_TYPE | typeof ARCHIVE_METRIC_JWS_TYPE,
   privateKeyPem = process.env.JWT_PRIVATE_KEY,
 ) {

--- a/convex/lib/skillZip.test.ts
+++ b/convex/lib/skillZip.test.ts
@@ -8,9 +8,21 @@ import {
   buildDeterministicZip,
   buildSkillMeta,
   type SkillZipMeta,
+  validateExportArchivePath,
 } from "./skillZip";
 
 describe("skillZip", () => {
+  describe("validateExportArchivePath", () => {
+    it("bounds the signed UTF-8 JSON representation instead of JavaScript characters", () => {
+      const prefix = "alice/demo/";
+      const asciiPath = `${prefix}${"a".repeat(900 - prefix.length)}`;
+      const multibytePath = `${prefix}${"界".repeat(400)}`;
+
+      expect(validateExportArchivePath(asciiPath)).toBe(true);
+      expect(validateExportArchivePath(multibytePath)).toBe(false);
+    });
+  });
+
   describe("buildSkillMeta", () => {
     it("returns metadata object with all fields", () => {
       const meta: SkillZipMeta = {

--- a/convex/lib/skillZip.ts
+++ b/convex/lib/skillZip.ts
@@ -24,6 +24,7 @@ const FIXED_ZIP_DATE = new Date(1980, 0, 1, 0, 0, 0);
 // Storage response chunk boundaries vary with transport backpressure; normalize
 // them so identical files still produce byte-for-byte identical archives.
 const ZIP_INPUT_CHUNK_BYTES = 64 * 1024;
+const MAX_EXPORT_ARCHIVE_PATH_JSON_BYTES = 900;
 
 // ==================== Zip Slip Protection ====================
 
@@ -43,7 +44,12 @@ export function validateFilePath(filePath: string): boolean {
 
 /** Validate a namespaced bulk-export path (publisher + slug + stored file path). */
 export function validateExportArchivePath(filePath: string): boolean {
-  return validateZipPath(filePath, 1_000);
+  if (!validateZipPath(filePath, 900)) return false;
+  // The path is repeated in the signed JSON handoff. Bound its encoded form,
+  // not UTF-16 code units, so multibyte and escaped names cannot overflow the
+  // manifest budget while still passing the character-count guard.
+  const encodedJsonBytes = new TextEncoder().encode(JSON.stringify(filePath)).byteLength - 2;
+  return encodedJsonBytes <= MAX_EXPORT_ARCHIVE_PATH_JSON_BYTES;
 }
 
 function validateZipPath(filePath: string, maxLength: number): boolean {

--- a/convex/lib/skillZip.ts
+++ b/convex/lib/skillZip.ts
@@ -38,7 +38,16 @@ export function validateSlug(slug: string): boolean {
 
 /** Validate file path against Zip Slip — rejects absolute paths, `..`, backslashes, and empty segments. */
 export function validateFilePath(filePath: string): boolean {
-  if (!filePath || filePath.length > 500) return false;
+  return validateZipPath(filePath, 500);
+}
+
+/** Validate a namespaced bulk-export path (publisher + slug + stored file path). */
+export function validateExportArchivePath(filePath: string): boolean {
+  return validateZipPath(filePath, 1_000);
+}
+
+function validateZipPath(filePath: string, maxLength: number): boolean {
+  if (!filePath || filePath.length > maxLength) return false;
   if (filePath.startsWith("/")) return false;
   if (filePath.includes("\\")) return false;
   const segments = filePath.split("/");
@@ -77,7 +86,36 @@ export function buildDeterministicZip(entries: ZipEntry[], meta?: SkillZipMeta) 
 }
 
 export function buildDeterministicZipStream(entries: AsyncZipEntry[], meta?: SkillZipMeta) {
-  const orderedEntries = orderZipEntries(entries, meta);
+  return buildOrderedZipStream(orderZipEntries(entries, meta));
+}
+
+export function buildMergedExportZipStream(
+  entries: AsyncZipEntry[],
+  manifest: MergedExportManifestEntry[],
+) {
+  const sorted = [...entries].sort((a, b) => a.path.localeCompare(b.path));
+  const seenPaths = new Set<string>();
+  for (const entry of sorted) {
+    if (seenPaths.has(entry.path)) {
+      throw new Error(`Duplicate ZIP path detected: "${entry.path}"`);
+    }
+    seenPaths.add(entry.path);
+  }
+  const manifestPath = "_manifest.json";
+  if (seenPaths.has(manifestPath)) {
+    throw new Error(`Duplicate ZIP path detected: "${manifestPath}" (conflicts with manifest)`);
+  }
+  const manifestBytes = new TextEncoder().encode(JSON.stringify(manifest, null, 2));
+  return buildOrderedZipStream([
+    ...sorted,
+    {
+      path: manifestPath,
+      openStream: async () => bytesToStream(manifestBytes),
+    },
+  ]);
+}
+
+function buildOrderedZipStream(orderedEntries: AsyncZipEntry[]) {
   const output: Uint8Array[] = [];
   let entryIndex = 0;
   let current:
@@ -200,6 +238,15 @@ export function buildDeterministicZipStream(entries: AsyncZipEntry[], meta?: Ski
   );
 }
 
+function bytesToStream(bytes: Uint8Array) {
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(bytes);
+      controller.close();
+    },
+  });
+}
+
 function orderZipEntries(entries: AsyncZipEntry[], meta?: SkillZipMeta) {
   const sorted = [...entries].sort((a, b) => a.path.localeCompare(b.path));
   const byPath = new Map(sorted.map((entry) => [entry.path, entry]));
@@ -210,13 +257,7 @@ function orderZipEntries(entries: AsyncZipEntry[], meta?: SkillZipMeta) {
     const metaBytes = new TextEncoder().encode(JSON.stringify(buildSkillMeta(meta), null, 2));
     byPath.set("_meta.json", {
       path: "_meta.json",
-      openStream: async () =>
-        new ReadableStream<Uint8Array>({
-          start(controller) {
-            controller.enqueue(metaBytes);
-            controller.close();
-          },
-        }),
+      openStream: async () => bytesToStream(metaBytes),
     });
     zipDataOrder["_meta.json"] = true;
   }

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -665,7 +665,13 @@ Response:
 - Each skill includes `_export_skill_meta.json`.
 - `_manifest.json` is always included at the ZIP root.
 - `_errors.json` is included when individual skills or files could not be
-  exported.
+  exported before the archive manifest is sealed. `X-Export-Errors` reports
+  those same pre-stream errors.
+- Once streaming starts, every hosted file is bound to the signed archive
+  manifest by path, size, and SHA-256. If a signed file disappears or fails an
+  integrity check, the stream terminates and the client must discard the
+  partial ZIP and retry; the proxy never emits a completed archive whose
+  `_manifest.json` or `X-Export-Errors` misstates its contents.
 
 Headers:
 

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -663,6 +663,8 @@ Response:
   `_source_handoff.json` with `sourceRef: "public-github"`, repo, commit, path,
   content hash, and archive URL. They do not include ClawHub-hosted source files.
 - Each skill includes `_export_skill_meta.json`.
+- Archive entry paths are limited to 900 bytes in their signed JSON encoding;
+  files beyond that limit are reported in `_errors.json`.
 - `_manifest.json` is always included at the ZIP root.
 - `_errors.json` is included when individual skills or files could not be
   exported before the archive manifest is sealed. `X-Export-Errors` reports

--- a/e2e/clawhub.e2e.test.ts
+++ b/e2e/clawhub.e2e.test.ts
@@ -72,6 +72,59 @@ async function startPackagePublishRegistry(
   };
 }
 
+async function startGitHubPackageSource() {
+  const commit = "a".repeat(40);
+  const archive = zipSync({
+    "kitchen-sink-main/package.json": strToU8(
+      JSON.stringify({
+        name: "@openclaw/kitchen-sink",
+        version: "1.0.0",
+        type: "module",
+        openclaw: {
+          extensions: ["./dist/index.js"],
+          compat: { pluginApi: ">=2026.3.24-beta.2" },
+          build: { openclawVersion: "2026.3.24-beta.2" },
+        },
+      }),
+    ),
+    "kitchen-sink-main/openclaw.plugin.json": strToU8(
+      JSON.stringify({ id: "kitchen-sink", name: "Kitchen Sink" }),
+    ),
+    "kitchen-sink-main/dist/index.js": strToU8("export const demo = true;\n"),
+  });
+  const requests: string[] = [];
+  const server = createServer((req, res) => {
+    requests.push(req.url ?? "");
+    if (req.url === "/repos/openclaw/kitchen-sink") {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ default_branch: "main" }));
+      return;
+    }
+    if (req.url === "/repos/openclaw/kitchen-sink/commits/main") {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ sha: commit }));
+      return;
+    }
+    if (req.url === `/repos/openclaw/kitchen-sink/zipball/${commit}`) {
+      res.writeHead(200, { "Content-Type": "application/zip" });
+      res.end(Buffer.from(archive));
+      return;
+    }
+    res.writeHead(404, { "Content-Type": "text/plain" });
+    res.end("not found");
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address() as AddressInfo;
+  return {
+    apiUrl: `http://127.0.0.1:${address.port}`,
+    requests,
+    close: () =>
+      new Promise<void>((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve())),
+      ),
+  };
+}
+
 async function writeCodePluginFixture(root: string, name: string) {
   const folder = join(root, name);
   await mkdir(join(folder, "dist"), { recursive: true });
@@ -831,35 +884,49 @@ describe("clawhub e2e", () => {
   });
 
   it("package publish --dry-run from a GitHub repo shows a summary", async () => {
+    const github = await startGitHubPackageSource();
     const registry = getRegistry();
     const site = getSite();
-    const result = spawnSync(
-      "bun",
-      [
-        "clawhub",
-        "package",
-        "publish",
-        "openclaw/openclaw",
-        "--source-path",
-        "extensions/cohere",
-        "--dry-run",
-        "--site",
-        site,
-        "--registry",
-        registry,
-      ],
-      {
-        cwd: process.cwd(),
-        env: { ...process.env, CLAWHUB_DISABLE_TELEMETRY: "1" },
-        encoding: "utf8",
-      },
-    );
+    try {
+      const result = await spawnCommand(
+        "bun",
+        [
+          "clawhub",
+          "package",
+          "publish",
+          "openclaw/kitchen-sink",
+          "--dry-run",
+          "--site",
+          site,
+          "--registry",
+          registry,
+        ],
+        {
+          cwd: process.cwd(),
+          env: {
+            ...process.env,
+            CLAWHUB_DISABLE_TELEMETRY: "1",
+            CLAWHUB_TEST_GITHUB_API_URL: github.apiUrl,
+            GITHUB_TOKEN: "",
+            NODE_ENV: "test",
+          },
+          encoding: "utf8",
+        },
+      );
 
-    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
-    expect(result.stdout).toMatch(/Dry run/i);
-    expect(result.stdout).toMatch(/@openclaw\/cohere-provider/);
-    expect(result.stdout).toMatch(/code-plugin/i);
-    expect(result.stdout).toMatch(/openclaw\.plugin\.json/);
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+      expect(result.stdout).toMatch(/Dry run/i);
+      expect(result.stdout).toMatch(/@openclaw\/kitchen-sink/);
+      expect(result.stdout).toMatch(/code-plugin/i);
+      expect(result.stdout).toMatch(/openclaw\.plugin\.json/);
+      expect(github.requests).toEqual([
+        "/repos/openclaw/kitchen-sink",
+        "/repos/openclaw/kitchen-sink/commits/main",
+        `/repos/openclaw/kitchen-sink/zipball/${"a".repeat(40)}`,
+      ]);
+    } finally {
+      await github.close();
+    }
   }, 30_000);
 
   it("package publish --dry-run --json outputs valid JSON", async () => {

--- a/packages/clawhub/src/cli/commands/github.ts
+++ b/packages/clawhub/src/cli/commands/github.ts
@@ -4,11 +4,21 @@ import { homedir, tmpdir } from "node:os";
 import { dirname, join, resolve, sep } from "node:path";
 import { unzipSync } from "fflate";
 
-const GITHUB_API = "https://api.github.com";
+const GITHUB_API = resolveGitHubApi();
 const GITHUB_HOSTS = new Set(["github.com", "www.github.com"]);
 const ZIP_USER_AGENT = "clawhub/package-publish";
 const GITHUB_RETRY_DELAYS_MS = [250, 500];
 const GITHUB_MAX_RATE_LIMIT_DELAY_MS = 5_000;
+
+function resolveGitHubApi() {
+  const testUrl = process.env.CLAWHUB_TEST_GITHUB_API_URL?.trim();
+  if (process.env.NODE_ENV !== "test" || !testUrl) return "https://api.github.com";
+  const url = new URL(testUrl);
+  if (url.protocol !== "http:" || (url.hostname !== "127.0.0.1" && url.hostname !== "localhost")) {
+    throw new Error("CLAWHUB_TEST_GITHUB_API_URL must use loopback HTTP");
+  }
+  return url.toString().replace(/\/$/, "");
+}
 
 type ResolvedPublishSource =
   | {

--- a/server/convexProxy.test.ts
+++ b/server/convexProxy.test.ts
@@ -388,7 +388,7 @@ describe("Convex HTTP proxy", () => {
     ]);
   });
 
-  it("keeps a bulk export readable when signed storage disappears", async () => {
+  it("fails a bulk export when signed storage disappears", async () => {
     const fetchMock = vi.fn(async (input: string | URL | Request) => {
       const url = input.toString();
       if (url.startsWith("https://preview-branch-123.convex.site/api/v1/skills/export")) {
@@ -459,15 +459,9 @@ describe("Convex HTTP proxy", () => {
 
     expect(response.status).toBe(200);
     expect(response.headers.get("X-Export-Errors")).toBe("1");
-    const archive = unzipSync(new Uint8Array(await response.arrayBuffer()));
-    expect(Object.keys(archive).sort()).toEqual([
-      "_errors.json",
-      "_manifest.json",
-      "alice/demo/_export_skill_meta.json",
-    ]);
-    expect(JSON.parse(new TextDecoder().decode(archive["_errors.json"]))).toEqual([
-      { slug: "missing", error: "version not found" },
-    ]);
+    await expect(response.arrayBuffer()).rejects.toThrow(
+      "Signed archive entry disappeared after manifest creation",
+    );
   });
 
   it("rejects bulk export manifests that point outside paired Convex storage", async () => {
@@ -508,6 +502,103 @@ describe("Convex HTTP proxy", () => {
     expect(response.status).toBe(502);
     expect(await response.text()).toBe("Invalid or expired archive manifest");
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects bulk export manifests with non-canonical storage paths", async () => {
+    const fetchMock = vi.fn(async () =>
+      Response.json(
+        {
+          schema: "clawhub.skill-export-archive-manifest.v1",
+          issuedAt: 1_000,
+          expiresAt: 31_000,
+          filename: "skills-export-1-5.zip",
+          entries: [
+            {
+              kind: "storage",
+              path: "alice/demo/SKILL.md",
+              url: "https://preview-branch-123.convex.cloud/api/storage/storage-1/extra",
+              size: 1,
+              sha256: "a".repeat(64),
+            },
+          ],
+          exportManifest: [],
+        },
+        { headers: { "content-type": ARCHIVE_MANIFEST_CONTENT_TYPE } },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(Date, "now").mockReturnValue(2_000);
+
+    const response = await proxyConvexRequest(
+      mockEvent("https://preview.example/api/v1/skills/export?startDate=1&endDate=5"),
+      {
+        VERCEL_ENV: "preview",
+        VITE_CONVEX_SITE_URL: "https://preview-branch-123.convex.site",
+        VITE_CONVEX_URL: "https://preview-branch-123.convex.cloud",
+      },
+      TEST_ARCHIVE_DEPENDENCIES,
+    );
+
+    expect(response.status).toBe(502);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps inline metadata in its bounded manifest budget", async () => {
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      const url = input.toString();
+      if (url.startsWith("https://preview-branch-123.convex.site/api/v1/skills/export")) {
+        return Response.json(
+          {
+            schema: "clawhub.skill-export-archive-manifest.v1",
+            issuedAt: 1_000,
+            expiresAt: 31_000,
+            filename: "skills-export-1-5.zip",
+            entries: [
+              {
+                kind: "storage",
+                path: "alice/demo/SKILL.md",
+                url: "https://preview-branch-123.convex.cloud/api/storage/storage-1",
+                size: 256 * 1024 * 1024,
+                sha256: "a".repeat(64),
+              },
+              {
+                kind: "inline",
+                path: "alice/demo/_export_skill_meta.json",
+                text: "x",
+              },
+            ],
+            exportManifest: [],
+          },
+          { headers: { "content-type": ARCHIVE_MANIFEST_CONTENT_TYPE } },
+        );
+      }
+      if (url === "https://preview-branch-123.convex.cloud/api/storage/storage-1") {
+        return new Response(
+          new ReadableStream<Uint8Array>({
+            start() {
+              // Keep the signed maximum-size storage entry unconsumed.
+            },
+          }),
+        );
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(Date, "now").mockReturnValue(2_000);
+
+    const response = await proxyConvexRequest(
+      mockEvent("https://preview.example/api/v1/skills/export?startDate=1&endDate=5"),
+      {
+        VERCEL_ENV: "preview",
+        VITE_CONVEX_SITE_URL: "https://preview-branch-123.convex.site",
+        VITE_CONVEX_URL: "https://preview-branch-123.convex.cloud",
+      },
+      TEST_ARCHIVE_DEPENDENCIES,
+    );
+
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    await response.body?.cancel();
   });
 
   it("fails a bulk export stream when stored bytes miss the signed digest", async () => {
@@ -568,6 +659,7 @@ describe("Convex HTTP proxy", () => {
       size: 1,
       sha256: "a".repeat(64),
     }));
+    const cancelledStorage = new Set<number>();
     const fetchMock = vi.fn(async (input: string | URL | Request) => {
       const url = input.toString();
       if (url.startsWith("https://preview-branch-123.convex.site/api/v1/skills/export")) {
@@ -596,10 +688,14 @@ describe("Convex HTTP proxy", () => {
         );
       }
       if (url.startsWith("https://preview-branch-123.convex.cloud/api/storage/")) {
+        const storageIndex = Number(url.slice(url.lastIndexOf("-") + 1));
         return new Response(
           new ReadableStream<Uint8Array>({
             start() {
               // Keep each prefetched response open so the test observes the live window.
+            },
+            cancel() {
+              cancelledStorage.add(storageIndex);
             },
           }),
         );
@@ -624,6 +720,7 @@ describe("Convex HTTP proxy", () => {
     );
     expect(storageCalls).toHaveLength(8);
     await response.body?.cancel();
+    expect([...cancelledStorage].sort((a, b) => a - b)).toEqual([0, 1, 2, 3, 4, 5, 6, 7]);
   });
 
   it("does not record a download when every source Blob has vanished", async () => {

--- a/server/convexProxy.test.ts
+++ b/server/convexProxy.test.ts
@@ -388,6 +388,88 @@ describe("Convex HTTP proxy", () => {
     ]);
   });
 
+  it("keeps a bulk export readable when signed storage disappears", async () => {
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      const url = input.toString();
+      if (url.startsWith("https://preview-branch-123.convex.site/api/v1/skills/export")) {
+        return Response.json(
+          {
+            schema: "clawhub.skill-export-archive-manifest.v1",
+            issuedAt: 1_000,
+            expiresAt: 31_000,
+            filename: "skills-export-1-5.zip",
+            entries: [
+              {
+                kind: "storage",
+                path: "alice/demo/SKILL.md",
+                url: "https://preview-branch-123.convex.cloud/api/storage/stale-storage",
+                size: 5,
+                sha256: createHash("sha256").update("hello").digest("hex"),
+              },
+              {
+                kind: "inline",
+                path: "alice/demo/_export_skill_meta.json",
+                text: '{"slug":"demo"}',
+              },
+              {
+                kind: "inline",
+                path: "_errors.json",
+                text: '[{"slug":"missing","error":"version not found"}]',
+              },
+            ],
+            exportManifest: [
+              {
+                publisher: "alice",
+                slug: "demo",
+                sourceRef: "public-clawhub",
+                version: "1.0.0",
+                displayName: "Demo",
+                createdAt: 1,
+                updatedAt: 2,
+                stats: {},
+                fileCount: 1,
+              },
+            ],
+          },
+          {
+            headers: {
+              "content-type": ARCHIVE_MANIFEST_CONTENT_TYPE,
+              "x-export-errors": "1",
+            },
+          },
+        );
+      }
+      if (url === "https://preview-branch-123.convex.cloud/api/storage/stale-storage") {
+        return new Response("Not found", { status: 404 });
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(Date, "now").mockReturnValue(2_000);
+
+    const response = await proxyConvexRequest(
+      mockEvent("https://preview.example/api/v1/skills/export?startDate=1&endDate=5"),
+      {
+        VERCEL_ENV: "preview",
+        VITE_CONVEX_SITE_URL: "https://preview-branch-123.convex.site",
+        VITE_CONVEX_URL: "https://preview-branch-123.convex.cloud",
+      },
+      TEST_ARCHIVE_DEPENDENCIES,
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("X-Export-Errors")).toBe("1");
+    const archive = unzipSync(new Uint8Array(await response.arrayBuffer()));
+    expect(Object.keys(archive).sort()).toEqual([
+      "_errors.json",
+      "_manifest.json",
+      "alice/demo/_export_skill_meta.json",
+    ]);
+    expect(JSON.parse(new TextDecoder().decode(archive["_errors.json"]))).toEqual([
+      { slug: "missing", error: "version not found" },
+    ]);
+  });
+
   it("rejects bulk export manifests that point outside paired Convex storage", async () => {
     const fetchMock = vi.fn(async () =>
       Response.json(

--- a/server/convexProxy.test.ts
+++ b/server/convexProxy.test.ts
@@ -1,5 +1,6 @@
 /* @vitest-environment node */
 
+import { createHash } from "node:crypto";
 import { unzipSync } from "fflate";
 import { mockEvent } from "h3";
 import { createLocalJWKSet, exportJWK, exportPKCS8, generateKeyPair } from "jose";
@@ -239,6 +240,308 @@ describe("Convex HTTP proxy", () => {
     ).toBeGreaterThan(
       fetchedUrls.indexOf("https://preview-branch-123.convex.cloud/api/storage/storage-1"),
     );
+  });
+
+  it("streams bulk skill exports before a stored entry finishes", async () => {
+    const firstStorageChunk = new Uint8Array(64 * 1024).fill(0x61);
+    let releaseStorage: (() => void) | undefined;
+    const storageReleased = new Promise<void>((resolve) => {
+      releaseStorage = resolve;
+    });
+    const fetchMock = vi.fn(async (input: string | URL | Request, _init?: RequestInit) => {
+      const url = input.toString();
+      if (url.startsWith("https://preview-branch-123.convex.site/api/v1/skills/export")) {
+        return Response.json(
+          {
+            schema: "clawhub.skill-export-archive-manifest.v1",
+            issuedAt: 1_000,
+            expiresAt: 31_000,
+            filename: "skills-export-1-5.zip",
+            entries: [
+              {
+                kind: "storage",
+                path: "alice/demo/SKILL.md",
+                url: "https://preview-branch-123.convex.cloud/api/storage/storage-1",
+                size: firstStorageChunk.byteLength + 1,
+                sha256: createHash("sha256")
+                  .update(firstStorageChunk)
+                  .update(Uint8Array.of(0x62))
+                  .digest("hex"),
+              },
+              {
+                kind: "inline",
+                path: "alice/demo/_export_skill_meta.json",
+                text: '{"slug":"demo"}',
+              },
+              {
+                kind: "inline",
+                path: "_errors.json",
+                text: '[{"slug":"missing","error":"version not found"}]',
+              },
+            ],
+            exportManifest: [
+              {
+                publisher: "alice",
+                slug: "demo",
+                sourceRef: "public-clawhub",
+                version: "1.0.0",
+                displayName: "Demo",
+                createdAt: 1,
+                updatedAt: 2,
+                stats: {},
+                fileCount: 1,
+              },
+            ],
+          },
+          {
+            headers: {
+              "content-type": ARCHIVE_MANIFEST_CONTENT_TYPE,
+              "x-export-errors": "1",
+              "x-total-returned": "1",
+            },
+          },
+        );
+      }
+      if (url === "https://preview-branch-123.convex.cloud/api/storage/storage-1") {
+        let sentFirstChunk = false;
+        return new Response(
+          new ReadableStream<Uint8Array>({
+            async pull(controller) {
+              if (!sentFirstChunk) {
+                sentFirstChunk = true;
+                controller.enqueue(firstStorageChunk);
+                return;
+              }
+              await storageReleased;
+              controller.enqueue(Uint8Array.of(0x62));
+              controller.close();
+            },
+          }),
+        );
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(Date, "now").mockReturnValue(2_000);
+
+    const response = await proxyConvexRequest(
+      mockEvent("https://preview.example/api/v1/skills/export?startDate=1&endDate=5", {
+        headers: { authorization: "Bearer user-token" },
+      }),
+      {
+        VERCEL_ENV: "preview",
+        VITE_CONVEX_SITE_URL: "https://preview-branch-123.convex.site",
+        VITE_CONVEX_URL: "https://preview-branch-123.convex.cloud",
+      },
+      TEST_ARCHIVE_DEPENDENCIES,
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe("application/zip");
+    expect(response.headers.get("Content-Disposition")).toBe(
+      'attachment; filename="skills-export-1-5.zip"',
+    );
+    expect(response.headers.get("X-Export-Errors")).toBe("1");
+    const reader = response.body!.getReader();
+    const firstZipChunk = await reader.read();
+    expect(firstZipChunk.done).toBe(false);
+    expect(firstZipChunk.value?.byteLength).toBeGreaterThan(0);
+    expect(
+      new Headers(fetchMock.mock.calls[0]?.[1]?.headers).get("x-clawhub-archive-manifest"),
+    ).toBe("v1");
+    expect(new Headers(fetchMock.mock.calls[0]?.[1]?.headers).get("authorization")).toBe(
+      "Bearer user-token",
+    );
+
+    releaseStorage?.();
+    const chunks = [firstZipChunk.value!];
+    for (;;) {
+      const chunk = await reader.read();
+      if (chunk.done) break;
+      chunks.push(chunk.value);
+    }
+    const archiveBytes = new Uint8Array(
+      chunks.reduce((total, chunk) => total + chunk.byteLength, 0),
+    );
+    let offset = 0;
+    for (const chunk of chunks) {
+      archiveBytes.set(chunk, offset);
+      offset += chunk.byteLength;
+    }
+    const archive = unzipSync(archiveBytes);
+    expect(Object.keys(archive).sort()).toEqual([
+      "_errors.json",
+      "_manifest.json",
+      "alice/demo/SKILL.md",
+      "alice/demo/_export_skill_meta.json",
+    ]);
+    expect(JSON.parse(new TextDecoder().decode(archive["_errors.json"]))).toEqual([
+      { slug: "missing", error: "version not found" },
+    ]);
+    expect(JSON.parse(new TextDecoder().decode(archive["_manifest.json"]))).toEqual([
+      expect.objectContaining({
+        publisher: "alice",
+        slug: "demo",
+        sourceRef: "public-clawhub",
+        fileCount: 1,
+      }),
+    ]);
+  });
+
+  it("rejects bulk export manifests that point outside paired Convex storage", async () => {
+    const fetchMock = vi.fn(async () =>
+      Response.json(
+        {
+          schema: "clawhub.skill-export-archive-manifest.v1",
+          issuedAt: 1_000,
+          expiresAt: 31_000,
+          filename: "skills-export-1-5.zip",
+          entries: [
+            {
+              kind: "storage",
+              path: "alice/demo/SKILL.md",
+              url: "https://attacker.example/private",
+              size: 1,
+              sha256: "a".repeat(64),
+            },
+          ],
+          exportManifest: [],
+        },
+        { headers: { "content-type": ARCHIVE_MANIFEST_CONTENT_TYPE } },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(Date, "now").mockReturnValue(2_000);
+
+    const response = await proxyConvexRequest(
+      mockEvent("https://preview.example/api/v1/skills/export?startDate=1&endDate=5"),
+      {
+        VERCEL_ENV: "preview",
+        VITE_CONVEX_SITE_URL: "https://preview-branch-123.convex.site",
+        VITE_CONVEX_URL: "https://preview-branch-123.convex.cloud",
+      },
+      TEST_ARCHIVE_DEPENDENCIES,
+    );
+
+    expect(response.status).toBe(502);
+    expect(await response.text()).toBe("Invalid or expired archive manifest");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails a bulk export stream when stored bytes miss the signed digest", async () => {
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      const url = input.toString();
+      if (url.startsWith("https://preview-branch-123.convex.site/api/v1/skills/export")) {
+        return Response.json(
+          {
+            schema: "clawhub.skill-export-archive-manifest.v1",
+            issuedAt: 1_000,
+            expiresAt: 31_000,
+            filename: "skills-export-1-5.zip",
+            entries: [
+              {
+                kind: "storage",
+                path: "alice/demo/SKILL.md",
+                url: "https://preview-branch-123.convex.cloud/api/storage/storage-1",
+                size: 5,
+                sha256: createHash("sha256").update("right").digest("hex"),
+              },
+            ],
+            exportManifest: [],
+          },
+          { headers: { "content-type": ARCHIVE_MANIFEST_CONTENT_TYPE } },
+        );
+      }
+      if (url === "https://preview-branch-123.convex.cloud/api/storage/storage-1") {
+        return new Response("wrong");
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(Date, "now").mockReturnValue(2_000);
+
+    const response = await proxyConvexRequest(
+      mockEvent("https://preview.example/api/v1/skills/export?startDate=1&endDate=5"),
+      {
+        VERCEL_ENV: "preview",
+        VITE_CONVEX_SITE_URL: "https://preview-branch-123.convex.site",
+        VITE_CONVEX_URL: "https://preview-branch-123.convex.cloud",
+      },
+      TEST_ARCHIVE_DEPENDENCIES,
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.arrayBuffer()).rejects.toThrow(
+      "Archive entry did not match its signed manifest",
+    );
+  });
+
+  it("prefetches only a bounded window of bulk export storage responses", async () => {
+    const publisher = "p".repeat(200);
+    const slug = "s".repeat(200);
+    const entries = Array.from({ length: 10 }, (_, index) => ({
+      kind: "storage" as const,
+      path: `${publisher}/${slug}/${"f".repeat(120)}-${String(index).padStart(2, "0")}.txt`,
+      url: `https://preview-branch-123.convex.cloud/api/storage/storage-${index}`,
+      size: 1,
+      sha256: "a".repeat(64),
+    }));
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      const url = input.toString();
+      if (url.startsWith("https://preview-branch-123.convex.site/api/v1/skills/export")) {
+        return Response.json(
+          {
+            schema: "clawhub.skill-export-archive-manifest.v1",
+            issuedAt: 1_000,
+            expiresAt: 31_000,
+            filename: "skills-export-1-5.zip",
+            entries,
+            exportManifest: [
+              {
+                publisher,
+                slug,
+                sourceRef: "public-clawhub",
+                version: "1.0.0",
+                displayName: "Demo",
+                createdAt: 1,
+                updatedAt: 2,
+                stats: {},
+                fileCount: entries.length,
+              },
+            ],
+          },
+          { headers: { "content-type": ARCHIVE_MANIFEST_CONTENT_TYPE } },
+        );
+      }
+      if (url.startsWith("https://preview-branch-123.convex.cloud/api/storage/")) {
+        return new Response(
+          new ReadableStream<Uint8Array>({
+            start() {
+              // Keep each prefetched response open so the test observes the live window.
+            },
+          }),
+        );
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(Date, "now").mockReturnValue(2_000);
+
+    const response = await proxyConvexRequest(
+      mockEvent("https://preview.example/api/v1/skills/export?startDate=1&endDate=5"),
+      {
+        VERCEL_ENV: "preview",
+        VITE_CONVEX_SITE_URL: "https://preview-branch-123.convex.site",
+        VITE_CONVEX_URL: "https://preview-branch-123.convex.cloud",
+      },
+      TEST_ARCHIVE_DEPENDENCIES,
+    );
+
+    const storageCalls = fetchMock.mock.calls.filter(([input]) =>
+      input.toString().startsWith("https://preview-branch-123.convex.cloud/api/storage/"),
+    );
+    expect(storageCalls).toHaveLength(8);
+    await response.body?.cancel();
   });
 
   it("does not record a download when every source Blob has vanished", async () => {
@@ -610,8 +913,8 @@ describe("Convex HTTP proxy", () => {
     );
 
     expect(response.status).toBe(502);
-    expect(bodyRead.mock.calls.length).toBeGreaterThanOrEqual(5);
-    expect(bodyRead.mock.calls.length).toBeLessThanOrEqual(6);
+    expect(bodyRead.mock.calls.length).toBeGreaterThanOrEqual(17);
+    expect(bodyRead.mock.calls.length).toBeLessThanOrEqual(18);
   });
 
   it("exposes the permanent Test backend name for deployment proof", async () => {

--- a/server/convexProxy.ts
+++ b/server/convexProxy.ts
@@ -322,7 +322,7 @@ function prefetchSkillExportEntries(
       entry.kind === "storage",
   );
   type PrefetchResult =
-    | { ok: true; stream: ReadableStream<Uint8Array> }
+    | { ok: true; stream: ReadableStream<Uint8Array> | null }
     | { ok: false; error: unknown };
   const pending = new Map<
     Extract<SkillExportArchiveManifestEntry, { kind: "storage" }>,
@@ -335,6 +335,7 @@ function prefetchSkillExportEntries(
   ): Promise<PrefetchResult> => {
     try {
       const response = await fetch(entry.url, { redirect: "error", signal });
+      if (response.status === 404) return { ok: true, stream: null };
       if (!response.ok || !response.body) {
         throw new Error(`Failed to fetch archive entry: ${response.status}`);
       }

--- a/server/convexProxy.ts
+++ b/server/convexProxy.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "node:buffer";
 import { createHash } from "node:crypto";
 import { getVercelOidcToken } from "@vercel/oidc";
 import { defineEventHandler, getRequestURL, proxyRequest, type H3Event } from "h3";
@@ -304,8 +305,9 @@ function streamSkillExportArchive(
   target: string,
   signal: AbortSignal,
 ) {
-  const archiveEntries = prefetchSkillExportEntries(manifest.entries, signal);
-  const stream = buildMergedExportZipStream(archiveEntries, manifest.exportManifest);
+  const prefetched = prefetchSkillExportEntries(manifest.entries, signal);
+  const archiveStream = buildMergedExportZipStream(prefetched.entries, manifest.exportManifest);
+  const stream = cancelPrefetchWithArchive(archiveStream, prefetched.cancel);
   const headers = archiveResponseHeaders(manifestResponse, manifest.filename);
   const response = new Response(stream, { status: 200, headers });
   addDeploymentProofHeader(response, env, target);
@@ -316,26 +318,33 @@ function prefetchSkillExportEntries(
   entries: SkillExportArchiveManifestEntry[],
   signal: AbortSignal,
 ) {
+  const controller = new AbortController();
+  const abortFromRequest = () => controller.abort(signal.reason);
+  if (signal.aborted) abortFromRequest();
+  else signal.addEventListener("abort", abortFromRequest, { once: true });
   const ordered = [...entries].sort((a, b) => a.path.localeCompare(b.path));
   const storageEntries = ordered.filter(
     (entry): entry is Extract<SkillExportArchiveManifestEntry, { kind: "storage" }> =>
       entry.kind === "storage",
   );
   type PrefetchResult =
-    | { ok: true; stream: ReadableStream<Uint8Array> | null }
+    | { ok: true; stream: ReadableStream<Uint8Array> }
     | { ok: false; error: unknown };
   const pending = new Map<
     Extract<SkillExportArchiveManifestEntry, { kind: "storage" }>,
     Promise<PrefetchResult>
   >();
   let nextStorageIndex = 0;
+  let cancelled = false;
 
   const fetchEntry = async (
     entry: Extract<SkillExportArchiveManifestEntry, { kind: "storage" }>,
   ): Promise<PrefetchResult> => {
     try {
-      const response = await fetch(entry.url, { redirect: "error", signal });
-      if (response.status === 404) return { ok: true, stream: null };
+      const response = await fetch(entry.url, { redirect: "error", signal: controller.signal });
+      if (response.status === 404) {
+        throw new Error("Signed archive entry disappeared after manifest creation");
+      }
       if (!response.ok || !response.body) {
         throw new Error(`Failed to fetch archive entry: ${response.status}`);
       }
@@ -349,6 +358,7 @@ function prefetchSkillExportEntries(
   };
   const fillPrefetchWindow = () => {
     while (
+      !cancelled &&
       pending.size < SKILL_EXPORT_STORAGE_PREFETCH &&
       nextStorageIndex < storageEntries.length
     ) {
@@ -358,25 +368,70 @@ function prefetchSkillExportEntries(
   };
   fillPrefetchWindow();
 
-  return ordered.map((entry) => ({
-    path: entry.path,
-    openStream: async () => {
-      if (entry.kind === "inline") {
-        const bytes = new TextEncoder().encode(entry.text);
-        return new ReadableStream<Uint8Array>({
-          start(controller) {
-            controller.enqueue(bytes);
-            controller.close();
-          },
-        });
-      }
-      const result = await (pending.get(entry) ?? fetchEntry(entry));
-      pending.delete(entry);
-      fillPrefetchWindow();
-      if (!result.ok) throw result.error;
-      return result.stream;
+  return {
+    entries: ordered.map((entry) => ({
+      path: entry.path,
+      openStream: async () => {
+        if (entry.kind === "inline") {
+          const bytes = new TextEncoder().encode(entry.text);
+          return new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(bytes);
+              controller.close();
+            },
+          });
+        }
+        const result = await (pending.get(entry) ?? fetchEntry(entry));
+        pending.delete(entry);
+        fillPrefetchWindow();
+        if (!result.ok) throw result.error;
+        return result.stream;
+      },
+    })),
+    cancel: async (reason?: unknown) => {
+      if (cancelled) return;
+      cancelled = true;
+      controller.abort(reason);
+      const results = await Promise.allSettled(pending.values());
+      pending.clear();
+      await Promise.allSettled(
+        results.flatMap((result) =>
+          result.status === "fulfilled" && result.value.ok
+            ? [result.value.stream.cancel(reason)]
+            : [],
+        ),
+      );
     },
-  }));
+  };
+}
+
+function cancelPrefetchWithArchive(
+  stream: ReadableStream<Uint8Array>,
+  cancelPrefetch: (reason?: unknown) => Promise<void>,
+) {
+  const reader = stream.getReader();
+  return new ReadableStream<Uint8Array>(
+    {
+      async pull(controller) {
+        try {
+          const chunk = await reader.read();
+          if (chunk.done) {
+            reader.releaseLock();
+            controller.close();
+          } else {
+            controller.enqueue(chunk.value);
+          }
+        } catch (error) {
+          await cancelPrefetch(error);
+          controller.error(error);
+        }
+      },
+      async cancel(reason) {
+        await Promise.allSettled([reader.cancel(reason), cancelPrefetch(reason)]);
+      },
+    },
+    { highWaterMark: 0 },
+  );
 }
 
 function enforceStreamIntegrity(
@@ -516,8 +571,7 @@ function parseSkillArchiveManifest(
     } catch {
       return null;
     }
-    if (url.username || url.password || url.origin !== expectedStorageOrigin) return null;
-    if (!url.pathname.startsWith("/api/storage/")) return null;
+    if (!isCanonicalConvexStorageUrl(url, expectedStorageOrigin)) return null;
   }
   return manifest as SkillArchiveManifest;
 }
@@ -548,6 +602,10 @@ function parseSkillExportArchiveManifest(
 
   const seenPaths = new Set<string>();
   let totalStorageBytes = 0;
+  let totalInlineBytes = Buffer.byteLength(
+    JSON.stringify(manifest.exportManifest, null, 2),
+    "utf8",
+  );
   for (const entry of manifest.entries) {
     if (!isSkillExportArchiveEntry(entry, expectedStorageOrigin)) return null;
     if (entry.path === "_manifest.json" || seenPaths.has(entry.path)) return null;
@@ -555,6 +613,11 @@ function parseSkillExportArchiveManifest(
     if (entry.kind === "storage") {
       totalStorageBytes += entry.size;
       if (totalStorageBytes > MAX_SKILL_EXPORT_TOTAL_BYTES) return null;
+    } else {
+      // Stored payload keeps its existing 256 MiB contract. Inline entries and
+      // the generated manifest share the separately bounded signed-JWS budget.
+      totalInlineBytes += Buffer.byteLength(entry.text, "utf8");
+      if (totalInlineBytes > MAX_ARCHIVE_MANIFEST_BYTES) return null;
     }
   }
   if (!manifest.exportManifest.every(isMergedExportManifestEntry)) return null;
@@ -598,11 +661,17 @@ function isSkillExportArchiveEntry(
   } catch {
     return false;
   }
+  return isCanonicalConvexStorageUrl(url, expectedStorageOrigin);
+}
+
+function isCanonicalConvexStorageUrl(url: URL, expectedStorageOrigin: string) {
   return (
     !url.username &&
     !url.password &&
+    !url.search &&
+    !url.hash &&
     url.origin === expectedStorageOrigin &&
-    url.pathname.startsWith("/api/storage/")
+    /^\/api\/storage\/[A-Za-z0-9_-]+$/.test(url.pathname)
   );
 }
 

--- a/server/convexProxy.ts
+++ b/server/convexProxy.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { getVercelOidcToken } from "@vercel/oidc";
 import { defineEventHandler, getRequestURL, proxyRequest, type H3Event } from "h3";
 import { compactVerify, type CompactVerifyGetKey, createRemoteJWKSet } from "jose";
@@ -6,6 +7,8 @@ import {
   ARCHIVE_MANIFEST_CONTENT_TYPE,
   ARCHIVE_MANIFEST_JWS_TYPE,
   type SkillArchiveManifest,
+  type SkillExportArchiveManifest,
+  type SkillExportArchiveManifestEntry,
 } from "../convex/lib/archiveManifest";
 import {
   ARCHIVE_REQUEST_IDENTITY_HEADER,
@@ -14,7 +17,9 @@ import {
 } from "../convex/lib/clawhubVercelOidc";
 import {
   buildDeterministicZipStream,
+  buildMergedExportZipStream,
   type SkillZipMeta,
+  validateExportArchivePath,
   validateFilePath,
   validateSlug,
 } from "../convex/lib/skillZip";
@@ -24,8 +29,13 @@ const ARCHIVE_MANIFEST_REQUEST_HEADER = "x-clawhub-archive-manifest";
 const ARCHIVE_MANIFEST_MAX_AGE_MS = 60_000;
 const ARCHIVE_MANIFEST_CLOCK_SKEW_MS = 5_000;
 const MAX_ARCHIVE_MANIFEST_ENTRIES = 8_192;
+const MAX_SKILL_EXPORT_ARCHIVE_ENTRIES = 10_501;
+const MAX_SKILL_EXPORT_MANIFEST_ENTRIES = 250;
+const MAX_SKILL_EXPORT_TOTAL_BYTES = 256 * 1024 * 1024;
 const MAX_ARCHIVE_ENTRY_URL_LENGTH = 4_096;
-const MAX_ARCHIVE_MANIFEST_BYTES = 4 * 1024 * 1024;
+// Mirrors the Convex signer bound for the 10,000-file bulk export contract.
+const MAX_ARCHIVE_MANIFEST_BYTES = 16 * 1024 * 1024;
+const SKILL_EXPORT_STORAGE_PREFETCH = 8;
 const ARCHIVE_FILENAME_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._+-]{0,499}\.zip$/;
 const ARCHIVE_METRIC_FETCH_TIMEOUT_MS = 1_500;
 const ARCHIVE_REPRESENTATION_HEADERS = [
@@ -128,7 +138,7 @@ export async function proxyConvexRequest(
 
   const requestUrl = getRequestURL(event);
   const target = buildConvexProxyTarget(`${requestUrl.pathname}${requestUrl.search}`, env);
-  const isArchiveRequest = isSkillDownloadPath(new URL(target).pathname);
+  const isArchiveRequest = isArchivePath(new URL(target).pathname);
   let archiveRequestToken: string | undefined;
   if (isArchiveRequest) {
     try {
@@ -161,7 +171,7 @@ export async function proxyConvexRequest(
   });
   const contentType = response.headers.get("content-type")?.split(";", 1)[0]?.trim();
   if (contentType === ARCHIVE_MANIFEST_CONTENT_TYPE) {
-    return streamSkillArchive(
+    return streamArchive(
       response,
       env,
       target,
@@ -170,7 +180,7 @@ export async function proxyConvexRequest(
     );
   }
   if (
-    isSkillDownloadPath(new URL(target).pathname) &&
+    isArchivePath(new URL(target).pathname) &&
     contentType?.startsWith("application/vnd.clawhub.skill-archive-manifest")
   ) {
     return new Response("Invalid or expired archive manifest", { status: 502 });
@@ -187,11 +197,15 @@ export async function proxyConvexRequest(
   return response;
 }
 
-function isSkillDownloadPath(pathname: string) {
-  return pathname === "/api/v1/download" || pathname === "/api/download";
+function isArchivePath(pathname: string) {
+  return (
+    pathname === "/api/v1/download" ||
+    pathname === "/api/download" ||
+    pathname === "/api/v1/skills/export"
+  );
 }
 
-async function streamSkillArchive(
+async function streamArchive(
   manifestResponse: Response,
   env: ProxyEnv,
   target: string,
@@ -207,15 +221,29 @@ async function streamSkillArchive(
     return new Response("Invalid or expired archive manifest", { status: 502 });
   }
   const expectedStorageOrigin = resolveConvexStorageOrigin(target, env);
-  const manifest = parseSkillArchiveManifest(
+  const expectedIssuer = new URL(target).origin;
+  const now = Date.now();
+  const skillManifest = parseSkillArchiveManifest(
     value,
-    new URL(target).origin,
+    expectedIssuer,
     expectedStorageOrigin,
-    Date.now(),
+    now,
   );
-  if (!manifest) {
+  const exportManifest = parseSkillExportArchiveManifest(
+    value,
+    expectedIssuer,
+    expectedStorageOrigin,
+    now,
+  );
+  if (!skillManifest && !exportManifest) {
     return new Response("Invalid or expired archive manifest", { status: 502 });
   }
+
+  if (exportManifest) {
+    return streamSkillExportArchive(exportManifest, manifestResponse, env, target, signal);
+  }
+
+  const manifest = skillManifest!;
 
   let metricRecorded = false;
   const recordMetric = () => {
@@ -267,6 +295,141 @@ async function streamSkillArchive(
     }
   }
   return response;
+}
+
+function streamSkillExportArchive(
+  manifest: SkillExportArchiveManifest,
+  manifestResponse: Response,
+  env: ProxyEnv,
+  target: string,
+  signal: AbortSignal,
+) {
+  const archiveEntries = prefetchSkillExportEntries(manifest.entries, signal);
+  const stream = buildMergedExportZipStream(archiveEntries, manifest.exportManifest);
+  const headers = archiveResponseHeaders(manifestResponse, manifest.filename);
+  const response = new Response(stream, { status: 200, headers });
+  addDeploymentProofHeader(response, env, target);
+  return response;
+}
+
+function prefetchSkillExportEntries(
+  entries: SkillExportArchiveManifestEntry[],
+  signal: AbortSignal,
+) {
+  const ordered = [...entries].sort((a, b) => a.path.localeCompare(b.path));
+  const storageEntries = ordered.filter(
+    (entry): entry is Extract<SkillExportArchiveManifestEntry, { kind: "storage" }> =>
+      entry.kind === "storage",
+  );
+  type PrefetchResult =
+    | { ok: true; stream: ReadableStream<Uint8Array> }
+    | { ok: false; error: unknown };
+  const pending = new Map<
+    Extract<SkillExportArchiveManifestEntry, { kind: "storage" }>,
+    Promise<PrefetchResult>
+  >();
+  let nextStorageIndex = 0;
+
+  const fetchEntry = async (
+    entry: Extract<SkillExportArchiveManifestEntry, { kind: "storage" }>,
+  ): Promise<PrefetchResult> => {
+    try {
+      const response = await fetch(entry.url, { redirect: "error", signal });
+      if (!response.ok || !response.body) {
+        throw new Error(`Failed to fetch archive entry: ${response.status}`);
+      }
+      return {
+        ok: true,
+        stream: enforceStreamIntegrity(response.body, entry.size, entry.sha256),
+      };
+    } catch (error) {
+      return { ok: false, error };
+    }
+  };
+  const fillPrefetchWindow = () => {
+    while (
+      pending.size < SKILL_EXPORT_STORAGE_PREFETCH &&
+      nextStorageIndex < storageEntries.length
+    ) {
+      const entry = storageEntries[nextStorageIndex++];
+      pending.set(entry, fetchEntry(entry));
+    }
+  };
+  fillPrefetchWindow();
+
+  return ordered.map((entry) => ({
+    path: entry.path,
+    openStream: async () => {
+      if (entry.kind === "inline") {
+        const bytes = new TextEncoder().encode(entry.text);
+        return new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(bytes);
+            controller.close();
+          },
+        });
+      }
+      const result = await (pending.get(entry) ?? fetchEntry(entry));
+      pending.delete(entry);
+      fillPrefetchWindow();
+      if (!result.ok) throw result.error;
+      return result.stream;
+    },
+  }));
+}
+
+function enforceStreamIntegrity(
+  stream: ReadableStream<Uint8Array>,
+  expectedBytes: number,
+  expectedSha256: string,
+) {
+  const reader = stream.getReader();
+  const hash = createHash("sha256");
+  let receivedBytes = 0;
+  return new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      const chunk = await reader.read();
+      if (chunk.done) {
+        const digestMatches = hash.digest("hex") === expectedSha256.toLowerCase();
+        if (receivedBytes !== expectedBytes || !digestMatches) {
+          controller.error(new Error("Archive entry did not match its signed manifest"));
+        } else {
+          controller.close();
+        }
+        reader.releaseLock();
+        return;
+      }
+      receivedBytes += chunk.value.byteLength;
+      if (receivedBytes > expectedBytes) {
+        await reader.cancel("Archive entry exceeded its signed size").catch(() => undefined);
+        controller.error(new Error("Archive entry exceeded its signed size"));
+        return;
+      }
+      hash.update(chunk.value);
+      controller.enqueue(chunk.value);
+    },
+    async cancel(reason) {
+      await reader.cancel(reason);
+    },
+  });
+}
+
+function archiveResponseHeaders(manifestResponse: Response, filename: string) {
+  const headers = new Headers(manifestResponse.headers);
+  for (const name of ARCHIVE_REPRESENTATION_HEADERS) headers.delete(name);
+  headers.set("content-type", "application/zip");
+  headers.set("content-disposition", `attachment; filename="${filename}"`);
+  return headers;
+}
+
+function addDeploymentProofHeader(response: Response, env: ProxyEnv, target: string) {
+  if (!isPreviewFrontend(env) && !isTestFrontend(env)) return;
+  const deployment = convexDeploymentName(target);
+  if (!deployment) return;
+  response.headers.set(
+    isTestFrontend(env) ? "X-ClawHub-Test-Backend" : "X-ClawHub-Preview-Backend",
+    deployment,
+  );
 }
 
 async function readBoundedArchiveManifest(response: Response) {
@@ -356,6 +519,110 @@ function parseSkillArchiveManifest(
     if (!url.pathname.startsWith("/api/storage/")) return null;
   }
   return manifest as SkillArchiveManifest;
+}
+
+function parseSkillExportArchiveManifest(
+  value: unknown,
+  expectedIssuer: string,
+  expectedStorageOrigin: string | null,
+  now: number,
+): SkillExportArchiveManifest | null {
+  if (!value || typeof value !== "object") return null;
+  const manifest = value as Partial<SkillExportArchiveManifest>;
+  if (manifest.schema !== "clawhub.skill-export-archive-manifest.v1") return null;
+  if (
+    manifest.issuer !== expectedIssuer ||
+    manifest.audience !== ARCHIVE_MANIFEST_AUDIENCE ||
+    !expectedStorageOrigin ||
+    !isFreshArchiveManifest(manifest, now) ||
+    typeof manifest.filename !== "string" ||
+    !ARCHIVE_FILENAME_PATTERN.test(manifest.filename) ||
+    !Array.isArray(manifest.entries) ||
+    manifest.entries.length > MAX_SKILL_EXPORT_ARCHIVE_ENTRIES ||
+    !Array.isArray(manifest.exportManifest) ||
+    manifest.exportManifest.length > MAX_SKILL_EXPORT_MANIFEST_ENTRIES
+  ) {
+    return null;
+  }
+
+  const seenPaths = new Set<string>();
+  let totalStorageBytes = 0;
+  for (const entry of manifest.entries) {
+    if (!isSkillExportArchiveEntry(entry, expectedStorageOrigin)) return null;
+    if (entry.path === "_manifest.json" || seenPaths.has(entry.path)) return null;
+    seenPaths.add(entry.path);
+    if (entry.kind === "storage") {
+      totalStorageBytes += entry.size;
+      if (totalStorageBytes > MAX_SKILL_EXPORT_TOTAL_BYTES) return null;
+    }
+  }
+  if (!manifest.exportManifest.every(isMergedExportManifestEntry)) return null;
+  return manifest as SkillExportArchiveManifest;
+}
+
+function isFreshArchiveManifest(manifest: { issuedAt?: number; expiresAt?: number }, now: number) {
+  if (!Number.isFinite(manifest.issuedAt) || !Number.isFinite(manifest.expiresAt)) return false;
+  const issuedAt = manifest.issuedAt as number;
+  const expiresAt = manifest.expiresAt as number;
+  return (
+    issuedAt <= now + ARCHIVE_MANIFEST_CLOCK_SKEW_MS &&
+    expiresAt > now &&
+    expiresAt > issuedAt &&
+    expiresAt - issuedAt <= ARCHIVE_MANIFEST_MAX_AGE_MS
+  );
+}
+
+function isSkillExportArchiveEntry(
+  value: unknown,
+  expectedStorageOrigin: string,
+): value is SkillExportArchiveManifestEntry {
+  if (!value || typeof value !== "object") return false;
+  const entry = value as Partial<SkillExportArchiveManifestEntry>;
+  if (typeof entry.path !== "string" || !validateExportArchivePath(entry.path)) return false;
+  if (entry.kind === "inline") return typeof entry.text === "string";
+  if (
+    entry.kind !== "storage" ||
+    typeof entry.url !== "string" ||
+    entry.url.length > MAX_ARCHIVE_ENTRY_URL_LENGTH ||
+    !Number.isSafeInteger(entry.size) ||
+    (entry.size as number) < 0 ||
+    typeof entry.sha256 !== "string" ||
+    !/^[a-f0-9]{64}$/i.test(entry.sha256)
+  ) {
+    return false;
+  }
+  let url: URL;
+  try {
+    url = new URL(entry.url);
+  } catch {
+    return false;
+  }
+  return (
+    !url.username &&
+    !url.password &&
+    url.origin === expectedStorageOrigin &&
+    url.pathname.startsWith("/api/storage/")
+  );
+}
+
+function isMergedExportManifestEntry(value: unknown) {
+  if (!value || typeof value !== "object") return false;
+  const entry = value as Record<string, unknown>;
+  return (
+    typeof entry.publisher === "string" &&
+    validateSlug(entry.publisher) &&
+    typeof entry.slug === "string" &&
+    validateSlug(entry.slug) &&
+    (entry.sourceRef === "public-clawhub" || entry.sourceRef === "public-github") &&
+    (entry.version === null || typeof entry.version === "string") &&
+    typeof entry.displayName === "string" &&
+    Number.isFinite(entry.createdAt) &&
+    Number.isFinite(entry.updatedAt) &&
+    (entry.stats === null ||
+      (!!entry.stats && typeof entry.stats === "object" && !Array.isArray(entry.stats))) &&
+    Number.isSafeInteger(entry.fileCount) &&
+    (entry.fileCount as number) >= 0
+  );
 }
 
 function isSkillZipMeta(value: unknown): value is SkillZipMeta {

--- a/specs/spec.md
+++ b/specs/spec.md
@@ -178,6 +178,16 @@ Local fixture data lives in `convex/devSeed.ts` and `fixtures/public-corpus/`.
   the app-level `test` label is not an OIDC trust claim. Convex derives this
   expected target from its explicit runtime environment markers, not a fixed
   deployment hostname, and fails closed when a remote runtime is unclassified.
+- Bulk skill export uses the same signed-manifest boundary. Convex records
+  recoverable missing-skill, missing-version, missing-file, invalid-path, and
+  duplicate-path errors before signing, and those errors remain represented by
+  `_errors.json` plus `X-Export-Errors`. The signed manifest then becomes the
+  complete archive contract: Nitro must not omit or rewrite a signed entry,
+  because doing so would make the embedded `_manifest.json` and response error
+  count false. A post-signing storage failure, size mismatch, or digest mismatch
+  therefore terminates the stream; clients discard the partial ZIP and retry.
+  This integrity rule applies while file reads, compression, and response output
+  remain bounded and backpressured.
   Nitro never accepts a
   client-supplied manifest and
   accepts Convex's response only as a short-lived RS256 JWS signed by the

--- a/specs/spec.md
+++ b/specs/spec.md
@@ -188,6 +188,11 @@ Local fixture data lives in `convex/devSeed.ts` and `fixtures/public-corpus/`.
   therefore terminates the stream; clients discard the partial ZIP and retry.
   This integrity rule applies while file reads, compression, and response output
   remain bounded and backpressured.
+  Bulk-export archive paths are capped at 900 bytes in their JSON-encoded UTF-8
+  representation, so multibyte or escaped legacy names cannot exceed the bounded
+  signed-handoff budget while passing a JavaScript character-count check. Files
+  outside that archive-path contract are omitted before signing and recorded in
+  `_errors.json`.
   Nitro never accepts a
   client-supplied manifest and
   accepts Convex's response only as a short-lived RS256 JWS signed by the


### PR DESCRIPTION
## Summary

- extend the existing Convex-to-Nitro signed archive handoff to `GET /api/v1/skills/export`
- keep authorization, rate limiting, pagination, duplicate-path handling, `_manifest.json`, `_errors.json`, `X-Export-Errors`, and public export headers in Convex
- stream stored entries through Nitro with a 64 KiB compression window, an eight-response prefetch bound, signed size enforcement, and incremental SHA-256 verification
- make the GitHub package-publish e2e fixture hermetic instead of downloading the live `openclaw/openclaw` archive

## Root cause

Current `main` at `d0c0f66acc31fc4e245297197061090958a3f723` still called `ctx.storage.get()` for every hosted file, materialized every Blob as a `Uint8Array`, accumulated the full entry set, and finally called synchronous `zipSync`. Streaming only the outer response could not reduce this archive/entry accumulation.

This is the residual OOM class called out by [#3474](https://github.com/openclaw/clawhub/pull/3474). It reuses the signed-manifest ownership boundary established by [#3451](https://github.com/openclaw/clawhub/pull/3451): Convex remains the authorization/control plane, while Nitro owns storage streaming, backpressure, compression, and public response headers.

The hosted CI failure on the original head was not caused by the Dependabot updates: the selected CLI e2e downloaded the live `openclaw/openclaw` GitHub archive and exceeded its 30-second timeout. The replacement loopback fixture exercises the same real CLI process and GitHub archive contract without external repository-size/network variance.

## Contract and owner decisions

- API-token authorization and export rate limiting still execute in Convex.
- Nitro-only manifest requests require the existing verified Vercel OIDC identity.
- Storage URLs remain inside the signed internal handoff and are accepted only from the canonical paired Convex storage origin.
- Duplicate legacy paths still retain the first entry and append the same `_errors.json` record without fetching the duplicate.
- Missing versions/blobs discovered before signing, invalid paths, byte/file caps, GitHub handoffs, export metadata, pagination headers, `X-Export-Errors`, and `_manifest.json` retain their existing shapes.
- Once a stored entry is signed into the manifest, a later 404 fails the archive instead of silently emitting a ZIP whose `_manifest.json` and `X-Export-Errors` no longer describe its contents. This atomic post-signing integrity decision is documented in `docs/http-api.md` and `specs/spec.md`; clients discard the partial ZIP and retry.
- Archive paths are bounded by their JSON-encoded UTF-8 representation (900 bytes), not JavaScript character count. Oversized multibyte/escaped legacy names become pre-signing `_errors.json` entries. A real 10,000-entry RS256 regression proves the maximum accepted shape remains inside the 16 MiB handoff cap.
- Stored bytes must match both the signed size and published SHA-256 before the streamed archive can complete.

## TDD / bounded-memory evidence

Red on current `main` before implementation:

```text
bunx vitest run server/convexProxy.test.ts --testNamePattern "streams bulk skill exports before a stored entry finishes"
FAIL: expected 502 to be 200
```

Review-driven red before the signed-path fix:

```text
skills export reports archive paths that exceed the signed byte budget
FAIL: expected X-Export-Errors "1", received "0"

bounds the signed UTF-8 JSON representation instead of JavaScript characters
FAIL: expected false, received true
```

Green behavior on this head:

- Convex returns a bounded signed manifest and never calls `storage.get()` for the 64 MiB test entry.
- Nitro emits ZIP bytes after a 64 KiB input window while the storage response is still unfinished.
- Only eight storage responses are prefetched; all prefetched bodies are cancelled when the archive stops.
- The completed ZIP preserves `_manifest.json`, `_errors.json`, metadata, duplicate-path handling, and `X-Export-Errors`.
- Same-size wrong content and post-signing storage disappearance fail archive integrity.
- Stored payload has a separate 256 MiB cap; signed inline content remains inside the 16 MiB manifest budget.

## Validation on `8a3c499605ec02167289b8b68f792dafb51ba051`

- focused archive/HTTP tests — 482 passed
- `bun run ci:static` — passed
- `bun run ci:unit` — 6,168 passed, 3 skipped
- `bun run ci:types-build` — passed
- `bun run ci:packages` — passed (29 files/444 tests plus package type/artifact gates)
- `bun run ci:e2e-http` — passed (4 prod HTTP, 1 agent discovery, 12 selected CLI/HTTP with 9 skipped, 1 permissions with 2 skipped)
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --stream-engine-output` — clean; no accepted/actionable findings (0.90 confidence)

Backend/CLI-test-only change; no UI proof applies. No deploy, production mutation, or monitor change was performed.
