### PR TITLE
fix: remove manual override controls

### DIFF
--- a/src/__tests__/skill-detail-page.test.tsx
+++ b/src/__tests__/skill-detail-page.test.tsx
@@ -1507,7 +1507,7 @@ describe("SkillDetailPage", () => {
     ).toBeTruthy();
   });
 
-  it("applies staff-cleared moderation overrides to the public security summary", async () => {
+  it("shows the version scanner verdict even with legacy clean moderation metadata", async () => {
     useQueryMock.mockImplementation((_fn: unknown, args: unknown) => {
       if (args === "skip") return undefined;
       return undefined;
@@ -1584,7 +1584,6 @@ describe("SkillDetailPage", () => {
               isSuspicious: false,
               isHiddenByMod: false,
               isRemoved: false,
-              overrideActive: true,
               verdict: "clean",
               reasonCodes: ["suspicious.dynamic_code_execution"],
               summary: "Security findings were reviewed by staff and cleared for public use.",
@@ -1601,10 +1600,10 @@ describe("SkillDetailPage", () => {
     );
 
     expect((await screen.findAllByText("Security audit")).length).toBeGreaterThan(0);
-    expect(screen.getAllByText("Cleared").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Review").length).toBeGreaterThan(0);
     expect(screen.getByRole("link", { name: "View Security Audit" })).toBeTruthy();
     expect(screen.queryByText(/reviewed by staff and cleared/i)).toBeNull();
-    expect(screen.queryByRole("link", { name: /Suspicious/i })).toBeNull();
+    expect(screen.queryByText("Cleared")).toBeNull();
   });
 
   it("does not show a scanner rerun action on the settings page for owned skills", async () => {

--- a/src/__tests__/version-delete-ui.test.tsx
+++ b/src/__tests__/version-delete-ui.test.tsx
@@ -132,8 +132,6 @@ function makeSkillVersionsPanel({
       canDeleteVersions={canDeleteVersions}
       nixPlugin={false}
       skillSlug={skillSlug}
-      suppressScanResults={false}
-      suppressedMessage={null}
     />
   );
 }
@@ -437,8 +435,6 @@ describe("version Delete UI", () => {
         canDeleteVersions
         nixPlugin={false}
         skillSlug="weather"
-        suppressScanResults={false}
-        suppressedMessage={null}
       />,
     );
 

--- a/src/components/DetailSecuritySummary.test.tsx
+++ b/src/components/DetailSecuritySummary.test.tsx
@@ -48,18 +48,16 @@ describe("DetailSecuritySummary", () => {
     expect(document.querySelector(".security-audit-meter")?.getAttribute("data-level")).toBe("0");
   });
 
-  it("shows staff-cleared public scan summaries as cleared", () => {
+  it("shows suspicious version scans without a clearance path", () => {
     render(
       <DetailSecuritySummary
         auditHref="/suka233/kmind-markdown-to-mindmap/security-audit"
         vtAnalysis={{ status: "suspicious", verdict: "suspicious", checkedAt: 1 }}
         llmAnalysis={{ status: "suspicious", verdict: "suspicious", checkedAt: 1 }}
-        suppressScanResults
       />,
     );
 
-    expect(screen.getByText("Cleared")).toBeTruthy();
-    expect(screen.queryByText("Warn")).toBeNull();
+    expect(screen.getByText("Review")).toBeTruthy();
   });
 
   it("rolls ClawScan review and warning states into the compact verdict", () => {

--- a/src/components/DetailSecuritySummary.tsx
+++ b/src/components/DetailSecuritySummary.tsx
@@ -8,7 +8,6 @@ type DetailSecuritySummaryProps = {
   vtAnalysis?: VtAnalysis | null;
   llmAnalysis?: LlmAnalysis | null;
   githubScanStatus?: string | null;
-  suppressScanResults?: boolean;
 };
 
 export function auditVerdictMeterLevel(status: string) {
@@ -22,7 +21,6 @@ export function auditVerdictMeterLevel(status: string) {
       return 2;
     case "benign":
     case "clean":
-    case "cleared":
       return 3;
     default:
       return 0;
@@ -34,15 +32,10 @@ export function DetailSecuritySummary({
   vtAnalysis,
   llmAnalysis,
   githubScanStatus,
-  suppressScanResults = false,
 }: DetailSecuritySummaryProps) {
   const hasVersionScanResult = Boolean(vtAnalysis || llmAnalysis);
   const auditVerdict = hasVersionScanResult
-    ? aggregateAuditVerdict({
-        vtAnalysis,
-        llmAnalysis,
-        suppressScanResults,
-      })
+    ? aggregateAuditVerdict({ vtAnalysis, llmAnalysis })
     : (githubScanStatus ?? "pending");
   const auditVerdictInfo = getScanStatusInfo(auditVerdict);
   const meterLevel = auditVerdictMeterLevel(auditVerdict);

--- a/src/components/SkillDetailPage.tsx
+++ b/src/components/SkillDetailPage.tsx
@@ -440,14 +440,6 @@ export function SkillDetailPage({
 
   const forkOf = result?.forkOf ?? null;
   const canonical = result?.canonical ?? null;
-  const suppressVersionScanResults =
-    !isStaff &&
-    Boolean(modInfo?.overrideActive) &&
-    !modInfo?.isMalwareBlocked &&
-    !modInfo?.isSuspicious;
-  const scanResultsSuppressedMessage = suppressVersionScanResults
-    ? "Security findings on these releases were reviewed by staff and cleared for public use."
-    : null;
   const forkOfLabel = forkOf?.kind === "duplicate" ? "duplicate of" : "fork of";
   const forkOfOwnerHandle = forkOf?.owner?.handle ?? null;
   const forkOfOwnerId = forkOf?.owner?.userId ?? null;
@@ -837,7 +829,6 @@ export function SkillDetailPage({
         vtAnalysis={latestVersion?.vtAnalysis ?? null}
         llmAnalysis={latestVersion?.llmAnalysis ?? null}
         githubScanStatus={githubScanStatus}
-        suppressScanResults={suppressVersionScanResults}
       />
     ) : null;
   const staffVisibilityAlert = staffModerationNote ? (
@@ -1014,8 +1005,6 @@ export function SkillDetailPage({
         versions={versions}
         nixPlugin={Boolean(nixPlugin)}
         showArchiveTabs={!isGitHubBackedSkill}
-        suppressVersionScanResults={suppressVersionScanResults}
-        scanResultsSuppressedMessage={scanResultsSuppressedMessage}
         clawdis={clawdis}
         osLabels={osLabels}
         readmeHrefResolver={readmeHrefResolver}

--- a/src/components/SkillDetailPageView.tsx
+++ b/src/components/SkillDetailPageView.tsx
@@ -41,7 +41,6 @@ type SkillModerationInfo = {
   isSuspicious: boolean;
   isHiddenByMod: boolean;
   isRemoved: boolean;
-  overrideActive?: boolean;
   verdict?: "clean" | "suspicious" | "malicious";
   reason?: string;
 };

--- a/src/components/SkillDetailTabs.test.tsx
+++ b/src/components/SkillDetailTabs.test.tsx
@@ -40,8 +40,6 @@ function renderReadme(readmeContent: string) {
       diffVersions={undefined}
       versions={undefined}
       nixPlugin={false}
-      suppressVersionScanResults={false}
-      scanResultsSuppressedMessage={null}
       clawdis={undefined}
       osLabels={[]}
     />,
@@ -66,8 +64,6 @@ function renderReadmeForOwner(readmeContent: string) {
       diffVersions={undefined}
       versions={undefined}
       nixPlugin={false}
-      suppressVersionScanResults={false}
-      scanResultsSuppressedMessage={null}
       clawdis={undefined}
       osLabels={[]}
     />,
@@ -92,8 +88,6 @@ describe("SkillDetailTabs README links", () => {
         diffVersions={undefined}
         versions={undefined}
         nixPlugin={false}
-        suppressVersionScanResults={false}
-        scanResultsSuppressedMessage={null}
         clawdis={undefined}
         osLabels={[]}
       />,
@@ -118,8 +112,6 @@ describe("SkillDetailTabs README links", () => {
         diffVersions={undefined}
         versions={undefined}
         nixPlugin={false}
-        suppressVersionScanResults={false}
-        scanResultsSuppressedMessage={null}
         clawdis={undefined}
         osLabels={[]}
       />,
@@ -157,8 +149,6 @@ describe("SkillDetailTabs README links", () => {
         versions={undefined}
         nixPlugin={false}
         showArchiveTabs={false}
-        suppressVersionScanResults={false}
-        scanResultsSuppressedMessage={null}
         clawdis={undefined}
         osLabels={[]}
       />,
@@ -220,8 +210,6 @@ describe("SkillDetailTabs README links", () => {
         diffVersions={undefined}
         versions={undefined}
         nixPlugin={false}
-        suppressVersionScanResults={false}
-        scanResultsSuppressedMessage={null}
         clawdis={undefined}
         osLabels={[]}
       />,
@@ -261,8 +249,6 @@ describe("SkillDetailTabs README links", () => {
           } as unknown as Doc<"skillVersions">,
         ]}
         nixPlugin={false}
-        suppressVersionScanResults={false}
-        scanResultsSuppressedMessage={null}
         clawdis={undefined}
         osLabels={[]}
       />,
@@ -293,8 +279,6 @@ describe("SkillDetailTabs README links", () => {
         diffVersions={undefined}
         versions={undefined}
         nixPlugin={false}
-        suppressVersionScanResults={false}
-        scanResultsSuppressedMessage={null}
         clawdis={undefined}
         osLabels={[]}
         readmeHrefResolver={(href) => `https://github.com/NVIDIA/skills/blob/abc/${href}`}
@@ -325,8 +309,6 @@ describe("SkillDetailTabs README links", () => {
           diffVersions={undefined}
           versions={undefined}
           nixPlugin={false}
-          suppressVersionScanResults={false}
-          scanResultsSuppressedMessage={null}
           osLabels={["macOS"]}
           clawdis={
             {
@@ -380,8 +362,6 @@ describe("SkillDetailTabs README links", () => {
         diffVersions={undefined}
         versions={undefined}
         nixPlugin={false}
-        suppressVersionScanResults={false}
-        scanResultsSuppressedMessage={null}
         clawdis={undefined}
         osLabels={[]}
       />,
@@ -413,8 +393,6 @@ describe("SkillDetailTabs README links", () => {
         diffVersions={undefined}
         versions={undefined}
         nixPlugin={false}
-        suppressVersionScanResults={false}
-        scanResultsSuppressedMessage={null}
         clawdis={undefined}
         osLabels={[]}
       />,
@@ -454,8 +432,6 @@ describe("SkillDetailTabs evaluation tab", () => {
           versions={undefined}
           nixPlugin={false}
           showArchiveTabs={false}
-          suppressVersionScanResults={false}
-          scanResultsSuppressedMessage={null}
           clawdis={undefined}
           osLabels={[]}
           evaluationContent={<div>Native SkillEvaluator report</div>}

--- a/src/components/SkillDetailTabs.tsx
+++ b/src/components/SkillDetailTabs.tsx
@@ -64,8 +64,6 @@ type SkillDetailTabsProps = {
   versions: Doc<"skillVersions">[] | undefined;
   nixPlugin: boolean;
   showArchiveTabs?: boolean;
-  suppressVersionScanResults: boolean;
-  scanResultsSuppressedMessage: string | null;
   clawdis: ClawdisSkillMetadata | undefined;
   osLabels: string[];
   readmeHrefResolver?: (href: string) => string;
@@ -91,8 +89,6 @@ export function SkillDetailTabs({
   versions,
   nixPlugin,
   showArchiveTabs = true,
-  suppressVersionScanResults,
-  scanResultsSuppressedMessage,
   clawdis,
   osLabels,
   readmeHrefResolver,
@@ -380,8 +376,6 @@ export function SkillDetailTabs({
             nixPlugin={nixPlugin}
             skillSlug={skill.slug}
             ownerHandle={ownerHandle}
-            suppressScanResults={suppressVersionScanResults}
-            suppressedMessage={scanResultsSuppressedMessage}
           />
         </div>
       ) : null}

--- a/src/components/SkillSecurityScanResults.tsx
+++ b/src/components/SkillSecurityScanResults.tsx
@@ -153,8 +153,6 @@ export function getScanStatusInfo(status: string) {
     case "clean":
     case "undetected-only-fallback":
       return { label: "Pass", className: "scan-status-clean", badgeVariant: "success" };
-    case "cleared":
-      return { label: "Cleared", className: "scan-status-clean", badgeVariant: "success" };
     case "malicious":
       return {
         label: "Malicious",

--- a/src/components/SkillVersionsPanel.tsx
+++ b/src/components/SkillVersionsPanel.tsx
@@ -22,8 +22,6 @@ type SkillVersionsPanelProps = {
   nixPlugin: boolean;
   skillSlug: string;
   ownerHandle?: string | null;
-  suppressScanResults: boolean;
-  suppressedMessage: string | null;
 };
 
 function mergeSkillVersions(...groups: Doc<"skillVersions">[][]) {
@@ -58,7 +56,6 @@ export function SkillVersionsPanel({
   nixPlugin,
   skillSlug,
   ownerHandle,
-  suppressedMessage,
 }: SkillVersionsPanelProps) {
   const deleteOwnedVersion = useMutation(api.skills.deleteOwnedVersion);
   const restoreOwnedVersion = useMutation(api.skills.restoreOwnedVersion);
@@ -164,9 +161,6 @@ export function SkillVersionsPanel({
       <div className="tab-body skill-versions-panel">
         <div className="skill-versions-header">
           <h2>Versions</h2>
-          {suppressedMessage ? (
-            <p className="skill-versions-suppressed-message">{suppressedMessage}</p>
-          ) : null}
         </div>
         <div className="skill-versions-scroll">
           <div className="skill-versions-list skill-versions-list-skills">

--- a/src/components/securityAuditModel.ts
+++ b/src/components/securityAuditModel.ts
@@ -19,7 +19,6 @@ type SecurityAuditSignals = {
     findings?: unknown[] | null;
     checkedAt?: number | null;
   } | null;
-  suppressScanResults?: boolean;
 };
 
 export const AUDIT_SCANNER_LABELS: Record<AuditScannerKind, string> = {
@@ -35,7 +34,6 @@ const SUPPORTING_AUDIT_SCANNER_ORDER: AuditScannerKind[] = DEFAULT_AUDIT_SCANNER
 );
 
 export function aggregateAuditVerdict(signals: SecurityAuditSignals) {
-  if (signals.suppressScanResults) return "cleared";
   const clawScanStatus = getClawScanDisplayStatus(signals.llmAnalysis);
   const staticStatus = signals.staticScan?.status?.trim().toLowerCase();
   if (clawScanStatus === "malicious" || staticStatus === "malicious") return "malicious";
@@ -57,14 +55,9 @@ export function aggregateAuditVerdict(signals: SecurityAuditSignals) {
 
 export function getSecurityAuditOverviewCopy({
   llmAnalysis,
-  suppressScanResults,
-  suppressedMessage,
 }: {
   llmAnalysis?: LlmAnalysis | null;
-  suppressScanResults?: boolean;
-  suppressedMessage?: string | null;
 }) {
-  if (suppressScanResults && suppressedMessage?.trim()) return [suppressedMessage.trim()];
   return [
     llmAnalysis?.summary?.trim() || "No security analysis has been recorded yet.",
     llmAnalysis?.guidance?.trim() || null,

--- a/src/lib/skillPage.ts
+++ b/src/lib/skillPage.ts
@@ -25,7 +25,6 @@ export type SkillBySlugResult = {
     isSuspicious: boolean;
     isHiddenByMod: boolean;
     isRemoved: boolean;
-    overrideActive?: boolean;
     verdict?: "clean" | "suspicious" | "malicious";
     reasonCodes?: string[];
     summary?: string | null;

--- a/src/routes/-management/SkillsPage.tsx
+++ b/src/routes/-management/SkillsPage.tsx
@@ -19,7 +19,6 @@ import {
   formatAuditActionLabel,
   formatAuditMetadataSummary,
   formatManagementUserLabel,
-  formatManualOverrideState,
   formatTimestamp,
   resolveOwnerParam,
   SKILL_AUDIT_LOG_LIMIT,
@@ -39,18 +38,14 @@ export function SkillsPage({
   selectedOwner,
   selectedSkill,
   selectedSlug,
-  skillOverrideNote,
   skillSearch,
   staff,
-  onApplySkillOverride,
   onBanUser,
   onChangeOwner,
   onChangeOwnerSearch,
   onChangeSelectedDuplicate,
   onChangeSelectedOwner,
-  onChangeSkillOverrideNote,
   onChangeSkillSearch,
-  onClearSkillOverride,
   onHardDeleteSkill,
   onManageSkill,
   onSetBatch,
@@ -69,18 +64,14 @@ export function SkillsPage({
   selectedOwner: Id<"users"> | "";
   selectedSkill: SkillBySlugResult | undefined;
   selectedSlug: string | undefined;
-  skillOverrideNote: string;
   skillSearch: string;
   staff: boolean;
-  onApplySkillOverride: () => void;
   onBanUser: (userId: Id<"users">, label: string) => void;
   onChangeOwner: (skillId: Id<"skills">, ownerUserId: Id<"users">) => void;
   onChangeOwnerSearch: (value: string) => void;
   onChangeSelectedDuplicate: (value: string) => void;
   onChangeSelectedOwner: (value: Id<"users"> | "") => void;
-  onChangeSkillOverrideNote: (value: string) => void;
   onChangeSkillSearch: (value: string) => void;
-  onClearSkillOverride: () => void;
   onHardDeleteSkill: (skill: Doc<"skills">) => void;
   onManageSkill: () => void;
   onSetBatch: (skillId: Id<"skills">, batch: "highlighted" | undefined) => void;
@@ -93,7 +84,7 @@ export function SkillsPage({
     <div className="management-view">
       <h2 className="section-title text-[1.2rem] m-0">Skill tools</h2>
       <p className="section-subtitle m-0 mt-1">
-        Look up a skill by slug to manage moderation overrides and view its audit history.
+        Look up a skill by slug to manage it and view its audit history.
       </p>
       <div className="management-controls">
         <div className="management-control management-search">
@@ -141,8 +132,7 @@ export function SkillsPage({
           <div className="management-empty">No skill found for "{selectedSlug}".</div>
         ) : (
           (() => {
-            const { skill, latestVersion, owner, canonical, overrideReviewer, auditLogs } =
-              selectedSkill;
+            const { skill, latestVersion, owner, canonical, auditLogs } = selectedSkill;
             const ownerParam = resolveOwnerParam(
               owner?.handle ?? null,
               owner?._id ?? skill.ownerUserId,
@@ -179,58 +169,6 @@ export function SkillsPage({
                       ))}
                     </div>
                   ) : null}
-                  <div className="management-sublist">
-                    <div className="section-subtitle m-0">Manual overrides</div>
-                    <section className="management-override-panel">
-                      <div className="management-report-item">
-                        <span className="management-report-meta">Current override</span>
-                        <span>
-                          {formatManualOverrideState(skill.manualOverride, overrideReviewer)}
-                        </span>
-                      </div>
-                      <div className="management-report-item">
-                        <span className="management-report-meta">Latest version</span>
-                        <span>
-                          {latestVersion ? `v${latestVersion.version}` : "No published version."}
-                        </span>
-                      </div>
-                      <div className="management-report-item">
-                        <span className="management-report-meta">Behavior</span>
-                        <span>Applies to the full skill until a moderator clears it.</span>
-                      </div>
-                      <textarea
-                        className="form-input management-textarea"
-                        rows={4}
-                        placeholder={
-                          skill.manualOverride
-                            ? "Audit note required to update or clear the okay override"
-                            : "Audit note required to mark this skill okay"
-                        }
-                        value={skillOverrideNote}
-                        onChange={(event) => onChangeSkillOverrideNote(event.target.value)}
-                      />
-                      <div className="management-actions management-actions-start">
-                        <Button
-                          className="management-action-btn"
-                          type="button"
-                          disabled={!skillOverrideNote.trim()}
-                          onClick={onApplySkillOverride}
-                        >
-                          {skill.manualOverride ? "Update okay override" : "Mark skill okay"}
-                        </Button>
-                        {skill.manualOverride ? (
-                          <Button
-                            className="management-action-btn"
-                            type="button"
-                            disabled={!skillOverrideNote.trim()}
-                            onClick={onClearSkillOverride}
-                          >
-                            Clear skill override
-                          </Button>
-                        ) : null}
-                      </div>
-                    </section>
-                  </div>
                   <div className="management-sublist">
                     <div className="section-subtitle m-0">Recent audit activity</div>
                     <section className="management-override-panel management-audit-panel">

--- a/src/routes/-management/managementShared.ts
+++ b/src/routes/-management/managementShared.ts
@@ -14,7 +14,7 @@ export type ReportedSkillEntry = FunctionReturnType<typeof api.skills.listReport
 export type DuplicateCandidateEntry = FunctionReturnType<
   typeof api.skills.listDuplicateCandidates
 >[number];
-export type ManagementUserSummary = NonNullable<NonNullable<SkillBySlugResult>["overrideReviewer"]>;
+export type ManagementUserSummary = ManagementUserListResult["items"][number];
 
 export type PublisherAbuseReviewDashboard = FunctionReturnType<
   typeof api.publisherAbuse.listReviewDashboard
@@ -119,24 +119,6 @@ export function formatScore(value: number) {
 
 export function formatMutationError(error: unknown) {
   return getUserFacingConvexError(error, "Request failed.");
-}
-
-export function formatManualOverrideState(
-  override:
-    | {
-        verdict: string;
-        note: string;
-        reviewerUserId: string;
-        updatedAt: number;
-      }
-    | null
-    | undefined,
-  reviewer?: ManagementUserSummary | null,
-) {
-  if (!override) return "No override.";
-  return `${formatVerdictLabel(override.verdict)} · reviewer ${formatManagementUserLabel(reviewer, override.reviewerUserId)} · updated ${formatTimestamp(
-    override.updatedAt,
-  )} · ${override.note}`;
 }
 
 export function formatManagementUserLabel(

--- a/src/routes/management.tsx
+++ b/src/routes/management.tsx
@@ -274,8 +274,6 @@ export function Management() {
   const setDuplicate = useMutation(api.skills.setDuplicate);
   const setOfficialBadge = useMutation(api.skills.setOfficialBadge);
   const setDeprecatedBadge = useMutation(api.skills.setDeprecatedBadge);
-  const setSkillManualOverride = useMutation(api.skills.setSkillManualOverride);
-  const clearSkillManualOverride = useMutation(api.skills.clearSkillManualOverride);
   const banPublisherAbuseOwnerMutation = useMutation(api.publisherAbuse.banPublisherAbuseOwner);
   const markPublisherAbuseNominationReviewed = useMutation(
     api.publisherAbuse.markPublisherAbuseNominationReviewed,
@@ -304,7 +302,6 @@ export function Management() {
   const [ownerSearchDebounced, setOwnerSearchDebounced] = useState("");
   const [pluginSearch, setPluginSearch] = useState(selectedPluginName ?? "");
   const [skillSearch, setSkillSearch] = useState(selectedSlug ?? "");
-  const [skillOverrideNote, setSkillOverrideNote] = useState("");
   const [confirmRequest, setConfirmRequest] = useState<ManagementConfirmRequest | null>(null);
   const [publisherAbuseTab, setPublisherAbuseTab] = useState<PublisherAbuseTab>(
     abuseViewActive ? (search.tab ?? "potential_ban_candidate") : "potential_ban_candidate",
@@ -396,10 +393,6 @@ export function Management() {
     setSelectedDuplicate(selectedCanonicalSlug);
     setSelectedOwner(selectedOwnerUserId);
   }, [selectedCanonicalSlug, selectedOwnerUserId, selectedSkillId]);
-
-  useEffect(() => {
-    setSkillOverrideNote("");
-  }, [selectedSkillId]);
 
   useEffect(() => {
     setPluginSearch(selectedPluginName ?? "");
@@ -523,32 +516,6 @@ export function Management() {
         : "No users yet."
       : ""
     : "Loading users…";
-
-  const applySkillOverride = () => {
-    if (!selectedSkill?.skill) return;
-    void setSkillManualOverride({
-      skillId: selectedSkill.skill._id,
-      note: skillOverrideNote,
-    })
-      .then(() => {
-        setSkillOverrideNote("");
-        toast.success("Skill marked okay.");
-      })
-      .catch((error) => toast.error(formatMutationError(error)));
-  };
-
-  const clearSkillOverride = () => {
-    if (!selectedSkill?.skill?.manualOverride) return;
-    void clearSkillManualOverride({
-      skillId: selectedSkill.skill._id,
-      note: skillOverrideNote,
-    })
-      .then(() => {
-        setSkillOverrideNote("");
-        toast.success("Override cleared.");
-      })
-      .catch((error) => toast.error(formatMutationError(error)));
-  };
 
   const managePlugin = () => {
     const name = pluginSearch.trim();
@@ -991,10 +958,8 @@ export function Management() {
             selectedOwner={selectedOwner}
             selectedSkill={selectedSkill}
             selectedSlug={selectedSlug}
-            skillOverrideNote={skillOverrideNote}
             skillSearch={skillSearch}
             staff={staff}
-            onApplySkillOverride={applySkillOverride}
             onBanUser={requestBanUser}
             onChangeOwner={(skillId, ownerUserId) => {
               void changeOwner({ skillId, ownerUserId });
@@ -1002,9 +967,7 @@ export function Management() {
             onChangeOwnerSearch={setOwnerSearch}
             onChangeSelectedDuplicate={setSelectedDuplicate}
             onChangeSelectedOwner={setSelectedOwner}
-            onChangeSkillOverrideNote={setSkillOverrideNote}
             onChangeSkillSearch={setSkillSearch}
-            onClearSkillOverride={clearSkillOverride}
             onHardDeleteSkill={requestHardDeleteSkill}
             onManageSkill={manageSkill}
             onSetBatch={(skillId, batch) => {

--- a/src/styles.css
+++ b/src/styles.css
@@ -11984,17 +11984,6 @@ a.skills-sh-security-audit-row:focus-visible {
   min-width: 0;
 }
 
-.skill-versions-suppressed-message {
-  min-width: 0;
-  color: var(--ink-soft);
-  font-size: 0.86rem;
-  line-height: 1.4;
-}
-
-.skill-versions-suppressed-message {
-  margin: 0;
-}
-
 .skill-versions-scroll {
   overflow: visible;
 }


### PR DESCRIPTION
## What Problem This Solves

Removes UI that allowed staff to create or clear skill-wide trust overrides and fixes the public security summary so it does not display an override-derived “Cleared” result.

## Why This Change Was Made

The management controls and override display branches are removed. Public skill pages now show the exact version scanner outcome, including `Review` for suspicious versions.

## User Impact

Staff no longer see manual override controls. Users see the scanner result that belongs to the displayed version.

## Evidence

- `bun run ci:static`
- `bun run ci:unit` — 6,230 passed, 3 skipped
- `bun run ci:types-build`
- Autoreview: clean

Stack 2/3. Depends on #3535; followed by #3537.
