### PR TITLE
fix: bound package scan backfill reads

### DIFF
--- a/convex/packages.backfill.runtime.test.ts
+++ b/convex/packages.backfill.runtime.test.ts
@@ -1,0 +1,117 @@
+/// <reference types="vite/client" />
+/* @vitest-environment edge-runtime */
+
+import { convexTest } from "convex-test";
+import { describe, expect, it, vi } from "vitest";
+import { internal } from "./_generated/api";
+import schema from "./schema";
+
+const modules = import.meta.glob("./**/*.ts");
+const CRON_BATCH_SIZE = 100;
+const LARGE_TEXT = "x".repeat(820_000);
+
+async function seedLargeScannedPackageReleases(t: ReturnType<typeof convexTest>, count: number) {
+  const userId = await t.run(async (ctx) => await ctx.db.insert("users", {}));
+  const releaseCreationTimes: number[] = [];
+
+  for (let index = 0; index < count; index += 1) {
+    const packageId = await t.run(async (ctx) =>
+      ctx.db.insert("packages", {
+        name: `@runtime/backfill-${index}`,
+        normalizedName: `@runtime/backfill-${index}`,
+        displayName: `Backfill ${index}`,
+        summary: LARGE_TEXT,
+        ownerUserId: userId,
+        family: "code-plugin",
+        channel: "community",
+        isOfficial: false,
+        tags: {},
+        compatibility: {},
+        verification: { tier: "structural", scope: "artifact-only", scanStatus: "clean" },
+        scanStatus: "clean",
+        stats: { downloads: 0, installs: 0, stars: 0, versions: 1 },
+        createdAt: index,
+        updatedAt: index,
+      }),
+    );
+    const releaseId = await t.run(async (ctx) =>
+      ctx.db.insert("packageReleases", {
+        packageId,
+        version: "1.0.0",
+        changelog: "",
+        summary: LARGE_TEXT,
+        distTags: [],
+        files: [],
+        integritySha256: `${index}`.padStart(64, "0"),
+        compatibility: {},
+        verification: { tier: "structural", scope: "artifact-only", scanStatus: "clean" },
+        vtAnalysis: { status: "clean", checkedAt: 1 },
+        llmAnalysis: { status: "clean", checkedAt: 1 },
+        staticScan: {
+          status: "clean",
+          reasonCodes: [],
+          findings: [],
+          summary: "clean",
+          engineVersion: "runtime-test",
+          checkedAt: 1,
+        },
+        source: {},
+        createdBy: userId,
+        publishActor: { kind: "user", userId },
+        createdAt: index,
+      }),
+    );
+    const release = await t.run(async (ctx) => ctx.db.get(releaseId));
+    releaseCreationTimes.push(release?._creationTime ?? 0);
+  }
+
+  return releaseCreationTimes;
+}
+
+describe("package release scan backfill runtime", () => {
+  it("keeps a cron-sized historical continuation within the Convex read limit", async () => {
+    const t = convexTest({ schema, modules, transactionLimits: true });
+    const creationTimes = await seedLargeScannedPackageReleases(t, 20);
+
+    let cursor = 0;
+    let done = false;
+    let pages = 0;
+    while (!done) {
+      const page = await t.query(internal.packages.getPackageReleaseScanBackfillBatchInternal, {
+        cursor,
+        batchSize: CRON_BATCH_SIZE,
+        prioritizeRecent: false,
+      });
+      expect(page.nextCursor).toBeGreaterThan(cursor);
+      cursor = page.nextCursor;
+      done = page.done;
+      pages += 1;
+    }
+
+    expect(pages).toBeGreaterThan(1);
+    expect(cursor).toBe(Math.max(...creationTimes));
+  });
+
+  it("completes the normal cron action through large historical continuation pages", async () => {
+    const t = convexTest({ schema, modules, transactionLimits: true });
+    await seedLargeScannedPackageReleases(t, 20);
+
+    const initial = await t.action(internal.packages.backfillPackageReleaseScansInternal, {
+      batchSize: CRON_BATCH_SIZE,
+    });
+    expect(initial).toEqual({ scheduled: 0, nextCursor: 0, done: false });
+
+    vi.useFakeTimers();
+    try {
+      await t.finishAllScheduledFunctions(vi.runAllTimers);
+    } finally {
+      vi.useRealTimers();
+    }
+
+    const scheduled = await t.run(async (ctx) =>
+      ctx.db.system.query("_scheduled_functions").collect(),
+    );
+    expect(scheduled.length).toBeGreaterThan(1);
+    expect(scheduled.every((job) => job.state.kind === "success")).toBe(true);
+  });
+});

--- a/convex/packages.public.test.ts
+++ b/convex/packages.public.test.ts
@@ -17915,6 +17915,31 @@ describe("package scan backfill", () => {
     expect(result).toEqual({ releases: [], nextCursor: 0, done: false });
   });
 
