### PR TITLE
chore: add guarded override cleanup runner

### DIFF
--- a/.github/workflows/skill-manual-override-cleanup.yml
+++ b/.github/workflows/skill-manual-override-cleanup.yml
@@ -1,0 +1,82 @@
+name: Skill Manual Override Cleanup
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "Preview or apply the cleanup"
+        required: true
+        default: preview
+        type: choice
+        options:
+          - preview
+          - apply
+      confirm:
+        description: "For apply, enter: remove-skill-manual-overrides"
+        required: false
+        default: ""
+        type: string
+
+concurrency:
+  group: skill-manual-override-cleanup-production
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    environment:
+      name: Production
+    steps:
+      - uses: actions/checkout@v7.0.1
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+        with:
+          bun-version: 1.3.10
+
+      - name: Install
+        run: bun install --frozen-lockfile
+
+      - name: Validate request
+        env:
+          CLEANUP_MODE: ${{ inputs.mode }}
+          CLEANUP_CONFIRM: ${{ inputs.confirm }}
+        run: |
+          set -euo pipefail
+          if [[ "$CLEANUP_MODE" == "apply" && "$CLEANUP_CONFIRM" != "remove-skill-manual-overrides" ]]; then
+            echo "::error::Apply requires the exact cleanup confirmation."
+            exit 1
+          fi
+          if [[ "$CLEANUP_MODE" == "preview" && -n "$CLEANUP_CONFIRM" ]]; then
+            echo "::error::Preview must not include an apply confirmation."
+            exit 1
+          fi
+
+      - name: Run cleanup
+        env:
+          CLEANUP_MODE: ${{ inputs.mode }}
+          CLEANUP_CONFIRM: ${{ inputs.confirm }}
+          CONVEX_DEPLOY_KEY: ${{ secrets.CONVEX_DEPLOY_KEY }}
+        run: |
+          set -euo pipefail
+          if [[ "$CLEANUP_MODE" == "preview" ]]; then
+            args='{"dryRun":true}'
+          else
+            args="$(jq -cn --arg confirm "$CLEANUP_CONFIRM" '{dryRun:false, confirm:$confirm}')"
+          fi
+          bunx convex run --prod migrations:runSkillManualOverrideCleanup "$args" | tee cleanup-result.json
+
+      - name: Write summary
+        if: always()
+        run: |
+          if [[ -f cleanup-result.json ]]; then
+            {
+              echo '```json'
+              cat cleanup-result.json
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi


### PR DESCRIPTION
## Summary

- add a temporary production workflow for previewing the manual-override cleanup
- require the exact confirmation token before applying any destructive cleanup
- publish the structured migration result in the workflow summary

## Validation

- `bun run ci:static`

This workflow will be removed with the temporary migration after cleanup verification.