### PR TITLE
fix(ci): prevent moved tooling from reaching package publish

### DIFF
--- a/.github/scripts/verify-trusted-tooling-identity.cjs
+++ b/.github/scripts/verify-trusted-tooling-identity.cjs
@@ -3,8 +3,8 @@ const POSITIVE_INTEGER_PATTERN = /^[1-9][0-9]*$/;
 const REPOSITORY_PATTERN = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
 const SHA_PATTERN = /^[a-f0-9]{40}$/;
 const WORKFLOW_PATTERN = /^\.github\/workflows\/[A-Za-z0-9_.-]+\.ya?ml$/;
-const PROTECTED_TAG_PATTERN =
-  /^refs\/tags\/(release-publish\/([a-f0-9]{12})-[1-9][0-9]*)$/;
+const FULL_REF_PATTERN = /^refs\/(?:heads|tags)\/(.+)$/;
+const PROTECTED_TAG_PATTERN = /^refs\/tags\/(release-publish\/([a-f0-9]{12})-[1-9][0-9]*)$/;
 const MAIN_FULL_REF = "refs/heads/main";
 const REQUIRED_KEYS = [
   "fullRef",
@@ -13,6 +13,9 @@ const REQUIRED_KEYS = [
   "runAttempt",
   "runId",
   "sha",
+  "toolingFullRef",
+  "toolingRef",
+  "toolingSha",
   "version",
   "workflow",
 ];
@@ -26,6 +29,13 @@ function requireString(value, name, pattern) {
     fail(`trusted tooling identity ${name} is invalid`);
   }
   return value;
+}
+
+function requireMatchingRef(ref, fullRef, name) {
+  const match = FULL_REF_PATTERN.exec(fullRef);
+  if (!match || match[1] !== ref) {
+    fail(`trusted tooling identity ${name} ref does not match its full ref`);
+  }
 }
 
 function parseTrustedToolingIdentity(raw) {
@@ -66,21 +76,25 @@ function parseTrustedToolingIdentity(raw) {
     ref: requireString(value.ref, "ref"),
     fullRef: requireString(value.fullRef, "fullRef"),
     sha: requireString(value.sha, "sha", SHA_PATTERN),
+    toolingRef: requireString(value.toolingRef, "toolingRef"),
+    toolingFullRef: requireString(value.toolingFullRef, "toolingFullRef"),
+    toolingSha: requireString(value.toolingSha, "toolingSha", SHA_PATTERN),
   };
+  requireMatchingRef(identity.ref, identity.fullRef, "caller");
 
-  if (identity.fullRef === MAIN_FULL_REF) {
-    if (identity.ref !== "main") {
-      fail("trusted main identity ref must be main");
+  if (identity.toolingFullRef === MAIN_FULL_REF) {
+    if (identity.toolingRef !== "main") {
+      fail("trusted main tooling ref must be main");
     }
     return { ...identity, route: "main" };
   }
 
-  const protectedTag = PROTECTED_TAG_PATTERN.exec(identity.fullRef);
-  if (!protectedTag || identity.ref !== protectedTag[1]) {
-    fail("trusted release-publish identity must use an exact protected tag ref");
+  const protectedTag = PROTECTED_TAG_PATTERN.exec(identity.toolingFullRef);
+  if (!protectedTag || identity.toolingRef !== protectedTag[1]) {
+    fail("trusted release-publish tooling must use an exact protected tag ref");
   }
-  if (identity.sha.slice(0, 12) !== protectedTag[2]) {
-    fail("trusted release-publish tag prefix does not match its workflow SHA");
+  if (identity.toolingSha.slice(0, 12) !== protectedTag[2]) {
+    fail("trusted release-publish tag prefix does not match its tooling SHA");
   }
   return { ...identity, route: "protected-tag" };
 }
@@ -90,8 +104,16 @@ function requireContextValue(env, name) {
 }
 
 function validateInvocationContext(identity, env) {
+  const expectedWorkflowRef = `${identity.repository}/${identity.workflow}@${identity.fullRef}`;
   const checks = [
     ["GITHUB_REPOSITORY", identity.repository],
+    ["GITHUB_RUN_ID", identity.runId],
+    ["GITHUB_RUN_ATTEMPT", identity.runAttempt],
+    ["GITHUB_WORKFLOW_REF", expectedWorkflowRef],
+    ["GITHUB_WORKFLOW_SHA", identity.sha],
+    ["GITHUB_REF", identity.fullRef],
+    ["GITHUB_REF_NAME", identity.ref],
+    ["GITHUB_SHA", identity.sha],
     ["GITHUB_EVENT_NAME", "workflow_dispatch"],
   ];
   for (const [name, expected] of checks) {
@@ -101,10 +123,10 @@ function validateInvocationContext(identity, env) {
   }
 }
 
-function normalizeQualifiedWorkflowRef(value, route) {
+function normalizeQualifiedWorkflowRef(value, identity) {
   if (!value) return "";
   if (value.startsWith("refs/")) return value;
-  if (route === "main" && value === "main") return MAIN_FULL_REF;
+  if (value === identity.ref && identity.fullRef === MAIN_FULL_REF) return MAIN_FULL_REF;
   fail("trusted tooling workflow path uses an ambiguous ref qualifier");
 }
 
@@ -129,20 +151,20 @@ function validateWorkflowRun(identity, run) {
     }
   }
 
-  const normalizedQualifiedRef = normalizeQualifiedWorkflowRef(qualifiedRef, identity.route);
+  const normalizedQualifiedRef = normalizeQualifiedWorkflowRef(qualifiedRef, identity);
   if (normalizedQualifiedRef && normalizedQualifiedRef !== identity.fullRef) {
     fail("trusted tooling workflow path ref mismatch");
   }
 }
 
 function validateProtectedTag(identity, tagRef) {
-  if (tagRef?.ref !== identity.fullRef) {
+  if (tagRef?.ref !== identity.toolingFullRef) {
     fail("trusted release-publish tag ref mismatch");
   }
   if (tagRef?.object?.type !== "commit") {
     fail("trusted release-publish ref must be a lightweight tag");
   }
-  if (tagRef.object.sha !== identity.sha) {
+  if (tagRef.object.sha !== identity.toolingSha) {
     fail("trusted release-publish tag moved after approval");
   }
 }
@@ -150,9 +172,9 @@ function validateProtectedTag(identity, tagRef) {
 function validateMainLineage(identity, comparison) {
   if (
     !["ahead", "identical"].includes(String(comparison?.status ?? "")) ||
-    comparison?.merge_base_commit?.sha !== identity.sha
+    comparison?.merge_base_commit?.sha !== identity.toolingSha
   ) {
-    fail("trusted main workflow SHA is no longer reachable from main");
+    fail("trusted main tooling SHA is no longer reachable from main");
   }
 }
 
@@ -167,12 +189,12 @@ async function verifyTrustedToolingIdentity({ rawIdentity, env, getJson }) {
 
   if (identity.route === "main") {
     const comparison = await getJson(
-      `repos/${identity.repository}/compare/${identity.sha}...main`,
+      `repos/${identity.repository}/compare/${identity.toolingSha}...main`,
     );
     validateMainLineage(identity, comparison);
   } else {
     const tagRef = await getJson(
-      `repos/${identity.repository}/git/ref/tags/${encodeURIComponent(identity.ref)}`,
+      `repos/${identity.repository}/git/ref/tags/${encodeURIComponent(identity.toolingRef)}`,
     );
     validateProtectedTag(identity, tagRef);
   }
@@ -204,7 +226,7 @@ async function main() {
     getJson: (path) => githubJson(path, token),
   });
   console.log(
-    `Verified trusted tooling identity v${identity.version} for ${identity.repository} ${identity.fullRef}.`,
+    `Verified trusted tooling identity v${identity.version} for ${identity.repository} ${identity.toolingFullRef}.`,
   );
 }
 

--- a/.github/scripts/verify-trusted-tooling-identity.cjs
+++ b/.github/scripts/verify-trusted-tooling-identity.cjs
@@ -1,0 +1,229 @@
+const MAX_IDENTITY_BYTES = 8 * 1024;
+const POSITIVE_INTEGER_PATTERN = /^[1-9][0-9]*$/;
+const REPOSITORY_PATTERN = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+const SHA_PATTERN = /^[a-f0-9]{40}$/;
+const WORKFLOW_PATTERN = /^\.github\/workflows\/[A-Za-z0-9_.-]+\.ya?ml$/;
+const PROTECTED_TAG_PATTERN =
+  /^refs\/tags\/(release-publish\/([a-f0-9]{12})-[1-9][0-9]*)$/;
+const MAIN_FULL_REF = "refs/heads/main";
+const REQUIRED_KEYS = [
+  "fullRef",
+  "ref",
+  "repository",
+  "runAttempt",
+  "runId",
+  "sha",
+  "version",
+  "workflow",
+];
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function requireString(value, name, pattern) {
+  if (typeof value !== "string" || !value || (pattern && !pattern.test(value))) {
+    fail(`trusted tooling identity ${name} is invalid`);
+  }
+  return value;
+}
+
+function parseTrustedToolingIdentity(raw) {
+  if (typeof raw !== "string" || !raw.trim()) {
+    fail("trusted tooling identity JSON is required");
+  }
+  if (Buffer.byteLength(raw, "utf8") > MAX_IDENTITY_BYTES) {
+    fail("trusted tooling identity JSON exceeds the 8 KiB limit");
+  }
+
+  let value;
+  try {
+    value = JSON.parse(raw);
+  } catch {
+    fail("trusted tooling identity JSON is malformed");
+  }
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    fail("trusted tooling identity must be a JSON object");
+  }
+
+  const keys = Object.keys(value).sort();
+  if (
+    keys.length !== REQUIRED_KEYS.length ||
+    keys.some((key, index) => key !== REQUIRED_KEYS[index])
+  ) {
+    fail(`trusted tooling identity v1 must contain exactly: ${REQUIRED_KEYS.join(", ")}`);
+  }
+  if (value.version !== 1) {
+    fail("trusted tooling identity version must be 1");
+  }
+
+  const identity = {
+    version: 1,
+    repository: requireString(value.repository, "repository", REPOSITORY_PATTERN),
+    workflow: requireString(value.workflow, "workflow", WORKFLOW_PATTERN),
+    runId: requireString(value.runId, "runId", POSITIVE_INTEGER_PATTERN),
+    runAttempt: requireString(value.runAttempt, "runAttempt", POSITIVE_INTEGER_PATTERN),
+    ref: requireString(value.ref, "ref"),
+    fullRef: requireString(value.fullRef, "fullRef"),
+    sha: requireString(value.sha, "sha", SHA_PATTERN),
+  };
+
+  if (identity.fullRef === MAIN_FULL_REF) {
+    if (identity.ref !== "main") {
+      fail("trusted main identity ref must be main");
+    }
+    return { ...identity, route: "main" };
+  }
+
+  const protectedTag = PROTECTED_TAG_PATTERN.exec(identity.fullRef);
+  if (!protectedTag || identity.ref !== protectedTag[1]) {
+    fail("trusted release-publish identity must use an exact protected tag ref");
+  }
+  if (identity.sha.slice(0, 12) !== protectedTag[2]) {
+    fail("trusted release-publish tag prefix does not match its workflow SHA");
+  }
+  return { ...identity, route: "protected-tag" };
+}
+
+function requireContextValue(env, name) {
+  return requireString(env[name], name);
+}
+
+function validateInvocationContext(identity, env) {
+  const checks = [
+    ["GITHUB_REPOSITORY", identity.repository],
+    ["GITHUB_EVENT_NAME", "workflow_dispatch"],
+  ];
+  for (const [name, expected] of checks) {
+    if (requireContextValue(env, name) !== expected) {
+      fail(`trusted tooling identity does not match ${name}`);
+    }
+  }
+}
+
+function normalizeQualifiedWorkflowRef(value, route) {
+  if (!value) return "";
+  if (value.startsWith("refs/")) return value;
+  if (route === "main" && value === "main") return MAIN_FULL_REF;
+  fail("trusted tooling workflow path uses an ambiguous ref qualifier");
+}
+
+function validateWorkflowRun(identity, run) {
+  if (!run || typeof run !== "object" || Array.isArray(run)) {
+    fail("trusted tooling workflow run response is invalid");
+  }
+
+  const [workflowPath, qualifiedRef = ""] = String(run.path ?? "").split("@", 2);
+  const checks = [
+    ["repository", run.repository?.full_name, identity.repository],
+    ["run id", String(run.id ?? ""), identity.runId],
+    ["run attempt", String(run.run_attempt ?? ""), identity.runAttempt],
+    ["workflow path", workflowPath, identity.workflow],
+    ["head branch", String(run.head_branch ?? ""), identity.ref],
+    ["head SHA", String(run.head_sha ?? ""), identity.sha],
+    ["event", String(run.event ?? ""), "workflow_dispatch"],
+  ];
+  for (const [name, actual, expected] of checks) {
+    if (actual !== expected) {
+      fail(`trusted tooling workflow ${name} mismatch`);
+    }
+  }
+
+  const normalizedQualifiedRef = normalizeQualifiedWorkflowRef(qualifiedRef, identity.route);
+  if (normalizedQualifiedRef && normalizedQualifiedRef !== identity.fullRef) {
+    fail("trusted tooling workflow path ref mismatch");
+  }
+}
+
+function validateProtectedTag(identity, tagRef) {
+  if (tagRef?.ref !== identity.fullRef) {
+    fail("trusted release-publish tag ref mismatch");
+  }
+  if (tagRef?.object?.type !== "commit") {
+    fail("trusted release-publish ref must be a lightweight tag");
+  }
+  if (tagRef.object.sha !== identity.sha) {
+    fail("trusted release-publish tag moved after approval");
+  }
+}
+
+function validateMainLineage(identity, comparison) {
+  if (
+    !["ahead", "identical"].includes(String(comparison?.status ?? "")) ||
+    comparison?.merge_base_commit?.sha !== identity.sha
+  ) {
+    fail("trusted main workflow SHA is no longer reachable from main");
+  }
+}
+
+async function verifyTrustedToolingIdentity({ rawIdentity, env, getJson }) {
+  const identity = parseTrustedToolingIdentity(rawIdentity);
+  validateInvocationContext(identity, env);
+
+  const run = await getJson(
+    `repos/${identity.repository}/actions/runs/${identity.runId}/attempts/${identity.runAttempt}`,
+  );
+  validateWorkflowRun(identity, run);
+
+  if (identity.route === "main") {
+    const comparison = await getJson(
+      `repos/${identity.repository}/compare/${identity.sha}...main`,
+    );
+    validateMainLineage(identity, comparison);
+  } else {
+    const tagRef = await getJson(
+      `repos/${identity.repository}/git/ref/tags/${encodeURIComponent(identity.ref)}`,
+    );
+    validateProtectedTag(identity, tagRef);
+  }
+
+  return identity;
+}
+
+async function githubJson(path, token) {
+  const response = await fetch(`https://api.github.com/${path}`, {
+    headers: {
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${token}`,
+      "User-Agent": "clawhub-package-publish",
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+    signal: AbortSignal.timeout(30_000),
+  });
+  if (!response.ok) {
+    fail(`GitHub API request failed with HTTP ${response.status}: ${path}`);
+  }
+  return await response.json();
+}
+
+async function main() {
+  const token = requireString(process.env.GH_TOKEN, "GH_TOKEN");
+  const identity = await verifyTrustedToolingIdentity({
+    rawIdentity: process.env.TRUSTED_TOOLING_IDENTITY_JSON,
+    env: process.env,
+    getJson: (path) => githubJson(path, token),
+  });
+  console.log(
+    `Verified trusted tooling identity v${identity.version} for ${identity.repository} ${identity.fullRef}.`,
+  );
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(
+      `Trusted tooling identity verification failed: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    process.exitCode = 1;
+  });
+}
+
+module.exports = {
+  parseTrustedToolingIdentity,
+  validateInvocationContext,
+  validateMainLineage,
+  validateProtectedTag,
+  validateWorkflowRun,
+  verifyTrustedToolingIdentity,
+};

--- a/.github/scripts/verify-trusted-tooling-identity.node-test.cjs
+++ b/.github/scripts/verify-trusted-tooling-identity.node-test.cjs
@@ -6,30 +6,35 @@ const {
   verifyTrustedToolingIdentity,
 } = require("./verify-trusted-tooling-identity.cjs");
 
-const sha = "a".repeat(40);
+const callerSha = "c".repeat(40);
+const callerRunId = "32440000001";
+const callerRef = "v2026.8.3-beta.3";
+const workflow = ".github/workflows/plugin-clawhub-release.yml";
+const toolingSha = "a".repeat(40);
 const tagProofRunId = "32410682801";
-const runId = "32440000001";
-const tag = `release-publish/${sha.slice(0, 12)}-${tagProofRunId}`;
-const workflow = ".github/workflows/openclaw-release-publish.yml";
+const toolingRef = `release-publish/${toolingSha.slice(0, 12)}-${tagProofRunId}`;
 
 function protectedIdentity(overrides = {}) {
   return {
     version: 1,
     repository: "openclaw/openclaw",
     workflow,
-    runId,
+    runId: callerRunId,
     runAttempt: "2",
-    ref: tag,
-    fullRef: `refs/tags/${tag}`,
-    sha,
+    ref: callerRef,
+    fullRef: `refs/tags/${callerRef}`,
+    sha: callerSha,
+    toolingRef,
+    toolingFullRef: `refs/tags/${toolingRef}`,
+    toolingSha,
     ...overrides,
   };
 }
 
 function mainIdentity(overrides = {}) {
   return protectedIdentity({
-    ref: "main",
-    fullRef: "refs/heads/main",
+    toolingRef: "main",
+    toolingFullRef: "refs/heads/main",
     ...overrides,
   });
 }
@@ -37,6 +42,13 @@ function mainIdentity(overrides = {}) {
 function callerEnv(identity) {
   return {
     GITHUB_REPOSITORY: identity.repository,
+    GITHUB_RUN_ID: identity.runId,
+    GITHUB_RUN_ATTEMPT: identity.runAttempt,
+    GITHUB_WORKFLOW_REF: `${identity.repository}/${identity.workflow}@${identity.fullRef}`,
+    GITHUB_WORKFLOW_SHA: identity.sha,
+    GITHUB_REF: identity.fullRef,
+    GITHUB_REF_NAME: identity.ref,
+    GITHUB_SHA: identity.sha,
     GITHUB_EVENT_NAME: "workflow_dispatch",
   };
 }
@@ -54,7 +66,7 @@ function runFixture(identity, overrides = {}) {
   };
 }
 
-test("accepts the exact protected tooling run and re-reads the lightweight tag last", async () => {
+test("binds the invoking run and re-reads the protected tooling tag last", async () => {
   const identity = protectedIdentity();
   const calls = [];
   const result = await verifyTrustedToolingIdentity({
@@ -64,8 +76,8 @@ test("accepts the exact protected tooling run and re-reads the lightweight tag l
       calls.push(path);
       if (path.includes("/actions/runs/")) return runFixture(identity);
       return {
-        ref: identity.fullRef,
-        object: { type: "commit", sha: identity.sha },
+        ref: identity.toolingFullRef,
+        object: { type: "commit", sha: identity.toolingSha },
       };
     },
   });
@@ -73,11 +85,11 @@ test("accepts the exact protected tooling run and re-reads the lightweight tag l
   assert.equal(result.route, "protected-tag");
   assert.deepEqual(calls, [
     `repos/${identity.repository}/actions/runs/${identity.runId}/attempts/${identity.runAttempt}`,
-    `repos/${identity.repository}/git/ref/tags/${encodeURIComponent(identity.ref)}`,
+    `repos/${identity.repository}/git/ref/tags/${encodeURIComponent(identity.toolingRef)}`,
   ]);
 });
 
-test("preserves the ordinary main route when the workflow SHA remains on main", async () => {
+test("preserves the ordinary main tooling route when its SHA remains on main", async () => {
   const identity = mainIdentity();
   const calls = [];
   const result = await verifyTrustedToolingIdentity({
@@ -85,18 +97,16 @@ test("preserves the ordinary main route when the workflow SHA remains on main", 
     env: callerEnv(identity),
     getJson: async (path) => {
       calls.push(path);
-      if (path.includes("/actions/runs/")) {
-        return runFixture(identity, { path: `${identity.workflow}@main` });
-      }
+      if (path.includes("/actions/runs/")) return runFixture(identity);
       return {
         status: "ahead",
-        merge_base_commit: { sha: identity.sha },
+        merge_base_commit: { sha: identity.toolingSha },
       };
     },
   });
 
   assert.equal(result.route, "main");
-  assert.equal(calls[1], `repos/${identity.repository}/compare/${identity.sha}...main`);
+  assert.equal(calls[1], `repos/${identity.repository}/compare/${identity.toolingSha}...main`);
 });
 
 test("requires the exact v1 tuple without hidden compatibility fields", () => {
@@ -111,20 +121,33 @@ test("requires the exact v1 tuple without hidden compatibility fields", () => {
   assert.throws(() => parseTrustedToolingIdentity("{"), /malformed/);
 });
 
-test("keeps the tag provenance suffix separate from the approving workflow run", () => {
+test("keeps the tooling tag provenance suffix separate from the invoking run", () => {
   const identity = parseTrustedToolingIdentity(JSON.stringify(protectedIdentity()));
 
-  assert.equal(identity.runId, runId);
+  assert.equal(identity.runId, callerRunId);
   assert.notEqual(identity.runId, tagProofRunId);
 });
 
-test("rejects same-name branches and tag names with the wrong SHA prefix", () => {
+test("rejects caller refs that do not match their full ref", () => {
   assert.throws(
     () =>
       parseTrustedToolingIdentity(
         JSON.stringify({
           ...protectedIdentity(),
-          fullRef: `refs/heads/${tag}`,
+          fullRef: "refs/heads/main",
+        }),
+      ),
+    /caller ref does not match/,
+  );
+});
+
+test("rejects tooling same-name branches and tag names with the wrong SHA prefix", () => {
+  assert.throws(
+    () =>
+      parseTrustedToolingIdentity(
+        JSON.stringify({
+          ...protectedIdentity(),
+          toolingFullRef: `refs/heads/${toolingRef}`,
         }),
       ),
     /exact protected tag ref/,
@@ -134,16 +157,27 @@ test("rejects same-name branches and tag names with the wrong SHA prefix", () =>
       parseTrustedToolingIdentity(
         JSON.stringify({
           ...protectedIdentity(),
-          ref: `release-publish/${"b".repeat(12)}-32410682801`,
-          fullRef: `refs/tags/release-publish/${"b".repeat(12)}-32410682801`,
+          toolingRef: `release-publish/${"b".repeat(12)}-${tagProofRunId}`,
+          toolingFullRef: `refs/tags/release-publish/${"b".repeat(12)}-${tagProofRunId}`,
         }),
-    ),
+      ),
     /prefix does not match/,
   );
 });
 
 for (const [name, mutate] of [
   ["repository", (identity, env) => (env.GITHUB_REPOSITORY = "other/repo")],
+  ["run", (identity, env) => (env.GITHUB_RUN_ID = "999")],
+  ["run attempt", (identity, env) => (env.GITHUB_RUN_ATTEMPT = "9")],
+  [
+    "workflow",
+    (identity, env) =>
+      (env.GITHUB_WORKFLOW_REF = `${identity.repository}/.github/workflows/other.yml@${identity.fullRef}`),
+  ],
+  ["workflow SHA", (identity, env) => (env.GITHUB_WORKFLOW_SHA = "b".repeat(40))],
+  ["full ref", (identity, env) => (env.GITHUB_REF = `refs/heads/${identity.ref}`)],
+  ["ref", (identity, env) => (env.GITHUB_REF_NAME = "main")],
+  ["SHA", (identity, env) => (env.GITHUB_SHA = "b".repeat(40))],
   ["event", (identity, env) => (env.GITHUB_EVENT_NAME = "push")],
 ]) {
   test(`rejects an invocation context with the wrong ${name}`, async () => {
@@ -169,12 +203,9 @@ for (const [name, overrides] of [
   ["head branch", { head_branch: "main" }],
   ["head SHA", { head_sha: "b".repeat(40) }],
   ["event", { event: "push" }],
-  [
-    "same-name branch qualifier",
-    { path: `${workflow}@refs/heads/${tag}` },
-  ],
+  ["same-name branch qualifier", { path: `${workflow}@refs/heads/${callerRef}` }],
 ]) {
-  test(`rejects a live workflow run with the wrong ${name}`, () => {
+  test(`rejects a live invoking workflow run with the wrong ${name}`, () => {
     const identity = parseTrustedToolingIdentity(JSON.stringify(protectedIdentity()));
     assert.throws(
       () => validateWorkflowRun(identity, runFixture(identity, overrides)),
@@ -184,23 +215,19 @@ for (const [name, overrides] of [
 }
 
 for (const [name, tagRef, message] of [
-  [
-    "deleted tag",
-    undefined,
-    /tag ref mismatch/,
-  ],
+  ["deleted tag", undefined, /tag ref mismatch/],
   [
     "annotated tag",
     {
-      ref: `refs/tags/${tag}`,
-      object: { type: "tag", sha },
+      ref: `refs/tags/${toolingRef}`,
+      object: { type: "tag", sha: toolingSha },
     },
     /lightweight tag/,
   ],
   [
     "moved tag",
     {
-      ref: `refs/tags/${tag}`,
+      ref: `refs/tags/${toolingRef}`,
       object: { type: "commit", sha: "b".repeat(40) },
     },
     /moved after approval/,
@@ -212,15 +239,14 @@ for (const [name, tagRef, message] of [
       verifyTrustedToolingIdentity({
         rawIdentity: JSON.stringify(identity),
         env: callerEnv(identity),
-        getJson: async (path) =>
-          path.includes("/actions/runs/") ? runFixture(identity) : tagRef,
+        getJson: async (path) => (path.includes("/actions/runs/") ? runFixture(identity) : tagRef),
       }),
       message,
     );
   });
 }
 
-test("rejects a main workflow SHA removed from current main lineage", async () => {
+test("rejects a main tooling SHA removed from current main lineage", async () => {
   const identity = mainIdentity();
   await assert.rejects(
     verifyTrustedToolingIdentity({

--- a/.github/scripts/verify-trusted-tooling-identity.node-test.cjs
+++ b/.github/scripts/verify-trusted-tooling-identity.node-test.cjs
@@ -1,0 +1,236 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+const {
+  parseTrustedToolingIdentity,
+  validateWorkflowRun,
+  verifyTrustedToolingIdentity,
+} = require("./verify-trusted-tooling-identity.cjs");
+
+const sha = "a".repeat(40);
+const tagProofRunId = "32410682801";
+const runId = "32440000001";
+const tag = `release-publish/${sha.slice(0, 12)}-${tagProofRunId}`;
+const workflow = ".github/workflows/openclaw-release-publish.yml";
+
+function protectedIdentity(overrides = {}) {
+  return {
+    version: 1,
+    repository: "openclaw/openclaw",
+    workflow,
+    runId,
+    runAttempt: "2",
+    ref: tag,
+    fullRef: `refs/tags/${tag}`,
+    sha,
+    ...overrides,
+  };
+}
+
+function mainIdentity(overrides = {}) {
+  return protectedIdentity({
+    ref: "main",
+    fullRef: "refs/heads/main",
+    ...overrides,
+  });
+}
+
+function callerEnv(identity) {
+  return {
+    GITHUB_REPOSITORY: identity.repository,
+    GITHUB_EVENT_NAME: "workflow_dispatch",
+  };
+}
+
+function runFixture(identity, overrides = {}) {
+  return {
+    id: Number(identity.runId),
+    run_attempt: Number(identity.runAttempt),
+    path: `${identity.workflow}@${identity.fullRef}`,
+    head_branch: identity.ref,
+    head_sha: identity.sha,
+    event: "workflow_dispatch",
+    repository: { full_name: identity.repository },
+    ...overrides,
+  };
+}
+
+test("accepts the exact protected tooling run and re-reads the lightweight tag last", async () => {
+  const identity = protectedIdentity();
+  const calls = [];
+  const result = await verifyTrustedToolingIdentity({
+    rawIdentity: JSON.stringify(identity),
+    env: callerEnv(identity),
+    getJson: async (path) => {
+      calls.push(path);
+      if (path.includes("/actions/runs/")) return runFixture(identity);
+      return {
+        ref: identity.fullRef,
+        object: { type: "commit", sha: identity.sha },
+      };
+    },
+  });
+
+  assert.equal(result.route, "protected-tag");
+  assert.deepEqual(calls, [
+    `repos/${identity.repository}/actions/runs/${identity.runId}/attempts/${identity.runAttempt}`,
+    `repos/${identity.repository}/git/ref/tags/${encodeURIComponent(identity.ref)}`,
+  ]);
+});
+
+test("preserves the ordinary main route when the workflow SHA remains on main", async () => {
+  const identity = mainIdentity();
+  const calls = [];
+  const result = await verifyTrustedToolingIdentity({
+    rawIdentity: JSON.stringify(identity),
+    env: callerEnv(identity),
+    getJson: async (path) => {
+      calls.push(path);
+      if (path.includes("/actions/runs/")) {
+        return runFixture(identity, { path: `${identity.workflow}@main` });
+      }
+      return {
+        status: "ahead",
+        merge_base_commit: { sha: identity.sha },
+      };
+    },
+  });
+
+  assert.equal(result.route, "main");
+  assert.equal(calls[1], `repos/${identity.repository}/compare/${identity.sha}...main`);
+});
+
+test("requires the exact v1 tuple without hidden compatibility fields", () => {
+  assert.throws(
+    () => parseTrustedToolingIdentity(JSON.stringify({ ...protectedIdentity(), version: 2 })),
+    /version must be 1/,
+  );
+  assert.throws(
+    () => parseTrustedToolingIdentity(JSON.stringify({ ...protectedIdentity(), extra: true })),
+    /must contain exactly/,
+  );
+  assert.throws(() => parseTrustedToolingIdentity("{"), /malformed/);
+});
+
+test("keeps the tag provenance suffix separate from the approving workflow run", () => {
+  const identity = parseTrustedToolingIdentity(JSON.stringify(protectedIdentity()));
+
+  assert.equal(identity.runId, runId);
+  assert.notEqual(identity.runId, tagProofRunId);
+});
+
+test("rejects same-name branches and tag names with the wrong SHA prefix", () => {
+  assert.throws(
+    () =>
+      parseTrustedToolingIdentity(
+        JSON.stringify({
+          ...protectedIdentity(),
+          fullRef: `refs/heads/${tag}`,
+        }),
+      ),
+    /exact protected tag ref/,
+  );
+  assert.throws(
+    () =>
+      parseTrustedToolingIdentity(
+        JSON.stringify({
+          ...protectedIdentity(),
+          ref: `release-publish/${"b".repeat(12)}-32410682801`,
+          fullRef: `refs/tags/release-publish/${"b".repeat(12)}-32410682801`,
+        }),
+    ),
+    /prefix does not match/,
+  );
+});
+
+for (const [name, mutate] of [
+  ["repository", (identity, env) => (env.GITHUB_REPOSITORY = "other/repo")],
+  ["event", (identity, env) => (env.GITHUB_EVENT_NAME = "push")],
+]) {
+  test(`rejects an invocation context with the wrong ${name}`, async () => {
+    const identity = protectedIdentity();
+    const env = callerEnv(identity);
+    mutate(identity, env);
+    await assert.rejects(
+      verifyTrustedToolingIdentity({
+        rawIdentity: JSON.stringify(identity),
+        env,
+        getJson: async () => assert.fail("GitHub API must not be called"),
+      }),
+      /does not match/,
+    );
+  });
+}
+
+for (const [name, overrides] of [
+  ["repository", { repository: { full_name: "other/repo" } }],
+  ["run", { id: 999 }],
+  ["run attempt", { run_attempt: 9 }],
+  ["workflow", { path: ".github/workflows/other.yml" }],
+  ["head branch", { head_branch: "main" }],
+  ["head SHA", { head_sha: "b".repeat(40) }],
+  ["event", { event: "push" }],
+  [
+    "same-name branch qualifier",
+    { path: `${workflow}@refs/heads/${tag}` },
+  ],
+]) {
+  test(`rejects a live workflow run with the wrong ${name}`, () => {
+    const identity = parseTrustedToolingIdentity(JSON.stringify(protectedIdentity()));
+    assert.throws(
+      () => validateWorkflowRun(identity, runFixture(identity, overrides)),
+      /mismatch|ambiguous/,
+    );
+  });
+}
+
+for (const [name, tagRef, message] of [
+  [
+    "deleted tag",
+    undefined,
+    /tag ref mismatch/,
+  ],
+  [
+    "annotated tag",
+    {
+      ref: `refs/tags/${tag}`,
+      object: { type: "tag", sha },
+    },
+    /lightweight tag/,
+  ],
+  [
+    "moved tag",
+    {
+      ref: `refs/tags/${tag}`,
+      object: { type: "commit", sha: "b".repeat(40) },
+    },
+    /moved after approval/,
+  ],
+]) {
+  test(`rejects ${name === "annotated tag" ? "an" : "a"} ${name} after workflow approval`, async () => {
+    const identity = protectedIdentity();
+    await assert.rejects(
+      verifyTrustedToolingIdentity({
+        rawIdentity: JSON.stringify(identity),
+        env: callerEnv(identity),
+        getJson: async (path) =>
+          path.includes("/actions/runs/") ? runFixture(identity) : tagRef,
+      }),
+      message,
+    );
+  });
+}
+
+test("rejects a main workflow SHA removed from current main lineage", async () => {
+  const identity = mainIdentity();
+  await assert.rejects(
+    verifyTrustedToolingIdentity({
+      rawIdentity: JSON.stringify(identity),
+      env: callerEnv(identity),
+      getJson: async (path) =>
+        path.includes("/actions/runs/")
+          ? runFixture(identity)
+          : { status: "diverged", merge_base_commit: { sha: "b".repeat(40) } },
+    }),
+    /no longer reachable/,
+  );
+});

--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -115,6 +115,11 @@ on:
         required: false
         type: string
         default: clawhub-package-publish-json
+      trusted_tooling_identity_json:
+        description: Optional versioned trusted tooling workflow identity JSON to revalidate immediately before publication.
+        required: false
+        type: string
+        default: ""
     secrets:
       clawhub_token:
         required: false
@@ -693,6 +698,15 @@ jobs:
           name: ${{ inputs.inspector_artifact_name }}
           path: ${{ runner.temp }}/plugin-inspector
           if-no-files-found: ignore
+
+      - name: Revalidate trusted tooling identity
+        if: inputs.trusted_tooling_identity_json != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TRUSTED_TOOLING_IDENTITY_JSON: ${{ inputs.trusted_tooling_identity_json }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+        run: node "$GITHUB_WORKSPACE/clawhub-source/.github/scripts/verify-trusted-tooling-identity.cjs"
 
       - name: Run package publish
         run: |

--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -705,6 +705,13 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           TRUSTED_TOOLING_IDENTITY_JSON: ${{ inputs.trusted_tooling_identity_json }}
           GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}
+          GITHUB_WORKFLOW_REF: ${{ github.workflow_ref }}
+          GITHUB_WORKFLOW_SHA: ${{ github.workflow_sha }}
+          GITHUB_REF: ${{ github.ref }}
+          GITHUB_REF_NAME: ${{ github.ref_name }}
+          GITHUB_SHA: ${{ github.sha }}
           GITHUB_EVENT_NAME: ${{ github.event_name }}
         run: node "$GITHUB_WORKSPACE/clawhub-source/.github/scripts/verify-trusted-tooling-identity.cjs"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixes
 
+- GitHub Actions: revalidate versioned trusted tooling workflow identity immediately before package publication, including exact protected lightweight tags, so approval waits cannot authorize moved tooling.
 - CI: authenticate the scheduled project-skill updater's pull request mutations with the Barnacle GitHub App while retaining the workflow token for provenance lookup and branch publication.
 - Workers: materialize zero-byte directory markers without colliding with descendant files, while retaining real empty files and verifying every downloaded artifact digest.
 - Deploy: allow an explicitly confirmed backend-only deploy to pause and reliably restore active external-skill rollouts instead of requiring a manual dashboard toggle.

--- a/scripts/security/package-publish-workflow.test.ts
+++ b/scripts/security/package-publish-workflow.test.ts
@@ -40,6 +40,10 @@ describe("package publish reusable workflow", () => {
       type: "number",
       default: 30,
     });
+    expect(workflow.on?.workflow_call?.inputs?.trusted_tooling_identity_json).toMatchObject({
+      type: "string",
+      default: "",
+    });
 
     const job = workflow.jobs.publish;
     expect(job["timeout-minutes"]).toBe(75);
@@ -68,5 +72,19 @@ describe("package publish reusable workflow", () => {
       WAIT_FOR_PUBLICATION: "${{ inputs.wait_for_publication }}",
     });
     expect(captureStep?.run).toContain('parsed.get("publicationStatus") != "published"');
+
+    const verifyIndex = job.steps.findIndex(
+      (step) => step.name === "Revalidate trusted tooling identity",
+    );
+    const publishIndex = job.steps.findIndex((step) => step.name === "Run package publish");
+    const verifyStep = job.steps[verifyIndex];
+    expect(verifyIndex + 1).toBe(publishIndex);
+    expect(verifyStep?.env).toMatchObject({
+      GH_TOKEN: "${{ github.token }}",
+      TRUSTED_TOOLING_IDENTITY_JSON: "${{ inputs.trusted_tooling_identity_json }}",
+      GITHUB_REPOSITORY: "${{ github.repository }}",
+      GITHUB_EVENT_NAME: "${{ github.event_name }}",
+    });
+    expect(verifyStep?.run).toContain("verify-trusted-tooling-identity.cjs");
   });
 });

--- a/scripts/security/package-publish-workflow.test.ts
+++ b/scripts/security/package-publish-workflow.test.ts
@@ -83,6 +83,10 @@ describe("package publish reusable workflow", () => {
       GH_TOKEN: "${{ github.token }}",
       TRUSTED_TOOLING_IDENTITY_JSON: "${{ inputs.trusted_tooling_identity_json }}",
       GITHUB_REPOSITORY: "${{ github.repository }}",
+      GITHUB_RUN_ID: "${{ github.run_id }}",
+      GITHUB_RUN_ATTEMPT: "${{ github.run_attempt }}",
+      GITHUB_WORKFLOW_REF: "${{ github.workflow_ref }}",
+      GITHUB_WORKFLOW_SHA: "${{ github.workflow_sha }}",
       GITHUB_EVENT_NAME: "${{ github.event_name }}",
     });
     expect(verifyStep?.run).toContain("verify-trusted-tooling-identity.cjs");

--- a/specs/package-publish-tooling-identity.md
+++ b/specs/package-publish-tooling-identity.md
@@ -7,22 +7,24 @@ tooling across a moving default branch.
 The version 1 object contains exactly:
 
 - `version`: `1`
-- `repository`: trusted tooling `owner/repo`
-- `workflow`: trusted tooling workflow path under `.github/workflows/`
-- `runId` and `runAttempt`: positive decimal strings for the trusted tooling
-  workflow execution
-- `ref` and `fullRef`: either `main` / `refs/heads/main` or an exact
-  `release-publish/<sha12>-<decimal>` lightweight tag
-- `sha`: the exact trusted tooling workflow commit
+- `repository`: invoking workflow `owner/repo`
+- `workflow`: invoking workflow path under `.github/workflows/`
+- `runId` and `runAttempt`: positive decimal strings for the invoking workflow
+  execution
+- `ref`, `fullRef`, and `sha`: exact invoking workflow ref and commit
+- `toolingRef`, `toolingFullRef`, and `toolingSha`: either `main` /
+  `refs/heads/main` plus its trusted commit, or an exact
+  `release-publish/<sha12>-<decimal>` lightweight tag and commit
 
 The decimal suffix on a protected tooling tag records tag-creation provenance.
-It is intentionally distinct from the later approving workflow `runId`.
+It is intentionally distinct from the invoking publish workflow `runId`.
 
-When present, the workflow requires the caller repository to match the tuple,
-then verifies the trusted tooling run directly through GitHub. Immediately
-before package publication, it then:
+When present, the workflow binds the tuple to the live invoking GitHub context
+and re-reads that exact workflow run through GitHub. Immediately before package
+publication, it then:
 
-- requires the main-route SHA to remain an ancestor of current `main`; or
+- requires the main-route tooling SHA to remain an ancestor of current `main`;
+  or
 - re-reads the protected tag and requires an exact lightweight
   tag-to-commit match.
 

--- a/specs/package-publish-tooling-identity.md
+++ b/specs/package-publish-tooling-identity.md
@@ -1,0 +1,35 @@
+# Package Publish Tooling Identity
+
+The reusable package publish workflow may receive
+`trusted_tooling_identity_json` when a caller must preserve reviewed workflow
+tooling across a moving default branch.
+
+The version 1 object contains exactly:
+
+- `version`: `1`
+- `repository`: trusted tooling `owner/repo`
+- `workflow`: trusted tooling workflow path under `.github/workflows/`
+- `runId` and `runAttempt`: positive decimal strings for the trusted tooling
+  workflow execution
+- `ref` and `fullRef`: either `main` / `refs/heads/main` or an exact
+  `release-publish/<sha12>-<decimal>` lightweight tag
+- `sha`: the exact trusted tooling workflow commit
+
+The decimal suffix on a protected tooling tag records tag-creation provenance.
+It is intentionally distinct from the later approving workflow `runId`.
+
+When present, the workflow requires the caller repository to match the tuple,
+then verifies the trusted tooling run directly through GitHub. Immediately
+before package publication, it then:
+
+- requires the main-route SHA to remain an ancestor of current `main`; or
+- re-reads the protected tag and requires an exact lightweight
+  tag-to-commit match.
+
+Moved, deleted, or annotated tags fail closed. A wrong repository, run,
+attempt, workflow, event, ref, or SHA also fails closed. A same-name branch
+does not satisfy the protected-tag route. Unknown fields and future versions
+also fail closed so contract evolution remains explicit.
+
+The input is optional for compatibility with ordinary reusable-workflow
+callers. Release workflows that depend on frozen tooling must supply it.

--- a/src/__tests__/package-publish-workflow.test.ts
+++ b/src/__tests__/package-publish-workflow.test.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
@@ -185,6 +186,66 @@ describe("package publish workflow", () => {
     );
     expect(workflow).not.toContain("Prebuilt artifact mode does not accept source_path");
     expect(workflow).toContain('cmd += ["--source-path", source_path]');
+  });
+
+  it("revalidates a supplied trusted tooling tuple immediately before publication", () => {
+    const workflowText = readFileSync(resolve(".github/workflows/package-publish.yml"), "utf8");
+    const workflow = parseYaml(workflowText) as {
+      on?: {
+        workflow_call?: {
+          inputs?: Record<
+            string,
+            { default?: boolean | number | string; required?: boolean; type?: string }
+          >;
+        };
+      };
+      jobs?: {
+        publish?: {
+          steps?: Array<{
+            env?: Record<string, string>;
+            if?: string;
+            name?: string;
+            run?: string;
+          }>;
+        };
+      };
+    };
+    const steps = workflow.jobs?.publish?.steps ?? [];
+    const verifyIndex = steps.findIndex(
+      (step) => step.name === "Revalidate trusted tooling identity",
+    );
+    const publishIndex = steps.findIndex((step) => step.name === "Run package publish");
+    const verifyStep = steps[verifyIndex];
+
+    expect(workflow.on?.workflow_call?.inputs?.trusted_tooling_identity_json).toEqual({
+      description:
+        "Optional versioned trusted tooling workflow identity JSON to revalidate immediately before publication.",
+      required: false,
+      type: "string",
+      default: "",
+    });
+    expect(verifyIndex).toBeGreaterThan(-1);
+    expect(verifyIndex + 1).toBe(publishIndex);
+    expect(verifyStep?.if).toBe("inputs.trusted_tooling_identity_json != ''");
+    expect(verifyStep?.env).toMatchObject({
+      GH_TOKEN: "${{ github.token }}",
+      TRUSTED_TOOLING_IDENTITY_JSON: "${{ inputs.trusted_tooling_identity_json }}",
+      GITHUB_REPOSITORY: "${{ github.repository }}",
+      GITHUB_EVENT_NAME: "${{ github.event_name }}",
+    });
+    expect(verifyStep?.run).toContain("verify-trusted-tooling-identity.cjs");
+  });
+
+  it("passes the trusted tooling identity behavior contract", () => {
+    const result = spawnSync(
+      process.execPath,
+      ["--test", ".github/scripts/verify-trusted-tooling-identity.node-test.cjs"],
+      { encoding: "utf8" },
+    );
+
+    expect(result.status, result.stderr || result.stdout).toBe(0);
+    expect(result.stdout).toMatch(/# tests [1-9][0-9]*/);
+    expect(result.stdout).toContain("# fail 0");
   });
 
   it("forwards optional catalog metadata and changelog inputs", () => {

--- a/src/__tests__/package-publish-workflow.test.ts
+++ b/src/__tests__/package-publish-workflow.test.ts
@@ -231,6 +231,13 @@ describe("package publish workflow", () => {
       GH_TOKEN: "${{ github.token }}",
       TRUSTED_TOOLING_IDENTITY_JSON: "${{ inputs.trusted_tooling_identity_json }}",
       GITHUB_REPOSITORY: "${{ github.repository }}",
+      GITHUB_RUN_ID: "${{ github.run_id }}",
+      GITHUB_RUN_ATTEMPT: "${{ github.run_attempt }}",
+      GITHUB_WORKFLOW_REF: "${{ github.workflow_ref }}",
+      GITHUB_WORKFLOW_SHA: "${{ github.workflow_sha }}",
+      GITHUB_REF: "${{ github.ref }}",
+      GITHUB_REF_NAME: "${{ github.ref_name }}",
+      GITHUB_SHA: "${{ github.sha }}",
       GITHUB_EVENT_NAME: "${{ github.event_name }}",
     });
     expect(verifyStep?.run).toContain("verify-trusted-tooling-identity.cjs");


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/pull/126881

## What Problem This Solves

Fixes an issue where a release approved from frozen tooling could reach the
ClawHub registry write after its protected tooling tag moved, was deleted, or
was replaced during the approval window.

## Why This Change Was Made

The reusable package-publish workflow now accepts an optional versioned
trusted-tooling tuple. Immediately before a real or dry-run publish command,
it binds the exact repository, invoking run and attempt, workflow, ref, and SHA
to both the current GitHub context and live Actions run, then separately
re-reads the protected lightweight tooling tag. The existing main route and
callers that do not opt into frozen tooling are unchanged.

The tuple's protected-tag decimal suffix remains tag-creation provenance; it is
not conflated with the invoking package-publish workflow run.

## User Impact

OpenClaw release operators can keep approved tooling frozen while `main`
continues moving, without allowing an approval wait to authorize moved or
substituted tooling. No package was published, tagged, or merged by this PR.

## Evidence

- `node --test .github/scripts/verify-trusted-tooling-identity.node-test.cjs`
  - 27 passed, 0 failed
  - covers main and protected-tag success, current-run replay rejection, plus
    moved, deleted, annotated, wrong-repository, wrong-run, wrong-attempt,
    wrong-workflow, wrong-ref, wrong-SHA, and same-name-branch rejection
- `node --check .github/scripts/verify-trusted-tooling-identity.cjs`
- `oxfmt --check` for both dependency-free verifier files
- `git diff --check`
- Live contract check: GitHub's run-attempt endpoint exposes repository, run
  attempt, workflow path, head branch, head SHA, and event; the exact Git-ref
  endpoint exposes the lightweight `commit` object required at the final
  boundary.
- Initial Blacksmith run
  https://github.com/openclaw/clawhub/actions/runs/32436494551 passed all
  browser shards and the OpenClaw contract job, then stopped at formatter
  findings in the two new CJS files before later aggregate gates ran.
- Exact-head Blacksmith run
  https://github.com/openclaw/clawhub/actions/runs/32437547169 passed:
  - aggregate static checks
  - unit coverage
  - package checks
  - typecheck and build
  - HTTP E2E
  - ClawHub to OpenClaw contract proof
  - browser smoke and all seven local-auth shards
