### PR TITLE
fix(ci): exclude design audit artifacts from vitest

### DIFF
--- a/scripts/design-audit/design-audit-workflow.test.ts
+++ b/scripts/design-audit/design-audit-workflow.test.ts
@@ -51,11 +51,14 @@ describe("weekly design-system audit workflow", () => {
     const workflow = parseYaml(
       await readFile(".github/workflows/design-system-audit.yml", "utf8"),
     ) as { jobs: { audit: { steps: Step[] } } };
+    const vitestConfig = await readFile("vitest.config.ts", "utf8");
     const steps = workflow.jobs.audit.steps;
     const upload = steps.find((step) => step.name === "Upload audit artifacts");
     const commit = steps.find((step) => step.name === "Commit audit branch");
     const failure = steps.find((step) => step.name === "Fail unsuccessful audit");
 
+    expect(vitestConfig).toContain('"artifacts/**"');
+    expect(vitestConfig).not.toContain('"**/artifacts/**"');
     expect(upload?.if).toBe("always()");
     expect(upload?.uses).toMatch(/^actions\/upload-artifact@[0-9a-f]{40}$/);
     expect(commit?.if).toBe("steps.finalize.outputs.open_pr == 'true'");

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -35,6 +35,7 @@ export default defineConfig({
     exclude: [
       "**/node_modules/**",
       "**/.artifacts/**",
+      "artifacts/**",
       "**/.vercel/output/**",
       "**/.output/**",
       "**/.nitro/**",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the weekly design-system audit could make the main Vitest suite collect generated audit fixtures that import `bun:test`, causing unrelated CI failures after audit artifacts were created.

## Why This Change Was Made

Exclude only the repository-root `artifacts/**` output directory from Vitest collection. The regression assertion also rejects `**/artifacts/**` so legitimate nested test directories are not hidden.

## User Impact

Maintainers can run the weekly design audit and the normal unit suite in the same checkout without generated foreign-runner tests breaking Vitest.

## Evidence

- `bunx vitest run scripts/design-audit/design-audit-workflow.test.ts`
- Root `artifacts/design-audit/foreign-bun.test.ts` fixture using `bun:test` was not collected by `bunx vitest list ... --filesOnly --passWithNoTests`
- `bun run ci:static`
- Node 24.16.0: `bun run ci:unit` (470 files passed, 6,228 tests passed, coverage thresholds passed)
- `bun run format:check -- vitest.config.ts scripts/design-audit/design-audit-workflow.test.ts`
- `git diff --check`
