### PR TITLE
fix(api): route direct downloads through Nitro

### DIFF
--- a/convex/downloads.test.ts
+++ b/convex/downloads.test.ts
@@ -133,6 +133,39 @@ describe("downloads helpers", () => {
     expect(runQuery).not.toHaveBeenCalled();
   });
 
+  it("keeps local direct downloads on the local Convex handler", async () => {
+    vi.stubEnv("CONVEX_DEPLOYMENT", "anonymous:anonymous-clawhub-test");
+    vi.stubEnv("SITE_URL", "http://127.0.0.1:3000");
+    const runMutation = vi.fn(async () => okRate());
+    const runQuery = vi.fn(async () => null);
+
+    const response = await downloadZipHandler(
+      { runMutation, runQuery } as unknown as ActionCtx,
+      new Request("http://127.0.0.1:3211/api/v1/download?slug=demo"),
+    );
+
+    expect(response.status).toBe(404);
+    expect(response.headers.get("Location")).toBeNull();
+    expect(runMutation).toHaveBeenCalled();
+    expect(runQuery).toHaveBeenCalledOnce();
+  });
+
+  it("redirects direct downloads from a hosted Convex custom domain", async () => {
+    vi.stubEnv("SITE_URL", "https://clawhub.ai");
+    const runMutation = vi.fn(async () => okRate());
+    const runQuery = vi.fn(async () => null);
+
+    const response = await downloadZipHandler(
+      { runMutation, runQuery } as unknown as ActionCtx,
+      new Request("https://api.clawhub.example/api/v1/download?slug=demo"),
+    );
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("Location")).toBe("https://clawhub.ai/api/v1/download?slug=demo");
+    expect(runMutation).not.toHaveBeenCalled();
+    expect(runQuery).not.toHaveBeenCalled();
+  });
+
   it("schedules zip download stats outside the response path", async () => {
     vi.stubEnv("TRUST_FORWARDED_IPS", "true");
 

--- a/convex/downloads.test.ts
+++ b/convex/downloads.test.ts
@@ -112,6 +112,27 @@ describe("downloads helpers", () => {
     expect(__test.getDownloadIdentityValue(request, null)).toBeNull();
   });
 
+  it("redirects direct production downloads to the Nitro streaming owner", async () => {
+    vi.stubEnv("CONVEX_DEPLOYMENT", "prod:wry-manatee-359");
+    vi.stubEnv("SITE_URL", "");
+    vi.stubEnv("VITE_SITE_URL", "");
+    const runMutation = vi.fn(async () => okRate());
+    const runQuery = vi.fn(async () => null);
+
+    const response = await downloadZipHandler(
+      { runMutation, runQuery } as unknown as ActionCtx,
+      new Request("https://wry-manatee-359.convex.site/api/v1/download?slug=demo&version=1.0.0"),
+    );
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("Location")).toBe(
+      "https://clawhub.ai/api/v1/download?slug=demo&version=1.0.0",
+    );
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(runMutation).not.toHaveBeenCalled();
+    expect(runQuery).not.toHaveBeenCalled();
+  });
+
   it("schedules zip download stats outside the response path", async () => {
     vi.stubEnv("TRUST_FORWARDED_IPS", "true");
 

--- a/convex/downloads.ts
+++ b/convex/downloads.ts
@@ -46,6 +46,7 @@ const ARCHIVE_MANIFEST_CLOCK_SKEW_MS = 5_000;
 const MAX_ARCHIVE_MANIFEST_FILES = 8_192;
 const MAX_ARCHIVE_MANIFEST_BYTES = 4 * 1024 * 1024;
 const MAX_ARCHIVE_METRIC_TOKEN_BYTES = 16 * 1024;
+const LOCAL_DOWNLOAD_HOSTS = new Set(["localhost", "127.0.0.1", "0.0.0.0", "[::1]"]);
 
 type DownloadCtx = Parameters<Parameters<typeof httpAction>[0]>[0];
 
@@ -83,7 +84,8 @@ export async function downloadZipHandler(
 
   const manifestRequested = request.headers.get(ARCHIVE_MANIFEST_REQUEST_HEADER) === "v1";
   const publicOrigin = publicApiOrigin(request);
-  if (!manifestRequested && publicOrigin !== url.origin) {
+  const isLocalDownload = LOCAL_DOWNLOAD_HOSTS.has(url.hostname);
+  if (!manifestRequested && !isLocalDownload && publicOrigin !== url.origin) {
     return new Response(null, {
       status: 307,
       headers: mergeHeaders(

--- a/convex/downloads.ts
+++ b/convex/downloads.ts
@@ -2,7 +2,7 @@ import { api, internal } from "./_generated/api";
 import type { Id } from "./_generated/dataModel";
 import { buildDownloadMetricArgs, getDownloadIdentity } from "./downloadMetrics";
 import { httpAction } from "./functions";
-import { ambiguousSkillSlugResponse } from "./httpApiV1/shared";
+import { ambiguousSkillSlugResponse, publicApiOrigin } from "./httpApiV1/shared";
 import { getOptionalActiveAuthUserIdFromAction } from "./lib/access";
 import { getOptionalApiTokenUserId } from "./lib/apiTokenAuth";
 import {
@@ -82,6 +82,19 @@ export async function downloadZipHandler(
   }
 
   const manifestRequested = request.headers.get(ARCHIVE_MANIFEST_REQUEST_HEADER) === "v1";
+  const publicOrigin = publicApiOrigin(request);
+  if (!manifestRequested && publicOrigin !== url.origin) {
+    return new Response(null, {
+      status: 307,
+      headers: mergeHeaders(
+        {
+          Location: new URL(`${url.pathname}${url.search}`, publicOrigin).href,
+          "Cache-Control": "no-store",
+        },
+        corsHeaders(),
+      ),
+    });
+  }
   if (manifestRequested) {
     const token = request.headers.get(ARCHIVE_REQUEST_IDENTITY_HEADER)?.trim();
     const expectedEnvironment = expectedVercelEnvironmentForConvexSite(request.url);

--- a/specs/spec.md
+++ b/specs/spec.md
@@ -169,7 +169,7 @@ Local fixture data lives in `convex/devSeed.ts` and `fixtures/public-corpus/`.
 - Nitro streams those source files into the deterministic ZIP with backpressure
   and owns the public response headers. Archive bytes must not pass through a
   Convex HTTP action because those responses are capped at 20 MiB.
-- Direct requests to a production Convex-site download URL redirect to the
+- Direct requests to a hosted Convex-site download URL redirect to the
   canonical public API origin before rate limiting, database reads, or storage
   access so the archive still crosses the Nitro manifest boundary.
 - The manifest is an internal server-to-server capability, not a client token.

--- a/specs/spec.md
+++ b/specs/spec.md
@@ -169,6 +169,9 @@ Local fixture data lives in `convex/devSeed.ts` and `fixtures/public-corpus/`.
 - Nitro streams those source files into the deterministic ZIP with backpressure
   and owns the public response headers. Archive bytes must not pass through a
   Convex HTTP action because those responses are capped at 20 MiB.
+- Direct requests to a production Convex-site download URL redirect to the
+  canonical public API origin before rate limiting, database reads, or storage
+  access so the archive still crosses the Nitro manifest boundary.
 - The manifest is an internal server-to-server capability, not a client token.
   Nitro overwrites the internal request headers and authenticates to Convex with
   its Vercel OIDC identity; Convex verifies the Vercel signature plus the exact


### PR DESCRIPTION
## Summary

- redirect direct production Convex-site download requests to the canonical ClawHub API origin before rate limiting, database reads, or storage access
- keep authenticated Nitro manifest requests and explicit loopback downloads on their existing paths while covering hosted Convex custom domains
- document that all production archive bytes must cross the existing signed Convex-to-Nitro manifest boundary

## Evidence

- Axiom recorded 2,029 `HttpResponseTooLarge` failures for direct `GET /api/v1/download` in `2026-08-20T15:19:31Z..2026-08-21T17:54:10Z`, through `2026-08-21T17:09:27Z`, at Convex's 20 MiB response ceiling.
- [#3451](https://github.com/openclaw/clawhub/pull/3451) and [#3498](https://github.com/openclaw/clawhub/pull/3498) are merged; there is no open duplicate download-streaming PR.
- Current `main` at `845c6d3bdb1a36573d8d28be2a8fb85a3c476720` still returned the direct ZIP body from `convex/downloads.ts` when the internal manifest header was absent.
- Red: the public-handler regression expected `307` and received `404` after the request entered Convex backend work.
- Green: the same request redirects to `https://clawhub.ai/api/v1/download` with its query intact and performs no rate-limit mutation or database query.
- First-head hosted red: local-auth version deletion expected direct local Convex status `410` and received `503` because the redirect also caught loopback. The final patch exempts only explicit loopback hosts; a custom-domain regression proves non-local hosted origins still redirect.

## Validation

- `bunx vitest run convex/downloads.test.ts server/convexProxy.test.ts` - 56 passed
- three initially starved full-suite timeout cases rerun individually - 3 passed
- `bun run ci:static` - passed
- `bun run ci:unit` - 6,216 passed, 3 skipped; coverage gate passed
- `bun run ci:types-build` - passed
- `bun run ci:e2e-http` - passed
- `.agents/skills/autoreview/scripts/autoreview --mode local --stream-engine-output` - clean after one accepted custom-domain finding (0.96 confidence)

Local Convex function preparation was attempted against `127.0.0.1`; the copied fixture snapshot failed schema validation because it contains the unrelated `skillVersions.aigAnalysis` field missing from current `main`. No cloud deployment, production mutation, monitor change, merge, or release was performed.

Exact head: `f02c0bfa604b366a8cc0ee23e6ced7a1c337ac17`

Punchcard-Session: calm-lantern-orchard-96
