### PR TITLE
fix(ci): stabilize weekly design audit

### DIFF
--- a/.github/workflows/design-system-audit.yml
+++ b/.github/workflows/design-system-audit.yml
@@ -20,7 +20,7 @@ env:
 
 jobs:
   audit:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-8vcpu-ubuntu-2404
     timeout-minutes: 75
     permissions:
       contents: write

--- a/scripts/design-audit/design-audit-workflow.test.ts
+++ b/scripts/design-audit/design-audit-workflow.test.ts
@@ -1,5 +1,6 @@
 /* @vitest-environment node */
 import { readFile } from "node:fs/promises";
+import { parseConfigFileTextToJson } from "typescript";
 import { describe, expect, it } from "vitest";
 import { parse as parseYaml } from "yaml";
 
@@ -20,10 +21,11 @@ describe("weekly design-system audit workflow", () => {
         workflow_dispatch: unknown;
       };
       env: Record<string, string>;
-      jobs: { audit: { steps: Step[] } };
+      jobs: { audit: { "runs-on": string; steps: Step[] } };
     };
     const steps = workflow.jobs.audit.steps;
 
+    expect(workflow.jobs.audit["runs-on"]).toBe("blacksmith-8vcpu-ubuntu-2404");
     expect(workflow.on.schedule).toEqual([{ cron: "17 15 * * 1" }]);
     expect(workflow.on.workflow_dispatch).toBeDefined();
     expect(workflow.env.AUDIT_BRANCH).toBe("automation/design-system-audit");
@@ -63,6 +65,31 @@ describe("weekly design-system audit workflow", () => {
     expect(upload?.uses).toMatch(/^actions\/upload-artifact@[0-9a-f]{40}$/);
     expect(commit?.if).toBe("steps.finalize.outputs.open_pr == 'true'");
     expect(failure?.if).toContain("steps.validation.outcome == 'failure'");
+  });
+
+  it("keeps Codex workspace-scoped with restricted networking", async () => {
+    const runCodex = await readFile("scripts/design-audit/run-codex.ts", "utf8");
+    const forbiddenOverrides = [
+      "danger-full-access",
+      "--dangerously-bypass-approvals-and-sandbox",
+      "use_legacy_landlock=true",
+      "use_legacy_landlock = true",
+      "network_access=true",
+      "network_access = true",
+    ];
+
+    expect(runCodex).toContain('"--sandbox",\n    "workspace-write"');
+    for (const override of forbiddenOverrides) {
+      expect(runCodex).not.toContain(override);
+    }
+  });
+
+  it("excludes generated audit artifacts from the root TypeScript project", async () => {
+    const source = await readFile("tsconfig.json", "utf8");
+    const parsed = parseConfigFileTextToJson("tsconfig.json", source);
+
+    expect(parsed.error).toBeUndefined();
+    expect(parsed.config.exclude).toContain("artifacts/**");
   });
 
   it("enforces the agent change boundary before running repository scripts", async () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "include": ["**/*.ts", "**/*.tsx"],
+  "exclude": ["artifacts/**"],
   "compilerOptions": {
     "target": "ES2022",
     "jsx": "react-jsx",


### PR DESCRIPTION
## Summary

- What changed:
  - run the weekly design audit on the Blacksmith Ubuntu 24.04 runner
  - exclude top-level `artifacts/**` from the root TypeScript project
  - lock the runner, artifact exclusion, and restricted Codex sandbox contract into the workflow test
- Why:
  - the first production audit exposed two runner/tooling failures: GitHub's hosted runner could not create the Codex bubblewrap network namespace, and root TypeScript validation collected the cloned design-system repository under `artifacts/`

## Linked Issue

- Closes #
- Related #3523

## Screenshots

- [x] N/A

## Behavioural Proof

- [x] A deliberately invalid `artifacts/design-audit/design-system/poison.ts` was ignored by root `bunx tsc --noEmit`.
- [x] The focused workflow test verifies the Blacksmith runner, `workspace-write`, restricted networking, and the root artifact exclusion.

## Security / Trust Impact

- [x] Security/trust impact explained

Codex remains pinned at `0.142.3`, uses `workspace-write`, keeps `approval_policy=never`, and does not enable network access, legacy Landlock, `danger-full-access`, or sandbox bypass flags. The runner change restores the existing restricted sandbox rather than weakening it.

### Maintainer security-boundary disposition

Exact reviewed head: `b67f9251ca79818c4a105852ead2778c7703a5c5`.

- Blacksmith is approved for this scheduled audit's existing `contents: write`, `pull-requests: write`, and `OPENAI_API_KEY` boundary.
- The workflow retains empty top-level permissions, job-scoped write permissions, restricted Codex networking, `workspace-write`, and `approval_policy=never`.
- Pre-merge end-to-end dispatch is intentionally unavailable because the audit checks out `main`. Pointing a secret-bearing workflow at a pull-request ref would weaken the trust boundary.
- Immediately after squash merge, manually dispatch the landed workflow and require the Blacksmith job, Codex audit, cloned design-system validation, artifact upload, and overall workflow to pass.

## Data / Deploy Impact

- [x] No data/deploy impact

## Verification

- [x] `bun run ci:static`
- [x] Focused tests for touched behavior: `bunx vitest run scripts/design-audit/design-audit-workflow.test.ts` (6 passed)
- [x] `bun run ci:unit` under Node 24.16.0 (470 files passed, 1 skipped; 6,241 tests passed, 3 skipped)
- [x] Broader gate when required: `bun run ci:types-build`
- [x] Other: root TypeScript poison probe under `artifacts/design-audit/design-system/`
