### PR TITLE
feat: stage publisher signal indexes

### DIFF
--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -4109,16 +4109,6 @@ const publisherAbuseSignals = defineTable({
   notificationClaimedAt: v.optional(v.number()),
   lastNotifiedAt: v.optional(v.number()),
   lastNotificationError: v.optional(v.string()),
-  attentionState: v.optional(
-    v.union(
-      v.literal("needs_attention"),
-      v.literal("awaiting_owner"),
-      v.literal("contact_failed"),
-      v.literal("not_contacted"),
-      v.literal("none"),
-    ),
-  ),
-  needsAttention: v.optional(v.boolean()),
 })
   .index("by_last_seen_at", ["lastSeenAt"])
   .index("by_signal_type_and_last_seen_at", ["signalType", "lastSeenAt"])
@@ -4130,14 +4120,6 @@ const publisherAbuseSignals = defineTable({
   .index("by_skill_and_signal_type", ["skillId", "signalType"])
   .index("by_skill_signal_type_and_owner_key", ["skillId", "signalType", "ownerKey"])
   .index("by_review_status_and_last_seen_at", ["reviewStatus", "lastSeenAt"])
-  .index("by_review_status_and_attention_state_and_last_seen_at", {
-    fields: ["reviewStatus", "attentionState", "lastSeenAt"],
-    staged: true,
-  })
-  .index("by_review_status_and_needs_attention_and_last_seen_at", {
-    fields: ["reviewStatus", "needsAttention", "lastSeenAt"],
-    staged: true,
-  })
   .index("by_needs_notification_and_last_changed_at", ["needsNotification", "lastChangedAt"])
   .index("by_needs_notification_and_notification_claimed_at", [
     "needsNotification",

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -4113,6 +4113,10 @@ const publisherAbuseSignals = defineTable({
   .index("by_last_seen_at", ["lastSeenAt"])
   .index("by_signal_type_and_last_seen_at", ["signalType", "lastSeenAt"])
   .index("by_owner_key_and_last_seen_at", ["ownerKey", "lastSeenAt"])
+  .index("by_latest_run_id_and_last_seen_at", {
+    fields: ["latestRunId", "lastSeenAt"],
+    staged: true,
+  })
   .index("by_owner_key_and_signal_type", {
     fields: ["ownerKey", "signalType"],
     staged: true,

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -3885,6 +3885,7 @@ const publisherAbuseTemporalScanScoreValidator = v.object({
 
 const publisherAbuseTemporalScanCandidates = defineTable({
   runId: v.id("publisherAbuseScoreRuns"),
+  synchronyEligible: v.optional(v.boolean()),
   ownerKey: v.string(),
   ownerPublisherId: v.optional(v.id("publishers")),
   ownerUserId: v.optional(v.id("users")),
@@ -3898,6 +3899,10 @@ const publisherAbuseTemporalScanCandidates = defineTable({
   expirationTime: v.number(),
 })
   .index("by_run_id", ["runId"])
+  .index("by_run_id_and_synchrony_eligible_and_owner_key", {
+    fields: ["runId", "synchronyEligible", "ownerKey"],
+    staged: true,
+  })
   .index("by_expiration_time", ["expirationTime"]);
 
 const publisherAbuseScores = defineTable({
@@ -4113,10 +4118,6 @@ const publisherAbuseSignals = defineTable({
   .index("by_last_seen_at", ["lastSeenAt"])
   .index("by_signal_type_and_last_seen_at", ["signalType", "lastSeenAt"])
   .index("by_owner_key_and_last_seen_at", ["ownerKey", "lastSeenAt"])
-  .index("by_latest_run_id_and_last_seen_at", {
-    fields: ["latestRunId", "lastSeenAt"],
-    staged: true,
-  })
   .index("by_owner_key_and_signal_type", {
     fields: ["ownerKey", "signalType"],
     staged: true,

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -4109,6 +4109,16 @@ const publisherAbuseSignals = defineTable({
   notificationClaimedAt: v.optional(v.number()),
   lastNotifiedAt: v.optional(v.number()),
   lastNotificationError: v.optional(v.string()),
+  attentionState: v.optional(
+    v.union(
+      v.literal("needs_attention"),
+      v.literal("awaiting_owner"),
+      v.literal("contact_failed"),
+      v.literal("not_contacted"),
+      v.literal("none"),
+    ),
+  ),
+  needsAttention: v.optional(v.boolean()),
 })
   .index("by_last_seen_at", ["lastSeenAt"])
   .index("by_signal_type_and_last_seen_at", ["signalType", "lastSeenAt"])
@@ -4120,6 +4130,14 @@ const publisherAbuseSignals = defineTable({
   .index("by_skill_and_signal_type", ["skillId", "signalType"])
   .index("by_skill_signal_type_and_owner_key", ["skillId", "signalType", "ownerKey"])
   .index("by_review_status_and_last_seen_at", ["reviewStatus", "lastSeenAt"])
+  .index("by_review_status_and_attention_state_and_last_seen_at", {
+    fields: ["reviewStatus", "attentionState", "lastSeenAt"],
+    staged: true,
+  })
+  .index("by_review_status_and_needs_attention_and_last_seen_at", {
+    fields: ["reviewStatus", "needsAttention", "lastSeenAt"],
+    staged: true,
+  })
   .index("by_needs_notification_and_last_changed_at", ["needsNotification", "lastChangedAt"])
   .index("by_needs_notification_and_notification_claimed_at", [
     "needsNotification",

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -3842,10 +3842,15 @@ const publisherAbuseTemporalScanSamples = defineTable({
   runId: v.id("publisherAbuseScoreRuns"),
   recent30Downloads: v.number(),
   spikeMultiplier: v.number(),
+  excess7Downloads: v.optional(v.number()),
   expirationTime: v.number(),
 })
   .index("by_run_id_and_recent30_downloads", ["runId", "recent30Downloads"])
   .index("by_run_id_and_spike_multiplier", ["runId", "spikeMultiplier"])
+  .index("by_run_id_and_excess7_downloads", {
+    fields: ["runId", "excess7Downloads"],
+    staged: true,
+  })
   .index("by_expiration_time", ["expirationTime"]);
 
 const publisherAbuseTemporalScanScoreValidator = v.object({
@@ -4108,6 +4113,10 @@ const publisherAbuseSignals = defineTable({
   .index("by_last_seen_at", ["lastSeenAt"])
   .index("by_signal_type_and_last_seen_at", ["signalType", "lastSeenAt"])
   .index("by_owner_key_and_last_seen_at", ["ownerKey", "lastSeenAt"])
+  .index("by_owner_key_and_signal_type", {
+    fields: ["ownerKey", "signalType"],
+    staged: true,
+  })
   .index("by_skill_and_signal_type", ["skillId", "signalType"])
   .index("by_skill_signal_type_and_owner_key", ["skillId", "signalType", "ownerKey"])
   .index("by_review_status_and_last_seen_at", ["reviewStatus", "lastSeenAt"])

--- a/specs/security-moderation.md
+++ b/specs/security-moderation.md
@@ -80,6 +80,13 @@ See also: [acceptable-usage.md](./acceptable-usage.md) for the marketplace polic
   recovery continues the same durable run instead of replacing it, and
   cursor-guarded writes prevent overlapping late workers from duplicating work.
   Explicitly bounded manual scans remain diagnostic-only.
+  New scan indexes must ship in a staging-only release before any function
+  queries them. Keep the indexes marked `staged: true`, deploy that schema,
+  and wait until Convex reports every index ready. Only a later release may
+  activate and query them. This applies to
+  `by_run_id_and_excess7_downloads`,
+  `by_run_id_and_synchrony_eligible_and_owner_key`, and
+  `by_owner_key_and_signal_type`.
   The `review` label remains a calibration/manual-review signal. The
   `potential_ban_candidate` label is an
   enforcement signal only for pressure-score nominations: the first eligible


### PR DESCRIPTION
The detector in #3493 needs three database indexes that production does not have yet. This PR lets Convex build those indexes before any code tries to query them.

**Stack position: 1 of 2.** `main` → **#3501** → #3493.

## What this PR stages

| Index | Why #3493 needs it |
| --- | --- |
| `by_run_id_and_excess7_downloads` | Calculates the platform's extra-download percentiles. |
| `by_run_id_and_synchrony_eligible_and_owner_key` | Reads temporary publisher-pattern candidates from the current scan. |
| `by_owner_key_and_signal_type` | Updates one publisher signal in place. |

There are no query consumers here. The rollout rule is recorded in `specs/security-moderation.md`: deploy these indexes with `staged: true`, wait until all three report ready, then activate and query them in #3493.

## Rollout

![Three-step rollout: deploy staged indexes, wait for Convex, then deploy the detector](https://github.com/user-attachments/assets/87b3c932-ddb0-4284-8147-1f759d606d5b)

*What this explains: #3501 prepares the database; #3493 only starts the detector after the indexes are ready.*

## Proof

```text
staged indexes added: 3
active indexes added: 0
query consumers added: 0
rollout rule recorded in specs: yes
production deployment performed: no
```

## Code size

| Part | Files | +LOC | -LOC |
| --- | ---: | ---: | ---: |
| Schema staging | 1 | +14 | 0 |
| Rollout specification | 1 | +7 | 0 |
| **Total** | **2** | **+21** | **0** |

## Validation

- Exact head: `565bb8c61406b9328981e7ab65909bc33efca88e`.
- Exact-head review: two native clean passes and one fresh cold review across both changed files; no findings.
- GitHub Actions passed, including static, unit, types/build, packages, HTTP end-to-end, Playwright smoke, and local-auth coverage.
- No production deployment or production data change occurred.

This PR remains a draft until the required sign-off reaction is present.
