### PR TITLE
fix: surface a retryable error when the skills catalog fails to load

### DIFF
--- a/src/__tests__/skills-index.test.tsx
+++ b/src/__tests__/skills-index.test.tsx
@@ -1087,6 +1087,51 @@ describe("SkillsIndex", () => {
     },
   );
 
+  it("dispatches one first-page request when Try again is activated twice before it settles", async () => {
+    vi.stubGlobal("IntersectionObserver", undefined);
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      let settleRetry: (page: unknown) => void = () => {};
+      convexHttpMock.query
+        .mockRejectedValueOnce(new Error("temporary failure"))
+        .mockImplementationOnce(
+          () =>
+            new Promise((resolve) => {
+              settleRetry = resolve;
+            }),
+        )
+        .mockRejectedValue(new Error("duplicate retry dispatched"));
+
+      render(<SkillsIndex />);
+      await act(async () => {});
+
+      const retryButton = screen.getByRole("button", { name: "Try again" });
+      await act(async () => {
+        fireEvent.click(retryButton);
+        fireEvent.click(retryButton);
+      });
+
+      // Both activations land before React rerenders, so only the guard can keep the second
+      // one from starting a rival request that outlives the first.
+      expect(convexHttpMock.query).toHaveBeenCalledTimes(2);
+
+      await act(async () => {
+        settleRetry({
+          page: [makeListResult("recovered-skill", "Recovered Skill")],
+          hasMore: false,
+          nextCursor: null,
+        });
+      });
+
+      expect(convexHttpMock.query).toHaveBeenCalledTimes(2);
+      expect(screen.getByText("Recovered Skill")).toBeTruthy();
+      expect(screen.queryByRole("alert")).toBeNull();
+      expect(screen.queryByRole("button", { name: "Try again" })).toBeNull();
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
+  });
+
   it("keeps the first-page failure state when the retry fails again", async () => {
     vi.stubGlobal("IntersectionObserver", undefined);
     const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});

