### PR TITLE
fix(workers): process skipped and failed skill evaluations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixes
 
+- API: record skipped and failed skill evaluation outcomes without passing worker tokens to internal mutations.
 - GitHub Actions/CLI/API: require v2 authorization for every OpenClaw OIDC publish, bind large-artifact upload tickets and package mutations to the exact authorization transaction, consume scoped capabilities with non-public staging, then require an immutable successful parent attempt and atomic durable authorization revalidation before final publication.
 - GitHub Actions: revalidate versioned trusted tooling workflow identity immediately before package publication, including exact protected lightweight tags, so approval waits cannot authorize moved tooling.
 - CI: authenticate the scheduled project-skill updater's pull request mutations with the Barnacle GitHub App while retaining the workflow token for provenance lookup and branch publication.

--- a/convex/skillEvaluations.runtime.test.ts
+++ b/convex/skillEvaluations.runtime.test.ts
@@ -378,4 +378,82 @@ describe("skill evaluation runtime queue", () => {
       skipReason: "stale-version",
     });
   });
+
+  it("terminalizes a claimed unsupported configuration through the worker action", async () => {
+    vi.stubEnv("SECURITY_SCAN_WORKER_TOKEN", "worker-token");
+    const t = convexTest(schema, modules);
+    const skillId = await insertNvidiaSkill(t, { hash: "current", slug: "unsupported" });
+    const runId = await t.run(
+      async (ctx) =>
+        await ctx.db.insert("skillEvaluationRuns", {
+          ...evaluationRow({
+            skillId,
+            contentHash: "current",
+            scanStatus: "clean",
+            source: "sync",
+          }),
+          evaluatorCommit: "unsupported",
+        }),
+    );
+    const [claimed] = await t.mutation(
+      internal.skillEvaluations.claimQueuedSkillEvaluationsInternal,
+      { workerId: "worker", limit: 1 },
+    );
+
+    await expect(
+      t.action(api.skillEvaluations.skipSkillEvaluation, {
+        token: "worker-token",
+        runId,
+        leaseToken: claimed.leaseToken,
+        reason: "unsupported-config: worker configuration changed",
+      }),
+    ).resolves.toEqual({ ok: true });
+    const run = await t.run(async (ctx) => await ctx.db.get(runId));
+    expect(run).toMatchObject({
+      status: "skipped",
+      skipReason: "unsupported-config: worker configuration changed",
+    });
+    expect(run).not.toHaveProperty("leaseToken");
+    expect(run).not.toHaveProperty("leaseExpiresAt");
+  });
+
+  it("applies the existing retry policy through the worker failure action", async () => {
+    vi.stubEnv("SECURITY_SCAN_WORKER_TOKEN", "worker-token");
+    const t = convexTest(schema, modules);
+    const skillId = await insertNvidiaSkill(t, { hash: "current", slug: "failed" });
+    const runId = await t.run(
+      async (ctx) =>
+        await ctx.db.insert(
+          "skillEvaluationRuns",
+          evaluationRow({
+            skillId,
+            contentHash: "current",
+            scanStatus: "clean",
+            source: "sync",
+          }),
+        ),
+    );
+    const [claimed] = await t.mutation(
+      internal.skillEvaluations.claimQueuedSkillEvaluationsInternal,
+      { workerId: "worker", limit: 1 },
+    );
+
+    await expect(
+      t.action(api.skillEvaluations.failSkillEvaluation, {
+        token: "worker-token",
+        runId,
+        leaseToken: claimed.leaseToken,
+        error: "evaluator failed",
+      }),
+    ).resolves.toEqual({ ok: true, retry: true });
+    const run = await t.run(async (ctx) => await ctx.db.get(runId));
+    expect(run).toMatchObject({
+      status: "queued",
+      attempts: 1,
+      lastError: "evaluator failed",
+    });
+    expect(run).not.toHaveProperty("leaseToken");
+    expect(run).not.toHaveProperty("leaseExpiresAt");
+    expect(run).not.toHaveProperty("completedAt");
+  });
 });

--- a/convex/skillEvaluations.ts
+++ b/convex/skillEvaluations.ts
@@ -471,7 +471,11 @@ export const skipSkillEvaluation = action({
     const result = await runMutationRef<{ ok: true }>(
       ctx,
       internalRefs.skillEvaluations.skipSkillEvaluationInternal,
-      args,
+      {
+        runId: args.runId,
+        leaseToken: args.leaseToken,
+        reason: args.reason,
+      },
     );
     await requestNextSkillEvaluationDispatch(ctx);
     return result;
@@ -490,7 +494,11 @@ export const failSkillEvaluation = action({
     const result = await runMutationRef<{ ok: true; retry: boolean }>(
       ctx,
       internalRefs.skillEvaluations.failSkillEvaluationInternal,
-      args,
+      {
+        runId: args.runId,
+        leaseToken: args.leaseToken,
+        error: args.error,
+      },
     );
     await requestNextSkillEvaluationDispatch(ctx);
     return result;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where skill evaluation workers could not record skipped or failed outcomes after claiming a run. The authenticated public actions forwarded their worker token into stricter internal mutations, so Convex rejected the payload before the existing lifecycle policy ran.

Unsupported evaluator configurations could therefore remain `running` until lease recovery instead of immediately becoming durable `skipped` outcomes with the existing `unsupported-config` reason.

## Why This Change Was Made

The public skip and fail actions still authenticate the worker token, then call their existing internal mutations with explicit token-free payloads. Existing public worker calls, validators, skip reasons, failure retry policy, dispatch behavior, schema, backfill, and worker scripts remain unchanged.

The Unreleased changelog records the corrected worker outcome handling.

## User Impact

Claimed evaluations with unsupported configurations now clear their lease and record the existing skipped reason immediately. Worker failures again follow the existing retry or terminal failure policy instead of failing Convex argument validation.

There is no UI or public payload shape change.

## Evidence

Focused runtime proof:

```text
PATH="$(brew --prefix node@24)/bin:$PATH" bun run test -- convex/skillEvaluations.runtime.test.ts
Test Files  1 passed (1)
Tests       11 passed (11)
```

The runtime tests exercise the exact public-action-to-internal-mutation boundary:

- A queued run with an unsupported evaluator configuration is claimed, then `api.skillEvaluations.skipSkillEvaluation` authenticates the public token and calls the internal mutation with only `runId`, `leaseToken`, and `reason`. The assertion verifies `status: "skipped"`, the existing `unsupported-config: worker configuration changed` reason, and cleared lease fields.
- A claimed run passed through `api.skillEvaluations.failSkillEvaluation` authenticates the public token and calls the internal mutation with only `runId`, `leaseToken`, and `error`. The assertion verifies the existing first-attempt retry policy, recorded error, and cleared lease fields without a validator error.

Additional checks:

```text
bunx tsc -p convex/tsconfig.json --noEmit
bunx oxlint --type-aware --tsconfig ./tsconfig.oxlint.json convex/skillEvaluations.ts convex/skillEvaluations.runtime.test.ts
bun run format:check -- CHANGELOG.md convex/skillEvaluations.ts convex/skillEvaluations.runtime.test.ts
git diff --check
```

Limits:

- No schema, backfill, retry-policy, validator, dispatch, or worker-script changes.
- No deployed worker smoke; `convex-test` covers the public action and internal mutation validator boundary directly.
