### PR TITLE
fix: preserve ordinary trusted publish refs

### DIFF
--- a/convex/packages.public.test.ts
+++ b/convex/packages.public.test.ts
@@ -11719,7 +11719,7 @@ describe("packages public queries", () => {
     );
   });
 
-  it("revokes trusted publish tokens after a successful publish", async () => {
+  it("accepts and records tag refs for ordinary trusted publishes", async () => {
     const runMutation = vi.fn(async (_ref: unknown, args: unknown) => {
       if (
         typeof args === "object" &&
@@ -11762,7 +11762,7 @@ describe("packages public queries", () => {
           environment: "clawhub-release",
           version: "1.0.0",
           sha: "abc123",
-          ref: "refs/heads/main",
+          ref: "refs/tags/v1.0.0",
           runId: "100",
           runAttempt: "1",
           expiresAt: Date.now() + 60_000,
@@ -11789,6 +11789,15 @@ describe("packages public queries", () => {
           version: "1.0.0",
           changelog: "init",
           bundle: { hostTargets: ["desktop"] },
+          source: {
+            kind: "github",
+            url: "https://github.com/example/example",
+            repo: "example/example",
+            ref: "refs/tags/v1.0.0",
+            commit: "abc123",
+            path: ".",
+            importedAt: 1,
+          },
           files: [packageManifestFile],
         },
       }),
@@ -11801,7 +11810,114 @@ describe("packages public queries", () => {
     expect(runMutation).toHaveBeenCalledWith(expect.anything(), {
       tokenId: "packagePublishTokens:1",
     });
+    expect(runMutation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        source: expect.objectContaining({
+          repo: "example/example",
+          ref: "refs/tags/v1.0.0",
+          commit: "abc123",
+          path: ".",
+        }),
+      }),
+    );
   });
+
+  it.each([
+    {
+      mode: "ordinary commit",
+      candidateSha: undefined,
+      sourceCommit: "wrong-sha",
+      sourceRef: "refs/tags/v1.0.0",
+      expectedError: "Trusted publish source commit must match the authorized source commit",
+    },
+    {
+      mode: "ordinary ref",
+      candidateSha: undefined,
+      sourceCommit: "abc123",
+      sourceRef: "refs/tags/v2.0.0",
+      expectedError: "Trusted publish source ref must match the authorized source ref",
+    },
+    {
+      mode: "split-candidate commit",
+      candidateSha: "candidate-sha",
+      sourceCommit: "abc123",
+      sourceRef: "candidate-sha",
+      expectedError: "Trusted publish source commit must match the authorized source commit",
+    },
+    {
+      mode: "split-candidate ref",
+      candidateSha: "candidate-sha",
+      sourceCommit: "candidate-sha",
+      sourceRef: "refs/tags/v1.0.0",
+      expectedError: "Trusted publish source ref must match the authorized source ref",
+    },
+  ])(
+    "rejects $mode mismatches",
+    async ({ candidateSha, sourceCommit, sourceRef, expectedError }) => {
+      const trustedPublisher = {
+        _id: "packageTrustedPublishers:1",
+        packageId: "packages:demo",
+        provider: "github-actions",
+        repository: "example/example",
+        repositoryId: "1",
+        repositoryOwner: "example",
+        repositoryOwnerId: "2",
+        workflowFilename: "plugin-clawhub-release.yml",
+        environment: "clawhub-release",
+      };
+      const ctx = {
+        runQuery: vi
+          .fn()
+          .mockResolvedValueOnce({
+            _id: "packagePublishTokens:1",
+            packageId: "packages:demo",
+            provider: "github-actions",
+            repository: "example/example",
+            repositoryId: "1",
+            repositoryOwner: "example",
+            repositoryOwnerId: "2",
+            workflowFilename: "plugin-clawhub-release.yml",
+            environment: "clawhub-release",
+            version: "1.0.0",
+            sha: "abc123",
+            ref: "refs/tags/v1.0.0",
+            runId: "100",
+            runAttempt: "1",
+            candidateSha,
+            expiresAt: Date.now() + 60_000,
+          })
+          .mockResolvedValueOnce(trustedPublisher)
+          .mockResolvedValueOnce(makePackageDoc({ family: "bundle-plugin" }))
+          .mockResolvedValueOnce(trustedPublisher),
+      };
+
+      await expect(
+        publishPackageForTrustedPublisherInternalHandler(ctx as never, {
+          publishTokenId: "packagePublishTokens:1",
+          payload: {
+            name: "demo-plugin",
+            family: "bundle-plugin",
+            version: "1.0.0",
+            changelog: "init",
+            bundle: { hostTargets: ["desktop"] },
+            source: {
+              kind: "github",
+              url: "https://github.com/example/example",
+              repo: "example/example",
+              ref: sourceRef,
+              commit: sourceCommit,
+              path: ".",
+              importedAt: 1,
+            },
+            files: [packageManifestFile],
+          },
+        }),
+      ).rejects.toThrow(expectedError);
+
+      expect(ctx.runQuery).toHaveBeenCalledTimes(4);
+    },
+  );
 
   it("revokes trusted publish tokens when a staged publish is accepted for checks", async () => {
     const previousFlag = process.env.CLAWHUB_STAGED_PREPUBLICATION_PUBLISHES;

--- a/convex/packages.ts
+++ b/convex/packages.ts
@@ -8113,6 +8113,9 @@ function resolveTrustedPublishSource(
   const source = payload.source;
   const sourceRepository = publishToken.candidateRepository ?? publishToken.repository;
   const sourceSha = publishToken.candidateSha ?? publishToken.sha;
+  // Split-candidate credentials pin both fields to the candidate SHA; ordinary credentials
+  // preserve the verified workflow ref while still binding the commit to its authorized SHA.
+  const sourceRef = publishToken.candidateSha ?? publishToken.ref;
   if (source && source.kind !== "github") {
     throw new ConvexError("Trusted publishes only support GitHub source metadata");
   }
@@ -8124,17 +8127,17 @@ function resolveTrustedPublishSource(
     throw new ConvexError("Trusted publish source repo must match the verified GitHub repository");
   }
   if (source?.commit && source.commit !== sourceSha) {
-    throw new ConvexError("Trusted publish source commit must match the authorized candidate SHA");
+    throw new ConvexError("Trusted publish source commit must match the authorized source commit");
   }
-  if (source?.ref && source.ref !== sourceSha) {
-    throw new ConvexError("Trusted publish source ref must match the authorized candidate SHA");
+  if (source?.ref && source.ref !== sourceRef) {
+    throw new ConvexError("Trusted publish source ref must match the authorized source ref");
   }
   const path = source?.path?.trim() || ".";
   return {
     kind: "github",
     url: `https://github.com/${sourceRepository}`,
     repo: sourceRepository,
-    ref: sourceSha,
+    ref: sourceRef,
     commit: sourceSha,
     path,
     importedAt: source?.importedAt ?? Date.now(),


### PR DESCRIPTION
Closes #3507

## What Problem This Solves

Fixes an issue where ordinary GitHub Actions trusted publishers using a tag source ref would have publication rejected because ClawHub compared that ref to the authorized commit SHA. Split-candidate OpenClaw publishes must still bind both ref and commit to the frozen candidate SHA.

## Why This Change Was Made

`resolveTrustedPublishSource()` already owns the verified source contract. Resolving the authorized commit and ref separately there restores the documented ordinary-caller behavior without adding network ref resolution or relaxing the split-candidate provenance boundary.

## User Impact

Ordinary trusted publishers can publish from verified tag refs again. Candidate-backed publishes retain the same fail-closed immutable provenance checks.

## Evidence

Baseline reproduction on `upstream/main`:

- The focused ordinary tag-ref test failed before the fix with `Trusted publish source ref must match the authorized candidate SHA`.
- On this branch, the ordinary tag-ref success path, the existing split-candidate success path, and four ordinary/candidate commit/ref mismatch cases all pass.

An isolated local Convex 1.44 proof used real `packages`, `users`, and `packagePublishTokens` rows. The full redacted command/output trace is inspectable in [this PR comment](https://github.com/openclaw/clawhub/pull/3528#issuecomment-5408660765):

- an ordinary token (`sha: ordinary-commit-sha`, `ref: refs/tags/v1.0.0`) resolved the effective persisted source to `commit: ordinary-commit-sha` and `ref: refs/tags/v1.0.0`;
- a split-candidate token resolved both `commit` and `ref` to `candidate-commit-sha`;
- ordinary and split-candidate ref/commit mismatches were rejected before publication;
- the terminal output confirms both real token rows were loaded and every synthetic row was cleaned up.

Proof-only functions and fixture rows were removed. The final branch was pushed to the same local deployment and verified clean at `fbdc0a4818c48f19a07e00e16f8f59ffe24f74f0`.

The final branch was also validated with:

- `bun run test convex/packages.public.test.ts` — 369 passed;
- `bun run ci:static` — passed;
- `bun run ci:unit` — 470 files passed, 1 skipped; 6245 tests passed, 3 skipped; coverage passed;
- `bun run ci:types-build` — passed;
- `bunx convex dev --once` — local Convex functions ready;
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main` — clean, no accepted/actionable findings;
- `git diff --check` — passed.