+  it("bounds the historical candidate page independently of the scan batch size", async () => {
+    const backlogTake = vi.fn().mockResolvedValue([]);
+
+    const result = await getPackageReleaseScanBackfillBatchInternalHandler(
+      {
+        db: {
+          query: vi.fn((table: string) => {
+            if (table !== "packageReleases") throw new Error(`Unexpected table ${table}`);
+            return {
+              order: vi.fn(),
+              withIndex: vi.fn(() => ({
+                order: vi.fn(() => ({ take: backlogTake })),
+              })),
+            };
+          }),
+          get: vi.fn(),
+        },
+      } as never,
+      { batchSize: 100, prioritizeRecent: false },
+    );
+
+    expect(backlogTake).toHaveBeenCalledWith(8);
+    expect(result).toEqual({ releases: [], nextCursor: 0, done: true });
+  });
+
   it("runs the recent-release probe before draining older backlog", async () => {
     const result = await getPackageReleaseScanBackfillBatchInternalHandler(
       {

--- a/convex/packages.public.test.ts
+++ b/convex/packages.public.test.ts
@@ -17834,7 +17834,7 @@ describe("package scan backfill", () => {
           }),
         },
       } as never,
-      { batchSize: 10 },
+      { batchSize: 10, prioritizeRecent: false },
     );
 
     expect(result.releases).toEqual([
@@ -17882,13 +17882,40 @@ describe("package scan backfill", () => {
           }),
         },
       } as never,
-      { batchSize: 10 },
+      { batchSize: 10, prioritizeRecent: false },
     );
 
     expect(result.releases).toEqual([]);
   });
 
