### PR TITLE
fix(ci): authenticate design audit pull requests

### DIFF
--- a/.github/workflows/design-system-audit.yml
+++ b/.github/workflows/design-system-audit.yml
@@ -202,12 +202,38 @@ jobs:
           git commit -m "chore: apply weekly design audit"
           git push --force-with-lease origin "HEAD:$AUDIT_BRANCH"
 
+      - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        id: app-token
+        continue-on-error: true
+        if: steps.finalize.outputs.open_pr == 'true'
+        with:
+          app-id: "2729701"
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-pull-requests: write
+
+      - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        id: app-token-fallback
+        continue-on-error: true
+        if: steps.finalize.outputs.open_pr == 'true' && steps.app-token.outcome == 'failure'
+        with:
+          app-id: "2971289"
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY_FALLBACK }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-pull-requests: write
+
       - name: Open or update draft pull request
         if: steps.finalize.outputs.open_pr == 'true'
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || steps.app-token-fallback.outputs.token }}
         run: |
           set -euo pipefail
+          if [[ -z "${GH_TOKEN:-}" ]]; then
+            echo "::error::Unable to create a Barnacle GitHub App token. Check the primary GH_APP_PRIVATE_KEY and fallback GH_APP_PRIVATE_KEY_FALLBACK credentials and their pull-request permissions." >&2
+            exit 1
+          fi
           open_pr="$(
             gh pr list \
               --repo "$GITHUB_REPOSITORY" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixes
 
+- CI: authenticate weekly design-audit pull request mutations with the Barnacle GitHub App while retaining the workflow token for branch publication and clean-audit closure.
 - API: record skipped and failed skill evaluation outcomes without passing worker tokens to internal mutations.
 - GitHub Actions/CLI/API: require v2 authorization for every OpenClaw OIDC publish, bind large-artifact upload tickets and package mutations to the exact authorization transaction, consume scoped capabilities with non-public staging, then require an immutable successful parent attempt and atomic durable authorization revalidation before final publication.
 - GitHub Actions: revalidate versioned trusted tooling workflow identity immediately before package publication, including exact protected lightweight tags, so approval waits cannot authorize moved tooling.

