### PR TITLE
Fix truncated SkillSpector finding display

### DIFF
--- a/src/components/SkillSecurityScanResults.test.tsx
+++ b/src/components/SkillSecurityScanResults.test.tsx
@@ -562,6 +562,51 @@ describe("SecurityScanResults static guidance", () => {
     expect(await screen.findByText("matched line")).toBeTruthy();
   });
 
+  it("preserves complete SkillSpector evidence when a location fetch is narrower", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("first\n<!-- validation-guidance:start -->\nthird\n"));
+    const analysis: SkillSpectorAnalysis = {
+      ...skillSpectorAnalysis,
+      issues: [
+        {
+          ...skillSpectorAnalysis.issues[0],
+          issueId: "P2",
+          file: "SKILL.md",
+          startLine: 2,
+          endLine: undefined,
+          codeSnippet:
+            "<!-- validation-guidance:start -->\nFollow these visible validation instructions.\n<!-- validation-guidance:end -->",
+          finding: "<!-- validation-guidance:end --> into the private worksheet",
+          explanation:
+            "The scanner interpreted visible validation guidance as hidden instructions.",
+        },
+      ],
+    };
+
+    render(
+      <SecurityAuditPage
+        entity={{
+          kind: "skill",
+          title: "Release Validation",
+          name: "release-validation",
+          version: "0.1.3",
+          detailPath: "/openclaw/release-validation",
+        }}
+        skillSpectorAnalysis={analysis}
+      />,
+    );
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    expect(screen.getByText(/Follow these visible validation instructions/)).toBeTruthy();
+    expect(
+      screen.getByText(
+        "The scanner interpreted visible validation guidance as hidden instructions.",
+      ),
+    ).toBeTruthy();
+    expect(screen.queryByText(/into the private worksheet/)).toBeNull();
+  });
+
   it("uses ClawScan only for the security audit outcome", () => {
     const { container } = render(
       <SecurityAuditPage

--- a/src/components/SkillSecurityScanResults.tsx
+++ b/src/components/SkillSecurityScanResults.tsx
@@ -420,7 +420,7 @@ function SkillSpectorFindingCard({
   issue: SkillSpectorIssue;
 }) {
   const confidence = formatSkillSpectorConfidence(issue.confidence);
-  const trimmedSnippet = contentSnippet?.trim() || issue.codeSnippet?.trim();
+  const trimmedSnippet = issue.codeSnippet?.trim() || contentSnippet?.trim();
 
   return (
     <article className="static-analysis-finding">
@@ -453,7 +453,7 @@ function SkillSpectorFindingCard({
         ) : null}
         <div>
           <dt>Finding</dt>
-          <dd>{issue.finding || issue.explanation}</dd>
+          <dd>{issue.explanation || issue.finding}</dd>
         </div>
       </dl>
     </article>


### PR DESCRIPTION
## Summary

- prefer SkillSpector's complete contextual `codeSnippet` over a narrower location fetch
- show the scanner's explanatory finding text instead of its raw regex match fragment
- add a regression test using the `release-validation@0.1.3` result shape

## Root cause

SkillSpector emitted both a complete contextual snippet/explanation and a malformed raw match fragment. ClawHub replaced the complete snippet with a one-line source fetch when `endLine` was absent, then preferred the raw `finding` fragment over `explanation`.

The upstream false positive is handled separately in NVIDIA/SkillSpector#452. This change keeps existing stored scans readable and hardens the UI against partial scanner locations.

## Validation

- `bunx vitest run src/components/SkillSecurityScanResults.test.tsx` (40 passed)
- `bun run ci:static`
- `bun run ci:unit` (6,231 passed, 3 skipped)
- `bun run ci:types-build`
- autoreview: clean, no accepted/actionable findings

## Before/after visual proof

Both screenshots render the same live `release-validation@0.1.3` audit record through real local ClawHub instances against the public read backend. The baseline is `origin/main`; the candidate is this PR.

| Before: clipped raw scanner fragments | After: complete context and explanation |
| --- | --- |
| <img src="https://raw.githubusercontent.com/openclaw/clawhub/qa-artifacts/clawhub-ui-proof/pr-3542/2026-08-28T17-36-40-718Z/baseline/baseline-skillspector-finding-display.png" width="420" alt="Before: clipped SkillSpector content and raw finding fragment"> | <img src="https://raw.githubusercontent.com/openclaw/clawhub/qa-artifacts/clawhub-ui-proof/pr-3542/2026-08-28T17-36-40-718Z/candidate/candidate-skillspector-finding-display.png" width="420" alt="After: full contextual snippet and plain-language explanation"> |

[Open the complete proof bundle](https://github.com/openclaw/clawhub/tree/qa-artifacts/clawhub-ui-proof/pr-3542/2026-08-28T17-36-40-718Z).
