### PR TITLE
feat: stage signal workflow indexes

### DIFF
--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -253,6 +253,13 @@ if (process.env.CLAWHUB_DISABLE_CRONS !== "1" && process.env.CLAWHUB_PREVIEW !==
   );
 
   crons.interval(
+    "publisher-abuse-signal-communications-retention-prune",
+    { hours: 24 },
+    internal.retention.pruneExpiredPublisherAbuseSignalCommunicationsInternal,
+    { batchSize: RETENTION_STANDARD_BATCH_SIZE },
+  );
+
+  crons.interval(
     "publisher-invite-retention-prune",
     { hours: 6 },
     internal.retention.pruneExpiredPublisherInvitesInternal,

--- a/convex/lib/retentionPolicy.test.ts
+++ b/convex/lib/retentionPolicy.test.ts
@@ -84,6 +84,13 @@ describe("retention policies", () => {
     expect(getRetentionPolicy("publisherAbuseSignals")).toMatchObject({
       classification: "permanent",
     });
+    expect(getRetentionPolicy("publisherAbuseSignalCommunications")).toMatchObject({
+      classification: "ephemeral",
+      expirationField: "expirationTime",
+      expirationIndex: "by_expiration_time",
+      prune: "retention.pruneExpiredPublisherAbuseSignalCommunicationsInternal",
+      retention: "180 days after the latest owner-contact activity.",
+    });
   });
 
   it("documents package stat events as processed-event retention", () => {

--- a/convex/lib/retentionPolicy.ts
+++ b/convex/lib/retentionPolicy.ts
@@ -326,6 +326,15 @@ export const RETENTION_POLICIES = {
   publisherAbuseReviewNominations: permanent("Abuse review workflow state."),
   publisherAbuseReviewEvents: permanent("Abuse review event history."),
   publisherAbuseSignals: permanent("Durable publisher abuse signal archive for staff review."),
+  publisherAbuseSignalCommunications: ephemeral(
+    "Owner-contact recipient data, message content, secure-link state, and delivery details are sensitive case data.",
+    {
+      expirationField: "expirationTime",
+      expirationIndex: "by_expiration_time",
+      prune: "retention.pruneExpiredPublisherAbuseSignalCommunicationsInternal",
+      retention: "180 days after the latest owner-contact activity.",
+    },
+  ),
   publisherAbuseSignalReviewEvents: permanent("Abuse signal review event history."),
   vtScanLogs: permanent("VirusTotal scan log history."),
   apiTokens: permanent("User API tokens until revoked."),

--- a/convex/retention.test.ts
+++ b/convex/retention.test.ts
@@ -4,6 +4,9 @@ import { describe, expect, it, vi } from "vitest";
 const retentionRefs = vi.hoisted(() => ({
   pruneExpiredAuthSessionsInternal: Symbol("pruneExpiredAuthSessionsInternal"),
   pruneExpiredAuthRefreshTokensInternal: Symbol("pruneExpiredAuthRefreshTokensInternal"),
+  pruneExpiredPublisherAbuseSignalCommunicationsInternal: Symbol(
+    "pruneExpiredPublisherAbuseSignalCommunicationsInternal",
+  ),
   pruneExpiredPublisherInvitesInternal: Symbol("pruneExpiredPublisherInvitesInternal"),
   pruneExpiredSkillPublishUploadsInternal: Symbol("pruneExpiredSkillPublishUploadsInternal"),
 }));
@@ -17,6 +20,7 @@ vi.mock("./_generated/api", () => ({
 const {
   pruneExpiredAuthRefreshTokensInternal,
   pruneExpiredAuthSessionsInternal,
+  pruneExpiredPublisherAbuseSignalCommunicationsInternal,
   pruneExpiredPublisherInvitesInternal,
   pruneExpiredSkillPublishUploadsInternal,
 } = await import("./retention");
@@ -33,6 +37,12 @@ const pruneSessionsHandler = (
 )._handler;
 const pruneTokensHandler = (
   pruneExpiredAuthRefreshTokensInternal as unknown as WrappedHandler<
+    { batchSize?: number },
+    { deleted: number; hasMore: boolean }
+  >
+)._handler;
+const pruneSignalCommunicationsHandler = (
+  pruneExpiredPublisherAbuseSignalCommunicationsInternal as unknown as WrappedHandler<
     { batchSize?: number },
     { deleted: number; hasMore: boolean }
   >
@@ -187,6 +197,42 @@ describe("auth retention", () => {
     expect(result).toEqual({ deleted: 1, hasMore: false });
     expect(lt).toHaveBeenCalledWith("expirationTime", now);
     expect(deleteDoc).toHaveBeenCalledWith("authRefreshTokens:expired");
+  });
+
+  it("deletes expired publisher abuse communication payloads in bounded batches", async () => {
+    const now = 2_500_000;
+    vi.spyOn(Date, "now").mockReturnValue(now);
+    const rows = [{ _id: "publisherAbuseSignalCommunications:expired" }];
+    const deleteDoc = vi.fn();
+    const runAfter = vi.fn();
+    const lt = vi.fn(() => ({}));
+    const ctx = {
+      db: makeDb({
+        query: vi.fn((table: string) => {
+          expect(table).toBe("publisherAbuseSignalCommunications");
+          return {
+            withIndex: vi.fn((indexName: string, build: (q: unknown) => unknown) => {
+              expect(indexName).toBe("by_expiration_time");
+              build({ lt });
+              return { take: vi.fn(async () => rows) };
+            }),
+          };
+        }),
+        delete: deleteDoc,
+      }),
+      scheduler: { runAfter },
+    };
+
+    const result = await pruneSignalCommunicationsHandler(ctx as never, { batchSize: 1 });
+
+    expect(result).toEqual({ deleted: 1, hasMore: true });
+    expect(lt).toHaveBeenCalledWith("expirationTime", now);
+    expect(deleteDoc).toHaveBeenCalledWith("publisherAbuseSignalCommunications:expired");
+    expect(runAfter).toHaveBeenCalledWith(
+      0,
+      retentionRefs.pruneExpiredPublisherAbuseSignalCommunicationsInternal,
+      { batchSize: 1 },
+    );
   });
 
   it("deletes expired publisher invites by expiry time", async () => {

--- a/convex/retention.ts
+++ b/convex/retention.ts
@@ -84,6 +84,34 @@ export const pruneExpiredAuthRefreshTokensInternal = internalMutation({
   },
 });
 
+export const pruneExpiredPublisherAbuseSignalCommunicationsInternal = internalMutation({
+  args: {
+    batchSize: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const batchSize = normalizeRetentionBatchSize(args.batchSize);
+    const stale = await ctx.db
+      .query("publisherAbuseSignalCommunications")
+      .withIndex("by_expiration_time", (q) => q.lt("expirationTime", Date.now()))
+      .take(batchSize);
+
+    for (const communication of stale) {
+      await ctx.db.delete(communication._id);
+    }
+
+    const hasMore = stale.length === batchSize;
+    if (hasMore) {
+      await ctx.scheduler.runAfter(
+        0,
+        internal.retention.pruneExpiredPublisherAbuseSignalCommunicationsInternal,
+        { batchSize },
+      );
+    }
+
+    return { deleted: stale.length, hasMore };
+  },
+});
+
 export const pruneExpiredPublisherInvitesInternal = internalMutation({
   args: {
     batchSize: v.optional(v.number()),

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -4167,6 +4167,43 @@ const publisherAbuseSignals = defineTable({
   notificationClaimedAt: v.optional(v.number()),
   lastNotifiedAt: v.optional(v.number()),
   lastNotificationError: v.optional(v.string()),
+  contactState: v.optional(
+    v.union(
+      v.literal("not_requested"),
+      v.literal("queued"),
+      v.literal("retrying"),
+      v.literal("sent"),
+      v.literal("cancelled"),
+      v.literal("not_deliverable"),
+    ),
+  ),
+  attentionState: v.optional(
+    v.union(
+      v.literal("needs_attention"),
+      v.literal("awaiting_owner"),
+      v.literal("contact_failed"),
+      v.literal("not_contacted"),
+      v.literal("none"),
+    ),
+  ),
+  needsAttention: v.optional(v.boolean()),
+  notificationEventKind: v.optional(
+    v.union(
+      v.literal("publisher_abuse_signal_owner_contact_failed"),
+      v.literal("publisher_abuse_signal_owner_response_submitted"),
+    ),
+  ),
+  notificationState: v.optional(
+    v.union(
+      v.literal("queued"),
+      v.literal("retrying"),
+      v.literal("delivered"),
+      v.literal("failed"),
+    ),
+  ),
+  notificationAttemptCount: v.optional(v.number()),
+  notificationLatestAttemptAt: v.optional(v.number()),
+  notificationDeliveredAt: v.optional(v.number()),
 })
   .index("by_last_seen_at", ["lastSeenAt"])
   .index("by_signal_type_and_last_seen_at", ["signalType", "lastSeenAt"])
@@ -4175,11 +4212,58 @@ const publisherAbuseSignals = defineTable({
   .index("by_skill_and_signal_type", ["skillId", "signalType"])
   .index("by_skill_signal_type_and_owner_key", ["skillId", "signalType", "ownerKey"])
   .index("by_review_status_and_last_seen_at", ["reviewStatus", "lastSeenAt"])
+  .index("by_review_status_and_attention_state_and_last_seen_at", {
+    fields: ["reviewStatus", "attentionState", "lastSeenAt"],
+    staged: true,
+  })
+  .index("by_review_status_and_needs_attention_and_last_seen_at", {
+    fields: ["reviewStatus", "needsAttention", "lastSeenAt"],
+    staged: true,
+  })
   .index("by_needs_notification_and_last_changed_at", ["needsNotification", "lastChangedAt"])
   .index("by_needs_notification_and_notification_claimed_at", [
     "needsNotification",
     "notificationClaimedAt",
   ]);
+
+const publisherAbuseSignalCommunications = defineTable({
+  signalId: v.id("publisherAbuseSignals"),
+  request: v.object({
+    requestedAt: v.number(),
+    tokenHash: v.optional(v.string()),
+    state: v.optional(
+      v.union(
+        v.literal("queued"),
+        v.literal("retrying"),
+        v.literal("sent"),
+        v.literal("cancelled"),
+        v.literal("not_deliverable"),
+      ),
+    ),
+    latestAttemptAt: v.optional(v.number()),
+    attemptCount: v.optional(v.number()),
+    sentAt: v.optional(v.number()),
+    recipientUserId: v.optional(v.id("users")),
+    recipientEmail: v.optional(v.string()),
+    providerId: v.optional(v.string()),
+    deliveryError: v.optional(v.string()),
+    subject: v.optional(v.string()),
+    templateVersion: v.optional(v.string()),
+    reasonBullets: v.optional(v.array(v.string())),
+    redactedTextSnapshot: v.optional(v.string()),
+  }),
+  response: v.optional(
+    v.object({
+      kind: v.union(v.literal("expected"), v.literal("not_recognized"), v.literal("unsure")),
+      message: v.optional(v.string()),
+      submittedAt: v.number(),
+      submittedByUserId: v.id("users"),
+    }),
+  ),
+  expirationTime: v.number(),
+})
+  .index("by_signal_id", ["signalId"])
+  .index("by_expiration_time", ["expirationTime"]);
 
 const publisherAbuseSignalReviewEventTypeValidator = v.union(
   v.literal("snoozed"),
@@ -4525,6 +4609,7 @@ export default defineSchema({
   publisherAbuseReviewNominations,
   publisherAbuseReviewEvents,
   publisherAbuseSignals,
+  publisherAbuseSignalCommunications,
   publisherAbuseSignalReviewEvents,
   vtScanLogs,
   apiTokens,

--- a/specs/security-moderation.md
+++ b/specs/security-moderation.md
@@ -150,6 +150,13 @@ See also: [acceptable-usage.md](./acceptable-usage.md) for the marketplace polic
   When a model version renames an equivalent signal type, it must reuse the
   existing signal row and preserve its snoozed/dismissed state; a type rename
   must never bypass an operator decision or create a fresh owner email.
+- Publisher abuse owner-contact payloads are not permanent signal evidence.
+  The permanent signal stores only workflow state. A one-to-one communication
+  record stores the recipient, token hash, email content and snapshot, provider
+  metadata, delivery errors, and owner response for 180 days after the latest
+  contact activity, then an indexed bounded cleanup deletes it. Audit events may
+  retain lifecycle facts and stable reason codes, but must never copy recipient
+  email, message text, raw provider errors, the token, or the live link.
 - Every `publisher-abuse-temporal.*` model version, including legacy rows,
   remains ineligible for warning-first automatic enforcement. A future decision
   to enforce temporal traffic signals requires an explicit policy and code


### PR DESCRIPTION
The owner-response workflow in #3494 needs to store contact details, secure-link state, delivery errors, and the owner's response. That information is sensitive and should not remain in the permanent signal history. This PR stores it in a separate record for 180 days and deletes expired records in small batches. It also adds the two staff indexes without querying them, so Convex can finish building them before #3494 starts using them.

**Stack position: 3 of 4.** #3493 → **#3514** → #3494.

## System map

![Data diagram showing which owner-contact fields remain on a signal, which fields expire after 180 days, and why PR #3494 waits for two indexes](https://github.com/user-attachments/assets/76f5f71c-cb70-49bb-b764-a683892a63ff)

The diagram shows which data stays on the signal, which data expires after 180 days, and when #3494 may start using the indexes.

## Proof

| Data or behaviour | Before: direct base | After: PR |
| --- | --- | --- |
| Permanent signal | No owner-contact fields | Contact status, attention state, and notification state only |
| Temporary contact record | Absent | Recipient, token hash, message snapshot, provider details, and one response in `publisherAbuseSignalCommunications` |
| Expired records | No cleanup | Daily deletion by `by_expiration_time`, in small batches |
| Staff indexes | Absent | Two staged indexes with no queries on this head |

The cleanup deletes one batch, then schedules another run immediately if expired records remain. This PR does not write contact records, send email or Discord messages, or change production data.

## How to verify

1. Deploy #3493, then this PR.
2. Wait for Convex to report that both staff indexes have finished building.
3. Deploy #3494, which writes contact records and queries the indexes.

## Validation and gates

- Retention and cleanup tests passed. Development Convex accepted the schema.
- GitHub CI passed on this exact head, including static, unit, packages, types/build, HTTP E2E, and PR gates.
- This PR is still a draft. The required exact-head `code-review` and sign-off reaction have not been requested.
