### PR TITLE
fix(publish): ignore duplicate leased recovery dispatches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@
 
 ### Fixes
 
-- Workers: treat targeted pre-publication attempts with active leases as no work instead of retrying another claim path.
 - GitHub Actions/CLI/API: require v2 authorization for every OpenClaw OIDC publish, bind large-artifact upload tickets and package mutations to the exact authorization transaction, consume scoped capabilities with non-public staging, then require an immutable successful parent attempt and atomic durable authorization revalidation before final publication.
 - GitHub Actions: revalidate versioned trusted tooling workflow identity immediately before package publication, including exact protected lightweight tags, so approval waits cannot authorize moved tooling.
 - CI: authenticate the scheduled project-skill updater's pull request mutations with the Barnacle GitHub App while retaining the workflow token for provenance lookup and branch publication.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixes
 
+- Workers: treat targeted pre-publication attempts with active leases as no work instead of retrying another claim path.
 - GitHub Actions/CLI/API: require v2 authorization for every OpenClaw OIDC publish, bind large-artifact upload tickets and package mutations to the exact authorization transaction, consume scoped capabilities with non-public staging, then require an immutable successful parent attempt and atomic durable authorization revalidation before final publication.
 - GitHub Actions: revalidate versioned trusted tooling workflow identity immediately before package publication, including exact protected lightweight tags, so approval waits cannot authorize moved tooling.
 - CI: authenticate the scheduled project-skill updater's pull request mutations with the Barnacle GitHub App while retaining the workflow token for provenance lookup and branch publication.

--- a/convex/publishAttempts.runtime.test.ts
+++ b/convex/publishAttempts.runtime.test.ts
@@ -1,13 +1,69 @@
 /// <reference types="vite/client" />
 /* @vitest-environment edge-runtime */
 import { convexTest } from "convex-test";