--- a/scripts/design-audit/design-audit-workflow.test.ts
+++ b/scripts/design-audit/design-audit-workflow.test.ts
@@ -5,6 +5,9 @@ import { describe, expect, it } from "vitest";
 import { parse as parseYaml } from "yaml";
 
 type Step = {
+  "continue-on-error"?: boolean;
+  env?: Record<string, unknown>;
+  id?: string;
   name?: string;
   if?: string;
   run?: string;
@@ -38,15 +41,59 @@ describe("weekly design-system audit workflow", () => {
     expect(createPr?.run).toContain("gh pr edit");
     expect(createPr?.run).toContain('--head "$AUDIT_BRANCH"');
 
+    const primaryToken = steps.find((step) => step.id === "app-token");
+    expect(primaryToken).toMatchObject({
+      uses: "actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3",
+      "continue-on-error": true,
+      if: "steps.finalize.outputs.open_pr == 'true'",
+      with: {
+        "app-id": "2729701",
+        "private-key": "${{ secrets.GH_APP_PRIVATE_KEY }}",
+        owner: "${{ github.repository_owner }}",
+        repositories: "${{ github.event.repository.name }}",
+        "permission-pull-requests": "write",
+      },
+    });
+
+    const fallbackToken = steps.find((step) => step.id === "app-token-fallback");
+    expect(fallbackToken).toMatchObject({
+      uses: "actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3",
+      "continue-on-error": true,
+      if: "steps.finalize.outputs.open_pr == 'true' && steps.app-token.outcome == 'failure'",
+      with: {
+        "app-id": "2971289",
+        "private-key": "${{ secrets.GH_APP_PRIVATE_KEY_FALLBACK }}",
+        owner: "${{ github.repository_owner }}",
+        repositories: "${{ github.event.repository.name }}",
+        "permission-pull-requests": "write",
+      },
+    });
+
+    expect(createPr?.env).toEqual({
+      GH_TOKEN: "${{ steps.app-token.outputs.token || steps.app-token-fallback.outputs.token }}",
+    });
+    const createPrRun = createPr?.run ?? "";
+    const tokenGuard = 'if [[ -z "${GH_TOKEN:-}" ]]';
+    expect(createPrRun).toContain(tokenGuard);
+    expect(createPrRun).toContain("primary GH_APP_PRIVATE_KEY");
+    expect(createPrRun).toContain("fallback GH_APP_PRIVATE_KEY_FALLBACK");
+    expect(createPrRun.indexOf(tokenGuard)).toBeLessThan(createPrRun.indexOf("gh pr list"));
+    expect(JSON.stringify(createPr)).not.toContain("github.token");
+    expect(createPrRun).not.toContain("git push");
+
+    const commit = steps.find((step) => step.name === "Commit audit branch");
+    expect(commit?.run).toContain('git push --force-with-lease origin "HEAD:$AUDIT_BRANCH"');
+    expect(JSON.stringify(commit)).not.toContain("steps.app-token");
+
     const closeClean = steps.find(
       (step) => step.name === "Close obsolete clean audit pull request",
     );
     expect(closeClean?.if).toContain("steps.validation.outcome == 'success'");
     expect(closeClean?.run).toContain("gh pr close");
+    expect(closeClean?.env).toEqual({ GH_TOKEN: "${{ github.token }}" });
+    expect(JSON.stringify(closeClean)).not.toContain("steps.app-token");
 
-    expect(steps.some((step) => step.name === "Create repository token")).toBe(false);
     expect(source).not.toContain("DESIGN_SYSTEM_READ_TOKEN");
-    expect(source).not.toContain("steps.app-token.outputs.token");
   });
 
   it("preserves artifacts and suppresses PRs when validation fails", async () => {


### PR DESCRIPTION
## Summary

- What changed:
  - mint the existing primary or fallback Barnacle GitHub App token only when the design audit needs to open or update its draft pull request
  - keep the workflow credential responsible for publishing the audit branch and closing an obsolete clean-audit pull request
  - fail explicitly before any `gh pr` command when neither app credential produces a token
- Why:
  - the audit completed and pushed `automation/design-system-audit`, but repository policy correctly rejected pull-request creation by `GITHUB_TOKEN`

## Linked Issue

- Related #3523

## Screenshots

- [x] N/A

## Behavioural Proof

- [x] The workflow contract asserts the exact pinned action, primary/fallback conditions, repository scope, pull-request-only app permission, empty-token guard, and credential separation.
- [x] The existing update-skills workflow contract remains green against the same Barnacle pattern.
- [x] Exact-head workflow dispatch `32828115874` succeeded at `6490d76e1b8d45cc79adb1742c986dee05bcd4b9`: primary App-token mint, full audit validation, artifact upload, and draft-PR mutation all passed.
- [x] The run created draft PR #3527 from `automation/design-system-audit` to `main` as `app/openclaw-barnacle` with a non-empty generated audit body.

## Security / Trust Impact

- [x] Security/trust impact explained: the app token is repository-scoped and requests only `pull-requests: write`; it is not used for checkout or branch publication, and there is no `github.token` fallback for PR creation.

## Data / Deploy Impact

- [x] No data/deploy impact

## Verification

- [x] `bun run ci:static`
- [x] Focused tests for touched behavior: `bunx vitest run scripts/design-audit/design-audit-workflow.test.ts scripts/update-skills-workflow.test.ts` (7 passed, Node 24.16.0)
- [x] `bun run ci:unit` (470 files passed, 1 skipped; 6,241 tests passed, 3 skipped; Node 24.16.0)
- [x] Broader gate when required: `bun run ci:types-build` (Node 24.16.0)
- [x] Other: `git diff --check`
