### PR TITLE
chore: add guarded manual override cleanup

### DIFF
--- a/convex/migrations.test.ts
+++ b/convex/migrations.test.ts
@@ -754,7 +754,7 @@ describe("skill manual override cleanup migration", () => {
     isDone: true,
   };
 
-  it("dry-runs through the tracked migration and reports affected verdicts", async () => {
+  it("previews affected verdicts without invoking the write runner", async () => {
     const runMutation = vi.fn().mockResolvedValue({});
     const runQuery = vi.fn().mockResolvedValue(previewPage);
     const handler = (
@@ -763,11 +763,7 @@ describe("skill manual override cleanup migration", () => {
 
     const result = await handler({ runMutation, runQuery }, {});
 
-    expect(runMutation).toHaveBeenCalledWith(internal.migrations.run, {
-      fn: "migrations:removeSkillManualOverrides",
-      dryRun: true,
-      reset: true,
-    });
+    expect(runMutation).not.toHaveBeenCalled();
     expect(result).toMatchObject({
       ok: true,
       dryRun: true,

--- a/convex/migrations.test.ts
+++ b/convex/migrations.test.ts
@@ -17,6 +17,7 @@ import {
   runPluginManifestSummaryBackfillPage,
   runSkillManualOverrideCleanup,
   runSkillInstallBackfill,
+  shouldPreserveSkillModerationLock,
 } from "./migrations";
 
 type InstallBackfillWrappedHandler = {
@@ -739,7 +740,7 @@ describe("skill manual override cleanup migration", () => {
   const previewPage = {
     scanned: 1,
     affected: 1,
-    outcomes: { clean: 0, review: 1, suspicious: 0, malicious: 0 },
+    outcomes: { preserved: 0, clean: 0, review: 1, suspicious: 0, malicious: 0 },
     samples: [
       {
         skillId,
@@ -783,6 +784,23 @@ describe("skill manual override cleanup migration", () => {
     await expect(
       handler({ runMutation: vi.fn(), runQuery: vi.fn() }, { dryRun: false }),
     ).rejects.toThrow('Pass confirm="remove-skill-manual-overrides" to apply.');
+  });
+
+  it("preserves unrelated moderation quarantines while removing override metadata", () => {
+    expect(
+      shouldPreserveSkillModerationLock({
+        ...makeSkillDoc(),
+        moderationStatus: "hidden",
+        moderationReason: "quality.low",
+      }),
+    ).toBe(true);
+    expect(
+      shouldPreserveSkillModerationLock({
+        ...makeSkillDoc(),
+        moderationStatus: "hidden",
+        moderationReason: "scanner.llm.malicious",
+      }),
+    ).toBe(false);
   });
 });
 

--- a/convex/migrations.test.ts
+++ b/convex/migrations.test.ts
@@ -806,6 +806,15 @@ describe("skill manual override cleanup migration", () => {
         moderationReason: "scanner.llm.malicious",
       }),
     ).toBe(false);
+    expect(
+      shouldPreserveSkillModerationLock({
+        ...makeSkillDoc(),
+        softDeletedAt: 50,
+        moderationStatus: "hidden",
+        moderationReason: "manual.override.okay",
+        hiddenBy: ownerUserId,
+      }),
+    ).toBe(true);
   });
 
   it("fails closed when the latest version cannot be loaded", async () => {

--- a/convex/migrations.test.ts
+++ b/convex/migrations.test.ts
@@ -15,6 +15,7 @@ import {
   runCatalogMetadataCanonicalization,
   runPluginManifestSummaryBackfill,
   runPluginManifestSummaryBackfillPage,
+  runSkillManualOverrideCleanup,
   runSkillInstallBackfill,
 } from "./migrations";
 
@@ -50,6 +51,10 @@ type PluginManifestSummaryBackfillPageWrappedHandler = {
 };
 
 type CatalogMetadataCanonicalizationWrappedHandler = {
+  _handler: (ctx: unknown, args: { dryRun?: boolean; confirm?: string }) => Promise<unknown>;
+};
+
+type SkillManualOverrideCleanupWrappedHandler = {
   _handler: (ctx: unknown, args: { dryRun?: boolean; confirm?: string }) => Promise<unknown>;
 };
 
@@ -727,6 +732,57 @@ describe("skill install backfill migration", () => {
         }),
       }),
     );
+  });
+});
+
+describe("skill manual override cleanup migration", () => {
+  const previewPage = {
+    scanned: 1,
+    affected: 1,
+    outcomes: { clean: 0, review: 1, suspicious: 0, malicious: 0 },
+    samples: [
+      {
+        skillId,
+        slug: "release-validation",
+        latestVersion: "0.1.3",
+        currentVerdict: "clean",
+        nextOutcome: "review",
+      },
+    ],
+    continueCursor: "done",
+    isDone: true,
+  };
+
+  it("dry-runs through the tracked migration and reports affected verdicts", async () => {
+    const runMutation = vi.fn().mockResolvedValue({});
+    const runQuery = vi.fn().mockResolvedValue(previewPage);
+    const handler = (
+      runSkillManualOverrideCleanup as unknown as SkillManualOverrideCleanupWrappedHandler
+    )._handler;
+
+    const result = await handler({ runMutation, runQuery }, {});
+
+    expect(runMutation).toHaveBeenCalledWith(internal.migrations.run, {
+      fn: "migrations:removeSkillManualOverrides",
+      dryRun: true,
+      reset: true,
+    });
+    expect(result).toMatchObject({
+      ok: true,
+      dryRun: true,
+      confirmRequired: "remove-skill-manual-overrides",
+      before: { affected: 1, outcomes: { review: 1 } },
+    });
+  });
+
+  it("requires explicit confirmation before deleting stored overrides", async () => {
+    const handler = (
+      runSkillManualOverrideCleanup as unknown as SkillManualOverrideCleanupWrappedHandler
+    )._handler;
+
+    await expect(
+      handler({ runMutation: vi.fn(), runQuery: vi.fn() }, { dryRun: false }),
+    ).rejects.toThrow('Pass confirm="remove-skill-manual-overrides" to apply.');
   });
 });
 

--- a/convex/migrations.test.ts
+++ b/convex/migrations.test.ts
@@ -11,6 +11,7 @@ import {
   backfillOneNvidiaGitHubDownloadCount,
   backfillOneSkillInstallEstimate,
   buildCanonicalCatalogMetadataPatch,
+  buildSkillModerationAfterOverrideRemoval,
   runNvidiaGitHubDownloadBackfill,
   runCatalogMetadataCanonicalization,
   runPluginManifestSummaryBackfill,
@@ -797,6 +798,19 @@ describe("skill manual override cleanup migration", () => {
         moderationReason: "scanner.llm.malicious",
       }),
     ).toBe(false);
+  });
+
+  it("preserves moderation when the latest version cannot be loaded", async () => {
+    const result = await buildSkillModerationAfterOverrideRemoval(
+      { db: { get: vi.fn().mockResolvedValue(null) } } as never,
+      {
+        ...makeSkillDoc(),
+        latestVersionId: testId("skillVersions", "skillVersions:missing"),
+      },
+      100,
+    );
+
+    expect(result).toEqual({ latestVersion: null, patch: undefined });
   });
 });
 

--- a/convex/migrations.test.ts
+++ b/convex/migrations.test.ts
@@ -741,7 +741,15 @@ describe("skill manual override cleanup migration", () => {
   const previewPage = {
     scanned: 1,
     affected: 1,
-    outcomes: { preserved: 0, clean: 0, review: 1, suspicious: 0, malicious: 0 },
+    outcomes: {
+      preserved: 0,
+      clean: 0,
+      pending: 0,
+      error: 0,
+      review: 1,
+      suspicious: 0,
+      malicious: 0,
+    },
     samples: [
       {
         skillId,
@@ -800,7 +808,7 @@ describe("skill manual override cleanup migration", () => {
     ).toBe(false);
   });
 
-  it("preserves moderation when the latest version cannot be loaded", async () => {
+  it("fails closed when the latest version cannot be loaded", async () => {
     const result = await buildSkillModerationAfterOverrideRemoval(
       { db: { get: vi.fn().mockResolvedValue(null) } } as never,
       {
@@ -810,7 +818,26 @@ describe("skill manual override cleanup migration", () => {
       100,
     );
 
-    expect(result).toEqual({ latestVersion: null, patch: undefined });
+    expect(result).toEqual({
+      latestVersion: null,
+      patch: {
+        moderationStatus: "hidden",
+        moderationReason: "pending.scan.stale",
+        moderationNotes: undefined,
+        moderationFlags: undefined,
+        moderationVerdict: undefined,
+        moderationReasonCodes: ["review.scanner_source_missing"],
+        moderationEvidence: undefined,
+        moderationSummary: "Scanner source version is unavailable; hidden pending a new scan.",
+        moderationEngineVersion: undefined,
+        moderationEvaluatedAt: 100,
+        moderationSourceVersionId: undefined,
+        isSuspicious: false,
+        hiddenAt: 100,
+        hiddenBy: undefined,
+        lastReviewedAt: 100,
+      },
+    });
   });
 });
 

--- a/convex/migrations.ts
+++ b/convex/migrations.ts
@@ -103,6 +103,52 @@ export function shouldPreserveSkillModerationLock(skill: Doc<"skills">) {
   );
 }
 
+function buildMissingVersionModerationPatch(
+  skill: Doc<"skills">,
+  now: number,
+): Partial<Doc<"skills">> {
+  if (
+    skill.moderationVerdict === "malicious" ||
+    skill.moderationFlags?.some((flag) => flag === "blocked.malware")
+  ) {
+    return {
+      moderationStatus: "hidden",
+      moderationReason: skill.moderationReason ?? "scanner.llm.malicious",
+      moderationNotes: skill.moderationNotes,
+      moderationFlags: skill.moderationFlags,
+      moderationVerdict: "malicious",
+      moderationReasonCodes: skill.moderationReasonCodes,
+      moderationEvidence: skill.moderationEvidence,
+      moderationSummary:
+        skill.moderationSummary ?? "Malicious scanner verdict retained; source version is missing.",
+      moderationEngineVersion: skill.moderationEngineVersion,
+      moderationEvaluatedAt: now,
+      moderationSourceVersionId: undefined,
+      isSuspicious: true,
+      hiddenAt: skill.hiddenAt ?? now,
+      hiddenBy: skill.hiddenBy,
+      lastReviewedAt: now,
+    };
+  }
+  return {
+    moderationStatus: "hidden",
+    moderationReason: "pending.scan.stale",
+    moderationNotes: undefined,
+    moderationFlags: undefined,
+    moderationVerdict: undefined,
+    moderationReasonCodes: ["review.scanner_source_missing"],
+    moderationEvidence: undefined,
+    moderationSummary: "Scanner source version is unavailable; hidden pending a new scan.",
+    moderationEngineVersion: undefined,
+    moderationEvaluatedAt: now,
+    moderationSourceVersionId: undefined,
+    isSuspicious: false,
+    hiddenAt: now,
+    hiddenBy: undefined,
+    lastReviewedAt: now,
+  };
+}
+
 export async function buildSkillModerationAfterOverrideRemoval(
   ctx: Pick<MutationCtx, "db"> | Pick<QueryCtx, "db">,
   skill: Doc<"skills">,
@@ -116,7 +162,7 @@ export async function buildSkillModerationAfterOverrideRemoval(
     latestVersion: latestVersion?.version ?? null,
     patch: latestVersion
       ? buildScannerModerationPatchFromVersion({ owner, version: latestVersion, now })
-      : undefined,
+      : buildMissingVersionModerationPatch(skill, now),
   };
 }
 
@@ -131,10 +177,6 @@ export const removeSkillManualOverrides = migrations.define({
     }
     const now = Date.now();
     const { patch } = await buildSkillModerationAfterOverrideRemoval(ctx, skill, now);
-    if (!patch) {
-      await ctx.db.patch(skill._id, { manualOverride: undefined });
-      return;
-    }
     const nextSkill = { ...skill, ...patch, manualOverride: undefined } as Doc<"skills">;
     await ctx.db.patch(skill._id, { ...patch, manualOverride: undefined });
 
@@ -155,6 +197,8 @@ export const removeSkillManualOverrides = migrations.define({
 type SkillManualOverrideCleanupOutcome =
   | "preserved"
   | "clean"
+  | "pending"
+  | "error"
   | "review"
   | "suspicious"
   | "malicious";
@@ -182,6 +226,8 @@ type SkillManualOverrideCleanupPreview = Omit<
 function classifySkillManualOverrideCleanupOutcome(
   patch: Partial<Doc<"skills">>,
 ): SkillManualOverrideCleanupOutcome {
+  if (patch.moderationReason?.includes("error")) return "error";
+  if (patch.moderationReason?.startsWith("pending.")) return "pending";
   if (patch.moderationVerdict === "malicious") return "malicious";
   if (patch.moderationVerdict === "suspicious") return "suspicious";
   if (patch.moderationReasonCodes?.some((code) => code.startsWith("review."))) return "review";
@@ -201,6 +247,8 @@ export const previewSkillManualOverrideCleanupPageInternal = internalQuery({
     const outcomes: Record<SkillManualOverrideCleanupOutcome, number> = {
       preserved: 0,
       clean: 0,
+      pending: 0,
+      error: 0,
       review: 0,
       suspicious: 0,
       malicious: 0,
@@ -227,19 +275,6 @@ export const previewSkillManualOverrideCleanupPageInternal = internalQuery({
         skill,
         Date.now(),
       );
-      if (!patch) {
-        outcomes.preserved += 1;
-        if (samples.length < 20) {
-          samples.push({
-            skillId: skill._id,
-            slug: skill.slug,
-            latestVersion,
-            currentVerdict: skill.moderationVerdict ?? "unknown",
-            nextOutcome: "preserved",
-          });
-        }
-        continue;
-      }
       const nextOutcome = classifySkillManualOverrideCleanupOutcome(patch);
       outcomes[nextOutcome] += 1;
       if (samples.length < 20) {
@@ -271,7 +306,15 @@ async function previewSkillManualOverrideCleanup(
   const preview: SkillManualOverrideCleanupPreview = {
     scanned: 0,
     affected: 0,
-    outcomes: { preserved: 0, clean: 0, review: 0, suspicious: 0, malicious: 0 },
+    outcomes: {
+      preserved: 0,
+      clean: 0,
+      pending: 0,
+      error: 0,
+      review: 0,
+      suspicious: 0,
+      malicious: 0,
+    },
     samples: [],
   };
 
@@ -282,7 +325,15 @@ async function previewSkillManualOverrideCleanup(
     );
     preview.scanned += page.scanned;
     preview.affected += page.affected;
-    for (const outcome of ["preserved", "clean", "review", "suspicious", "malicious"] as const) {
+    for (const outcome of [
+      "preserved",
+      "clean",
+      "pending",
+      "error",
+      "review",
+      "suspicious",
+      "malicious",
+    ] as const) {
       preview.outcomes[outcome] += page.outcomes[outcome];
     }
     preview.samples.push(...page.samples.slice(0, 20 - preview.samples.length));

--- a/convex/migrations.ts
+++ b/convex/migrations.ts
@@ -1838,13 +1838,7 @@ export const runSkillManualOverrideCleanup: ReturnType<typeof internalAction> = 
     }
 
     const before = await previewSkillManualOverrideCleanup(ctx);
-    if (dryRun) {
-      await ctx.runMutation(internal.migrations.run, {
-        fn: "migrations:removeSkillManualOverrides",
-        dryRun: true,
-        reset: true,
-      });
-    } else {
+    if (!dryRun) {
       await runToCompletion(
         ctx,
         components.migrations,

--- a/convex/migrations.ts
+++ b/convex/migrations.ts
@@ -37,7 +37,7 @@ import { syncSkillSearchDigestForSkill } from "./lib/skillSearchDigest";
 import { readCanonicalStat } from "./lib/skillStats";
 import { adjustUserSkillStatsForSkillChange } from "./lib/userSkillStats";
 import schema from "./schema";
-import { buildScannerModerationPatchFromVersion } from "./skills";
+import { buildScannerModerationPatchFromVersion, setSkillEmbeddingsSoftDeleted } from "./skills";
 
 const CANONICALIZE_CATALOG_METADATA_CONFIRM = "canonicalize-catalog-metadata";
 const APPLY_SKILL_INSTALL_BACKFILL_CONFIRM = "apply-skill-install-backfill";
@@ -92,6 +92,17 @@ export const migrations = new Migrations(components.migrations, {
   defaultBatchSize: 25,
 });
 
+export function shouldPreserveSkillModerationLock(skill: Doc<"skills">) {
+  if (skill.moderationStatus !== "hidden") return false;
+  const reason = skill.moderationReason;
+  return !(
+    reason === "pending.scan" ||
+    reason === "pending.scan.stale" ||
+    reason?.startsWith("scanner.") ||
+    reason?.startsWith("manual.override.")
+  );
+}
+
 function buildNoVersionModerationPatch(now: number): Partial<Doc<"skills">> {
   return {
     moderationStatus: "active",
@@ -134,7 +145,12 @@ export const removeSkillManualOverrides = migrations.define({
   batchSize: 25,
   migrateOne: async (ctx, skill) => {
     if (!skill.manualOverride) return;
-    const { patch } = await buildSkillModerationAfterOverrideRemoval(ctx, skill, Date.now());
+    if (shouldPreserveSkillModerationLock(skill)) {
+      await ctx.db.patch(skill._id, { manualOverride: undefined });
+      return;
+    }
+    const now = Date.now();
+    const { patch } = await buildSkillModerationAfterOverrideRemoval(ctx, skill, now);
     const nextSkill = { ...skill, ...patch, manualOverride: undefined } as Doc<"skills">;
     await ctx.db.patch(skill._id, { ...patch, manualOverride: undefined });
 
@@ -142,11 +158,22 @@ export const removeSkillManualOverrides = migrations.define({
     await adjustGlobalPublicSkillsCount(ctx, globalDelta);
     await adjustPublisherStatsForSkillChange(ctx, skill, nextSkill);
     await adjustUserSkillStatsForSkillChange(ctx, skill, nextSkill);
+    await setSkillEmbeddingsSoftDeleted(
+      ctx,
+      skill._id,
+      Boolean(nextSkill.softDeletedAt || nextSkill.moderationStatus === "hidden"),
+      now,
+    );
     await syncSkillSearchDigestForSkill(ctx, nextSkill);
   },
 });
 
-type SkillManualOverrideCleanupOutcome = "clean" | "review" | "suspicious" | "malicious";
+type SkillManualOverrideCleanupOutcome =
+  | "preserved"
+  | "clean"
+  | "review"
+  | "suspicious"
+  | "malicious";
 
 type SkillManualOverrideCleanupPreviewPage = {
   scanned: number;
@@ -188,6 +215,7 @@ export const previewSkillManualOverrideCleanupPageInternal = internalQuery({
       numItems: Math.min(Math.max(Math.trunc(args.pageSize ?? 250), 10), 500),
     });
     const outcomes: Record<SkillManualOverrideCleanupOutcome, number> = {
+      preserved: 0,
       clean: 0,
       review: 0,
       suspicious: 0,
@@ -197,6 +225,19 @@ export const previewSkillManualOverrideCleanupPageInternal = internalQuery({
 
     for (const skill of result.page) {
       if (!skill.manualOverride) continue;
+      if (shouldPreserveSkillModerationLock(skill)) {
+        outcomes.preserved += 1;
+        if (samples.length < 20) {
+          samples.push({
+            skillId: skill._id,
+            slug: skill.slug,
+            latestVersion: null,
+            currentVerdict: skill.moderationVerdict ?? "unknown",
+            nextOutcome: "preserved",
+          });
+        }
+        continue;
+      }
       const { latestVersion, patch } = await buildSkillModerationAfterOverrideRemoval(
         ctx,
         skill,
@@ -233,7 +274,7 @@ async function previewSkillManualOverrideCleanup(
   const preview: SkillManualOverrideCleanupPreview = {
     scanned: 0,
     affected: 0,
-    outcomes: { clean: 0, review: 0, suspicious: 0, malicious: 0 },
+    outcomes: { preserved: 0, clean: 0, review: 0, suspicious: 0, malicious: 0 },
     samples: [],
   };
 
@@ -244,7 +285,7 @@ async function previewSkillManualOverrideCleanup(
     );
     preview.scanned += page.scanned;
     preview.affected += page.affected;
-    for (const outcome of ["clean", "review", "suspicious", "malicious"] as const) {
+    for (const outcome of ["preserved", "clean", "review", "suspicious", "malicious"] as const) {
       preview.outcomes[outcome] += page.outcomes[outcome];
     }
     preview.samples.push(...page.samples.slice(0, 20 - preview.samples.length));

--- a/convex/migrations.ts
+++ b/convex/migrations.ts
@@ -10,6 +10,7 @@ import type { Doc, Id } from "./_generated/dataModel";
 import type { ActionCtx, MutationCtx, QueryCtx } from "./_generated/server";
 import { internalAction, internalMutation, internalQuery } from "./_generated/server";
 import { syncPackageSearchDigestForPackageId } from "./functions";
+import { adjustGlobalPublicSkillsCount, getPublicSkillVisibilityDelta } from "./lib/globalStats";
 import { derivePluginManifestSummary, normalizePackageName } from "./lib/packageRegistry";
 import { adjustPublisherStatsForSkillChange } from "./lib/publisherStats";
 import {
@@ -36,6 +37,7 @@ import { syncSkillSearchDigestForSkill } from "./lib/skillSearchDigest";
 import { readCanonicalStat } from "./lib/skillStats";
 import { adjustUserSkillStatsForSkillChange } from "./lib/userSkillStats";
 import schema from "./schema";
+import { buildScannerModerationPatchFromVersion } from "./skills";
 
 const CANONICALIZE_CATALOG_METADATA_CONFIRM = "canonicalize-catalog-metadata";
 const APPLY_SKILL_INSTALL_BACKFILL_CONFIRM = "apply-skill-install-backfill";
@@ -43,6 +45,7 @@ const APPLY_NVIDIA_GITHUB_DOWNLOAD_BACKFILL_CONFIRM = "apply-nvidia-github-downl
 const BACKFILL_PLUGIN_MANIFEST_SUMMARIES_CONFIRM = "backfill-plugin-manifest-summaries";
 const RECOVER_SUSPICIOUS_PUBLISH_ATTEMPTS_CONFIRM = "recover-suspicious-publish-attempts";
 const APPLY_SKILL_HOURLY_STATS_BACKFILL_CONFIRM = "apply-skill-hourly-stats-backfill";
+const REMOVE_SKILL_MANUAL_OVERRIDES_CONFIRM = "remove-skill-manual-overrides";
 const SKILL_STAT_EVENTS_CURSOR_KEY = "skill_stat_events";
 const MAX_PENDING_SKILL_STAT_EVENTS_PER_SKILL = 1_000;
 const PLUGIN_PACKAGE_FAMILIES = ["code-plugin", "bundle-plugin"] as const;
@@ -88,6 +91,168 @@ export const migrations = new Migrations(components.migrations, {
   schema,
   defaultBatchSize: 25,
 });
+
+function buildNoVersionModerationPatch(now: number): Partial<Doc<"skills">> {
+  return {
+    moderationStatus: "active",
+    moderationReason: undefined,
+    moderationNotes: undefined,
+    moderationFlags: undefined,
+    moderationVerdict: "clean",
+    moderationReasonCodes: undefined,
+    moderationEvidence: undefined,
+    moderationSummary: "No suspicious patterns detected.",
+    moderationEngineVersion: undefined,
+    moderationEvaluatedAt: now,
+    moderationSourceVersionId: undefined,
+    isSuspicious: false,
+    hiddenAt: undefined,
+    hiddenBy: undefined,
+    lastReviewedAt: undefined,
+  };
+}
+
+async function buildSkillModerationAfterOverrideRemoval(
+  ctx: Pick<MutationCtx, "db"> | Pick<QueryCtx, "db">,
+  skill: Doc<"skills">,
+  now: number,
+) {
+  const [latestVersion, owner] = await Promise.all([
+    skill.latestVersionId ? ctx.db.get(skill.latestVersionId) : null,
+    skill.ownerUserId ? ctx.db.get(skill.ownerUserId) : null,
+  ]);
+  return {
+    latestVersion: latestVersion?.version ?? null,
+    patch: latestVersion
+      ? buildScannerModerationPatchFromVersion({ owner, version: latestVersion, now })
+      : buildNoVersionModerationPatch(now),
+  };
+}
+
+export const removeSkillManualOverrides = migrations.define({
+  table: "skills",
+  batchSize: 25,
+  migrateOne: async (ctx, skill) => {
+    if (!skill.manualOverride) return;
+    const { patch } = await buildSkillModerationAfterOverrideRemoval(ctx, skill, Date.now());
+    const nextSkill = { ...skill, ...patch, manualOverride: undefined } as Doc<"skills">;
+    await ctx.db.patch(skill._id, { ...patch, manualOverride: undefined });
+
+    const globalDelta = getPublicSkillVisibilityDelta(skill, nextSkill);
+    await adjustGlobalPublicSkillsCount(ctx, globalDelta);
+    await adjustPublisherStatsForSkillChange(ctx, skill, nextSkill);
+    await adjustUserSkillStatsForSkillChange(ctx, skill, nextSkill);
+    await syncSkillSearchDigestForSkill(ctx, nextSkill);
+  },
+});
+
+type SkillManualOverrideCleanupOutcome = "clean" | "review" | "suspicious" | "malicious";
+
+type SkillManualOverrideCleanupPreviewPage = {
+  scanned: number;
+  affected: number;
+  outcomes: Record<SkillManualOverrideCleanupOutcome, number>;
+  samples: Array<{
+    skillId: Id<"skills">;
+    slug: string;
+    latestVersion: string | null;
+    currentVerdict: string;
+    nextOutcome: SkillManualOverrideCleanupOutcome;
+  }>;
+  continueCursor: string;
+  isDone: boolean;
+};
+
+type SkillManualOverrideCleanupPreview = Omit<
+  SkillManualOverrideCleanupPreviewPage,
+  "continueCursor" | "isDone"
+>;
+
+function classifySkillManualOverrideCleanupOutcome(
+  patch: Partial<Doc<"skills">>,
+): SkillManualOverrideCleanupOutcome {
+  if (patch.moderationVerdict === "malicious") return "malicious";
+  if (patch.moderationVerdict === "suspicious") return "suspicious";
+  if (patch.moderationReasonCodes?.some((code) => code.startsWith("review."))) return "review";
+  return "clean";
+}
+
+export const previewSkillManualOverrideCleanupPageInternal = internalQuery({
+  args: {
+    cursor: v.optional(v.string()),
+    pageSize: v.optional(v.number()),
+  },
+  handler: async (ctx, args): Promise<SkillManualOverrideCleanupPreviewPage> => {
+    const result = await ctx.db.query("skills").paginate({
+      cursor: args.cursor ?? null,
+      numItems: Math.min(Math.max(Math.trunc(args.pageSize ?? 250), 10), 500),
+    });
+    const outcomes: Record<SkillManualOverrideCleanupOutcome, number> = {
+      clean: 0,
+      review: 0,
+      suspicious: 0,
+      malicious: 0,
+    };
+    const samples: SkillManualOverrideCleanupPreviewPage["samples"] = [];
+
+    for (const skill of result.page) {
+      if (!skill.manualOverride) continue;
+      const { latestVersion, patch } = await buildSkillModerationAfterOverrideRemoval(
+        ctx,
+        skill,
+        Date.now(),
+      );
+      const nextOutcome = classifySkillManualOverrideCleanupOutcome(patch);
+      outcomes[nextOutcome] += 1;
+      if (samples.length < 20) {
+        samples.push({
+          skillId: skill._id,
+          slug: skill.slug,
+          latestVersion,
+          currentVerdict: skill.moderationVerdict ?? "unknown",
+          nextOutcome,
+        });
+      }
+    }
+
+    return {
+      scanned: result.page.length,
+      affected: Object.values(outcomes).reduce((sum, count) => sum + count, 0),
+      outcomes,
+      samples,
+      continueCursor: result.continueCursor,
+      isDone: result.isDone,
+    };
+  },
+});
+
+async function previewSkillManualOverrideCleanup(
+  ctx: Pick<ActionCtx, "runQuery">,
+): Promise<SkillManualOverrideCleanupPreview> {
+  let cursor: string | undefined;
+  const preview: SkillManualOverrideCleanupPreview = {
+    scanned: 0,
+    affected: 0,
+    outcomes: { clean: 0, review: 0, suspicious: 0, malicious: 0 },
+    samples: [],
+  };
+
+  do {
+    const page: SkillManualOverrideCleanupPreviewPage = await ctx.runQuery(
+      internal.migrations.previewSkillManualOverrideCleanupPageInternal,
+      { cursor, pageSize: 250 },
+    );
+    preview.scanned += page.scanned;
+    preview.affected += page.affected;
+    for (const outcome of ["clean", "review", "suspicious", "malicious"] as const) {
+      preview.outcomes[outcome] += page.outcomes[outcome];
+    }
+    preview.samples.push(...page.samples.slice(0, 20 - preview.samples.length));
+    cursor = page.isDone ? undefined : page.continueCursor;
+  } while (cursor);
+
+  return preview;
+}
 
 async function requireSkillHourlyStatsBackfillState(ctx: Pick<MutationCtx, "db">) {
   const state = await ctx.db
@@ -1607,6 +1772,52 @@ export const runNvidiaGitHubDownloadBackfill = internalAction({
       dryRun,
       confirmRequired: dryRun ? APPLY_NVIDIA_GITHUB_DOWNLOAD_BACKFILL_CONFIRM : undefined,
       preview,
+    };
+  },
+});
+
+export const runSkillManualOverrideCleanup: ReturnType<typeof internalAction> = internalAction({
+  args: {
+    dryRun: v.optional(v.boolean()),
+    confirm: v.optional(v.string()),
+  },
+  handler: async (
+    ctx,
+    args,
+  ): Promise<{
+    ok: true;
+    dryRun: boolean;
+    confirmRequired?: string;
+    before: SkillManualOverrideCleanupPreview;
+    after: SkillManualOverrideCleanupPreview;
+  }> => {
+    const dryRun = args.dryRun !== false;
+    if (!dryRun && args.confirm !== REMOVE_SKILL_MANUAL_OVERRIDES_CONFIRM) {
+      throw new ConvexError(`Pass confirm="${REMOVE_SKILL_MANUAL_OVERRIDES_CONFIRM}" to apply.`);
+    }
+
+    const before = await previewSkillManualOverrideCleanup(ctx);
+    if (dryRun) {
+      await ctx.runMutation(internal.migrations.run, {
+        fn: "migrations:removeSkillManualOverrides",
+        dryRun: true,
+        reset: true,
+      });
+    } else {
+      await runToCompletion(
+        ctx,
+        components.migrations,
+        internal.migrations.removeSkillManualOverrides,
+      );
+    }
+    const after = dryRun ? before : await previewSkillManualOverrideCleanup(ctx);
+
+    return {
+      ok: true as const,
+      dryRun,
+      confirmRequired: dryRun ? REMOVE_SKILL_MANUAL_OVERRIDES_CONFIRM : undefined,
+      before,
+      after,
     };
   },
 });

--- a/convex/migrations.ts
+++ b/convex/migrations.ts
@@ -103,27 +103,7 @@ export function shouldPreserveSkillModerationLock(skill: Doc<"skills">) {
   );
 }
 
-function buildNoVersionModerationPatch(now: number): Partial<Doc<"skills">> {
-  return {
-    moderationStatus: "active",
-    moderationReason: undefined,
-    moderationNotes: undefined,
-    moderationFlags: undefined,
-    moderationVerdict: "clean",
-    moderationReasonCodes: undefined,
-    moderationEvidence: undefined,
-    moderationSummary: "No suspicious patterns detected.",
-    moderationEngineVersion: undefined,
-    moderationEvaluatedAt: now,
-    moderationSourceVersionId: undefined,
-    isSuspicious: false,
-    hiddenAt: undefined,
-    hiddenBy: undefined,
-    lastReviewedAt: undefined,
-  };
-}
-
-async function buildSkillModerationAfterOverrideRemoval(
+export async function buildSkillModerationAfterOverrideRemoval(
   ctx: Pick<MutationCtx, "db"> | Pick<QueryCtx, "db">,
   skill: Doc<"skills">,
   now: number,
@@ -136,7 +116,7 @@ async function buildSkillModerationAfterOverrideRemoval(
     latestVersion: latestVersion?.version ?? null,
     patch: latestVersion
       ? buildScannerModerationPatchFromVersion({ owner, version: latestVersion, now })
-      : buildNoVersionModerationPatch(now),
+      : undefined,
   };
 }
 
@@ -151,6 +131,10 @@ export const removeSkillManualOverrides = migrations.define({
     }
     const now = Date.now();
     const { patch } = await buildSkillModerationAfterOverrideRemoval(ctx, skill, now);
+    if (!patch) {
+      await ctx.db.patch(skill._id, { manualOverride: undefined });
+      return;
+    }
     const nextSkill = { ...skill, ...patch, manualOverride: undefined } as Doc<"skills">;
     await ctx.db.patch(skill._id, { ...patch, manualOverride: undefined });
 
@@ -243,6 +227,19 @@ export const previewSkillManualOverrideCleanupPageInternal = internalQuery({
         skill,
         Date.now(),
       );
+      if (!patch) {
+        outcomes.preserved += 1;
+        if (samples.length < 20) {
+          samples.push({
+            skillId: skill._id,
+            slug: skill.slug,
+            latestVersion,
+            currentVerdict: skill.moderationVerdict ?? "unknown",
+            nextOutcome: "preserved",
+          });
+        }
+        continue;
+      }
       const nextOutcome = classifySkillManualOverrideCleanupOutcome(patch);
       outcomes[nextOutcome] += 1;
       if (samples.length < 20) {

--- a/convex/migrations.ts
+++ b/convex/migrations.ts
@@ -93,6 +93,7 @@ export const migrations = new Migrations(components.migrations, {
 });
 
 export function shouldPreserveSkillModerationLock(skill: Doc<"skills">) {
+  if (skill.softDeletedAt) return true;
   if (skill.moderationStatus !== "hidden") return false;
   const reason = skill.moderationReason;
   return !(

--- a/convex/migrations.ts
+++ b/convex/migrations.ts
@@ -188,6 +188,7 @@ export const removeSkillManualOverrides = migrations.define({
         await recomputePublisherStats(ctx, skill.ownerPublisherId),
       );
     }
+    await adjustUserSkillStatsForSkillChange(ctx, skill, nextSkill);
     await setSkillEmbeddingsSoftDeleted(
       ctx,
       skill._id,

--- a/convex/migrations.ts
+++ b/convex/migrations.ts
@@ -12,7 +12,7 @@ import { internalAction, internalMutation, internalQuery } from "./_generated/se
 import { syncPackageSearchDigestForPackageId } from "./functions";
 import { adjustGlobalPublicSkillsCount, getPublicSkillVisibilityDelta } from "./lib/globalStats";
 import { derivePluginManifestSummary, normalizePackageName } from "./lib/packageRegistry";
-import { adjustPublisherStatsForSkillChange } from "./lib/publisherStats";
+import { adjustPublisherStatsForSkillChange, recomputePublisherStats } from "./lib/publisherStats";
 import {
   buildSkillDownloadBackfillPatch,
   calculatePublishedWeeks,
@@ -182,8 +182,12 @@ export const removeSkillManualOverrides = migrations.define({
 
     const globalDelta = getPublicSkillVisibilityDelta(skill, nextSkill);
     await adjustGlobalPublicSkillsCount(ctx, globalDelta);
-    await adjustPublisherStatsForSkillChange(ctx, skill, nextSkill);
-    await adjustUserSkillStatsForSkillChange(ctx, skill, nextSkill);
+    if (skill.ownerPublisherId) {
+      await ctx.db.patch(
+        skill.ownerPublisherId,
+        await recomputePublisherStats(ctx, skill.ownerPublisherId),
+      );
+    }
     await setSkillEmbeddingsSoftDeleted(
       ctx,
       skill._id,

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -961,6 +961,8 @@ const skills = defineTable({
   moderationEngineVersion: v.optional(v.string()),
   moderationEvaluatedAt: v.optional(v.number()),
   moderationSourceVersionId: v.optional(v.id("skillVersions")),
+  // Deprecated compatibility field. The cleanup migration removes stored
+  // values before this field and its validator are removed in a follow-up.
   manualOverride: v.optional(manualModerationOverride),
   quality: v.optional(
     v.object({

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -3061,16 +3061,10 @@ export const getBySlugForStaff = query({
       .take(auditLogLimit);
 
     const staffUserIds = new Set<Id<"users">>();
-    if (skill.manualOverride?.reviewerUserId) {
-      staffUserIds.add(skill.manualOverride.reviewerUserId);
-    }
     for (const log of rawAuditLogs) {
       if (log.actorUserId) staffUserIds.add(log.actorUserId);
     }
     const publicUsers = await loadPublicUsersById(ctx, [...staffUserIds]);
-    const overrideReviewer = skill.manualOverride?.reviewerUserId
-      ? (publicUsers.get(skill.manualOverride.reviewerUserId) ?? null)
-      : null;
     const auditLogs: StaffSkillAuditLogEntry[] = rawAuditLogs.map((log) => ({
       ...log,
       actor: log.actorUserId ? (publicUsers.get(log.actorUserId) ?? null) : null,
@@ -3098,7 +3092,6 @@ export const getBySlugForStaff = query({
       skill: { ...skill, badges },
       latestVersion: latestVersion ? { ...latestVersion, generatedSkillCard } : null,
       owner,
-      overrideReviewer,
       auditLogs,
       forkOf: forkOfSkill
         ? {
@@ -10881,22 +10874,6 @@ export const setSkillFeaturedForUserInternal = internalMutation({
       args.featured ? "highlighted" : undefined,
     );
     return { ...result, ownerHandle: args.ownerHandle ?? null };
-  },
-});
-
-// Temporary compatibility endpoints for the first layer of the stacked rollout.
-// They fail closed until the UI callers are removed by the next layer.
-export const setSkillManualOverride = mutation({
-  args: { skillId: v.id("skills"), note: v.string() },
-  handler: async () => {
-    throw new ConvexError("Manual skill overrides are no longer supported.");
-  },
-});
-
-export const clearSkillManualOverride = mutation({
-  args: { skillId: v.id("skills"), note: v.string() },
-  handler: async () => {
-    throw new ConvexError("Manual skill overrides are no longer supported.");
   },
 });
 


### PR DESCRIPTION
## What Problem This Solves

Removes stored legacy manual overrides safely so existing skills immediately return to version-scoped scanner truth after deployment.

## Why This Change Was Made

Adds a guarded, dry-run-first Convex migration. It preserves unrelated moderation and deletion locks, fails closed when a source version is missing, and reconciles visibility projections and aggregate statistics.

## User Impact

No data changes occur during deployment. Operators must inspect the production preview and provide the exact confirmation token before cleanup applies.

## Evidence

- `bun run ci:static`
- `bun run ci:unit` — 6,230 passed, 3 skipped
- `bun run ci:types-build`
- `bun run ci:packages`
- Autoreview: clean

Stack 3/3. Depends on #3535 and #3536.
