### PR TITLE
fix(sync): avoid duplicate skills.sh batches after timeouts

### DIFF
--- a/convex/skillsShMirror.test.ts
+++ b/convex/skillsShMirror.test.ts
@@ -1086,19 +1086,26 @@ describe("skills.sh external mirror", () => {
     await configure(t);
     const { runId } = await startRun(t, "snapshot:lease", 1);
 
-    await expect(
-      t.mutation(mirrorLeaseRefs.claimBatchLeaseInternal, {
-        runId,
-        page: 0,
-        offset: 0,
-        leaseToken: "lease:first",
-      }),
-    ).resolves.toMatchObject({
+    const claimed = await t.mutation(mirrorLeaseRefs.claimBatchLeaseInternal, {
+      runId,
+      page: 0,
+      offset: 0,
+      leaseToken: "lease:first",
+    });
+    expect(claimed).toMatchObject({
       runId,
       page: 0,
       offset: 0,
       leaseExpiresAt: expect.any(Number),
     });
+    await expect(t.query(internal.skillsShMirror.getRunInternal, { runId })).resolves.toMatchObject(
+      {
+        batchLeaseExpiresAt: claimed.leaseExpiresAt,
+      },
+    );
+    expect(await t.query(internal.skillsShMirror.getRunInternal, { runId })).not.toHaveProperty(
+      "batchLeaseToken",
+    );
     await expect(
       t.mutation(mirrorLeaseRefs.claimBatchLeaseInternal, {
         runId,

--- a/convex/skillsShMirror.ts
+++ b/convex/skillsShMirror.ts
@@ -961,6 +961,7 @@ type SummarizableMirrorRun = Pick<
   | "sourceDurationMs"
   | "page"
   | "offset"
+  | "batchLeaseExpiresAt"
   | "counts"
   | "operations"
   | "activatedTrendingRunId"
@@ -985,6 +986,7 @@ function summarizeRun(run: SummarizableMirrorRun) {
     sourceDurationMs: run.sourceDurationMs ?? 0,
     page: run.page,
     offset: run.offset,
+    batchLeaseExpiresAt: run.batchLeaseExpiresAt ?? null,
     counts: runCounts(run.counts),
     operations: run.operations,
     activatedTrendingRunId: run.activatedTrendingRunId ?? null,

--- a/scripts/skills-sh-catalog/sync.test.ts
+++ b/scripts/skills-sh-catalog/sync.test.ts
@@ -562,7 +562,7 @@ describe("skills.sh synchronization runner", () => {
           }
           return response(completedRun("leaderboard"));
         case "run":
-          return response(running);
+          return response({ ...running, batchLeaseExpiresAt: 0 });
         case "start-trending":
           return response(completedRun("trending"));
         case "verify-activate":
@@ -604,6 +604,233 @@ describe("skills.sh synchronization runner", () => {
       "configure",
       "status",
     ]);
+  });
+
+  it("waits for a live batch lease to clear before retrying the exact cursor", async () => {
+    let now = 1_000;
+    let runReads = 0;
+    let stepAttempts = 0;
+    const sleep = vi.fn(async (ms: number) => {
+      now += ms;
+    });
+    const running = {
+      runId: "run-leaderboard",
+      snapshotId: "skills-sh:leaderboard:live-lease",
+      sourceView: "leaderboard",
+      sourceTotal: 1,
+      sourcePageSize: 500,
+      sourceMeasuredAt: "2026-08-25T06:00:00.000Z",
+      page: 9,
+      offset: 50,
+      status: "running",
+      startedAt: 1,
+    };
+    const fetchImpl = vi.fn(async (_url: string, init: RequestInit) => {
+      const body = JSON.parse(String(init.body)) as Record<string, unknown>;
+      if (body.operation === "status") {
+        return response({ runs: [], invariants: { publicVisible: true } });
+      }
+      if (body.operation === "configure") return response({ ok: true });
+      if (body.operation === "start") return response(running);
+      if (body.operation === "step") {
+        stepAttempts += 1;
+        if (stepAttempts === 1) {
+          throw new DOMException("The operation timed out.", "TimeoutError");
+        }
+        return response(completedRun("leaderboard"));
+      }
+      if (body.operation === "run") {
+        runReads += 1;
+        return response({
+          ...running,
+          batchLeaseExpiresAt: runReads === 1 ? now + 5_000 : null,
+        });
+      }
+      if (body.operation === "start-trending") return response(completedRun("trending"));
+      if (body.operation === "verify-activate") return response({ ok: true, activated: true });
+      throw new Error(`unexpected operation ${String(body.operation)}`);
+    });
+
+    await expect(
+      runSkillsShSync({
+        targetUrl: "https://clawhub.ai/ops/skills-sh/mirror",
+        authorization: "github-oidc",
+        reason: "scheduled recovery",
+        fetchImpl,
+        sleep,
+        now: () => now,
+      }),
+    ).resolves.toMatchObject({
+      leaderboard: {
+        syncProof: {
+          steps: 1,
+          transportTimeouts: 1,
+          leaseReconcilePolls: 1,
+          leaseReconcileWaitMs: 5_000,
+        },
+      },
+    });
+    expect(stepAttempts).toBe(2);
+    expect(runReads).toBe(2);
+    expect(sleep).toHaveBeenCalledExactlyOnceWith(5_000);
+  });
+
+  it("follows a renewed lease until the original step advances", async () => {
+    let now = 1_000;
+    let runReads = 0;
+    const stepCursors: string[] = [];
+    const sleep = vi.fn(async (ms: number) => {
+      now += ms;
+    });
+    const running = {
+      runId: "run-leaderboard",
+      snapshotId: "skills-sh:leaderboard:renewed-lease",
+      sourceView: "leaderboard",
+      sourceTotal: 1,
+      sourcePageSize: 500,
+      sourceMeasuredAt: "2026-08-25T06:00:00.000Z",
+      page: 9,
+      offset: 50,
+      status: "running",
+      startedAt: 1,
+    };
+    const fetchImpl = vi.fn(async (_url: string, init: RequestInit) => {
+      const body = JSON.parse(String(init.body)) as Record<string, unknown>;
+      if (body.operation === "status") {
+        return response({ runs: [], invariants: { publicVisible: true } });
+      }
+      if (body.operation === "configure") return response({ ok: true });
+      if (body.operation === "start") return response(running);
+      if (body.operation === "step") {
+        stepCursors.push(`${body.page}:${body.offset}`);
+        if (body.offset === 50) {
+          throw new DOMException("The operation timed out.", "TimeoutError");
+        }
+        return response(completedRun("leaderboard"));
+      }
+      if (body.operation === "run") {
+        runReads += 1;
+        if (runReads < 3) {
+          return response({
+            ...running,
+            batchLeaseExpiresAt: now + (runReads === 1 ? 5_000 : 10_000),
+          });
+        }
+        return response({ ...running, offset: 100, batchLeaseExpiresAt: null });
+      }
+      if (body.operation === "start-trending") return response(completedRun("trending"));
+      if (body.operation === "verify-activate") return response({ ok: true, activated: true });
+      throw new Error(`unexpected operation ${String(body.operation)}`);
+    });
+
+    await expect(
+      runSkillsShSync({
+        targetUrl: "https://clawhub.ai/ops/skills-sh/mirror",
+        authorization: "github-oidc",
+        reason: "scheduled recovery",
+        fetchImpl,
+        sleep,
+        now: () => now,
+      }),
+    ).resolves.toMatchObject({
+      leaderboard: {
+        syncProof: {
+          steps: 2,
+          transportTimeouts: 1,
+          leaseReconcilePolls: 2,
+          leaseReconcileWaitMs: 10_000,
+        },
+      },
+    });
+    expect(stepCursors).toEqual(["9:50", "9:100"]);
+    expect(runReads).toBe(3);
+  });
+
+  it("fails closed when an unchanged cursor retains a permanently renewed lease", async () => {
+    let now = 1_000;
+    let runReads = 0;
+    const running = {
+      runId: "run-leaderboard",
+      snapshotId: "skills-sh:leaderboard:stuck-lease",
+      sourceView: "leaderboard",
+      sourceTotal: 1,
+      sourcePageSize: 500,
+      sourceMeasuredAt: "2026-08-25T06:00:00.000Z",
+      page: 9,
+      offset: 50,
+      status: "running",
+      startedAt: 1,
+    };
+    const fetchImpl = vi.fn(async (_url: string, init: RequestInit) => {
+      const body = JSON.parse(String(init.body)) as Record<string, unknown>;
+      if (body.operation === "status") {
+        return response({ runs: [], invariants: { publicVisible: true } });
+      }
+      if (body.operation === "configure") return response({ ok: true });
+      if (body.operation === "start") return response(running);
+      if (body.operation === "step") {
+        throw new DOMException("The operation timed out.", "TimeoutError");
+      }
+      if (body.operation === "run") {
+        runReads += 1;
+        return response({ ...running, batchLeaseExpiresAt: now + 60_000 });
+      }
+      throw new Error(`unexpected operation ${String(body.operation)}`);
+    });
+
+    await expect(
+      runSkillsShSync({
+        targetUrl: "https://clawhub.ai/ops/skills-sh/mirror",
+        authorization: "github-oidc",
+        reason: "scheduled recovery",
+        fetchImpl,
+        sleep: async (ms) => {
+          now += ms;
+        },
+        now: () => now,
+      }),
+    ).rejects.toThrow("retained a live lease after 360 polls and 1800000ms");
+    expect(runReads).toBe(361);
+  });
+
+  it.each([
+    ["missing", {}],
+    ["malformed", { batchLeaseExpiresAt: "later" }],
+  ])("fails closed on %s durable lease state", async (_label, leaseState) => {
+    const running = {
+      runId: "run-leaderboard",
+      snapshotId: "skills-sh:leaderboard:invalid-lease",
+      sourceView: "leaderboard",
+      sourceTotal: 1,
+      sourcePageSize: 500,
+      sourceMeasuredAt: "2026-08-25T06:00:00.000Z",
+      page: 9,
+      offset: 50,
+      status: "running",
+      startedAt: 1,
+    };
+    const fetchImpl = vi.fn(async (_url: string, init: RequestInit) => {
+      const body = JSON.parse(String(init.body)) as Record<string, unknown>;
+      if (body.operation === "status") {
+        return response({ runs: [], invariants: { publicVisible: true } });
+      }
+      if (body.operation === "configure") return response({ ok: true });
+      if (body.operation === "start") return response(running);
+      if (body.operation === "step") {
+        throw new DOMException("The operation timed out.", "TimeoutError");
+      }
+      if (body.operation === "run") return response({ ...running, ...leaseState });
+      throw new Error(`unexpected operation ${String(body.operation)}`);
+    });
+
+    await expect(
+      runSkillsShSync({
+        targetUrl: "https://clawhub.ai/ops/skills-sh/mirror",
+        authorization: "github-oidc",
+        reason: "scheduled recovery",
+        fetchImpl,
+      }),
+    ).rejects.toThrow(/batchLeaseExpiresAt/);
   });
 
   it("continues from the authoritative cursor when a timed-out step already committed", async () => {

--- a/scripts/skills-sh-catalog/sync.ts
+++ b/scripts/skills-sh-catalog/sync.ts
@@ -15,6 +15,9 @@ const MAX_RATE_LIMIT_RETRIES = 30;
 const MAX_RATE_LIMIT_WAIT_MS = 30 * 60 * 1_000;
 const MAX_TRANSPORT_TIMEOUTS = 3;
 const MAX_AUTHORIZATION_RETRIES = 3;
+const BATCH_LEASE_RECONCILE_POLL_MS = 5_000;
+const MAX_BATCH_LEASE_RECONCILE_POLLS = 360;
+const MAX_BATCH_LEASE_RECONCILE_WAIT_MS = 30 * 60 * 1_000;
 const MAX_NATIVE_TRENDING_RECONCILE_POLLS = 360;
 const ACTIVATION_RECONCILE_POLL_MS = 5_000;
 const MAX_ACTIVATION_RECONCILE_POLLS = 360;
@@ -53,6 +56,18 @@ function requiredInteger(value: unknown, name: string) {
 
 function optionalRecord(value: unknown) {
   return typeof value === "object" && value !== null ? (value as Record<string, unknown>) : null;
+}
+
+function batchLeaseExpiresAt(run: MirrorRun) {
+  if (!Object.hasOwn(run, "batchLeaseExpiresAt")) {
+    throw new Error("durable mirror run is missing batchLeaseExpiresAt");
+  }
+  const value = run.batchLeaseExpiresAt;
+  if (value === null) return null;
+  if (!Number.isSafeInteger(value) || Number(value) < 0) {
+    throw new Error("durable mirror run has invalid batchLeaseExpiresAt");
+  }
+  return Number(value);
 }
 
 function assertReadyNativeTrending(value: unknown, unavailableMessage: string) {
@@ -170,10 +185,12 @@ export async function runSkillsShSync(options: {
   reason: string;
   fetchImpl?: SyncFetch;
   sleep?: (ms: number) => Promise<void>;
+  now?: () => number;
 }) {
   const fetchImpl = options.fetchImpl ?? fetch;
   const sleep =
     options.sleep ?? ((ms: number) => new Promise((resolve) => setTimeout(resolve, ms)));
+  const now = options.now ?? Date.now;
   const callRaw = async (body: Record<string, unknown>, forceAuthorizationRefresh = false) => {
     const authorization =
       typeof options.authorization === "string"
@@ -222,6 +239,61 @@ export async function runSkillsShSync(options: {
     let rateLimitWaitMs = 0;
     let transportTimeouts = 0;
     let authorizationRetries = 0;
+    let leaseReconcilePolls = 0;
+    let leaseReconcileWaitMs = 0;
+    const readExactRun = async (request: {
+      operation: string;
+      runId: string;
+      page: number;
+      offset: number;
+    }) => {
+      const authoritativeRun = mirrorRunFromPayload(
+        await call({ operation: "run", runId: request.runId }),
+        "run",
+      );
+      if (
+        requiredString(authoritativeRun.runId, "runId") !== request.runId ||
+        (authoritativeRun.sourceView ?? "leaderboard") !== sourceView
+      ) {
+        throw new Error(`${request.operation} reconciled to a different durable run`);
+      }
+      return authoritativeRun;
+    };
+    const reconcileTimedOutStep = async (request: {
+      operation: string;
+      runId: string;
+      page: number;
+      offset: number;
+    }) => {
+      let authoritativeRun = await readExactRun(request);
+      while (
+        authoritativeRun.status === "running" &&
+        authoritativeRun.page === request.page &&
+        authoritativeRun.offset === request.offset
+      ) {
+        const leaseExpiresAt = batchLeaseExpiresAt(authoritativeRun);
+        if (leaseExpiresAt === null || leaseExpiresAt <= now()) break;
+        if (
+          leaseReconcilePolls >= MAX_BATCH_LEASE_RECONCILE_POLLS ||
+          leaseReconcileWaitMs >= MAX_BATCH_LEASE_RECONCILE_WAIT_MS
+        ) {
+          throw new Error(
+            `${request.operation} durable cursor ${request.page}:${request.offset} retained a live lease after ${leaseReconcilePolls} polls and ${leaseReconcileWaitMs}ms`,
+          );
+        }
+        const delayMs = Math.min(
+          BATCH_LEASE_RECONCILE_POLL_MS,
+          leaseExpiresAt - now(),
+          MAX_BATCH_LEASE_RECONCILE_WAIT_MS - leaseReconcileWaitMs,
+        );
+        if (delayMs <= 0) break;
+        leaseReconcilePolls += 1;
+        leaseReconcileWaitMs += delayMs;
+        await sleep(delayMs);
+        authoritativeRun = await readExactRun(request);
+      }
+      return authoritativeRun;
+    };
     if (run.status === "paused") {
       run = mirrorRunFromPayload(
         await call({
@@ -247,17 +319,7 @@ export async function runSkillsShSync(options: {
       } catch (error) {
         if (!isTransportTimeout(error)) throw error;
         transportTimeouts += 1;
-        const authoritativeRun = mirrorRunFromPayload(
-          await call({ operation: "run", runId: request.runId }),
-          "run",
-        );
-        if (
-          requiredString(authoritativeRun.runId, "runId") !== request.runId ||
-          (authoritativeRun.sourceView ?? "leaderboard") !== sourceView
-        ) {
-          throw new Error(`timed-out ${request.operation} reconciled to a different durable run`);
-        }
-        run = authoritativeRun;
+        run = await reconcileTimedOutStep(request);
         const cursorAdvanced = run.page !== request.page || run.offset !== request.offset;
         if (cursorAdvanced) steps += 1;
         if (
@@ -336,6 +398,8 @@ export async function runSkillsShSync(options: {
         rateLimitWaitMs,
         transportTimeouts,
         authorizationRetries,
+        leaseReconcilePolls,
+        leaseReconcileWaitMs,
       },
     };
   };
@@ -411,7 +475,7 @@ export async function runSkillsShSync(options: {
     throw new Error("timed-out native Trending preflight did not release its exact durable lock");
   };
 
-  const startedAt = Date.now();
+  const startedAt = now();
   const before = await call({ operation: "status" });
   const publicVisible = (before.invariants as Record<string, unknown> | undefined)?.publicVisible;
   if (typeof publicVisible !== "boolean") {
@@ -472,8 +536,8 @@ export async function runSkillsShSync(options: {
     return {
       ok: true as const,
       startedAt: new Date(startedAt).toISOString(),
-      completedAt: new Date().toISOString(),
-      durationMs: Date.now() - startedAt,
+      completedAt: new Date(now()).toISOString(),
+      durationMs: now() - startedAt,
       before,
       ...(nativeBefore ? { nativeBefore } : {}),
       ...(recovered ? { recovered } : {}),

--- a/server/skillsShCatalogSource.test.ts
+++ b/server/skillsShCatalogSource.test.ts
@@ -24,6 +24,56 @@ import {
   validateSkillsShCatalogGitHubOwnerProof,
 } from "./skillsShCatalogSource";
 
+const proofMetadataRow = {
+  id: "owner/repo/skill",
+  installUrl: "https://github.com/owner/repo",
+  installs: 1,
+  name: "Skill",
+  slug: "skill",
+  source: "owner/repo",
+  sourceType: "github",
+  url: "https://www.skills.sh/owner/repo/skill",
+};
+
+function proofMetadataFetch(metadataResponse: () => Response) {
+  return vi.fn(async (input: string | URL | Request) => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+    if (url.includes("/api/v1/skills?page=0")) {
+      return new Response(
+        JSON.stringify({
+          data: [proofMetadataRow],
+          pagination: { page: 0, perPage: 500, total: 1, hasMore: false },
+        }),
+      );
+    }
+    if (url.includes("/api/v1/skills?page=1")) {
+      return new Response(
+        JSON.stringify({
+          data: [],
+          pagination: { page: 1, perPage: 500, total: 1, hasMore: false },
+        }),
+      );
+    }
+    if (url.includes("/api/v1/skills/search?")) {
+      return new Response(JSON.stringify({ data: [proofMetadataRow] }));
+    }
+    if (url.endsWith("/api/v1/skills/owner/repo/skill")) {
+      return new Response(
+        JSON.stringify({
+          files: [],
+          hash: "a".repeat(64),
+          id: proofMetadataRow.id,
+          installs: proofMetadataRow.installs,
+          slug: proofMetadataRow.slug,
+          source: proofMetadataRow.source,
+        }),
+      );
+    }
+    if (url === proofMetadataRow.url) return metadataResponse();
+    throw new Error(`unexpected URL ${url}`);
+  });
+}
+
 describe("skills.sh Vercel source boundary", () => {
   afterEach(() => {
     vi.useRealTimers();
@@ -214,7 +264,15 @@ describe("skills.sh Vercel source boundary", () => {
   });
 
   it("delegates long controlled-source Retry-After waits to durable recovery", async () => {
+    let attempts = 0;
     const fetchImpl = vi.fn(async () => {
+      attempts += 1;
+      if (attempts === 1) {
+        return new Response("request timeout", {
+          status: 408,
+          headers: { "retry-after": "0" },
+        });
+      }
       return new Response("rate limited", {
         status: 429,
         headers: { "retry-after": "120" },
@@ -234,7 +292,31 @@ describe("skills.sh Vercel source boundary", () => {
     ).catch((value: unknown) => value);
 
     expect(skillsShSourceRetryAfterSeconds(error)).toBe(120);
-    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("exhausts controlled-source request timeout retries", async () => {
+    const fetchImpl = vi.fn(async () => {
+      return new Response("request timeout", {
+        status: 408,
+        headers: { "retry-after": "0" },
+      });
+    });
+
+    await expect(
+      fetchSkillsShMirrorControlledBatch(
+        {
+          page: 0,
+          offset: 0,
+          limit: 1,
+          maxDetailBytes: 64,
+          sourceTotal: 1,
+          externalIds: ["patrick-erichsen/skills/html"],
+        },
+        { fetchImpl: fetchImpl as typeof fetch },
+      ),
+    ).rejects.toThrow("controlled skills.sh mirror source fetch failed");
+    expect(fetchImpl).toHaveBeenCalledTimes(4);
   });
 
   it("does not sleep after the final controlled-source rate-limit attempt", async () => {
@@ -485,58 +567,19 @@ describe("skills.sh Vercel source boundary", () => {
   });
 
   it("delegates long proof-metadata Retry-After waits to durable recovery", async () => {
-    const row = {
-      id: "owner/repo/skill",
-      installUrl: "https://github.com/owner/repo",
-      installs: 1,
-      name: "Skill",
-      slug: "skill",
-      source: "owner/repo",
-      sourceType: "github",
-      url: "https://www.skills.sh/owner/repo/skill",
-    };
     let metadataAttempts = 0;
-    const fetchImpl = vi.fn(async (input: string | URL | Request) => {
-      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
-      if (url.includes("/api/v1/skills?page=0")) {
-        return new Response(
-          JSON.stringify({
-            data: [row],
-            pagination: { page: 0, perPage: 500, total: 1, hasMore: false },
-          }),
-        );
-      }
-      if (url.includes("/api/v1/skills?page=1")) {
-        return new Response(
-          JSON.stringify({
-            data: [],
-            pagination: { page: 1, perPage: 500, total: 1, hasMore: false },
-          }),
-        );
-      }
-      if (url.includes("/api/v1/skills/search?")) {
-        return new Response(JSON.stringify({ data: [row] }));
-      }
-      if (url.endsWith("/api/v1/skills/owner/repo/skill")) {
-        return new Response(
-          JSON.stringify({
-            files: [],
-            hash: "a".repeat(64),
-            id: row.id,
-            installs: row.installs,
-            slug: row.slug,
-            source: row.source,
-          }),
-        );
-      }
-      if (url === row.url) {
-        metadataAttempts += 1;
-        return new Response("rate limited", {
-          status: 429,
-          headers: { "retry-after": "120" },
+    const fetchImpl = proofMetadataFetch(() => {
+      metadataAttempts += 1;
+      if (metadataAttempts === 1) {
+        return new Response("request timeout", {
+          status: 408,
+          headers: { "retry-after": "0" },
         });
       }
-      throw new Error(`unexpected URL ${url}`);
+      return new Response("rate limited", {
+        status: 429,
+        headers: { "retry-after": "120" },
+      });
     });
 
     const error = await measureSkillsShMirrorProofSource({
@@ -546,7 +589,27 @@ describe("skills.sh Vercel source boundary", () => {
     }).catch((value: unknown) => value);
 
     expect(skillsShSourceRetryAfterSeconds(error)).toBe(120);
-    expect(metadataAttempts).toBe(1);
+    expect(metadataAttempts).toBe(2);
+  });
+
+  it("exhausts proof-metadata request timeout retries", async () => {
+    let metadataAttempts = 0;
+    const fetchImpl = proofMetadataFetch(() => {
+      metadataAttempts += 1;
+      return new Response("request timeout", {
+        status: 408,
+        headers: { "retry-after": "0" },
+      });
+    });
+
+    await expect(
+      measureSkillsShMirrorProofSource({
+        oidcToken: "oidc-token",
+        fetchImpl: fetchImpl as typeof fetch,
+        minimumApiRequestIntervalMs: 0,
+      }),
+    ).rejects.toThrow("skills.sh proof metadata returned HTTP 408");
+    expect(metadataAttempts).toBe(4);
   });
 
   it("hashes captured leaderboard rows independently of upstream object key order", async () => {
@@ -1761,85 +1824,88 @@ describe("skills.sh Vercel source boundary", () => {
     );
   });
 
-  it("fetches the exact ambiguous source page only for identity resolution", async () => {
-    let identityPageAttempts = 0;
-    const fetchImpl = vi.fn(async (urlInput: string | URL | Request) => {
-      const url = String(urlInput);
-      if (url.includes("?page=0&per_page=500")) {
-        return new Response(
-          JSON.stringify({
-            data: [
-              {
-                id: "larksuite/cli/lark-doc",
-                installUrl: null,
-                installs: 383_123,
-                name: "lark-doc",
-                slug: "lark-doc",
-                source: "larksuite/cli",
-                sourceType: "well-known",
-                url: "https://www.skills.sh/larksuite/cli/lark-doc",
-              },
-            ],
-            pagination: { page: 0, perPage: 500, total: 1, hasMore: false },
-          }),
-        );
-      }
-      if (url === "https://www.skills.sh/larksuite/cli/lark-doc") {
-        identityPageAttempts += 1;
-        if (identityPageAttempts === 1) {
-          return new Response("retry", {
-            status: 503,
-            headers: { "retry-after": "0" },
-          });
+  it.each([408, 503])(
+    "fetches the exact ambiguous source page after transient HTTP %s",
+    async (retryStatus) => {
+      let identityPageAttempts = 0;
+      const fetchImpl = vi.fn(async (urlInput: string | URL | Request) => {
+        const url = String(urlInput);
+        if (url.includes("?page=0&per_page=500")) {
+          return new Response(
+            JSON.stringify({
+              data: [
+                {
+                  id: "larksuite/cli/lark-doc",
+                  installUrl: null,
+                  installs: 383_123,
+                  name: "lark-doc",
+                  slug: "lark-doc",
+                  source: "larksuite/cli",
+                  sourceType: "well-known",
+                  url: "https://www.skills.sh/larksuite/cli/lark-doc",
+                },
+              ],
+              pagination: { page: 0, perPage: 500, total: 1, hasMore: false },
+            }),
+          );
         }
-        return new Response(
-          `<main><section class="bg-background py-8"><div><span>Repository</span></div><a href="https://github.com/larksuite/cli.git">larksuite/cli</a></section></main>`,
-          { headers: { "content-type": "text/html; charset=utf-8" } },
-        );
-      }
-      if (url.includes("/api/v1/skills/audit/")) {
-        return new Response(JSON.stringify({ error: "not_found" }), { status: 404 });
-      }
-      if (url.includes("/api/v1/skills/larksuite/cli/lark-doc")) {
-        return new Response(
-          JSON.stringify({
-            id: "larksuite/cli/lark-doc",
-            source: "larksuite/cli",
-            slug: "lark-doc",
-            installs: 383_123,
-            hash: "c".repeat(64),
-            files: [{ path: "skills/lark-doc/SKILL.md", contents: "# Lark Doc" }],
-          }),
-        );
-      }
-      return new Response("unexpected request", { status: 500 });
-    });
+        if (url === "https://www.skills.sh/larksuite/cli/lark-doc") {
+          identityPageAttempts += 1;
+          if (identityPageAttempts === 1) {
+            return new Response("retry", {
+              status: retryStatus,
+              headers: { "retry-after": "0" },
+            });
+          }
+          return new Response(
+            `<main><section class="bg-background py-8"><div><span>Repository</span></div><a href="https://github.com/larksuite/cli.git">larksuite/cli</a></section></main>`,
+            { headers: { "content-type": "text/html; charset=utf-8" } },
+          );
+        }
+        if (url.includes("/api/v1/skills/audit/")) {
+          return new Response(JSON.stringify({ error: "not_found" }), { status: 404 });
+        }
+        if (url.includes("/api/v1/skills/larksuite/cli/lark-doc")) {
+          return new Response(
+            JSON.stringify({
+              id: "larksuite/cli/lark-doc",
+              source: "larksuite/cli",
+              slug: "lark-doc",
+              installs: 383_123,
+              hash: "c".repeat(64),
+              files: [{ path: "skills/lark-doc/SKILL.md", contents: "# Lark Doc" }],
+            }),
+          );
+        }
+        return new Response("unexpected request", { status: 500 });
+      });
 
-    const batch = await fetchSkillsShMirrorBatch(
-      { page: 0, offset: 0, limit: 1, maxDetailBytes: 64 },
-      {
-        oidcToken: "request-bound-oidc",
-        fetchImpl: fetchImpl as typeof fetch,
-        githubLocatorResolver: null,
-      },
-    );
+      const batch = await fetchSkillsShMirrorBatch(
+        { page: 0, offset: 0, limit: 1, maxDetailBytes: 64 },
+        {
+          oidcToken: "request-bound-oidc",
+          fetchImpl: fetchImpl as typeof fetch,
+          githubLocatorResolver: null,
+        },
+      );
 
-    expect(batch.rows).toEqual([
-      expect.objectContaining({
-        externalId: "larksuite/cli/lark-doc",
-        sourceType: "github",
-        upstreamSourceType: "well-known",
-        owner: "larksuite",
-        repo: "cli",
-        canonicalRepoUrl: "https://github.com/larksuite/cli",
-      }),
-    ]);
-    expect(batch.sourceRequests).toBe(5);
-    expect(fetchImpl).toHaveBeenCalledWith("https://www.skills.sh/larksuite/cli/lark-doc", {
-      headers: { Accept: "text/html" },
-      redirect: "manual",
-    });
-  });
+      expect(batch.rows).toEqual([
+        expect.objectContaining({
+          externalId: "larksuite/cli/lark-doc",
+          sourceType: "github",
+          upstreamSourceType: "well-known",
+          owner: "larksuite",
+          repo: "cli",
+          canonicalRepoUrl: "https://github.com/larksuite/cli",
+        }),
+      ]);
+      expect(batch.sourceRequests).toBe(5);
+      expect(fetchImpl).toHaveBeenCalledWith("https://www.skills.sh/larksuite/cli/lark-doc", {
+        headers: { Accept: "text/html" },
+        redirect: "manual",
+      });
+    },
+  );
 
   it("delegates long identity-page Retry-After waits to durable recovery", async () => {
     vi.useFakeTimers();
@@ -2268,59 +2334,62 @@ describe("skills.sh Vercel source boundary", () => {
     expect(batch.sourceBytes).toBeGreaterThan(64 * 1024);
   });
 
-  it("quarantines exhausted identity-page 5xx retries as a transient fetch failure", async () => {
-    let identityPageAttempts = 0;
-    const fetchImpl = vi.fn(async (urlInput: string | URL | Request) => {
-      const url = String(urlInput);
-      if (url.includes("?page=0&per_page=500")) {
-        return new Response(
-          JSON.stringify({
-            data: [
-              {
-                id: "larksuite/cli/lark-doc",
-                installUrl: null,
-                installs: 383_123,
-                name: "lark-doc",
-                slug: "lark-doc",
-                source: "larksuite/cli",
-                sourceType: "well-known",
-                url: "https://www.skills.sh/larksuite/cli/lark-doc",
-              },
-            ],
-            pagination: { page: 0, perPage: 500, total: 1, hasMore: false },
-          }),
-        );
-      }
-      if (url === "https://www.skills.sh/larksuite/cli/lark-doc") {
-        identityPageAttempts += 1;
-        return new Response("unavailable", {
-          status: 503,
-          headers: { "retry-after": "0" },
-        });
-      }
-      return new Response("unexpected request", { status: 500 });
-    });
+  it.each([408, 503])(
+    "quarantines exhausted identity-page HTTP %s retries as a transient fetch failure",
+    async (retryStatus) => {
+      let identityPageAttempts = 0;
+      const fetchImpl = vi.fn(async (urlInput: string | URL | Request) => {
+        const url = String(urlInput);
+        if (url.includes("?page=0&per_page=500")) {
+          return new Response(
+            JSON.stringify({
+              data: [
+                {
+                  id: "larksuite/cli/lark-doc",
+                  installUrl: null,
+                  installs: 383_123,
+                  name: "lark-doc",
+                  slug: "lark-doc",
+                  source: "larksuite/cli",
+                  sourceType: "well-known",
+                  url: "https://www.skills.sh/larksuite/cli/lark-doc",
+                },
+              ],
+              pagination: { page: 0, perPage: 500, total: 1, hasMore: false },
+            }),
+          );
+        }
+        if (url === "https://www.skills.sh/larksuite/cli/lark-doc") {
+          identityPageAttempts += 1;
+          return new Response("unavailable", {
+            status: retryStatus,
+            headers: { "retry-after": "0" },
+          });
+        }
+        return new Response("unexpected request", { status: 500 });
+      });
 
-    const batch = await fetchSkillsShMirrorBatch(
-      { page: 0, offset: 0, limit: 1, maxDetailBytes: 64 },
-      {
-        oidcToken: "request-bound-oidc",
-        fetchImpl: fetchImpl as typeof fetch,
-        githubLocatorResolver: null,
-      },
-    );
+      const batch = await fetchSkillsShMirrorBatch(
+        { page: 0, offset: 0, limit: 1, maxDetailBytes: 64 },
+        {
+          oidcToken: "request-bound-oidc",
+          fetchImpl: fetchImpl as typeof fetch,
+          githubLocatorResolver: null,
+        },
+      );
 
-    expect(batch.rows).toEqual([
-      {
-        quarantined: true,
-        externalId: "larksuite/cli/lark-doc",
-        upstreamSourceType: "well-known",
-        reason: "identity-page-fetch-failed",
-      },
-    ]);
-    expect(identityPageAttempts).toBe(4);
-    expect(batch.sourceRequests).toBe(5);
-  });
+      expect(batch.rows).toEqual([
+        {
+          quarantined: true,
+          externalId: "larksuite/cli/lark-doc",
+          upstreamSourceType: "well-known",
+          reason: "identity-page-fetch-failed",
+        },
+      ]);
+      expect(identityPageAttempts).toBe(4);
+      expect(batch.sourceRequests).toBe(5);
+    },
+  );
 
   it("quarantines an identity page without an explicit HTML content type", async () => {
     const fetchImpl = vi.fn(async (urlInput: string | URL | Request) => {
@@ -2704,6 +2773,50 @@ describe("skills.sh Vercel source boundary", () => {
     await vi.advanceTimersByTimeAsync(1);
     await pagePromise;
     expect(attempts).toBe(2);
+  });
+
+  it("recovers an authenticated API request after HTTP 408", async () => {
+    let attempts = 0;
+    const fetchImpl = vi.fn(async () => {
+      attempts += 1;
+      if (attempts === 1) {
+        return new Response("request timeout", {
+          status: 408,
+          headers: { "retry-after": "0" },
+        });
+      }
+      return new Response(
+        JSON.stringify({
+          data: [],
+          pagination: { page: 0, perPage: 500, total: 0, hasMore: false },
+        }),
+      );
+    });
+
+    await expect(
+      fetchSkillsShCatalogPage(
+        { page: 0, perPage: 500 },
+        { oidcToken: "request-bound-oidc", fetchImpl: fetchImpl as typeof fetch },
+      ),
+    ).resolves.toMatchObject({ pagination: { total: 0 } });
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("exhausts authenticated API request timeout retries", async () => {
+    const fetchImpl = vi.fn(async () => {
+      return new Response("request timeout", {
+        status: 408,
+        headers: { "retry-after": "0" },
+      });
+    });
+
+    await expect(
+      fetchSkillsShCatalogPage(
+        { page: 0, perPage: 500 },
+        { oidcToken: "request-bound-oidc", fetchImpl: fetchImpl as typeof fetch },
+      ),
+    ).rejects.toThrow("skills.sh catalog source returned HTTP 408");
+    expect(fetchImpl).toHaveBeenCalledTimes(4);
   });
 
   it("preserves Retry-After when bounded source retries are exhausted", async () => {

--- a/server/skillsShCatalogSource.ts
+++ b/server/skillsShCatalogSource.ts
@@ -496,6 +496,10 @@ export function skillsShSourceRetryAfterSeconds(error: unknown) {
     : null;
 }
 
+function isRetryableSkillsShHttpStatus(status: number) {
+  return status === 408 || status === 429 || status >= 500;
+}
+
 async function fetchSkillsShApiResponse(
   path: string,
   options: SkillsShFetchOptions,
@@ -517,7 +521,7 @@ async function fetchSkillsShApiResponse(
     }
     const retryAfterMs = response.status === 429 ? skillsShRetryAfterMs(response, attempt) : null;
     if (
-      (response.status !== 429 && response.status < 500) ||
+      !isRetryableSkillsShHttpStatus(response.status) ||
       attempt === MAX_SOURCE_ATTEMPTS - 1 ||
       (retryAfterMs !== null && retryAfterMs > MAX_INLINE_RETRY_AFTER_MS)
     ) {
@@ -890,7 +894,7 @@ async function fetchSkillsShIdentityPage(
         return failure("identity-page-http-404");
       }
       if (!response.ok) {
-        if (response.status === 429 || response.status >= 500) {
+        if (isRetryableSkillsShHttpStatus(response.status)) {
           const retryAfterMs =
             response.status === 429 ? skillsShRetryAfterMs(response, attempt) : null;
           if (
@@ -1793,7 +1797,7 @@ async function fetchSkillsShProofText(
     }
     const retryAfterMs = response.status === 429 ? skillsShRetryAfterMs(response, attempt) : null;
     if (
-      (response.status !== 429 && response.status < 500) ||
+      !isRetryableSkillsShHttpStatus(response.status) ||
       attempt === MAX_SOURCE_ATTEMPTS - 1 ||
       (retryAfterMs !== null && retryAfterMs > MAX_INLINE_RETRY_AFTER_MS)
     ) {
@@ -2320,7 +2324,7 @@ export async function fetchSkillsShMirrorControlledBatch(
           response = null;
         }
         if (response?.ok) break;
-        if (response && response.status !== 429 && response.status < 500) {
+        if (response && !isRetryableSkillsShHttpStatus(response.status)) {
           await cancelResponseBody(response);
           throw new Error(
             `controlled skills.sh mirror source returned HTTP ${response.status}: ${supplement.externalId}`,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the skills.sh synchronization job could retry an exact cursor while the original timed-out batch still held or renewed its durable lease, and where HTTP 408 responses were treated inconsistently across sibling source GET paths.

## Why This Change Was Made

The durable run projection now exposes only the batch lease expiry, never the lease token. After an ambiguous step timeout, the runner polls that exact durable run through live or renewed leases, adopts committed cursor progress, and retries the exact cursor only after authoritative expiry or release. The four bounded source GET loops now share the same retryable status policy for HTTP 408, 429, and 5xx while preserving the existing long-429 durable handoff and four-attempt cap.

No schema, config, migration, or deployment changes are included.

## User Impact

Operators can expect timed-out skills.sh mirror steps to avoid racing a still-running durable batch, and transient HTTP 408 responses to recover consistently without weakening bounded retry behavior.

## Evidence

- Focused regression suite: 3 files passed, 119 tests passed.
- `bun run ci:static`: passed.
- `bun run ci:unit`: 470 files passed, 1 skipped; 6,239 tests passed, 3 skipped.
- `bun run ci:types-build`: passed.
- Convex dry-run codegen/typecheck passed under Node 24.16.0 against the local anonymous deployment.
- `git diff --check`: passed.
- Added lease cases: expired, live then released, renewed then advanced, already advanced, permanently live bound, missing expiry, and malformed expiry.
- Added HTTP 408 recovery and exhaustion coverage across authenticated API, identity page, proof metadata, and controlled pinned-source GET loops.
- Structured autoreview's TruffleHog scan passed. The model review could not start because the required standalone Codex CLI is not installed in the execution environment; the diff received direct source review instead.

Production delta: +88/-18 lines. The added production code establishes the durable reconciliation owner boundary and central retry classification; tests are +534/-187 lines.
