### PR TITLE
fix(ci): version design audit reports

### DIFF
--- a/scripts/design-audit/design-audit.test.ts
+++ b/scripts/design-audit/design-audit.test.ts
@@ -4,6 +4,7 @@ import { validateSafeChanges } from "./finalize";
 import {
   curatedFindings,
   renderAuditMarkdown,
+  renderPullRequestBody,
   shouldOpenAuditPullRequest,
   sortAndDedupeFindings,
   summarizeFindings,
@@ -57,7 +58,9 @@ describe("design audit reporting", () => {
 
   it("renders immutable audit provenance", () => {
     const report: AuditReport = {
-      designSystemVersion: "v0.0.3",
+      schemaVersion: 2,
+      carapaceVersion: "v0.0.3",
+      designSystemVersion: "v0.0.2",
       consumerSha: "consumer",
       auditBaseSha: "base",
       generatedAt: "2026-07-08T00:00:00.000Z",
@@ -70,6 +73,12 @@ describe("design audit reporting", () => {
       validationPassed: true,
     };
     const markdown = renderAuditMarkdown(report);
+    const pullRequestBody = renderPullRequestBody(report, "https://example.test/run");
+    expect(report.schemaVersion).toBe(2);
+    expect(markdown).toContain("Carapace: `v0.0.3`");
+    expect(markdown).not.toContain("`v0.0.2`");
+    expect(pullRequestBody).toContain("Carapace: `v0.0.3`");
+    expect(pullRequestBody).not.toContain("`v0.0.2`");
     expect(markdown).toContain("`v0.0.3`");
     expect(markdown).toContain("`consumer`");
     expect(markdown).toContain("No significant design-system drift was found.");

--- a/scripts/design-audit/finalize.ts
+++ b/scripts/design-audit/finalize.ts
@@ -92,6 +92,8 @@ async function main() {
     ...parseFindings(codex),
   ]);
   const report: AuditReport = {
+    schemaVersion: 2,
+    carapaceVersion: release,
     designSystemVersion: release,
     consumerSha,
     auditBaseSha: baseSha,

--- a/scripts/design-audit/report.ts
+++ b/scripts/design-audit/report.ts
@@ -21,6 +21,8 @@ export type AuditSummary = {
 };
 
 export type AuditReport = {
+  schemaVersion: 2;
+  carapaceVersion: string;
   designSystemVersion: string;
   consumerSha: string;
   auditBaseSha: string;
@@ -130,7 +132,7 @@ export function renderAuditMarkdown(report: AuditReport) {
   const lines = [
     "# ClawHub design audit",
     "",
-    `- Design system: \`${report.designSystemVersion}\``,
+    `- Carapace: \`${report.carapaceVersion}\``,
     `- ClawHub commit: \`${report.consumerSha}\``,
     `- Comparison base: \`${report.auditBaseSha}\``,
     `- Generated: ${report.generatedAt}`,
@@ -173,7 +175,7 @@ export function renderPullRequestBody(report: AuditReport, runUrl: string) {
   const lines = [
     "## Audit",
     "",
-    `- Design system: \`${report.designSystemVersion}\``,
+    `- Carapace: \`${report.carapaceVersion}\``,
     `- Audited ClawHub SHA: \`${report.consumerSha}\``,
     `- Comparison base: \`${report.auditBaseSha}\``,
     `- Findings: ${report.summary.errors} errors, ${report.summary.warnings} warnings, ${report.summary.info} informational`,


### PR DESCRIPTION
## Summary

- What changed:
  - emit design-audit report schema version 2
  - emit both `carapaceVersion` and the migration-compatible `designSystemVersion`
  - render Markdown and pull-request provenance from `carapaceVersion`
- Why:
  - generated audit artifacts omitted required format metadata, so recurring audit PRs could not satisfy the installed report contract

## Linked Issue

- Related #3527

## Screenshots

- [x] N/A

## Behavioural Proof

The focused design-audit tests use different Carapace and legacy design-system versions and prove that both Markdown surfaces render the Carapace version. The finalizer emits schema version 2 and both version fields from the resolved release.

- [x] Behavioural proof included

## Security / Trust Impact

- [x] No security/trust impact

## Data / Deploy Impact

- [x] No data/deploy impact

## Verification

- [x] `bun run ci:static`
- [x] Focused tests: `bunx vitest run scripts/design-audit/design-audit.test.ts scripts/design-audit/design-audit-workflow.test.ts` (13 passed)
- [x] `bun run ci:unit` under Node 24.19.0 (470 files passed, 1 skipped; 6,241 tests passed, 3 skipped)
- [x] `bun run ci:types-build` under Node 24.19.0
- [x] `bunx tsc -p packages/schema/tsconfig.json --noEmit`
- [x] `bunx tsc -p packages/clawhub/tsconfig.json --noEmit`
- [x] `git diff --check`