-import { describe, expect, it } from "vitest";
-import { internal } from "./_generated/api";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { api, internal } from "./_generated/api";
 import schema from "./schema";
 
 const modules = import.meta.glob("./**/*.ts");
 
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
 describe("publish attempt runtime recovery", () => {
+  it.each([
+    { checkStatus: "pending", status: "pending_checks" },
+    { checkStatus: "clean", status: "ready_to_finalize" },
+  ] as const)(
+    "returns null without mutating a targeted $status foreign lease",
+    async ({ checkStatus, status }) => {
+      vi.stubEnv("SECURITY_SCAN_WORKER_TOKEN", "runtime-worker-token");
+      const t = convexTest(schema, modules);
+      const checkClaimExpiresAt = Date.now() + 60_000;
+      const attemptId = await t.run(async (ctx) => {
+        const userId = await ctx.db.insert("users", {});
+        return await ctx.db.insert("publishAttempts", {
+          kind: "skill",
+          status,
+          userId,
+          slug: "active-foreign-lease",
+          displayName: "Active Foreign Lease",
+          version: "1.0.0",
+          idempotencyKey: `runtime-${status}`,
+          artifactFingerprint: "fingerprint",
+          files: [],
+          checks: {
+            trufflehog: { status: checkStatus },
+            clawscan: { status: checkStatus },
+          },
+          checkClaimId: "foreign-claim",
+          checkClaimedAt: 1,
+          checkClaimExpiresAt,
+          createdAt: 1,
+          updatedAt: 1,
+          expiresAt: checkClaimExpiresAt + 60_000,
+        });
+      });
+      const before = await t.run(async (ctx) => await ctx.db.get(attemptId));
+
+      await expect(
+        t.action(api.publishAttempts.claimPrePublicationChecks, {
+          token: "runtime-worker-token",
+          attemptId,
+          preferRetry: true,
+        }),
+      ).resolves.toBeNull();
+
+      const after = await t.run(async (ctx) => await ctx.db.get(attemptId));
+      expect(after).toEqual(before);
+      expect(after).toMatchObject({
+        checkClaimId: "foreign-claim",
+        checkClaimExpiresAt,
+      });
+    },
+  );
+
   it("reserves retry-first claims for expired attempts under sustained fresh traffic", async () => {
     const t = convexTest(schema, modules);
     const now = Date.now();

--- a/convex/publishAttempts.test.ts
+++ b/convex/publishAttempts.test.ts
@@ -104,6 +104,54 @@ function makeAttemptLookupCtx(
   };
 }
 
+function makeClaimCtx(attempt: Record<string, unknown>) {
+  return {
+    db: {
+      delete: vi.fn(),
+      get: vi.fn(async () => attempt),
+      insert: vi.fn(),
+      normalizeId: vi.fn(),
+      patch: vi.fn(),
+      query: vi.fn(),
+      replace: vi.fn(),
+      system: {},
+    },
+  };
+}
+
+const TARGETED_CLAIM_CASES = [
+  {
+    name: "pending-check",
+    handler: claimPendingChecksHandler,
+    status: "pending_checks",
+  },
+  {
+    name: "ready-finalization",
+    handler: claimReadyFinalizationHandler,
+    status: "ready_to_finalize",
+  },
+] as const;
+
+function makeTargetedClaimAttempt(
+  status: (typeof TARGETED_CLAIM_CASES)[number]["status"],
+  claimId: string,
+) {
+  return {
+    _id: "publishAttempts:targeted",
+    kind: "skill",
+    status,
+    userId: "users:publisher",
+    slug: "demo-skill",
+    displayName: "Demo Skill",
+    version: "1.0.0",
+    artifactFingerprint: "fingerprint",
+    files: [],
+    checkClaimId: claimId,
+    checkClaimExpiresAt: Date.now() + 60_000,
+    createdAt: Date.now(),
+  };
+}
+
 describe("publishAttempts", () => {
   it("returns a finalized package attempt only for the exact actor, owner, and artifact", async () => {
     const result = {
@@ -795,6 +843,71 @@ describe("publishAttempts", () => {
     ).resolves.toBeNull();
   });
 
+  it.each(TARGETED_CLAIM_CASES)(
+    "handles targeted $name lease contention and recovery",
+    async ({ handler, status }) => {
+      const foreignCtx = makeClaimCtx(makeTargetedClaimAttempt(status, "existing-claim"));
+      await expect(
+        handler(foreignCtx, {
+          attemptId: "publishAttempts:targeted",
+          claimId: "new-claim",
+        }),
+      ).resolves.toEqual({ outcome: "active_claim" });
+      expect(foreignCtx.db.patch).not.toHaveBeenCalled();
+
+      const sameClaimCtx = makeClaimCtx(makeTargetedClaimAttempt(status, "same-claim"));
+      await expect(
+        handler(sameClaimCtx, {
+          attemptId: "publishAttempts:targeted",
+          claimId: "same-claim",
+        }),
+      ).resolves.toMatchObject({
+        attemptId: "publishAttempts:targeted",
+        claimId: "same-claim",
+      });
+      expect(sameClaimCtx.db.patch).toHaveBeenCalledWith(
+        "publishAttempts:targeted",
+        expect.objectContaining({ checkClaimId: "same-claim" }),
+      );
+
+      const previousToken = process.env.SECURITY_SCAN_WORKER_TOKEN;
+      process.env.SECURITY_SCAN_WORKER_TOKEN = "worker-token";
+      const readyClaim = "publishAttempts:claimReadyPublishAttemptFinalizationRetryInternal";
+      const pendingClaim = "publishAttempts:claimPendingPublishAttemptChecksInternal";
+      const results =
+        status === "ready_to_finalize"
+          ? [{ outcome: "active_claim" }]
+          : [null, { outcome: "active_claim" }];
+      const ctx = {
+        runMutation: vi.fn(),
+        storage: {
+          getUrl: vi.fn(),
+        },
+      };
+      for (const result of results) ctx.runMutation.mockResolvedValueOnce(result);
+
+      try {
+        await expect(
+          claimPrePublicationChecksHandler(ctx, {
+            token: "worker-token",
+            attemptId: "publishAttempts:targeted",
+            preferRetry: true,
+          }),
+        ).resolves.toBeNull();
+      } finally {
+        if (previousToken === undefined) delete process.env.SECURITY_SCAN_WORKER_TOKEN;
+        else process.env.SECURITY_SCAN_WORKER_TOKEN = previousToken;
+      }
+
+      expect(
+        ctx.runMutation.mock.calls.map(([ref]) =>
+          getFunctionName(ref as Parameters<typeof getFunctionName>[0]),
+        ),
+      ).toEqual(status === "ready_to_finalize" ? [readyClaim] : [readyClaim, pendingClaim]);
+      expect(ctx.storage.getUrl).not.toHaveBeenCalled();
+    },
+  );
+
   it("skips ready-to-finalize attempts with an active retry lease", async () => {
     const ctx = {
       db: {
@@ -916,35 +1029,37 @@ describe("publishAttempts", () => {
     expect(ctx.db.patch).not.toHaveBeenCalled();
   });
 
-  it("rejects targeted ready-finalization claims with mismatched filters", async () => {
-    const ctx = {
-      db: {
-        delete: vi.fn(),
-        get: vi.fn(async () => ({
-          _id: "publishAttempts:ready",
-          status: "ready_to_finalize",
+  it.each(TARGETED_CLAIM_CASES)(
+    "rejects targeted $name claims with mismatched filters before active leases",
+    async ({ handler, status }) => {
+      const mismatches = [
+        [{ kind: "package" }, "Publish attempt kind does not match worker claim."],
+        [{ slug: "different-skill" }, "Publish attempt slug does not match worker claim."],
+        [{ version: "2.0.0" }, "Publish attempt version does not match worker claim."],
+      ] as const;
+
+      for (const [mismatch, message] of mismatches) {
+        const ctx = makeClaimCtx({
+          _id: "publishAttempts:targeted",
+          status,
           kind: "skill",
           slug: "expected-skill",
           version: "1.0.0",
-        })),
-        insert: vi.fn(),
-        normalizeId: vi.fn(),
-        patch: vi.fn(),
-        query: vi.fn(),
-        replace: vi.fn(),
-        system: {},
-      },
-    };
+          checkClaimId: "existing-claim",
+          checkClaimExpiresAt: Date.now() + 60_000,
+        });
 
-    await expect(
-      claimReadyFinalizationHandler(ctx, {
-        attemptId: "publishAttempts:ready",
-        claimId: "claim-1",
-        slug: "different-skill",
-      }),
-    ).rejects.toThrow("Publish attempt slug does not match worker claim.");
-    expect(ctx.db.patch).not.toHaveBeenCalled();
-  });
+        await expect(
+          handler(ctx, {
+            attemptId: "publishAttempts:targeted",
+            claimId: "new-claim",
+            ...mismatch,
+          }),
+        ).rejects.toThrow(message);
+        expect(ctx.db.patch).not.toHaveBeenCalled();
+      }
+    },
+  );
 
   it("lets worker completion retries reclaim expired finalization leases", async () => {
     const now = Date.now();

--- a/convex/publishAttempts.ts
+++ b/convex/publishAttempts.ts
@@ -11,6 +11,7 @@ const CHECK_CLAIM_LEASE_MS = 30 * 60 * 1000;
 const CHECK_RETRY_BACKOFF_MS = 5 * 60 * 1000;
 const MAX_CONSECUTIVE_SCANNER_FAILURES = 3;
 const FINALIZATION_CLAIM_LEASE_MS = 10 * 60 * 1000;
+const ACTIVE_CLAIM_OUTCOME = { outcome: "active_claim" as const };
 const PUBLISH_ATTEMPT_STATUSES = [
   "pending_checks",
   "ready_to_finalize",
@@ -915,9 +916,7 @@ export const claimPendingPublishAttemptChecksInternal = internalMutation({
         continue;
       }
       if ((attempt.checkClaimExpiresAt ?? 0) > now && attempt.checkClaimId !== args.claimId) {
-        if (args.attemptId) {
-          throw new ConvexError("Publish attempt checks are already claimed.");
-        }
+        if (args.attemptId) return ACTIVE_CLAIM_OUTCOME;
         continue;
       }
       if (await terminalizeUnavailableStagedTarget(ctx, attempt, now)) continue;
@@ -1027,9 +1026,7 @@ export const claimReadyPublishAttemptFinalizationRetryInternal = internalMutatio
         continue;
       }
       if ((attempt.checkClaimExpiresAt ?? 0) > now && attempt.checkClaimId !== args.claimId) {
-        if (args.attemptId) {
-          throw new ConvexError("Publish attempt finalization retry is already claimed.");
-        }
+        if (args.attemptId) return ACTIVE_CLAIM_OUTCOME;
         continue;
       }
       if (await terminalizeUnavailableStagedTarget(ctx, attempt, now)) continue;
@@ -1352,12 +1349,13 @@ export const claimPrePublicationChecks: ReturnType<typeof action> = action({
       slug: args.slug,
       version: args.version,
     };
-    const reservedRetry = args.preferRetry
-      ? await ctx.runMutation(internal.publishAttempts.claimPendingPublishAttemptChecksInternal, {
-          ...claimArgs,
-          retryOnly: true,
-        })
-      : null;
+    const reservedRetry =
+      args.preferRetry && !args.attemptId
+        ? await ctx.runMutation(internal.publishAttempts.claimPendingPublishAttemptChecksInternal, {
+            ...claimArgs,
+            retryOnly: true,
+          })
+        : null;
     const claimed = (reservedRetry ??
       (await ctx.runMutation(
         internal.publishAttempts.claimReadyPublishAttemptFinalizationRetryInternal,
@@ -1366,36 +1364,39 @@ export const claimPrePublicationChecks: ReturnType<typeof action> = action({
       (await ctx.runMutation(
         internal.publishAttempts.claimPendingPublishAttemptChecksInternal,
         claimArgs,
-      ))) as null | {
-      attemptId: Id<"publishAttempts">;
-      status: "pending_checks" | "ready_to_finalize";
-      claimId: string;
-      kind: "skill" | "package";
-      userId: Id<"users">;
-      ownerUserId?: Id<"users">;
-      ownerPublisherId?: Id<"publishers">;
-      sourceOwnerPublisherId?: Id<"publishers">;
-      skillId?: Id<"skills">;
-      versionId?: Id<"skillVersions">;
-      packageId?: Id<"packages">;
-      releaseId?: Id<"packageReleases">;
-      slug: string;
-      displayName: string;
-      version: string;
-      artifactFingerprint: string;
-      files: Array<{
-        path: string;
-        size: number;
-        storageId: Id<"_storage">;
-        sha256: string;
-        contentType?: string;
-      }>;
-      clawpackStorageId?: Id<"_storage">;
-      scanContext?: Record<string, unknown>;
-      checkClaimExpiresAt: number;
-      createdAt: number;
-    };
-    if (!claimed) return null;
+      ))) as
+      | null
+      | typeof ACTIVE_CLAIM_OUTCOME
+      | {
+          attemptId: Id<"publishAttempts">;
+          status: "pending_checks" | "ready_to_finalize";
+          claimId: string;
+          kind: "skill" | "package";
+          userId: Id<"users">;
+          ownerUserId?: Id<"users">;
+          ownerPublisherId?: Id<"publishers">;
+          sourceOwnerPublisherId?: Id<"publishers">;
+          skillId?: Id<"skills">;
+          versionId?: Id<"skillVersions">;
+          packageId?: Id<"packages">;
+          releaseId?: Id<"packageReleases">;
+          slug: string;
+          displayName: string;
+          version: string;
+          artifactFingerprint: string;
+          files: Array<{
+            path: string;
+            size: number;
+            storageId: Id<"_storage">;
+            sha256: string;
+            contentType?: string;
+          }>;
+          clawpackStorageId?: Id<"_storage">;
+          scanContext?: Record<string, unknown>;
+          checkClaimExpiresAt: number;
+          createdAt: number;
+        };
+    if (!claimed || "outcome" in claimed) return null;
 
     const files = await Promise.all(
       claimed.files.map(async (file) => ({

--- a/specs/security-moderation.md
+++ b/specs/security-moderation.md
@@ -327,6 +327,10 @@ See also: [acceptable-usage.md](./acceptable-usage.md) for the marketplace polic
   exact pre-publication worker through the production GitHub App as soon as the
   attempt becomes pending; the scheduled worker remains recovery for missed
   dispatches.
+- For pending-check and ready-finalization attempts, duplicate targeted recovery
+  against a live foreign lease returns no work. It preserves the existing claim
+  ID and expiry without falling through to another claim path; the same claim
+  may resume its own lease.
 - Authenticated package publishers can read only their own exact publish
   attempt, or the exact package and version authorized by a GitHub Actions
   publish token. The response exposes one normalized pending, published,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where workers recovering an exact staged publish could treat an active lease as a claim failure or fall through to another claim path when `preferRetry` was enabled.

## Why This Change Was Made

Targeted pending-check and ready-finalization claims now return an internal `active_claim` outcome for a live foreign lease, and the public worker action maps that outcome to `null`. Exact `attemptId` requests use status-aware claim ordering, while untargeted batches retain expired-retry preference. The durable security specification records the same no-op and lease-preservation invariant.

## User Impact

Duplicate recovery dispatches now report no available work without disturbing the active worker lease. Mismatched kind, slug, or version filters still fail, and the same claim can still recover its leased attempt.

## Evidence

- Real `convex-test` action calls prove exact pending and ready attempts with `preferRetry: true` return `null` while preserving the foreign claim ID, claim expiry, and complete stored attempt row.
- Focused unit tests prove the public action does not fall through to another claim path.
- The production and test bytes at this head are unchanged from `ce859551`, where these checks passed:
  - `bun run test convex/publishAttempts.test.ts` - 43 passed.
  - `NODE_OPTIONS=--localstorage-file=<tmp> bun run test convex/publishAttempts.runtime.test.ts` - 5 passed.
  - `bun run test scripts/security/run-prepublication-worker.test.ts -t "reserves one batch claim for expired retries, including filtered batches"` - 1 passed.
  - `bun run ci:static` - peer, audit, generated text, formatting, type-aware lint, dead-code, and workflow pin checks passed.
  - `bunx tsc --noEmit` - passed.
- The specification-only exact-head follow-up passed `git diff --check` and `bun run format:check -- specs/security-moderation.md`.

## Limits

- The PR changes exactly four files: production `+43/-42`, tests `+198/-27`, and specification `+4/-0`.
- No release-note or changelog changes remain.
- No schema, generated API, public response shape, or worker implementation changes.
- Untargeted `preferRetry` queue behavior is unchanged.
- The worker regression test file remains unchanged; its existing null-claim test is included above as integration proof.

## Contribution Note

AI-assisted implementation under maintainer-directed scope; the behavior and focused validation above were reviewed before submission.