--- a/src/__tests__/skills-index.test.tsx
+++ b/src/__tests__/skills-index.test.tsx
@@ -1051,7 +1051,7 @@ describe("SkillsIndex", () => {
   });
 
   it.each(["new", "featured", "official"] as const)(
-    "keeps the %s first page retryable after a temporary fetch failure",
+    "surfaces a retryable failure on the %s first page after a temporary fetch failure",
     async (tab) => {
       searchMock = { tab };
       vi.stubGlobal("IntersectionObserver", undefined);
@@ -1069,20 +1069,64 @@ describe("SkillsIndex", () => {
         await act(async () => {});
 
         expect(screen.queryByText("No skills found")).toBeNull();
-        expect(screen.getByRole("button", { name: "Load more" })).toBeTruthy();
+        expect(screen.queryByRole("button", { name: "Load more" })).toBeNull();
+        expect(screen.getByRole("alert").textContent).toContain("Skills couldn't be loaded");
 
         await act(async () => {
-          fireEvent.click(screen.getByRole("button", { name: "Load more" }));
+          fireEvent.click(screen.getByRole("button", { name: "Try again" }));
         });
 
         expect(convexHttpMock.query).toHaveBeenCalledTimes(2);
+        expect(getLastListPageArgs().cursor ?? null).toBeNull();
         expect(screen.getByText("Recovered Skill")).toBeTruthy();
+        expect(screen.queryByRole("alert")).toBeNull();
         expect(screen.queryByRole("button", { name: "Load more" })).toBeNull();
       } finally {
         consoleErrorSpy.mockRestore();
       }
     },
   );
+
+  it("keeps the first-page failure state when the retry fails again", async () => {
+    vi.stubGlobal("IntersectionObserver", undefined);
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      convexHttpMock.query
+        .mockRejectedValueOnce(new Error("temporary failure"))
+        .mockRejectedValueOnce(new Error("still failing"));
+
+      render(<SkillsIndex />);
+      await act(async () => {});
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+      });
+
+      expect(convexHttpMock.query).toHaveBeenCalledTimes(2);
+      expect(screen.queryByText("No skills found")).toBeNull();
+      expect(screen.queryByRole("button", { name: "Load more" })).toBeNull();
+      expect(screen.getByRole("button", { name: "Try again" })).toBeTruthy();
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
+  });
+
+  it("leaves canonical Trending on its own unavailable path", async () => {
+    searchMock = { tab: "trending" };
+    vi.stubGlobal("IntersectionObserver", undefined);
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      fetchCanonicalTrendingPageMock.mockRejectedValue(new Error("temporary failure"));
+
+      render(<SkillsIndex />);
+      await act(async () => {});
+
+      expect(screen.queryByText("Skills couldn't be loaded")).toBeNull();
+      expect(screen.queryByRole("button", { name: "Try again" })).toBeNull();
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
+  });
 
   it("keeps loading across empty filtered pages without flashing terminal states", async () => {
     class IntersectionObserverMock {

--- a/src/routes/skills/-SkillsResults.tsx
+++ b/src/routes/skills/-SkillsResults.tsx
@@ -35,6 +35,8 @@ type SkillsResultsProps = {
   canAutoLoad: boolean;
   loadMoreRef: RefObject<HTMLDivElement | null>;
   loadMore: () => void;
+  listFailed: boolean;
+  retryLoad: () => void;
   catalogTab: SkillsCatalogTab;
   trendingState?: TrendingFeedState;
 };
@@ -221,6 +223,8 @@ export function SkillsResults({
   canAutoLoad,
   loadMoreRef,
   loadMore,
+  listFailed,
+  retryLoad,
   catalogTab,
   trendingState,
 }: SkillsResultsProps) {
@@ -232,6 +236,16 @@ export function SkillsResults({
     <>
       {isLoadingSkills ? (
         <BrowseResultsSkeleton label="Skill" showIcon={false} variant={effectiveView} />
+      ) : listFailed && sorted.length === 0 ? (
+        <div className="empty-state" role="alert">
+          <p className="empty-state-title">Skills couldn't be loaded</p>
+          <p className="empty-state-body">
+            We couldn't load this slice of the catalog. Give it another try in a moment.
+          </p>
+          <Button type="button" variant="outline" size="sm" className="mt-4" onClick={retryLoad}>
+            Try again
+          </Button>
+        </div>
       ) : sorted.length === 0 && listDoneLoading ? (
         <div className="empty-state">
           <p className="empty-state-title">

--- a/src/routes/skills/-useSkillsBrowseModel.ts
+++ b/src/routes/skills/-useSkillsBrowseModel.ts
@@ -84,7 +84,7 @@ type SkillsNavigate = (options: {
   replace?: boolean;
 }) => void | Promise<void>;
 
-type ListStatus = "loading" | "idle" | "loadingMore" | "done";
+type ListStatus = "loading" | "idle" | "loadingMore" | "done" | "error";
 
 export function buildSkillsSearchKey({
   categorySlug,
@@ -294,10 +294,14 @@ export function useSkillsBrowseModel({
           setListResults([]);
           setTrendingState("unavailable");
         }
-        // Keep canonical Trending's dedicated unavailable state; other pages remain retryable.
+        // Keep canonical Trending's dedicated unavailable state. Elsewhere a failed first page
+        // gets its own error state, so neither the empty state nor the load-more affordance has
+        // to stand in for "the request failed"; later pages stay retryable through load-more.
         setListCursor(pageCursor);
         setListAutoLoadPaused(Boolean(pageCursor));
-        setListStatus(catalogTab === "trending" && !pageCursor ? "done" : "idle");
+        setListStatus(
+          catalogTab === "trending" && !pageCursor ? "done" : pageCursor ? "idle" : "error",
+        );
       }
     },
     [
@@ -350,6 +354,7 @@ export function useSkillsBrowseModel({
   const isLoadingList = listStatus === "loading";
   const canLoadMoreList = listStatus === "idle";
   const isLoadingMoreList = listStatus === "loadingMore";
+  const listFailedList = listStatus === "error";
 
   useEffect(() => {
     window.clearTimeout(navigateTimer.current);
@@ -511,6 +516,7 @@ export function useSkillsBrowseModel({
     ? !isSearching && searchResults.length === searchLimit && searchResults.length > 0
     : canLoadMoreList;
   const isLoadingMore = hasQuery ? isSearching && searchResults.length > 0 : isLoadingMoreList;
+  const listFailed = !hasQuery && listFailedList;
   const canAutoLoad = false;
 
   const loadMore = useCallback(() => {
@@ -524,6 +530,13 @@ export function useSkillsBrowseModel({
       void fetchPage(listCursor, fetchGeneration.current);
     }
   }, [canLoadMore, fetchPage, hasQuery, isLoadingMore, listCursor]);
+
+  // The failed first page never advanced a cursor, so a retry just replays it.
+  const retryLoad = useCallback(() => {
+    if (!listFailed) return;
+    setListStatus("loading");
+    void fetchPage(null, fetchGeneration.current);
+  }, [fetchPage, listFailed]);
 
   useEffect(() => {
     if (!isLoadingMore) {
@@ -668,6 +681,7 @@ export function useSkillsBrowseModel({
     featuredOnly,
     isLoadingMore,
     isLoadingSkills,
+    listFailed,
     loadMore,
     loadMoreRef,
     onClearFilters,
@@ -678,6 +692,7 @@ export function useSkillsBrowseModel({
     onToggleFeatured,
     onToggleView,
     query,
+    retryLoad,
     sort,
     sorted,
     trendingState,

--- a/src/routes/skills/-useSkillsBrowseModel.ts
+++ b/src/routes/skills/-useSkillsBrowseModel.ts
@@ -121,6 +121,7 @@ export function useSkillsBrowseModel({
   const searchRequest = useRef(0);
   const loadMoreRef = useRef<HTMLDivElement | null>(null);
   const loadMoreInFlightRef = useRef(false);
+  const retryInFlightRef = useRef(false);
   const navigateTimer = useRef<number>(0);
 
   const view: SkillsView = normalizeSkillsView(search.view) ?? "list";
@@ -531,9 +532,12 @@ export function useSkillsBrowseModel({
     }
   }, [canLoadMore, fetchPage, hasQuery, isLoadingMore, listCursor]);
 
-  // The failed first page never advanced a cursor, so a retry just replays it.
+  // The failed first page never advanced a cursor, so a retry just replays it. Two activations
+  // can reach this callback before a rerender clears the failure, and both would replay the
+  // first page under the same generation, so an older reply could overwrite the newer one.
   const retryLoad = useCallback(() => {
-    if (!listFailed) return;
+    if (retryInFlightRef.current || !listFailed) return;
+    retryInFlightRef.current = true;
     setListStatus("loading");
     void fetchPage(null, fetchGeneration.current);
   }, [fetchPage, listFailed]);
@@ -543,6 +547,12 @@ export function useSkillsBrowseModel({
       loadMoreInFlightRef.current = false;
     }
   }, [isLoadingMore]);
+
+  useEffect(() => {
+    if (!isLoadingSkills) {
+      retryInFlightRef.current = false;
+    }
+  }, [isLoadingSkills]);
 
   useEffect(() => {
     return () => window.clearTimeout(navigateTimer.current);

--- a/src/routes/skills/index.tsx
+++ b/src/routes/skills/index.tsx
@@ -411,6 +411,8 @@ export function SkillsIndex() {
             canAutoLoad={model.canAutoLoad}
             loadMoreRef={model.loadMoreRef}
             loadMore={model.loadMore}
+            listFailed={model.listFailed}
+            retryLoad={model.retryLoad}
             catalogTab={model.catalogTab}
             trendingState={model.trendingState}
           />


### PR DESCRIPTION
Closes #3473

## What Problem This Solves

Fixes an issue where users browsing the Skills catalog would see an empty page whose only
content is a bare "Load more" card when the first page request fails on the New, Featured,
or Official tabs.

Nothing on the page says the request failed. The result list is empty, and the "No skills
found" empty state is gated on `listDoneLoading` (`!isLoadingSkills && !canLoadMore &&
!isLoadingMore`), which stays false while the tab is retryable. A user who hits a 503 gets a
button and no explanation.

## Why This Change Was Made

#3457 made a failed first page retryable by leaving the list status at `idle`, deliberately
leaving the failure presentation to a follow-up. `listDoneLoading` cannot tell "nothing
matched" from "the request failed", because `canLoadMore` is true in both cases, so the fix
is a distinct state rather than more conditions on the existing ones.

The browse model's `ListStatus` gains an `error` member, set only for a cursor-less failure
on the non-Trending tabs. The results component branches on it and renders an inline failure
message with a `Try again` action that replays the first page, matching the failure copy
already used by the home listing surface and the retry affordance already used by the plugin
versions panel.

`Try again` is single-flight. Two activations can reach the retry callback before React
rerenders the failure away, and both would replay the first page under the same fetch
generation, leaving the later-to-settle reply free to overwrite the earlier one and restore
the error after a successful recovery. An in-flight ref guards the dispatch and is released
once the request settles, mirroring the guard the adjacent `Load more` path already uses.

Boundaries kept intact:

- Canonical Trending keeps its own `canonicalTrendingUnavailable` / `trendingState =
  "unavailable"` path; it never reaches the new state.
- A failure on a later page still records the retry cursor and stays `idle`, so pagination
  resumes through `Load more` exactly as before.
- The empty-page auto-advance path (a filtered scan that advanced a cursor before failing)
  also keeps its existing `idle` behavior, since it has a real cursor to resume from.
- Search results are unaffected; `listFailed` is false whenever a query is active.

## User Impact

When a catalog request fails, the Skills page now says so and offers a `Try again` control
that reloads the tab in place, instead of showing an unexplained "Load more" button. The
failure message is announced to assistive technology (`role="alert"`). Recovery from a
transient failure takes one click and no longer depends on the user guessing that "Load
more" is really a retry.

## Evidence

Browser proof, local dev server on `http://localhost:3000` against the public read Convex
deployment (`wry-manatee-359`), failure forced with DevTools offline emulation on the
`New` tab:

**Before (current `main`) - the reported state, a bare "Load more" card:**

![before](https://raw.githubusercontent.com/Yigtwxx/clawhub/proof-3473-skills-first-page-error-state/01-before-main-bare-load-more.png)

**After - explicit failure with a retry action:**

![after](https://raw.githubusercontent.com/Yigtwxx/clawhub/proof-3473-skills-first-page-error-state/02-after-error-state.png)

**After clicking `Try again` with the network restored - the New tab loads normally:**

![after retry](https://raw.githubusercontent.com/Yigtwxx/clawhub/proof-3473-skills-first-page-error-state/03-after-retry-recovered.png)

Tests. The existing parameterized first-page-failure test in
`src/__tests__/skills-index.test.tsx` is updated: it still asserts that `No skills found`
never appears, and now asserts the failure message is present, the bare `Load more` card is
gone, and `Try again` replays the first page with no cursor and recovers. Three tests are
added: a repeated failure keeps the failure state (it must not fall back to the false empty
state), a canonical Trending failure never renders the new state, and two `Try again`
activations that land before the first reply settles dispatch a single first-page request
and leave the recovered list intact.

```
$ bunx vitest run src/__tests__/skills-index.test.tsx \
    src/__tests__/skills-index-load-more.test.tsx \
    src/__tests__/skills-index.claw591.test.tsx
Test Files  3 passed (3)
     Tests  77 passed (77)

$ bunx tsc --noEmit
(clean)

$ bun run lint
(clean)

$ bunx oxfmt --check <touched files>
All matched files use the correct format.
```

`bun run ci:unit` on this branch: 16 files / 27 tests fail. All of them are Windows-local
environment failures also present on `main` and untouched by this diff (worker/CLI suites
that shell out to `bun`, a Mermaid render timeout, and a number-format assertion); none are
in `src/routes/skills/**` or `src/__tests__/skills-index*`. `bun run format:check` fails on
`CLAUDE.md` and `.agents/skills/autoreview/CLAUDE.md`, which is pre-existing on `main` and
not part of this change.

`$autoreview` could not run in this environment: it requires TruffleHog, which is not
installed here and which it refuses to auto-install. The diff was reviewed manually against
the surrounding code paths instead.