-  it("prioritizes recent releases before draining older backlog", async () => {
+  it("bounds the recent-release probe independently of the scan batch size", async () => {
+    const recentTake = vi.fn().mockResolvedValue([]);
+    const backlogTake = vi.fn().mockResolvedValue([]);
+
+    const result = await getPackageReleaseScanBackfillBatchInternalHandler(
+      {
+        db: {
+          query: vi.fn((table: string) => {
+            if (table !== "packageReleases") throw new Error(`Unexpected table ${table}`);
+            return {
+              order: vi.fn(() => ({ take: recentTake })),
+              withIndex: vi.fn(() => ({
+                order: vi.fn(() => ({ take: backlogTake })),
+              })),
+            };
+          }),
+          get: vi.fn(),
+        },
+      } as never,
+      { batchSize: 100, prioritizeRecent: true },
+    );
+
+    expect(recentTake).toHaveBeenCalledWith(4);
+    expect(backlogTake).not.toHaveBeenCalled();
+    expect(result).toEqual({ releases: [], nextCursor: 0, done: false });
+  });
+
+  it("runs the recent-release probe before draining older backlog", async () => {
     const result = await getPackageReleaseScanBackfillBatchInternalHandler(
       {
         db: {
@@ -17934,22 +17961,43 @@ describe("package scan backfill", () => {
       { batchSize: 2, prioritizeRecent: true },
     );
 
-    expect(result.releases).toEqual([
+    expect(result).toEqual({
+      releases: [
+        {
+          releaseId: "packageReleases:recent-vt",
+          packageId: "packages:demo",
+          needsVt: true,
+          needsLlm: false,
+          needsStatic: false,
+        },
+      ],
+      nextCursor: 0,
+      done: false,
+    });
+  });
+
+  it("starts the cursor backlog after the bounded recent probe", async () => {
+    const runAfter = vi.fn().mockResolvedValue(undefined);
+
+    const result = await backfillPackageReleaseScansInternalHandler(
       {
-        releaseId: "packageReleases:recent-vt",
-        packageId: "packages:demo",
-        needsVt: true,
-        needsLlm: false,
-        needsStatic: false,
-      },
-      {
-        releaseId: "packageReleases:old-static",
-        packageId: "packages:demo",
-        needsVt: false,
-        needsLlm: false,
-        needsStatic: true,
-      },
-    ]);
+        runQuery: vi.fn().mockResolvedValue({
+          releases: [],
+          nextCursor: 0,
+          done: false,
+        }),
+        scheduler: { runAfter },
+      } as never,
+      { batchSize: 100 },
+    );
+
+    expect(result).toEqual({ scheduled: 0, nextCursor: 0, done: false });
+    expect(runAfter).toHaveBeenCalledTimes(1);
+    expect(runAfter).toHaveBeenCalledWith(0, expect.anything(), {
+      cursor: 0,
+      batchSize: 100,
+      scheduled: 0,
+    });
   });
 
   it("schedules static rescans for releases missing only static scan data", async () => {

--- a/convex/packages.ts
+++ b/convex/packages.ts
@@ -148,6 +148,8 @@ const MAX_PACKAGE_VERSION_DELETE_LOOKUP_CANDIDATES = 4;
 const MAX_POINTERLESS_RELEASE_SURVIVOR_SCAN = 100;
 // Release rows can approach 1 MiB, and trigger-wrapped patches materialize full documents.
 const PACKAGE_RELEASE_TAG_CLEANUP_BATCH_SIZE = 4;
+// The recent scan probe reads full release rows plus each parent package in one transaction.
+const MAX_PACKAGE_RELEASE_SCAN_RECENT_CANDIDATES = 4;
 const packageListScanStatusValidator = v.union(
   v.literal("clean"),
   v.literal("suspicious"),
@@ -8035,28 +8037,17 @@ export const getPackageReleaseScanBackfillBatchInternal = internalQuery({
     const cursor = args.cursor ?? 0;
     const prioritizeRecent = args.prioritizeRecent ?? true;
 
-    const [recentReleases, backlogReleases] = await Promise.all([
-      prioritizeRecent
-        ? ctx.db
-            .query("packageReleases")
-            .order("desc")
-            .take(batchSize * 2)
-        : Promise.resolve([]),
-      ctx.db
-        .query("packageReleases")
-        .withIndex("by_creation_time", (q) => q.gt("_creationTime", cursor))
-        .order("asc")
-        .take(batchSize * 3),
-    ]);
-
-    const releases = [
-      ...recentReleases,
-      ...backlogReleases.filter(
-        (release, index, all) =>
-          recentReleases.findIndex((candidate) => candidate._id === release._id) === -1 &&
-          all.findIndex((candidate) => candidate._id === release._id) === index,
-      ),
-    ];
+    const backlogCandidateLimit = batchSize * 3;
+    const releases = prioritizeRecent
+      ? await ctx.db
+          .query("packageReleases")
+          .order("desc")
+          .take(Math.min(batchSize * 2, MAX_PACKAGE_RELEASE_SCAN_RECENT_CANDIDATES))
+      : await ctx.db
+          .query("packageReleases")
+          .withIndex("by_creation_time", (q) => q.gt("_creationTime", cursor))
+          .order("asc")
+          .take(backlogCandidateLimit);
 
     const results: Array<{
       releaseId: Id<"packageReleases">;
@@ -8068,7 +8059,7 @@ export const getPackageReleaseScanBackfillBatchInternal = internalQuery({
     let nextCursor = cursor;
 
     for (const release of releases) {
-      nextCursor = release._creationTime;
+      if (!prioritizeRecent) nextCursor = release._creationTime;
       if (results.length >= batchSize) break;
       if (release.softDeletedAt) continue;
 
@@ -8092,7 +8083,7 @@ export const getPackageReleaseScanBackfillBatchInternal = internalQuery({
     return {
       releases: results,
       nextCursor,
-      done: backlogReleases.length < batchSize * 3,
+      done: prioritizeRecent ? false : releases.length < backlogCandidateLimit,
     };
   },
 });

--- a/convex/packages.ts
+++ b/convex/packages.ts
@@ -150,6 +150,7 @@ const MAX_POINTERLESS_RELEASE_SURVIVOR_SCAN = 100;
 const PACKAGE_RELEASE_TAG_CLEANUP_BATCH_SIZE = 4;
 // The recent scan probe reads full release rows plus each parent package in one transaction.
 const MAX_PACKAGE_RELEASE_SCAN_RECENT_CANDIDATES = 4;
+const MAX_PACKAGE_RELEASE_SCAN_BACKLOG_CANDIDATES = 8;
 const packageListScanStatusValidator = v.union(
   v.literal("clean"),
   v.literal("suspicious"),
@@ -8037,7 +8038,11 @@ export const getPackageReleaseScanBackfillBatchInternal = internalQuery({
     const cursor = args.cursor ?? 0;
     const prioritizeRecent = args.prioritizeRecent ?? true;
 
-    const backlogCandidateLimit = batchSize * 3;
+    // Each candidate can read a near-1 MiB release and parent package.
+    const backlogCandidateLimit = Math.min(
+      batchSize * 3,
+      MAX_PACKAGE_RELEASE_SCAN_BACKLOG_CANDIDATES,
+    );
     const releases = prioritizeRecent
       ? await ctx.db
           .query("packageReleases")


### PR DESCRIPTION
## Summary

- cap the scheduled recent package-release scan probe at four full release rows
- run that recent probe alone, then start the existing cursor backlog from zero in a separate Convex transaction
- preserve the successful backlog page size and add regression coverage for the bound and phase handoff

## Axiom evidence

From `2026-08-21T18:12:41Z` through `2026-08-24T15:04:14Z`, the scheduled package-release scan backfill root selector exceeded Convex's 16 MiB read limit 138 times. Cursor-recursive pages succeeded during the same window. Current `main` requested up to 200 newest full `packageReleases` documents plus 300 backlog documents in the root query; release rows can approach Convex's 1 MiB document limit.

This change bounds the newest-row safety probe to four releases and keeps it in a separate transaction from the empirically successful backlog page. The root action then schedules the backlog with cursor `0`, so historical rows are not skipped.

## Validation

- red proof: focused regression failed because the recent probe requested 200 rows instead of 4
- `bunx vitest run convex/packages.public.test.ts` (364 passed)
- `bun run ci:static`
- `bun run ci:unit` (6222 passed, 3 skipped; coverage thresholds passed)
- `bun run ci:types-build`
- `bun run ci:packages`
- `.agents/skills/autoreview/scripts/autoreview --mode local` (clean, no actionable findings)

No deployment, monitor change, or production mutation was performed.
