### PR TITLE
feat: detect OrcaRouter API keys in moderation scan

### DIFF
--- a/convex/lib/moderationEngine.test.ts
+++ b/convex/lib/moderationEngine.test.ts
@@ -238,6 +238,7 @@ describe("moderationEngine", () => {
           path: "mainapp.py",
           content: [
             'OPENROUTER_KEY = "fixture_openrouter_secret_1234567890"',
+            'ORCAROUTER_KEY = "fixture_orcarouter_secret_1234567890"',
             'SUPABASE_KEY = "fixture_supabase_secret_1234567890"',
             'BEARER = "fixture_bearer_secret_1234567890"',
           ].join("\n"),

--- a/convex/lib/moderationEngine.ts
+++ b/convex/lib/moderationEngine.ts
@@ -94,7 +94,7 @@ const GOOGLE_SHEETS_SPREADSHEET_URL_PATTERN =
   /https?:\/\/[^\s"'`]*\/spreadsheets\/([A-Za-z0-9_-]{20,})\/[^\s"'`]*/i;
 const DESTRUCTIVE_DELETE_PATTERN =
   /\brm\s+-[A-Za-z]*r[A-Za-z]*f[A-Za-z]*\s+(["']?)(\/root\/\.openclaw\/|\/home\/[^/\s"'`]+\/\.openclaw\/|\/Users\/[^/\s"'`]+\/\.openclaw\/|~\/\.openclaw\/|\$HOME\/\.openclaw\/|\$\{HOME\}\/\.openclaw\/|\/etc\/|\/usr\/|\/opt\/|\/Library\/|\/Applications\/)[^\s"'`;|&)]*\1/i;
-const SECRET_FIELD_PATTERN_SOURCE = String.raw`(?:[A-Za-z0-9]+[_\s-]+)*(?:(?:api|client|consumer)[_\s-]?(?:secret|key|token)|secret[_\s-]?key|access[_\s-]?(?:token|key|secret|grant)|auth[_\s-]?token|bearer(?:[_\s-]?token)?|private[_\s-]?key|service[_\s-]?role[_\s-]?key|github[_\s-]?(?:pat|token)|(?:openrouter|supabase|storj)[_\s-]?(?:key|token|secret|access[_\s-]?grant)|password)`;
+const SECRET_FIELD_PATTERN_SOURCE = String.raw`(?:[A-Za-z0-9]+[_\s-]+)*(?:(?:api|client|consumer)[_\s-]?(?:secret|key|token)|secret[_\s-]?key|access[_\s-]?(?:token|key|secret|grant)|auth[_\s-]?token|bearer(?:[_\s-]?token)?|private[_\s-]?key|service[_\s-]?role[_\s-]?key|github[_\s-]?(?:pat|token)|(?:openrouter|orcarouter|supabase|storj)[_\s-]?(?:key|token|secret|access[_\s-]?grant)|password)`;
 const SECRET_ASSIGNMENT_PATTERN = new RegExp(
   String.raw`\b${SECRET_FIELD_PATTERN_SOURCE}\b\s*[:=]\s*(.+)$`,
   "i",


### PR DESCRIPTION
Add [OrcaRouter](https://www.orcarouter.ai) to the moderation scanner's provider-secret list in `convex/lib/moderationEngine.ts`, mirroring the existing `openrouter`/`supabase`/`storj` handling. ClawHub is the public skill registry for OpenClaw, and its static scan flags skills that hardcode provider credentials — but `ORCAROUTER_KEY`, `ORCAROUTER_SECRET`, and `ORCAROUTER_TOKEN` currently slip through. OrcaRouter is an OpenAI-compatible AI gateway built for both models and agents: like OpenRouter it exposes a provider/model namespace across many models, but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. It also runs gateway-level, zero-trust security for AI agents on that endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes. Adding `orcarouter` as a first-class provider means OpenClaw skill publishers who use OrcaRouter get real secret detection instead of treating it as an anonymous custom base URL.

Validation:
- `vitest run convex/lib/moderationEngine.test.ts` → 130 passed, including a new `ORCAROUTER_KEY` fixture
- `oxlint` clean · `oxfmt --check` clean
- Live check: a real `ORCAROUTER_API_KEY` is flagged `suspicious.exposed_secret_literal` and redacted in the report

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team. AI-assisted contribution (Claude Code).
