### PR TITLE
fix: isolate and simplify UI-proof Convex bootstrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixes
 
+- UI proof: supervise isolated loopback backend and browser proof together without writing project dotenv, preserving diagnostics and private-state cleanup on failure.
 - CI: authenticate weekly design-audit pull request mutations with the Barnacle GitHub App while retaining the workflow token for branch publication and clean-audit closure.
 - API: record skipped and failed skill evaluation outcomes without passing worker tokens to internal mutations.
 - GitHub Actions/CLI/API: require v2 authorization for every OpenClaw OIDC publish, bind large-artifact upload tickets and package mutations to the exact authorization transaction, consume scoped capabilities with non-public staging, then require an immutable successful parent attempt and atomic durable authorization revalidation before final publication.

--- a/scripts/ui-proof-backend-smoke.mjs
+++ b/scripts/ui-proof-backend-smoke.mjs
@@ -1,0 +1,162 @@
+#!/usr/bin/env node
+// Opt-in only. Run through the session's approved server/preview launcher.
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs/promises";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { assertPortsFree, CONVEX_CLI_VERSION, runProofBackend } from "./ui-proof-backend.mjs";
+
+const args = process.argv.slice(2);
+if (
+  args[0] !== "--run" ||
+  args[1] !== "--cli" ||
+  !args[2] ||
+  args[3] !== "--backend-archive" ||
+  !args[4] ||
+  args.length !== 5
+) {
+  console.error(
+    "Usage (starts real loopback servers): node scripts/ui-proof-backend-smoke.mjs --run --cli /verified/convex/bin/main.js --backend-archive /verified/convex-local-backend-<target>.zip",
+  );
+  process.exitCode = 2;
+} else {
+  await smoke(path.resolve(args[2]), path.resolve(args[4]));
+}
+
+async function smoke(cliPath, backendArchive) {
+  const require = createRequire(cliPath);
+  const { ConvexHttpClient } = require("convex/browser");
+  const { anyApi } = require("convex/server");
+  const root = await fs.mkdtemp("/tmp/clawhub-proof-smoke-");
+  const wrapperRoot = path.join(root, "wrapper");
+  const packageRoot = path.resolve(path.dirname(cliPath), "..");
+  const modules = fileURLToPath(new URL("../node_modules", import.meta.url));
+  const identities = new Set();
+  try {
+    await fs.mkdir(wrapperRoot);
+    // Dependencies only, never copied dotenv/auth/Convex state. The helper itself
+    // is imported from this trusted script, not from either tiny app fixture.
+    await fs.symlink(modules, path.join(wrapperRoot, "node_modules"));
+    assert.equal(
+      execFileSync(process.execPath, [cliPath, "--version"], {
+        cwd: wrapperRoot,
+        env: {
+          PATH: process.env.PATH,
+          HOME: root,
+          XDG_CONFIG_HOME: path.join(root, "config"),
+          XDG_CACHE_HOME: path.join(root, "cache"),
+          NODE_PATH: modules,
+          CI: "1",
+        },
+        encoding: "utf8",
+        timeout: 30000,
+      }).trim(),
+      CONVEX_CLI_VERSION,
+    );
+    for (const [name, devAuth] of [
+      ["baseline", false],
+      ["candidate", true],
+      ["candidate", false],
+    ]) {
+      const appRoot = path.join(root, `${name}-${devAuth}`);
+      await fs.mkdir(path.join(appRoot, "convex"), { recursive: true });
+      await fs.mkdir(path.join(appRoot, "node_modules"));
+      await fs.symlink(packageRoot, path.join(appRoot, "node_modules/convex"));
+      await fs.writeFile(
+        path.join(appRoot, "package.json"),
+        JSON.stringify({ type: "module", dependencies: { convex: "1.44.0" } }),
+      );
+      await fs.writeFile(
+        path.join(appRoot, "convex/schema.ts"),
+        `import {defineSchema, defineTable} from "convex/server"; import {v} from "convex/values"; export default defineSchema({markers: defineTable({value:v.string()})});\n`,
+      );
+      await fs.writeFile(
+        path.join(appRoot, "convex/appMeta.ts"),
+        `
+import {queryGeneric as query, mutationGeneric as mutation} from "convex/server";
+export const getDeploymentInfo = query({args:{},handler:async(ctx)=>({
+  source:${JSON.stringify(name)}, count:(await ctx.db.query("markers").take(2)).length,
+  enabled:process.env.DEV_AUTH_ENABLED ?? null,
+  marker:process.env.DEV_AUTH_CONVEX_DEPLOYMENT ?? null,
+  site:process.env.CONVEX_SITE_URL ?? null
+})});
+export const insert = mutation({args:{},handler:async(ctx)=>{await ctx.db.insert("markers",{value:"smoke"});return null;}});
+`,
+      );
+      const lane = {
+        name,
+        convexCloudPort: name === "baseline" ? 4417 : 4418,
+        convexSitePort: name === "baseline" ? 4517 : 4518,
+        port: name === "baseline" ? 4317 : 4318,
+      };
+      const outputDir = path.join(root, "artifacts", `${name}-${devAuth}`);
+      let privateState;
+      const result = await runProofBackend({
+        appRoot,
+        wrapperRoot,
+        outputDir,
+        lane,
+        devAuth,
+        cliPath,
+        backendArchive,
+        continueWith: async ({ env, instanceName, signal }) => {
+          privateState = path.dirname(env.HOME);
+          const client = new ConvexHttpClient(env.VITE_CONVEX_URL, {
+            fetch: (url, init) => fetch(url, { ...init, signal }),
+          });
+          const read = () => client.query(anyApi.appMeta.getDeploymentInfo, {});
+          const value = await read();
+          assert.equal(value.source, name);
+          assert.equal(value.count, 0);
+          assert.equal(value.enabled, devAuth ? "1" : null);
+          assert.equal(value.marker, devAuth ? `local:${instanceName}` : null);
+          assert.equal(value.site, env.VITE_CONVEX_SITE_URL);
+          assert.equal(
+            await (await fetch(`${env.VITE_CONVEX_URL}/instance_name`, { signal })).text(),
+            instanceName,
+          );
+          await client.mutation(anyApi.appMeta.insert, {});
+          assert.equal((await read()).count, 1);
+          await fetch(env.VITE_CONVEX_SITE_URL, {
+            signal: AbortSignal.any([signal, AbortSignal.timeout(2000)]),
+          });
+          if (process.platform === "darwin") {
+            const sockets = execFileSync(
+              "/usr/sbin/lsof",
+              [
+                "-nP",
+                `-iTCP:${lane.convexCloudPort}`,
+                `-iTCP:${lane.convexSitePort}`,
+                "-sTCP:LISTEN",
+                "-Fn",
+              ],
+              { encoding: "utf8" },
+            )
+              .split("\n")
+              .filter((line) => line.startsWith("n"));
+            assert.deepEqual(
+              new Set(sockets),
+              new Set([`n127.0.0.1:${lane.convexCloudPort}`, `n127.0.0.1:${lane.convexSitePort}`]),
+            );
+          }
+        },
+      });
+      const completion = JSON.parse(
+        await fs.readFile(path.join(outputDir, "bootstrap-summary.json"), "utf8"),
+      );
+      assert.equal(completion.status, "pass");
+      assert.equal(completion.instanceName, result.instanceName);
+      assert(!identities.has(result.instanceName));
+      identities.add(result.instanceName);
+      await assertPortsFree([lane.convexCloudPort, lane.convexSitePort, lane.port]);
+      await assert.rejects(fs.stat(privateState), { code: "ENOENT" });
+      console.log(
+        `${name} devAuth=${devAuth}: source, fresh database, app query, site listener, teardown passed (${result.backendVersion}, CLI ${result.cliVersion})`,
+      );
+    }
+  } finally {
+    await fs.rm(root, { recursive: true, force: true });
+  }
+}

--- a/scripts/ui-proof-backend.mjs
+++ b/scripts/ui-proof-backend.mjs
@@ -1,0 +1,668 @@
+#!/usr/bin/env node
+import { spawn } from "node:child_process";
+import { createHash, randomBytes } from "node:crypto";
+import fs from "node:fs/promises";
+import net from "node:net";
+import path from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+import { pathToFileURL } from "node:url";
+
+export const CONVEX_CLI_VERSION = "1.44.0";
+const BACKEND_VERSION = "precompiled-2026-08-25-7cce8fb";
+// GitHub release asset digests, verified against the downloaded Mac arm64 ZIP.
+const BACKENDS = {
+  "darwin-arm64": [
+    "aarch64-apple-darwin",
+    "98831b0f511f6eed70b0b4dfca62015df57877e08017d2b2979b39d62ae7317b",
+  ],
+  "darwin-x64": [
+    "x86_64-apple-darwin",
+    "d142472d996f08907cd9fdf61cc154c36edee3039342f45fdd925cefedabea29",
+  ],
+  "linux-arm64": [
+    "aarch64-unknown-linux-gnu",
+    "a0601ec584fe9f514c473af6d57a4c209e4d2d775e4ac1b5d1b90bafd85b7e2f",
+  ],
+  "linux-x64": [
+    "x86_64-unknown-linux-gnu",
+    "470250263fcf6c71b931219550c3705d9ab03d79c3b1e1e8364465c2b44eff9f",
+  ],
+};
+
+export function assertProofEnvironment(env = {}) {
+  for (const key of Object.keys(env)) {
+    if (
+      !/^[A-Za-z_][A-Za-z0-9_]*$/u.test(key) ||
+      /^(CONVEX|DEV_AUTH|VITE_CONVEX|NODE|BUN|NPM|YARN|PNPM|XDG|LD_|DYLD_|GIT_|BASH|ZSH|PYTHON|PERL|RUBY|PLAYWRIGHT|CLAWHUB_UI_PROOF|SENTRY|SSL_|CURL_|LC_)/iu.test(
+        key,
+      ) ||
+      /^(APP_ROOT|WRAPPER_ROOT|REMOTE_OUT|HOME|PATH|USERPROFILE|LOCALAPPDATA|APPDATA|TMP|TEMP|TMPDIR|ENV|SHELL|SHELLOPTS|IFS|CDPATH|ZDOTDIR|BROWSER|DISPLAY|XAUTHORITY|HOST|PORT|SITE_URL|VITE_SITE_URL|VITE_ENABLE_DEV_AUTH|CI|LANG|LOCPATH|GCONV_PATH|GLIBC_TUNABLES|HTTP_PROXY|HTTPS_PROXY|ALL_PROXY|NO_PROXY)$/iu.test(
+        key,
+      ) ||
+      /(?:^|_)(TOKEN|SECRET|PASSWORD|CREDENTIALS?|API_KEY|ADMIN_KEY)(?:_|$)/iu.test(key) ||
+      /_(PATH|DIR|HOME|OPTIONS|CONFIG)$/iu.test(key)
+    ) {
+      throw new Error(`Reserved proof --env variable: ${key}; use --dev-auth for local dev auth.`);
+    }
+    if (typeof env[key] !== "string" || env[key].includes("\0")) {
+      throw new Error(`Invalid proof --env value for ${key}`);
+    }
+  }
+}
+
+async function assertCleanProofSource(root) {
+  // Inspect names only: never open, source, copy, or delete operator state.
+  for (const name of await fs.readdir(root)) {
+    if (
+      name === ".convex" ||
+      name === ".env" ||
+      /^\.env\.(?!example$|sample$|template$)/u.test(name)
+    ) {
+      throw new Error(
+        `UI proof refuses existing ${name} in ${root}; use an unhydrated disposable source checkout.`,
+      );
+    }
+  }
+}
+
+function isolatedProofEnvironment(state, inherited = {}) {
+  return {
+    PATH: inherited.PATH || "/usr/local/bin:/usr/bin:/bin",
+    DISPLAY: inherited.DISPLAY || ":99",
+    HOME: path.join(state, "home"),
+    XDG_CONFIG_HOME: path.join(state, "config"),
+    XDG_CACHE_HOME: path.join(state, "cache"),
+    XDG_DATA_HOME: path.join(state, "data"),
+    TMPDIR: path.join(state, "tmp"),
+    BUN_INSTALL: path.join(state, "bun"),
+    CI: "1", // Convex 1.44.0 disables CLI Sentry in CI.
+    DO_NOT_TRACK: "1",
+    SENTRY_DSN: "",
+  };
+}
+
+export async function assertPortsFree(ports, connect = net.createConnection) {
+  for (const port of ports) {
+    await new Promise((resolve, reject) => {
+      const socket = connect({ host: "127.0.0.1", port });
+      socket.setTimeout(1000);
+      socket.once("connect", () => {
+        socket.destroy();
+        reject(
+          new Error(`Proof port ${port} is already occupied; refusing to adopt another service.`),
+        );
+      });
+      socket.once("error", (error) => {
+        socket.destroy();
+        if (error.code === "ECONNREFUSED") resolve();
+        else reject(new Error(`Cannot check proof port ${port}: ${error.code}`));
+      });
+      socket.once("timeout", () => {
+        socket.destroy();
+        reject(new Error(`Timed out checking proof port ${port}`));
+      });
+    });
+  }
+}
+
+function backendArguments({ state, lane, instanceName, instanceSecret }) {
+  return [
+    "--interface",
+    "127.0.0.1",
+    "--port",
+    String(lane.convexCloudPort),
+    "--site-proxy-port",
+    String(lane.convexSitePort),
+    "--convex-origin",
+    `http://127.0.0.1:${lane.convexCloudPort}`,
+    "--convex-site",
+    `http://127.0.0.1:${lane.convexSitePort}`,
+    "--instance-name",
+    instanceName,
+    // This pinned backend supports the secret only via argv, not env/stdin/file.
+    "--instance-secret",
+    instanceSecret,
+    "--disable-beacon",
+    "--local-storage",
+    path.join(state, "storage"),
+    path.join(state, "db.sqlite3"),
+  ];
+}
+
+function redactProofText(text, secrets, boundaries = false) {
+  for (const secret of secrets) {
+    if (!secret) continue;
+    text = text.replaceAll(secret, "[REDACTED]");
+    // A bounded tail or an interrupted writer can retain only part of a secret.
+    if (boundaries) {
+      for (let size = secret.length - 1; size > 0; size--) {
+        if (text.startsWith(secret.slice(-size))) text = "[REDACTED]" + text.slice(size);
+        if (text.endsWith(secret.slice(0, size))) text = text.slice(0, -size) + "[REDACTED]";
+      }
+    }
+  }
+  return text;
+}
+
+// Lane-owned children share one cancellation path and one diagnostic collection.
+class LaneProcesses {
+  children = [];
+  secrets = [];
+  controller = new AbortController();
+
+  constructor(cwd, env, { spawnImpl = spawn, kill = process.kill, graceMs = 2000 } = {}) {
+    Object.assign(this, { cwd, env, spawnImpl, kill, graceMs });
+    this.cancelled = new Promise((_, reject) => {
+      this.controller.signal.addEventListener(
+        "abort",
+        () => reject(this.controller.signal.reason),
+        { once: true },
+      );
+    });
+    this.cancelled.catch(() => {});
+  }
+
+  start(
+    label,
+    command,
+    args,
+    { artifact = "convex.log", privateOutput = false, stopSignal = "SIGTERM", ...options } = {},
+  ) {
+    this.controller.signal.throwIfAborted();
+    const child = this.spawnImpl(command, args, {
+      cwd: this.cwd,
+      env: this.env,
+      ...options,
+      detached: true,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const record = { child, label, artifact, privateOutput, stopSignal, stdout: "", stderr: "" };
+    for (const stream of ["stdout", "stderr"])
+      child[stream]?.on("data", (chunk) => {
+        if (!privateOutput || stream === "stdout")
+          record[stream] = (record[stream] + chunk.toString()).slice(-128 * 1024);
+      });
+    record.done = new Promise((resolve) => {
+      child.once("exit", resolve);
+      child.once("error", (error) => {
+        record.spawnError = error.code || "spawn error";
+        resolve();
+      });
+    });
+    record.closed = new Promise((resolve) =>
+      child.once("close", () => {
+        record.stdioClosed = true;
+        resolve();
+      }),
+    );
+    this.children.push(record);
+    return record;
+  }
+
+  output(record) {
+    return record.privateOutput
+      ? ""
+      : [record.stderr, record.stdout]
+          .map((text) => redactProofText(text, this.secrets, true))
+          .join("");
+  }
+
+  failure(record) {
+    const code = record.spawnError || record.child.signalCode || record.child.exitCode;
+    return new Error(
+      `${record.label} exited (${code}); ${record.privateOutput ? "private output suppressed" : this.output(record)}`,
+    );
+  }
+
+  monitor(record) {
+    record.done.then(() => this.controller.abort(this.failure(record)));
+  }
+
+  async run(...args) {
+    const record = this.start(...args);
+    try {
+      await Promise.race([record.done, this.cancelled]);
+      if (record.child.exitCode !== 0) throw this.failure(record);
+      return record.stdout;
+    } finally {
+      // Preserve a command failure. Memoized release errors are collected at lane shutdown.
+      await this.release(record).catch((error) => this.controller.abort(error));
+    }
+  }
+
+  signal(record, value) {
+    if (!record.child.pid || record.groupGone) return false;
+    try {
+      this.kill(-record.child.pid, value);
+      return true;
+    } catch (error) {
+      if (error.code !== "ESRCH")
+        throw new Error(
+          `${record.label}: process group ${record.child.pid} ${value} failed (${error.code})`,
+        );
+      // Once absent, the numeric group ID may be reused. Never signal it again.
+      record.groupGone = true;
+      return false;
+    }
+  }
+
+  release(record) {
+    return (record.cleanup ??= (async () => {
+      const waitForClose = () =>
+        Promise.race([record.closed, delay(this.graceMs, undefined, { ref: false })]);
+      // macOS may report EPERM between exit and close. Reap first, but bound inherited pipes.
+      if (record.spawnError || record.child.exitCode !== null || record.child.signalCode !== null)
+        await waitForClose();
+      if (this.signal(record, 0)) this.signal(record, record.stopSignal);
+      await waitForClose();
+      if (this.signal(record, 0)) this.signal(record, "SIGKILL");
+      await waitForClose();
+      if (!record.stdioClosed)
+        throw new Error(`${record.label}: cleanup timed out waiting for child closure`);
+    })());
+  }
+
+  async stop() {
+    this.controller.abort(new Error("UI proof finished"));
+    const results = await Promise.allSettled(this.children.map((record) => this.release(record)));
+    return results.filter((result) => result.status === "rejected").map((result) => result.reason);
+  }
+
+  async writeLogs(outputDir, errors) {
+    const logs = new Map([
+      ["convex.log", []],
+      ["seed.log", []],
+    ]);
+    for (const record of this.children) {
+      if (record.privateOutput) continue;
+      if (!logs.has(record.artifact)) logs.set(record.artifact, []);
+      logs.get(record.artifact).push(`[${record.label}]\n${this.output(record)}`);
+    }
+    logs.get("convex.log").push(...errors.map((error) => error.message));
+    for (const [name, entries] of logs)
+      await fs.writeFile(
+        path.join(outputDir, name),
+        redactProofText(entries.join("\n"), this.secrets),
+      );
+  }
+}
+
+async function waitForProofEndpoint({
+  url,
+  instanceName,
+  signal,
+  fetchImpl = fetch,
+  timeoutMs = 30000,
+}) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    signal.throwIfAborted();
+    let response;
+    try {
+      const res = await fetchImpl(instanceName ? `${url}/instance_name` : url, {
+        signal: AbortSignal.any([signal, AbortSignal.timeout(1000)]),
+        redirect: "error",
+      });
+      response = { status: res.status, name: instanceName ? await res.text() : undefined };
+    } catch {
+      signal.throwIfAborted();
+    }
+    if (response) {
+      if (instanceName && (response.status !== 200 || response.name !== instanceName))
+        throw new Error(
+          `Unexpected backend identity at ${url}; refusing to adopt another service.`,
+        );
+      if (instanceName || response.status < 500) return;
+    }
+    await delay(100, undefined, { signal });
+  }
+  throw new Error(
+    `Timed out waiting for ${instanceName ? "backend identity" : "preview"} at ${url} within ${timeoutMs}ms`,
+  );
+}
+
+async function downloadProofBackend({ state, env, run, archivePath, signal }) {
+  const target = BACKENDS[`${process.platform}-${process.arch}`];
+  if (!target)
+    throw new Error(`Unsupported UI proof backend platform: ${process.platform}-${process.arch}`);
+  const [triple, digest] = target;
+  const url = `https://github.com/get-convex/convex-backend/releases/download/${BACKEND_VERSION}/convex-local-backend-${triple}.zip`;
+  let bytes;
+  if (archivePath) bytes = await fs.readFile(archivePath);
+  else {
+    const response = await fetch(url, {
+      signal: AbortSignal.any([signal, AbortSignal.timeout(120000)]),
+    });
+    if (!response.ok) throw new Error(`Backend download failed: HTTP ${response.status}`);
+    bytes = Buffer.from(await response.arrayBuffer());
+  }
+  if (createHash("sha256").update(bytes).digest("hex") !== digest)
+    throw new Error("Backend ZIP SHA-256 mismatch");
+  const zip = path.join(state, "backend.zip");
+  await fs.writeFile(zip, bytes, { mode: 0o600 });
+  await run("backend extraction", "unzip", ["-q", zip, "-d", path.join(state, "backend")], {
+    cwd: state,
+    env,
+  });
+  const binary = path.join(state, "backend", "convex-local-backend");
+  await fs.chmod(binary, 0o700);
+  return binary;
+}
+
+// Shell is limited to disposable-image provisioning and the user-supplied seed hook.
+const PROVISION_PROOF_TOOLS = `set -euo pipefail
+if ! command -v unzip >/dev/null 2>&1; then
+  if ! command -v apt-get >/dev/null 2>&1 || ! command -v timeout >/dev/null 2>&1; then
+    echo "UI proof requires unzip, or apt-get and timeout to provision it." >&2
+    exit 127
+  fi
+  provision_unzip() {
+    if command -v sudo >/dev/null 2>&1; then
+      sudo -n env HOME="$HOME" XDG_CONFIG_HOME="$XDG_CONFIG_HOME" XDG_CACHE_HOME="$XDG_CACHE_HOME" DEBIAN_FRONTEND=noninteractive timeout --signal=TERM --kill-after=5s 120s apt-get "$@"
+    else
+      DEBIAN_FRONTEND=noninteractive timeout --signal=TERM --kill-after=5s 120s apt-get "$@"
+    fi
+  }
+  provision_unzip update
+  provision_unzip install -y unzip
+fi
+if ! command -v bun >/dev/null 2>&1; then
+  curl --connect-timeout 15 --max-time 120 -fsSL https://bun.sh/install | bash
+fi`;
+
+async function prepareProofTools({ appRoot, wrapperRoot, skipInstall }, run, checkSources) {
+  await run("tool provisioning", "/bin/bash", ["-c", PROVISION_PROOF_TOOLS], { cwd: wrapperRoot });
+  await checkSources();
+  if (!skipInstall) {
+    for (const cwd of new Set([wrapperRoot, appRoot])) {
+      // --no-env-file is a runtime flag, not a prefix for Bun's install subcommand.
+      await run("dependency install", "bun", ["install", "--frozen-lockfile"], { cwd });
+      await checkSources();
+    }
+  }
+  // Browser binaries belong to this fresh cache, even when dependencies already exist.
+  await run(
+    "browser install",
+    process.execPath,
+    [path.join(wrapperRoot, "node_modules/playwright/cli.js"), "install", "chromium"],
+    { cwd: wrapperRoot },
+  );
+  await checkSources();
+}
+
+async function runUiProof(options, processes, env, fetchImpl) {
+  const run = processes.run.bind(processes);
+  const signal = processes.controller.signal;
+  const { appRoot, wrapperRoot, outputDir, lane, scenarioText, videoDuration } = options;
+  if (typeof scenarioText !== "string") throw new Error("Missing UI proof scenario");
+  const scenarioFile = path.join(outputDir, "scenario.mjs");
+  await fs.writeFile(scenarioFile, scenarioText);
+  await run("frontend build", "bun", ["--no-env-file", "run", "build"], {
+    env,
+    artifact: "build.log",
+  });
+  const preview = processes.start(
+    "Preview",
+    process.execPath,
+    [
+      path.join(appRoot, "node_modules/vite/bin/vite.js"),
+      "preview",
+      "--host",
+      "127.0.0.1",
+      "--port",
+      String(lane.port),
+      "--strictPort",
+    ],
+    { env, artifact: "preview.log" },
+  );
+  processes.monitor(preview);
+  await waitForProofEndpoint({ url: env.SITE_URL, signal, fetchImpl });
+  if (preview.child.exitCode !== null || preview.child.signalCode !== null || preview.spawnError)
+    throw processes.failure(preview);
+  const display = env.DISPLAY.includes(".") ? env.DISPLAY : `${env.DISPLAY}.0`;
+  const video = processes.start(
+    "video",
+    "ffmpeg",
+    [
+      "-hide_banner",
+      "-loglevel",
+      "error",
+      "-y",
+      "-f",
+      "x11grab",
+      "-framerate",
+      "15",
+      "-i",
+      display,
+      "-t",
+      videoDuration || "60",
+      "-pix_fmt",
+      "yuv420p",
+      path.join(outputDir, "full-run.mp4"),
+    ],
+    { env, artifact: "ffmpeg.log", stopSignal: "SIGINT" },
+  );
+  video.done.then(() => {
+    if (video.spawnError === "ENOENT") video.stderr = "ffmpeg missing; full-run.mp4 skipped";
+  });
+  await fs.writeFile(
+    path.join(outputDir, "lane-summary.json"),
+    `${JSON.stringify({ lane: lane.name, ref: lane.ref, baseURL: env.SITE_URL }, null, 2)}\n`,
+  );
+  await run(
+    "UI proof",
+    "bun",
+    [
+      "--no-env-file",
+      path.join(wrapperRoot, "scripts/ui-proof-runtime.mjs"),
+      "run-scenario",
+      "--scenario",
+      scenarioFile,
+      "--base-url",
+      env.SITE_URL,
+      "--lane",
+      lane.name,
+      "--output-dir",
+      outputDir,
+    ],
+    { cwd: wrapperRoot, env },
+  );
+}
+
+export async function runProofBackend(options, io = {}) {
+  const { appRoot, wrapperRoot, outputDir, lane, devAuth = false, env: featureEnv = {} } = options;
+  assertProofEnvironment(featureEnv);
+  const ports = [lane.convexCloudPort, lane.convexSitePort, lane.port];
+  if (
+    !/^(baseline|candidate)$/u.test(lane.name) ||
+    ports.some((port) => !Number.isInteger(port) || port < 1024 || port > 65535) ||
+    new Set(ports).size !== 3
+  )
+    throw new Error("UI proof requires a named lane and three distinct unprivileged ports");
+  const checkSources = async () => {
+    for (const root of new Set([appRoot, wrapperRoot])) await assertCleanProofSource(root);
+  };
+  await checkSources();
+  // Never use operator TMPDIR for private credentials, storage, HOME or caches.
+  const state = await fs.mkdtemp("/tmp/clawhub-ui-proof-");
+  const env = isolatedProofEnvironment(state, process.env);
+  env.PATH = `${path.join(state, "bun", "bin")}:${env.PATH}`;
+  const processes = new LaneProcesses(appRoot, env, io);
+  const run = processes.run.bind(processes);
+  const { signal } = processes.controller;
+  const interrupt = (name) =>
+    processes.controller.abort(new Error(`UI proof interrupted (${name})`));
+  const onInt = () => interrupt("SIGINT");
+  const onTerm = () => interrupt("SIGTERM");
+  process.on("SIGINT", onInt);
+  process.on("SIGTERM", onTerm);
+  const timer = setTimeout(() => interrupt("deadline"), io.timeoutMs ?? 20 * 60 * 1000);
+  const errors = [];
+  let result;
+  try {
+    await fs.chmod(state, 0o700);
+    await fs.mkdir(outputDir, { recursive: true });
+    const actualState = await fs.realpath(state);
+    for (const root of [appRoot, wrapperRoot, outputDir]) {
+      const actualRoot = await fs.realpath(root);
+      if (actualState === actualRoot || actualState.startsWith(`${actualRoot}/`))
+        throw new Error("Private UI proof state must be outside source and artifact directories");
+    }
+    for (const dir of ["home", "config", "cache", "data", "tmp", "storage"])
+      await fs.mkdir(path.join(state, dir), { mode: 0o700 });
+    await assertPortsFree(ports, io.connect);
+    if (!options.continueWith) await prepareProofTools(options, run, checkSources);
+    const cliPath = options.cliPath || path.join(wrapperRoot, "node_modules/convex/bin/main.js");
+    const cliPackage = JSON.parse(
+      await fs.readFile(path.resolve(path.dirname(cliPath), "../package.json"), "utf8"),
+    );
+    if (cliPackage.version !== CONVEX_CLI_VERSION)
+      throw new Error(
+        `UI proof requires Convex CLI ${CONVEX_CLI_VERSION}; installed ${cliPackage.version}`,
+      );
+    const binary = await (io.acquireBackend || downloadProofBackend)({
+      state,
+      env,
+      run,
+      archivePath: options.backendArchive,
+      signal,
+    });
+    const instanceName = `ui-proof-${lane.name}-${randomBytes(12).toString("hex")}`;
+    const instanceSecret = randomBytes(32).toString("hex");
+    processes.secrets.push(instanceSecret);
+    const adminKey = (
+      await run(
+        "backend key generation",
+        binary,
+        [
+          "keygen",
+          "admin-key",
+          "--instance-name",
+          instanceName,
+          "--instance-secret",
+          instanceSecret,
+        ],
+        { cwd: state, privateOutput: true },
+      )
+    ).trim();
+    processes.secrets.push(adminKey);
+    if (!adminKey.startsWith(`${instanceName}|`) || /\s/u.test(adminKey))
+      throw new Error("Backend returned an invalid admin key");
+    const url = `http://127.0.0.1:${lane.convexCloudPort}`;
+    const siteUrl = `http://127.0.0.1:${lane.convexSitePort}`;
+    const cliEnvFile = path.join(state, "cli.env");
+    await fs.writeFile(
+      cliEnvFile,
+      `CONVEX_SELF_HOSTED_URL=${url}\nCONVEX_SELF_HOSTED_ADMIN_KEY=${adminKey}\n`,
+      { mode: 0o600, flag: "wx" },
+    );
+    await assertPortsFree(ports, io.connect);
+    processes.monitor(
+      processes.start(
+        "Convex backend",
+        binary,
+        backendArguments({ state, lane, instanceName, instanceSecret }),
+        { cwd: state },
+      ),
+    );
+    const checkIdentity = () =>
+      waitForProofEndpoint({ url, instanceName, signal, fetchImpl: io.fetchImpl });
+    const cliEnv = { ...env, NODE_PATH: path.join(wrapperRoot, "node_modules") };
+    const cli = (label, args) =>
+      run(label, process.execPath, [cliPath, ...args, "--env-file", cliEnvFile], { env: cliEnv });
+    await checkIdentity();
+    const marker = `local:${instanceName}`;
+    if (devAuth) {
+      await cli("dev auth", ["env", "set", "DEV_AUTH_ENABLED", "1"]);
+      await cli("dev auth", ["env", "set", "DEV_AUTH_CONVEX_DEPLOYMENT", marker]);
+    }
+    await cli("source push", [
+      "run",
+      "--push",
+      "--typecheck",
+      "disable",
+      "--codegen",
+      "disable",
+      "appMeta:getDeploymentInfo",
+      "{}",
+    ]);
+    await checkIdentity();
+    await checkSources();
+    await cli("app readiness", ["run", "--no-push", "appMeta:getDeploymentInfo", "{}"]);
+    const appEnv = {
+      ...env,
+      ...featureEnv,
+      CONVEX_DEPLOYMENT: marker,
+      CONVEX_SITE_URL: siteUrl,
+      VITE_CONVEX_URL: url,
+      VITE_CONVEX_SITE_URL: siteUrl,
+      SITE_URL: `http://127.0.0.1:${lane.port}`,
+      VITE_SITE_URL: `http://127.0.0.1:${lane.port}`,
+      CLAWHUB_UI_PROOF_LANE: lane.name,
+      ...(devAuth
+        ? { DEV_AUTH_ENABLED: "1", DEV_AUTH_CONVEX_DEPLOYMENT: marker, VITE_ENABLE_DEV_AUTH: "1" }
+        : {}),
+    };
+    if (options.seedCommand) {
+      const seedEnv = {
+        ...appEnv,
+        ...cliEnv,
+        CONVEX_SELF_HOSTED_URL: url,
+        CONVEX_SELF_HOSTED_ADMIN_KEY: adminKey,
+        CLAWHUB_UI_PROOF_CLI: cliPath,
+        CLAWHUB_UI_PROOF_CLI_ENV_FILE: cliEnvFile,
+      };
+      delete seedEnv.CONVEX_DEPLOYMENT;
+      await run("seed", "/bin/bash", ["-c", options.seedCommand], {
+        env: seedEnv,
+        artifact: "seed.log",
+      });
+      await checkSources();
+    }
+    if (options.continueWith)
+      await Promise.race([
+        options.continueWith({ env: appEnv, instanceName, signal }),
+        processes.cancelled,
+      ]);
+    else await runUiProof(options, processes, appEnv, io.fetchImpl);
+    signal.throwIfAborted();
+    result = { backendVersion: BACKEND_VERSION, cliVersion: CONVEX_CLI_VERSION, instanceName };
+  } catch (error) {
+    errors.push(error.name === "AbortError" && signal.aborted ? signal.reason : error);
+  } finally {
+    clearTimeout(timer);
+    errors.push(...(await processes.stop()));
+    process.off("SIGINT", onInt);
+    process.off("SIGTERM", onTerm);
+    await fs
+      .mkdir(outputDir, { recursive: true })
+      .then(() => processes.writeLogs(outputDir, errors))
+      .catch((error) => errors.push(error));
+    await fs.rm(state, { recursive: true, force: true }).catch((error) => errors.push(error));
+  }
+  const failure = redactProofText(
+    [...new Set(errors.map((error) => error.message))].join("\n"),
+    processes.secrets,
+  );
+  // Completion certifies cleanup as well as the browser's separate UI manifest.
+  await fs
+    .writeFile(
+      path.join(outputDir, "bootstrap-summary.json"),
+      `${JSON.stringify({ ...result, status: failure ? "fail" : "pass", error: failure || undefined }, null, 2)}\n`,
+    )
+    .catch((error) => {
+      throw new Error(
+        redactProofText([failure, error.message].filter(Boolean).join("\n"), processes.secrets),
+      );
+    });
+  if (failure) throw new Error(failure);
+  return result;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const [config, appRoot, wrapperRoot, outputDir] = process.argv.slice(2);
+  runProofBackend({ ...JSON.parse(config), appRoot, wrapperRoot, outputDir }).catch((error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/ui-proof-backend.test.mjs
+++ b/scripts/ui-proof-backend.test.mjs
@@ -1,0 +1,477 @@
+/* @vitest-environment node */
+import { spawn } from "node:child_process";
+import { EventEmitter } from "node:events";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, expect, it, vi } from "vitest";
+import { assertProofEnvironment, runProofBackend } from "./ui-proof-backend.mjs";
+
+const temporary = [];
+afterEach(async () => {
+  vi.restoreAllMocks();
+  for (const root of temporary.splice(0)) await fs.rm(root, { recursive: true, force: true });
+});
+
+function fakeChild(pid) {
+  const child = Object.assign(new EventEmitter(), {
+    pid,
+    exitCode: null,
+    signalCode: null,
+    stdout: new EventEmitter(),
+    stderr: new EventEmitter(),
+  });
+  child.exit = (code) => {
+    child.exitCode = code;
+    child.emit("exit", code);
+  };
+  child.close = () => {
+    child.stdioClosed = true;
+    child.emit("close");
+  };
+  return child;
+}
+
+function fakeSocket(occupied = false) {
+  const socket = new EventEmitter();
+  socket.destroy = () => {};
+  socket.setTimeout = () => {};
+  queueMicrotask(() => socket.emit(occupied ? "connect" : "error", { code: "ECONNREFUSED" }));
+  return socket;
+}
+
+async function fixture(onSpawn) {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "clawhub-proof-test-"));
+  temporary.push(root);
+  const appRoot = path.join(root, "app");
+  const wrapperRoot = path.join(root, "wrapper");
+  await fs.mkdir(appRoot);
+  const packageRoot = path.join(wrapperRoot, "node_modules/convex");
+  await fs.mkdir(packageRoot, { recursive: true });
+  await fs.writeFile(path.join(packageRoot, "package.json"), '{"version":"1.44.0"}');
+  const options = {
+    appRoot,
+    wrapperRoot,
+    outputDir: path.join(root, "artifacts"),
+    lane: { name: "baseline", convexCloudPort: 4417, convexSitePort: 4517, port: 4317 },
+    continueWith: vi.fn(),
+  };
+  const jobs = [];
+  let instanceName;
+  const io = {
+    graceMs: 10,
+    acquireBackend: vi.fn(async () => "/owned/backend"),
+    connect: vi.fn(() => fakeSocket()),
+    fetchImpl: vi.fn(async () => ({ status: 200, text: async () => instanceName })),
+    spawnImpl(command, args, settings) {
+      const child = fakeChild(900 + jobs.length);
+      const job = { child, command, args, settings };
+      jobs.push(job);
+      Promise.resolve()
+        .then(async () => {
+          if (args[0] === "keygen") {
+            instanceName = args[args.indexOf("--instance-name") + 1];
+            child.stdout.emit("data", `${instanceName}|private-key\n`);
+            child.stderr.emit("data", "unregistered-keygen-diagnostic");
+          }
+          await onSpawn?.(job);
+          if (args.includes("--interface") || args.includes("preview") || command === "ffmpeg")
+            return;
+          if (child.exitCode === null) {
+            child.exit(0);
+            child.close();
+          }
+        })
+        .catch((error) => {
+          child.stderr.emit("data", `${error.message}\n`);
+          child.exit(1);
+          child.close();
+        });
+      return child;
+    },
+    kill: vi.fn((pid, signal) => {
+      const child = jobs.find((job) => job.child.pid === -pid).child;
+      if (child.stdioClosed) throw Object.assign(new Error("absent"), { code: "ESRCH" });
+      if (signal !== 0) {
+        child.exit(0);
+        child.close();
+      }
+    }),
+  };
+  async function run(overrides = {}) {
+    const firstJob = jobs.length;
+    const counts = [process.listenerCount("SIGINT"), process.listenerCount("SIGTERM")];
+    const result = await runProofBackend({ ...options, ...overrides }, io).catch((error) => error);
+    const completion = JSON.parse(
+      await fs.readFile(path.join(options.outputDir, "bootstrap-summary.json"), "utf8"),
+    );
+    expect(completion.status).toBe(result instanceof Error ? "fail" : "pass");
+    expect([process.listenerCount("SIGINT"), process.listenerCount("SIGTERM")]).toEqual(counts);
+    if (jobs[firstJob])
+      await expect(fs.stat(path.dirname(jobs[firstJob].settings.env.HOME))).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+    if (result instanceof Error) {
+      expect(completion.error).toBe(result.message);
+      throw result;
+    }
+    return result;
+  }
+  return { options, io, jobs, run };
+}
+
+it("rejects connection, credential, process and private-state overrides while allowing feature flags", () => {
+  for (const key of [
+    "CONVEX_DEPLOYMENT",
+    "CONVEX_SELF_HOSTED_ADMIN_KEY",
+    "VITE_CONVEX_URL",
+    "HOME",
+    "XDG_CACHE_HOME",
+    "PATH",
+    "NODE_OPTIONS",
+    "BASH_ENV",
+    "LD_PRELOAD",
+    "HTTPS_PROXY",
+    "DEV_AUTH_ENABLED",
+    "VITE_ENABLE_DEV_AUTH",
+  ])
+    expect(() => assertProofEnvironment({ [key]: "unsafe" })).toThrow("Reserved proof --env");
+  expect(() => assertProofEnvironment({ FEATURE_FLAG: "1" })).not.toThrow();
+});
+
+it.each([".convex", ".env", ".env.local", ".env.production"])(
+  "refuses remote %s by name without reading or removing it",
+  async (name) => {
+    const proof = await fixture();
+    const file = path.join(proof.options.appRoot, name);
+    await fs.symlink("/unreadable/operator-state", file);
+    await expect(runProofBackend(proof.options, proof.io)).rejects.toThrow(`existing ${name}`);
+    expect(proof.jobs).toHaveLength(0);
+    expect(await fs.readlink(file)).toBe("/unreadable/operator-state");
+  },
+);
+
+it("uses a private selection file and exact non-configuring push before the separate readiness query", async () => {
+  let selection;
+  const proof = await fixture(async ({ args, settings }) => {
+    if (!args.includes("--push")) return;
+    const file = args.at(-1);
+    selection = { file, text: await fs.readFile(file, "utf8") };
+    expect((await fs.stat(file)).mode & 0o777).toBe(0o600);
+    expect((await fs.stat(path.dirname(file))).mode & 0o777).toBe(0o700);
+    expect(settings.cwd).toBe(proof.options.appRoot);
+    expect(settings.env).not.toHaveProperty("CONVEX_DEPLOYMENT");
+    expect(settings.env).not.toHaveProperty("CONVEX_SELF_HOSTED_ADMIN_KEY");
+  });
+  const result = await proof.run();
+  const push = proof.jobs.find((job) => job.args.includes("--push"));
+  expect(push.command).toBe(process.execPath);
+  expect(push.args).toEqual([
+    path.join(proof.options.wrapperRoot, "node_modules/convex/bin/main.js"),
+    "run",
+    "--push",
+    "--typecheck",
+    "disable",
+    "--codegen",
+    "disable",
+    "appMeta:getDeploymentInfo",
+    "{}",
+    "--env-file",
+    selection.file,
+  ]);
+  expect(selection.text).toBe(
+    `CONVEX_SELF_HOSTED_URL=http://127.0.0.1:4417\nCONVEX_SELF_HOSTED_ADMIN_KEY=${result.instanceName}|private-key\n`,
+  );
+  expect(proof.jobs.at(-1).args.slice(1, 5)).toEqual([
+    "run",
+    "--no-push",
+    "appMeta:getDeploymentInfo",
+    "{}",
+  ]);
+  expect(proof.io.fetchImpl).toHaveBeenCalledTimes(2);
+  const backend = proof.jobs.find((job) => job.args.includes("--interface"));
+  expect(backend.args.slice(0, 6)).toEqual([
+    "--interface",
+    "127.0.0.1",
+    "--port",
+    "4417",
+    "--site-proxy-port",
+    "4517",
+  ]);
+  expect(backend.args).toContain("--disable-beacon");
+  expect(proof.io.connect.mock.calls.map(([address]) => address)).toEqual(
+    [4417, 4517, 4317, 4417, 4517, 4317].map((port) => ({ host: "127.0.0.1", port })),
+  );
+});
+
+it("creates fresh identity/state each run and enables backend and frontend dev auth only by opt-in", async () => {
+  const identities = new Set();
+  const homes = new Set();
+  for (const devAuth of [false, true, false]) {
+    const proof = await fixture();
+    const result = await proof.run({ devAuth });
+    identities.add(result.instanceName);
+    const { env } = proof.options.continueWith.mock.calls[0][0];
+    homes.add(env.HOME);
+    expect(env).not.toHaveProperty("CONVEX_SELF_HOSTED_ADMIN_KEY");
+    expect(env.VITE_ENABLE_DEV_AUTH).toBe(devAuth ? "1" : undefined);
+    expect(env.CI).toBe("1");
+    expect(
+      proof.jobs.filter((job) => job.args[1] === "env").map((job) => job.args.slice(2, 5)),
+    ).toEqual(
+      devAuth
+        ? [
+            ["set", "DEV_AUTH_ENABLED", "1"],
+            ["set", "DEV_AUTH_CONVEX_DEPLOYMENT", `local:${result.instanceName}`],
+          ]
+        : [],
+    );
+  }
+  expect(identities.size).toBe(3);
+  expect(homes.size).toBe(3);
+});
+
+it.each(["preparation", "push", "seed"])(
+  "rejects source state created by %s before continuation",
+  async (phase) => {
+    const proof = await fixture(async ({ command, args, settings }) => {
+      if (
+        (phase === "preparation" && command === "/bin/bash") ||
+        (phase === "push" && args.includes("--push")) ||
+        (phase === "seed" && args[1] === "seed-fixture")
+      )
+        await fs.writeFile(path.join(settings.cwd, ".env.local"), "FEATURE_FLAG=untrusted");
+    });
+    await expect(
+      proof.run({
+        continueWith: phase === "preparation" ? undefined : proof.options.continueWith,
+        skipInstall: true,
+        seedCommand: "seed-fixture",
+      }),
+    ).rejects.toThrow("existing .env.local");
+    expect(proof.options.continueWith).not.toHaveBeenCalled();
+  },
+);
+
+it.each(["keygen", "--push", "--no-push"])(
+  "stops on %s failure with private diagnostics",
+  async (argument) => {
+    const proof = await fixture(({ args }) => {
+      if (args.includes(argument)) throw new Error("failure private-key");
+    });
+    await expect(proof.run()).rejects.toThrow(
+      argument === "keygen" ? "private output suppressed" : "exited (1)",
+    );
+    expect(proof.options.continueWith).not.toHaveBeenCalled();
+    expect(
+      await fs.readFile(path.join(proof.options.outputDir, "convex.log"), "utf8"),
+    ).not.toContain("unregistered-keygen-diagnostic");
+  },
+);
+
+it.each(["occupied", "identity", "version", "archive"])(
+  "rejects %s before source continuation",
+  async (kind) => {
+    const proof = await fixture();
+    if (kind === "occupied") proof.io.connect = () => fakeSocket(true);
+    if (kind === "identity")
+      proof.io.fetchImpl = async () => ({ status: 200, text: async () => "other-instance" });
+    if (kind === "version")
+      await fs.writeFile(
+        path.join(proof.options.wrapperRoot, "node_modules/convex/package.json"),
+        '{"version":"1.43.0"}',
+      );
+    if (kind === "archive") {
+      proof.options.backendArchive = path.join(proof.options.appRoot, "backend.zip");
+      await fs.writeFile(proof.options.backendArchive, "unverified archive");
+      delete proof.io.acquireBackend;
+    }
+    await expect(proof.run()).rejects.toThrow(
+      {
+        occupied: "occupied",
+        identity: "Unexpected backend identity",
+        version: "installed 1.43.0",
+        archive: "SHA-256 mismatch",
+      }[kind],
+    );
+    expect(proof.options.continueWith).not.toHaveBeenCalled();
+  },
+);
+
+it.each(["exit", "deadline", "SIGINT", "SIGTERM"])(
+  "cancels pending readiness on %s and tears down",
+  async (cause) => {
+    const proof = await fixture();
+    if (cause === "deadline") proof.io.timeoutMs = 30;
+    proof.io.fetchImpl = async (_url, { signal }) => {
+      const pending = new Promise((_, reject) =>
+        signal.addEventListener("abort", () => reject(signal.reason), { once: true }),
+      );
+      if (cause === "exit") {
+        proof.jobs.at(-1).child.exit(9);
+        proof.jobs.at(-1).child.close();
+      } else if (cause !== "deadline") process.emit(cause);
+      return pending;
+    };
+    await expect(proof.run()).rejects.toThrow(
+      cause === "exit" ? "Convex backend exited (9)" : cause,
+    );
+    expect(proof.options.continueWith).not.toHaveBeenCalled();
+  },
+);
+
+it.each([0, "SIGTERM"])(
+  "stops signaling a denied record at %s but cleans others and preserves the primary failure",
+  async (deniedSignal) => {
+    const proof = await fixture(({ args }) => {
+      if (args.includes("--push")) throw new Error("source failed");
+    });
+    const kill = proof.io.kill;
+    proof.io.kill = vi.fn((pid, signal) => {
+      const job = proof.jobs.find((job) => job.child.pid === -pid);
+      if (job.args.includes("--push") && signal === deniedSignal)
+        throw Object.assign(new Error("denied"), { code: "EPERM" });
+      if (job.args.includes("--push")) return;
+      return kill(pid, signal);
+    });
+    await expect(proof.run()).rejects.toThrow(
+      /source push exited.*source failed\n+source push: process group .*EPERM/u,
+    );
+    const backend = proof.jobs.find((job) => job.args.includes("--interface"));
+    expect(backend.child.stdioClosed).toBe(true);
+    const push = proof.jobs.find((job) => job.args.includes("--push"));
+    expect(
+      proof.io.kill.mock.calls
+        .filter(([pid]) => pid === -push.child.pid)
+        .map(([, signal]) => signal),
+    ).toEqual(deniedSignal === 0 ? [0] : [0, "SIGTERM"]);
+  },
+);
+
+it("waits for exit-before-close and never probes an ESRCH group twice", async () => {
+  const proof = await fixture(({ args, child }) => {
+    if (args.includes("--push")) {
+      child.exit(0);
+      setImmediate(() => child.close());
+    }
+  });
+  const kill = proof.io.kill;
+  proof.io.kill = vi.fn((pid, signal) => {
+    const job = proof.jobs.find((job) => job.child.pid === -pid);
+    if (job.args.includes("--push")) expect(job.child.stdioClosed).toBe(true);
+    return kill(pid, signal);
+  });
+  await proof.run();
+  const push = proof.jobs.find((job) => job.args.includes("--push"));
+  expect(proof.io.kill.mock.calls.filter(([pid]) => pid === -push.child.pid)).toEqual([
+    [-push.child.pid, 0],
+  ]);
+});
+
+it("bounds public tails, redacts split/truncated secrets and removes state even when log writing fails", async () => {
+  let secret;
+  const proof = await fixture(({ args, child }) => {
+    if (args[0] === "keygen") secret = args.at(-1);
+    if (args.includes("--push")) {
+      child.stdout.emit("data", secret.slice(0, 20));
+      child.stdout.emit("data", secret.slice(20) + "!");
+      child.stdout.emit("data", "x".repeat(128 * 1024 - 8));
+      child.stderr.emit("data", "\n" + secret.slice(0, 10));
+    }
+  });
+  await proof.run();
+  const log = await fs.readFile(path.join(proof.options.outputDir, "convex.log"), "utf8");
+  expect(log.length).toBeLessThan(129 * 1024);
+  expect(log).not.toContain(secret.slice(-7));
+  expect(log).not.toContain(secret.slice(0, 10));
+  const writeFile = fs.writeFile;
+  vi.spyOn(fs, "writeFile").mockImplementation((file, ...args) => {
+    if (file.endsWith("convex.log")) throw new Error("log write denied");
+    return writeFile(file, ...args);
+  });
+  await expect(proof.run()).rejects.toThrow("log write denied");
+});
+
+it("keeps build/browser credential-free, uses direct lane/wrapper paths and finalizes video with INT", async () => {
+  const proof = await fixture(async ({ args, settings }) => {
+    if (args.includes("run-scenario")) {
+      expect(settings.cwd).toBe(proof.options.wrapperRoot);
+      await fs.writeFile(
+        path.join(proof.options.outputDir, "proof-steps.json"),
+        '{"status":"pass"}',
+      );
+    }
+  });
+  await proof.run({
+    continueWith: undefined,
+    scenarioText: "export default async () => {}",
+    skipInstall: false,
+    seedCommand: "seed-fixture",
+  });
+  const build = proof.jobs.find((job) => job.args.includes("build"));
+  expect([build.command, build.args, build.settings.cwd]).toEqual([
+    "bun",
+    ["--no-env-file", "run", "build"],
+    proof.options.appRoot,
+  ]);
+  for (const job of proof.jobs)
+    expect(job.settings.env.CONVEX_SELF_HOSTED_ADMIN_KEY).toEqual(
+      job.args[1] === "seed-fixture" ? expect.stringContaining("|private-key") : undefined,
+    );
+  const installs = proof.jobs.filter((job) => job.args.includes("--frozen-lockfile"));
+  expect(installs.map((job) => job.args)).toEqual([
+    ["install", "--frozen-lockfile"],
+    ["install", "--frozen-lockfile"],
+  ]);
+  const video = proof.jobs.find((job) => job.command === "ffmpeg");
+  expect(proof.io.kill.mock.calls).toContainEqual([-video.child.pid, "SIGINT"]);
+});
+
+it("installs browsers in the fresh private cache when dependency installation is skipped", async () => {
+  const proof = await fixture();
+  await proof.run({
+    continueWith: undefined,
+    scenarioText: "export default async () => {}",
+    skipInstall: true,
+  });
+  expect(proof.jobs.some((job) => job.args.includes("--frozen-lockfile"))).toBe(false);
+  const browserInstall = proof.jobs.find((job) => job.args.includes("chromium"));
+  expect(browserInstall.args).toEqual([
+    path.join(proof.options.wrapperRoot, "node_modules/playwright/cli.js"),
+    "install",
+    "chromium",
+  ]);
+  expect(browserInstall.settings.env.XDG_CACHE_HOME).toBe(
+    path.join(path.dirname(browserInstall.settings.env.HOME), "cache"),
+  );
+});
+
+it("reaps a real process tree whose leader exits while a grandchild holds pipes (no listeners)", async () => {
+  const proof = await fixture();
+  const spawnImpl = proof.io.spawnImpl;
+  const kill = proof.io.kill;
+  let backend;
+  proof.io.spawnImpl = (command, args, settings) => {
+    if (!args.includes("--interface")) return spawnImpl(command, args, settings);
+    backend = spawn(
+      process.execPath,
+      [
+        "-e",
+        `
+      require('node:child_process').spawn(process.execPath, ['-e', 'process.on("SIGTERM",()=>{}); setInterval(()=>{},1000)'], {stdio:'inherit'});
+      setTimeout(()=>process.exit(7),100);
+    `,
+      ],
+      settings,
+    );
+    return backend;
+  };
+  proof.io.kill = (pid, signal) =>
+    pid === -backend?.pid ? process.kill(pid, signal) : kill(pid, signal);
+  proof.io.fetchImpl = (_url, { signal }) =>
+    new Promise((_, reject) =>
+      signal.addEventListener("abort", () => reject(signal.reason), { once: true }),
+    );
+  await expect(proof.run()).rejects.toThrow("Convex backend exited (7)");
+  expect(() => process.kill(-backend.pid, 0)).toThrow();
+});

--- a/scripts/ui-proof.mjs
+++ b/scripts/ui-proof.mjs
@@ -4,6 +4,7 @@ import { existsSync } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
+import { assertProofEnvironment } from "./ui-proof-backend.mjs";
 
 const DEFAULT_BASELINE = "origin/main";
 const DEFAULT_CANDIDATE = "worktree";
@@ -137,6 +138,7 @@ export function parseProofUiArgs(argv = []) {
     if (opts.baselineUrl) assertLocalProofUrl(opts.baselineUrl, "--baseline-url");
     assertLocalProofUrl(opts.candidateUrl, "--candidate-url");
   }
+  if (opts.runner === "crabbox") assertProofEnvironment(opts.env);
   return opts;
 }
 
@@ -286,103 +288,8 @@ function shellQuote(value) {
   return `'${String(value).replaceAll("'", "'\\''")}'`;
 }
 
-function renderExportEnv(env) {
-  return Object.entries(env)
-    .map(([key, value]) => `export ${key}=${shellQuote(value)}`)
-    .join("\n");
-}
-
-function laneLocalConvexEnv(lane, opts) {
-  const appUrl = `http://127.0.0.1:${lane.port}`;
-  const convexUrl = `http://127.0.0.1:${lane.convexCloudPort}`;
-  const convexSiteUrl = `http://127.0.0.1:${lane.convexSitePort}`;
-  const deployment = `local:anonymous-clawhub-ui-proof-${lane.name}`;
-  return {
-    CONVEX_DEPLOYMENT: deployment,
-    CONVEX_SITE_URL: convexSiteUrl,
-    SITE_URL: appUrl,
-    VITE_CONVEX_SITE_URL: convexSiteUrl,
-    VITE_CONVEX_URL: convexUrl,
-    VITE_SITE_URL: appUrl,
-    ...(opts.devAuth
-      ? {
-          DEV_AUTH_CONVEX_DEPLOYMENT: deployment,
-          DEV_AUTH_ENABLED: "1",
-          VITE_ENABLE_DEV_AUTH: "1",
-        }
-      : {}),
-    ...opts.env,
-  };
-}
-
-function renderWaitForUrl(url, label) {
-  return `bun -e ${shellQuote(`const url = ${JSON.stringify(url)};
-const label = ${JSON.stringify(label)};
-const started = Date.now();
-async function tick() {
-  try {
-    const res = await fetch(url);
-    if (res.status < 500) process.exit(0);
-  } catch {}
-  if (Date.now() - started > 60000) {
-    console.error(label + " did not become ready: " + url);
-    process.exit(1);
-  }
-  setTimeout(tick, 500);
-}
-tick();`)}`;
-}
-
-function renderLocalConvexSetup({ lane, opts }) {
-  const env = laneLocalConvexEnv(lane, opts);
-  const envFileLines = Object.entries(env)
-    .map(([key, value]) => `${key}=${value}`)
-    .join("\n");
-  const convexUrl = env.VITE_CONVEX_URL;
-  const devAuthDeploymentExport = opts.devAuth
-    ? `export DEV_AUTH_CONVEX_DEPLOYMENT="$CONVEX_DEPLOYMENT"`
-    : "";
-  const seedCommand = opts.seedCommand
-    ? `(cd "$app_root" && ${opts.seedCommand} > "$remote_out/seed.log" 2>&1)`
-    : `: > "$remote_out/seed.log"`;
-  return `
-lane_env_file="$remote_out/.env.local"
-cat > "$lane_env_file" <<'CLAWHUB_UI_PROOF_ENV'
-${envFileLines}
-CLAWHUB_UI_PROOF_ENV
-rm -rf "$app_root/.convex/local/default"
-(cd "$app_root" && bunx convex dev --local --env-file "$lane_env_file" --typecheck disable --codegen disable --local-cloud-port ${lane.convexCloudPort} --local-site-port ${lane.convexSitePort} > "$remote_out/convex.log" 2>&1 & echo $! > "$remote_out/convex.pid")
-convex_pid="$(cat "$remote_out/convex.pid")"
-${renderWaitForUrl(convexUrl, "local Convex")}
-for _ in $(seq 1 120); do
-  if [ -f "$app_root/.env.local" ] && grep -q '^CONVEX_DEPLOYMENT=' "$app_root/.env.local"; then
-    break
-  fi
-  sleep 0.5
-done
-if [ ! -f "$app_root/.env.local" ] || ! grep -q '^CONVEX_DEPLOYMENT=' "$app_root/.env.local"; then
-  echo "local Convex did not write $app_root/.env.local" >&2
-  exit 1
-fi
-if [ -f "$app_root/.env.local" ]; then
-  set -a
-  . "$app_root/.env.local"
-  set +a
-fi
-export CONVEX_SITE_URL=${shellQuote(env.CONVEX_SITE_URL)}
-export SITE_URL=${shellQuote(env.SITE_URL)}
-export VITE_CONVEX_SITE_URL=${shellQuote(env.VITE_CONVEX_SITE_URL)}
-export VITE_CONVEX_URL=${shellQuote(env.VITE_CONVEX_URL)}
-export VITE_SITE_URL=${shellQuote(env.VITE_SITE_URL)}
-${devAuthDeploymentExport}
-(cd "$app_root" && bunx convex run --push --typecheck disable --codegen disable appMeta:getDeploymentInfo '{}' >> "$remote_out/convex.log" 2>&1)
-${seedCommand}
-`;
-}
-
 export function renderRemoteLaneScript({ lane, opts, plan, scenarioText }) {
-  const scenarioB64 = Buffer.from(scenarioText, "utf8").toString("base64");
-  const runtimePath = path.join("scripts", "ui-proof-runtime.mjs");
+  assertProofEnvironment(opts.env);
   const laneRemoteDir = `.artifacts/clawhub-ui-proof/remote-${path.basename(plan.outputDir)}/${lane.name}`;
   const appRootSetup =
     lane.name === "baseline"
@@ -394,128 +301,24 @@ export function renderRemoteLaneScript({ lane, opts, plan, scenarioText }) {
           `app_root="$PWD/.artifacts/clawhub-ui-proof/worktrees/${lane.name}"`,
         ].join("\n")
       : `app_root="$PWD"`;
-  const envExports = renderExportEnv(laneLocalConvexEnv(lane, opts));
-  const localConvexSetup = renderLocalConvexSetup({ lane, opts });
-
+  const config = JSON.stringify({
+    lane,
+    devAuth: opts.devAuth,
+    env: opts.env,
+    seedCommand: opts.seedCommand,
+    skipInstall: opts.skipInstall,
+    videoDuration: opts.videoDuration,
+    scenarioText,
+  });
   return `set -euo pipefail
-export DISPLAY="\${DISPLAY:-:99}"
+wrapper_root="$PWD"
 remote_out="$PWD/${laneRemoteDir}"
 rm -rf "$remote_out"
 mkdir -p "$remote_out"
 echo "__CLAWHUB_UI_PROOF_REMOTE_OUTPUT__=$remote_out"
-convex_pid=""
-video_pid=""
-cleanup_proof_processes() {
-  if [ -n "$video_pid" ]; then
-    kill -INT "$video_pid" >/dev/null 2>&1 || true
-    wait "$video_pid" >/dev/null 2>&1 || true
-    video_pid=""
-  fi
-  if [ -f "$remote_out/preview.pid" ]; then
-    kill "$(cat "$remote_out/preview.pid")" >/dev/null 2>&1 || true
-    rm -f "$remote_out/preview.pid"
-  fi
-  if [ -n "$convex_pid" ]; then
-    kill "$convex_pid" >/dev/null 2>&1 || true
-    wait "$convex_pid" >/dev/null 2>&1 || true
-    convex_pid=""
-  elif [ -f "$remote_out/convex.pid" ]; then
-    kill "$(cat "$remote_out/convex.pid")" >/dev/null 2>&1 || true
-    rm -f "$remote_out/convex.pid"
-  fi
-  return 0
-}
-trap cleanup_proof_processes EXIT
-scenario_file="$remote_out/scenario.mjs"
-printf %s ${shellQuote(scenarioB64)} | base64 -d > "$scenario_file"
 ${appRootSetup}
-${envExports}
-export CLAWHUB_UI_PROOF_LANE=${shellQuote(lane.name)}
-export BUN_INSTALL="\${BUN_INSTALL:-$HOME/.bun}"
-export PATH="$BUN_INSTALL/bin:$PATH"
-if ! command -v bun >/dev/null 2>&1; then
-  if ! command -v unzip >/dev/null 2>&1; then
-    if command -v apt-get >/dev/null 2>&1; then
-      if command -v sudo >/dev/null 2>&1; then
-        sudo env DEBIAN_FRONTEND=noninteractive apt-get update >/dev/null
-        sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y unzip >/dev/null
-      else
-        DEBIAN_FRONTEND=noninteractive apt-get update >/dev/null
-        DEBIAN_FRONTEND=noninteractive apt-get install -y unzip >/dev/null
-      fi
-    else
-      echo "bun is not installed on this Crabbox image and unzip is unavailable." >&2
-      exit 127
-    fi
-  fi
-  if ! command -v curl >/dev/null 2>&1; then
-    echo "bun is not installed on this Crabbox image and curl is unavailable to install it." >&2
-    exit 127
-  fi
-  curl -fsSL https://bun.sh/install | bash
-fi
-export PATH="$BUN_INSTALL/bin:$PATH"
-if [ ${opts.skipInstall ? "1" : "0"} -ne 1 ]; then
-  bun install --frozen-lockfile
-  if [ "$app_root" != "$PWD" ]; then
-    (cd "$app_root" && bun install --frozen-lockfile)
-  fi
-  bunx playwright install chromium > "$remote_out/playwright-install.log" 2>&1
-fi
-${localConvexSetup}
-(cd "$app_root" && bun run build > "$remote_out/build.log" 2>&1)
-(cd "$app_root" && bun run preview -- --host 127.0.0.1 --port ${lane.port} > "$remote_out/preview.log" 2>&1 & echo $! > "$remote_out/preview.pid")
-${renderWaitForUrl(`http://127.0.0.1:${lane.port}`, "preview")}
-if command -v ffmpeg >/dev/null 2>&1; then
-  display_input="$DISPLAY"
-  case "$display_input" in
-    *.*) ;;
-    *) display_input="$display_input.0" ;;
-  esac
-  ffmpeg -hide_banner -loglevel error -y -f x11grab -framerate 15 -i "$display_input" -t ${shellQuote(
-    opts.videoDuration,
-  )} -pix_fmt yuv420p "$remote_out/full-run.mp4" > "$remote_out/ffmpeg.log" 2>&1 &
-  video_pid=$!
-else
-  echo "ffmpeg missing; full-run.mp4 skipped" > "$remote_out/ffmpeg.log"
-fi
-status=0
-bun ${shellQuote(runtimePath)} run-scenario \
-  --scenario "$scenario_file" \
-  --base-url ${shellQuote(`http://127.0.0.1:${lane.port}`)} \
-  --lane ${shellQuote(lane.name)} \
-  --output-dir "$remote_out" || status=$?
-manifest_status=""
-if [ -f "$remote_out/proof-steps.json" ]; then
-  manifest_status="$(CLAWHUB_UI_PROOF_MANIFEST="$remote_out/proof-steps.json" bun -e 'const fs = require("fs"); const path = process.env.CLAWHUB_UI_PROOF_MANIFEST; process.stdout.write(JSON.parse(fs.readFileSync(path, "utf8")).status || "unknown");' 2>/dev/null || true)"
-  if [ "$manifest_status" = "pass" ]; then
-    status=0
-  elif [ "$manifest_status" = "fail" ] && [ "$status" -eq 0 ]; then
-    status=1
-  fi
-fi
-if [ -n "$video_pid" ]; then
-  kill -INT "$video_pid" >/dev/null 2>&1 || true
-  wait "$video_pid" >/dev/null 2>&1 || true
-  video_pid=""
-fi
-if [ -f "$remote_out/preview.pid" ]; then
-  kill "$(cat "$remote_out/preview.pid")" >/dev/null 2>&1 || true
-  rm -f "$remote_out/preview.pid"
-fi
-if [ -n "$convex_pid" ]; then
-  kill "$convex_pid" >/dev/null 2>&1 || true
-  wait "$convex_pid" >/dev/null 2>&1 || true
-  convex_pid=""
-fi
-cat > "$remote_out/lane-summary.json" <<CLAWHUB_UI_PROOF_SUMMARY
-{
-  "lane": ${JSON.stringify(lane.name)},
-  "ref": ${JSON.stringify(lane.ref)},
-  "baseURL": ${JSON.stringify(`http://127.0.0.1:${lane.port}`)}
-}
-CLAWHUB_UI_PROOF_SUMMARY
-exit "$status"
+# Replace the wrapper: the helper owns and awaits all backend/proof process groups.
+exec env -i PATH="$PATH" DISPLAY="\${DISPLAY:-:99}" node "$wrapper_root/scripts/ui-proof-backend.mjs" ${shellQuote(config)} "$app_root" "$wrapper_root" "$remote_out"
 `;
 }
 
@@ -558,9 +361,9 @@ function renderReport(summary) {
   return `${lines.join("\n")}\n`;
 }
 
-async function readLaneManifest(localOutputDir) {
+async function readLaneManifest(localOutputDir, name = "proof-steps.json") {
   try {
-    const raw = await fs.readFile(path.join(localOutputDir, "proof-steps.json"), "utf8");
+    const raw = await fs.readFile(path.join(localOutputDir, name), "utf8");
     return JSON.parse(raw);
   } catch {
     return {};
@@ -705,8 +508,19 @@ async function runLane({
     repoRoot,
   });
   const manifest = await readLaneManifest(lane.outputDir);
-  const status = manifest.status ?? (error ? "fail" : "pass");
-  const laneError = status === "pass" ? undefined : (manifest.error ?? error);
+  const bootstrap = await readLaneManifest(lane.outputDir, "bootstrap-summary.json");
+  const status = manifest.status === "pass" && bootstrap.status === "pass" ? "pass" : "fail";
+  const bootstrapError =
+    bootstrap.status === "pass"
+      ? undefined
+      : (bootstrap.error ?? "Backend bootstrap did not write a successful completion manifest.");
+  const laneError =
+    status === "pass"
+      ? undefined
+      : (manifest.error ??
+        bootstrapError ??
+        error ??
+        "UI proof did not write a passing result manifest.");
   return {
     error: laneError,
     localOutputDir: lane.outputDir,

--- a/scripts/ui-proof.test.mjs
+++ b/scripts/ui-proof.test.mjs
@@ -73,30 +73,10 @@ describe("ui-proof", () => {
     ).toThrow("local before-after proof requires --baseline-url and --candidate-url");
   });
 
-  it("parses explicit proof modes and rejects unknown modes", () => {
-    expect(
-      parseProofUiArgs([
-        "--mode",
-        "before-after",
-        "--scenario",
-        ".artifacts/proof-scenarios/demo.pw.ts",
-      ]),
-    ).toMatchObject({
-      mode: "before-after",
-    });
-    expect(
-      parseProofUiArgs([
-        "--mode",
-        "feature",
-        "--scenario",
-        ".artifacts/proof-scenarios/demo.pw.ts",
-      ]),
-    ).toMatchObject({
-      mode: "feature",
-    });
-    expect(() =>
-      parseProofUiArgs(["--mode", "smoke", "--scenario", ".artifacts/proof-scenarios/demo.pw.ts"]),
-    ).toThrow("Unknown proof:ui mode: smoke");
+  it.each(["before-after", "feature", "smoke"])("validates proof mode %s", (mode) => {
+    const parse = () => parseProofUiArgs(["--mode", mode, "--scenario", "scenario.mjs"]);
+    if (mode === "smoke") expect(parse).toThrow("Unknown proof:ui mode: smoke");
+    else expect(parse()).toMatchObject({ mode });
   });
 
   it("parses seed command and explicit proof env options", () => {
@@ -134,95 +114,60 @@ describe("ui-proof", () => {
     ).toThrow("--env requires KEY=VALUE");
   });
 
-  it("builds a before/after plan with stable lane output directories", () => {
+  it.each(["before-after", "feature"])("builds stable output directories for %s", (mode) => {
     const plan = buildProofUiPlan({
       now: () => new Date("2026-05-12T12:34:56.000Z"),
-      opts: parseProofUiArgs(["--scenario", ".artifacts/proof-scenarios/demo.pw.ts"]),
+      opts: parseProofUiArgs(["--mode", mode, "--scenario", "scenario.mjs"]),
       repoRoot: "/repo/clawhub",
     });
-
-    expect(plan.mode).toBe("before-after");
+    expect(plan.mode).toBe(mode);
     expect(plan.outputDir).toBe(
       "/repo/clawhub/.artifacts/clawhub-ui-proof/2026-05-12T12-34-56-000Z",
     );
-    expect(plan.lanes.map((lane) => [lane.name, lane.ref, lane.outputDir])).toEqual([
-      ["baseline", "origin/main", `${plan.outputDir}/baseline`],
-      ["candidate", "worktree", `${plan.outputDir}/candidate`],
-    ]);
-  });
-
-  it("builds a feature plan with candidate-only lane output", () => {
-    const plan = buildProofUiPlan({
-      now: () => new Date("2026-05-12T12:34:56.000Z"),
-      opts: parseProofUiArgs([
-        "--mode",
-        "feature",
-        "--scenario",
-        ".artifacts/proof-scenarios/demo.pw.ts",
+    const lanes = mode === "feature" ? ["candidate"] : ["baseline", "candidate"];
+    expect(plan.lanes.map((lane) => [lane.name, lane.ref, lane.outputDir])).toEqual(
+      lanes.map((name) => [
+        name,
+        name === "baseline" ? "origin/main" : "worktree",
+        `${plan.outputDir}/${name}`,
       ]),
-      repoRoot: "/repo/clawhub",
-    });
-
-    expect(plan.mode).toBe("feature");
-    expect(plan.lanes.map((lane) => [lane.name, lane.ref, lane.outputDir])).toEqual([
-      ["candidate", "worktree", `${plan.outputDir}/candidate`],
-    ]);
+    );
   });
 
-  it("dry-runs without invoking Crabbox and writes the planned report", async () => {
-    const repoRoot = await fs.mkdtemp(path.join(os.tmpdir(), "clawhub-proof-"));
-    const scenario = path.join(repoRoot, ".artifacts/proof-scenarios/demo.pw.ts");
-    await fs.mkdir(path.dirname(scenario), { recursive: true });
-    await fs.writeFile(scenario, "export default async function demo() {}\n");
-    const commands = [];
-
-    const result = await runProofUi({
-      args: ["--scenario", scenario, "--dry-run"],
-      commandRunner: async (command, commandArgs) => {
-        commands.push([command, commandArgs]);
-        return { stdout: "", stderr: "" };
-      },
-      now: () => new Date("2026-05-12T12:34:56.000Z"),
-      repoRoot,
-    });
-
-    expect(commands).toEqual([]);
-    expect(result.status).toBe("dry-run");
-    const report = await fs.readFile(path.join(result.outputDir, "report.md"), "utf8");
-    expect(report).toContain("Mode: `before-after`");
-    expect(report).toContain("Baseline: `origin/main`");
-    expect(report).toContain("Candidate: `worktree`");
-    expect(report).toContain("Dry run");
-    await expect(
-      fs.readFile(path.join(result.outputDir, "summary.json"), "utf8"),
-    ).resolves.toContain('"scenario"');
-  });
-
-  it("dry-runs feature proof with candidate-only report language", async () => {
-    const repoRoot = await fs.mkdtemp(path.join(os.tmpdir(), "clawhub-proof-"));
-    const scenario = path.join(repoRoot, ".artifacts/proof-scenarios/demo.pw.ts");
-    await fs.mkdir(path.dirname(scenario), { recursive: true });
-    await fs.writeFile(scenario, "export default async function demo() {}\n");
-
-    const result = await runProofUi({
-      args: ["--mode", "feature", "--scenario", scenario, "--dry-run"],
-      commandRunner: async () => {
-        throw new Error("Crabbox should not run during dry-run");
-      },
-      now: () => new Date("2026-05-12T12:34:56.000Z"),
-      repoRoot,
-    });
-
-    const report = await fs.readFile(path.join(result.outputDir, "report.md"), "utf8");
-    expect(report).toContain("Mode: `feature`");
-    expect(report).toContain("Baseline: not run for feature proof.");
-    expect(report).toContain("Candidate: `worktree`");
-    expect(report).not.toContain("### baseline");
-    expect(report).toContain("### candidate");
-    await expect(
-      fs.readFile(path.join(result.outputDir, "summary.json"), "utf8"),
-    ).resolves.toContain('"mode": "feature"');
-  });
+  it.each(["before-after", "feature"])(
+    "dry-runs %s without Crabbox and writes the planned report",
+    async (mode) => {
+      const repoRoot = await fs.mkdtemp(path.join(os.tmpdir(), "clawhub-proof-"));
+      try {
+        const scenario = path.join(repoRoot, "scenario.mjs");
+        await fs.writeFile(scenario, "export default async function demo() {}\n");
+        const result = await runProofUi({
+          args: ["--scenario", scenario, "--mode", mode, "--dry-run"],
+          commandRunner: async () => {
+            throw new Error("Crabbox should not run during dry-run");
+          },
+          now: () => new Date("2026-05-12T12:34:56.000Z"),
+          repoRoot,
+        });
+        expect(result.status).toBe("dry-run");
+        const report = await fs.readFile(path.join(result.outputDir, "report.md"), "utf8");
+        expect(report).toContain(`Mode: \`${mode}\``);
+        expect(report).toContain(
+          mode === "feature" ? "Baseline: not run for feature proof." : "Baseline: `origin/main`",
+        );
+        expect(report).toContain("Candidate: `worktree`");
+        expect(report).toContain("Dry run: no proof runtime was invoked.");
+        expect(report).toContain("### candidate");
+        expect(report.includes("### baseline")).toBe(mode === "before-after");
+        expect(JSON.parse(await fs.readFile(result.summaryPath, "utf8"))).toMatchObject({
+          scenario,
+          mode,
+        });
+      } finally {
+        await fs.rm(repoRoot, { recursive: true, force: true });
+      }
+    },
+  );
 
   it("runs a publishable local Playwright proof without invoking Crabbox", async () => {
     const repoRoot = await fs.mkdtemp(path.join(os.tmpdir(), "clawhub-proof-"));
@@ -279,72 +224,98 @@ describe("ui-proof", () => {
     );
   });
 
-  it("treats a passing proof manifest as authoritative after a Crabbox transport error", async () => {
-    const repoRoot = await fs.mkdtemp(path.join(os.tmpdir(), "clawhub-proof-"));
-    const scenario = path.join(repoRoot, ".artifacts/proof-scenarios/demo.pw.ts");
-    await fs.mkdir(path.dirname(scenario), { recursive: true });
-    await fs.writeFile(scenario, "export default async function demo() {}\n");
-    let laneIndex = 0;
+  it.each(["pass", "fail", "missing"])(
+    "recovers a Crabbox transport error only with successful UI and bootstrap manifests (%s)",
+    async (bootstrapStatus) => {
+      const repoRoot = await fs.mkdtemp(path.join(os.tmpdir(), "clawhub-proof-"));
+      const scenario = path.join(repoRoot, ".artifacts/proof-scenarios/demo.pw.ts");
+      await fs.mkdir(path.dirname(scenario), { recursive: true });
+      await fs.writeFile(scenario, "export default async function demo() {}\n");
+      // Ignored operator-state names in the local caller must not block remote proof.
+      await fs.symlink("/unreadable/operator-state", path.join(repoRoot, ".env.local"));
+      await fs.symlink("/unreadable/operator-state", path.join(repoRoot, ".convex"));
+      let laneIndex = 0;
 
-    const result = await runProofUi({
-      args: ["--scenario", scenario],
-      commandRunner: async (command, commandArgs) => {
-        if (commandArgs.includes("warmup")) {
-          return { stdout: "leased cbx_deadbeef", stderr: "" };
-        }
-        if (commandArgs.includes("run")) {
-          const lane = laneIndex === 0 ? "baseline" : "candidate";
-          laneIndex += 1;
-          const error = new Error(`transport failed for ${lane}`);
-          error.stdout = `__CLAWHUB_UI_PROOF_REMOTE_OUTPUT__=/remote/${lane}\n`;
-          error.stderr = "";
-          throw error;
-        }
-        if (commandArgs.includes("inspect")) {
-          return {
-            stdout: JSON.stringify({
-              sshHost: "203.0.113.10",
-              sshKey: "/tmp/crabbox key",
-              sshPort: 22,
-              sshUser: "crabbox",
-            }),
-            stderr: "",
-          };
-        }
-        if (command === "rsync") {
-          const localOutputDir = commandArgs.at(-1).replace(/\/$/u, "");
-          const lane = localOutputDir.endsWith("baseline") ? "baseline" : "candidate";
-          await fs.mkdir(localOutputDir, { recursive: true });
-          await fs.writeFile(
-            path.join(localOutputDir, "proof-steps.json"),
-            `${JSON.stringify({
-              lane,
-              status: "pass",
-              steps: [
-                {
-                  name: `${lane} /skills`,
-                  screenshot: "screenshots/skills.png",
-                  status: "pass",
-                },
-              ],
-            })}\n`,
-          );
-          return { stdout: "", stderr: "" };
-        }
-        if (commandArgs.includes("stop")) {
-          return { stdout: "", stderr: "" };
-        }
-        throw new Error(`unexpected command: ${command} ${commandArgs.join(" ")}`);
-      },
-      now: () => new Date("2026-05-12T12:34:56.000Z"),
-      repoRoot,
-    });
+      const result = await runProofUi({
+        args: ["--scenario", scenario],
+        commandRunner: async (command, commandArgs) => {
+          if (commandArgs.includes("warmup")) {
+            return { stdout: "leased cbx_deadbeef", stderr: "" };
+          }
+          if (commandArgs.includes("run")) {
+            const lane = laneIndex === 0 ? "baseline" : "candidate";
+            laneIndex += 1;
+            const error = new Error(`transport failed for ${lane}`);
+            error.stdout = `__CLAWHUB_UI_PROOF_REMOTE_OUTPUT__=/remote/${lane}\n`;
+            error.stderr = "";
+            throw error;
+          }
+          if (commandArgs.includes("inspect")) {
+            return {
+              stdout: JSON.stringify({
+                sshHost: "203.0.113.10",
+                sshKey: "/tmp/crabbox key",
+                sshPort: 22,
+                sshUser: "crabbox",
+              }),
+              stderr: "",
+            };
+          }
+          if (command === "rsync") {
+            const localOutputDir = commandArgs.at(-1).replace(/\/$/u, "");
+            const lane = localOutputDir.endsWith("baseline") ? "baseline" : "candidate";
+            await fs.mkdir(localOutputDir, { recursive: true });
+            await fs.writeFile(
+              path.join(localOutputDir, "proof-steps.json"),
+              `${JSON.stringify({
+                lane,
+                status: "pass",
+                steps: [
+                  {
+                    name: `${lane} /skills`,
+                    screenshot: "screenshots/skills.png",
+                    status: "pass",
+                  },
+                ],
+              })}\n`,
+            );
+            if (bootstrapStatus !== "missing") {
+              await fs.writeFile(
+                path.join(localOutputDir, "bootstrap-summary.json"),
+                JSON.stringify({
+                  status: bootstrapStatus,
+                  error: bootstrapStatus === "fail" ? "backend cleanup failed" : undefined,
+                }),
+              );
+            }
+            return { stdout: "", stderr: "" };
+          }
+          if (commandArgs.includes("stop")) {
+            return { stdout: "", stderr: "" };
+          }
+          throw new Error(`unexpected command: ${command} ${commandArgs.join(" ")}`);
+        },
+        now: () => new Date("2026-05-12T12:34:56.000Z"),
+        repoRoot,
+      });
 
-    expect(result.status).toBe("pass");
-    await expect(
-      fs.readFile(path.join(result.outputDir, "summary.json"), "utf8"),
-    ).resolves.toContain('"status": "pass"');
-  });
+      const expected = bootstrapStatus === "pass" ? "pass" : "fail";
+      expect(result.status).toBe(expected);
+      const summary = JSON.parse(
+        await fs.readFile(path.join(result.outputDir, "summary.json"), "utf8"),
+      );
+      expect(summary.status).toBe(expected);
+      if (bootstrapStatus !== "pass") {
+        expect(
+          summary.lanes.every((lane) =>
+            lane.error.includes(
+              bootstrapStatus === "fail" ? "backend cleanup failed" : "completion manifest",
+            ),
+          ),
+        ).toBe(true);
+      }
+    },
+  );
 
   it("quotes Crabbox ssh key paths with spaces for rsync artifact copying", () => {
     const { ssh } = buildRsyncSshCommand({
@@ -359,107 +330,83 @@ describe("ui-proof", () => {
     );
   });
 
-  it("bootstraps Bun on desktop Crabbox images before running proof commands", () => {
-    const script = renderRemoteLaneScript({
-      lane: {
-        name: "candidate",
-        outputDir: "/tmp/out/candidate",
-        port: 4318,
-        ref: "worktree",
-      },
-      opts: {
-        skipInstall: false,
-        videoDuration: "1",
-      },
-      plan: {
-        outputDir: "/tmp/out",
-      },
-      scenarioText: "export default async function scenario() {}\n",
-    });
+  it.each(["HOME", "CONVEX_DEPLOYMENT", "VITE_CONVEX_URL", "NODE_OPTIONS", "BASH_ENV"])(
+    "rejects reserved remote env %s during argument parsing",
+    (key) => {
+      expect(() =>
+        parseProofUiArgs(["--scenario", "scenario.mjs", "--env", `${key}=unsafe`]),
+      ).toThrow("Reserved proof --env");
+    },
+  );
 
-    expect(script).toContain("command -v bun");
-    expect(script).toContain("command -v unzip");
-    expect(script).toContain("curl -fsSL https://bun.sh/install | bash");
-    expect(script).toContain('export PATH="$BUN_INSTALL/bin:$PATH"');
-    expect(script).toContain("bunx playwright install chromium");
-    expect(script).toContain("trap cleanup_proof_processes EXIT");
-    expect(script).toContain("return 0");
-    expect(script).toContain("bun -e");
-    expect(script).toContain("bun 'scripts/ui-proof-runtime.mjs' run-scenario");
-    expect(script).toContain(
-      'manifest_status="$(CLAWHUB_UI_PROOF_MANIFEST="$remote_out/proof-steps.json" bun -e',
-    );
+  it("keeps the attach-only local environment path unchanged", () => {
+    expect(
+      parseProofUiArgs([
+        "--runner",
+        "local",
+        "--mode",
+        "feature",
+        "--candidate-url",
+        "http://127.0.0.1:4318",
+        "--scenario",
+        "scenario.mjs",
+        "--env",
+        "CONVEX_DEPLOYMENT=unused",
+      ]),
+    ).toMatchObject({ env: { CONVEX_DEPLOYMENT: "unused" } });
   });
 
-  it("renders lane-local Convex env, seed command, and process cleanup for proof lanes", () => {
-    const script = renderRemoteLaneScript({
-      lane: {
+  it.each(["baseline", "candidate"])(
+    "runs trusted tooling from the wrapper and builds %s from its lane root",
+    (name) => {
+      const lane = {
         convexCloudPort: 4417,
         convexSitePort: 4517,
-        name: "baseline",
-        outputDir: "/tmp/out/baseline",
+        name,
+        outputDir: `/tmp/out/${name}`,
         port: 4317,
-        ref: "origin/main",
-      },
-      opts: {
+        ref: name === "baseline" ? "origin/main" : "worktree",
+      };
+      const script = renderRemoteLaneScript({
+        lane,
+        opts: {
+          devAuth: true,
+          env: { FEATURE_FLAG: "1" },
+          seedCommand: "seed-fixture",
+          skipInstall: true,
+          videoDuration: "1",
+        },
+        plan: { outputDir: "/tmp/out" },
+        scenarioText: "export default async function scenario() {}\n",
+      });
+      // Decode the literal JSON argument using the same single-quote escaping as a shell.
+      const raw = script.match(/ui-proof-backend\.mjs" '(.*)' "\$app_root"/u)[1];
+      const config = JSON.parse(raw.replaceAll("'\\''", "'"));
+      expect(config).toMatchObject({
+        lane,
         devAuth: true,
         env: { FEATURE_FLAG: "1" },
-        seedCommand: "bunx convex run --no-push devSeed:seedNixSkills",
+        seedCommand: "seed-fixture",
+      });
+      expect(script).toContain('exec env -i PATH="$PATH"');
+      expect(script).toContain('node "$wrapper_root/scripts/ui-proof-backend.mjs"');
+      expect(script).toContain(
+        name === "baseline"
+          ? 'app_root="$PWD/.artifacts/clawhub-ui-proof/worktrees/baseline"'
+          : 'app_root="$PWD"',
+      );
+      expect(config).toMatchObject({
         skipInstall: true,
         videoDuration: "1",
-      },
-      plan: {
-        outputDir: "/tmp/out",
-      },
-      scenarioText: "export default async function scenario() {}\n",
-    });
-
-    expect(script).toContain('convex_pid=""');
-    expect(script).toContain('kill "$convex_pid"');
-    expect(script).toContain("VITE_CONVEX_URL='http://127.0.0.1:4417'");
-    expect(script).toContain("VITE_CONVEX_SITE_URL='http://127.0.0.1:4517'");
-    expect(script).toContain("CONVEX_DEPLOYMENT='local:anonymous-clawhub-ui-proof-baseline'");
-    expect(script).toContain(
-      "DEV_AUTH_CONVEX_DEPLOYMENT='local:anonymous-clawhub-ui-proof-baseline'",
-    );
-    expect(script).toContain("local Convex did not write $app_root/.env.local");
-    expect(script).toContain('. "$app_root/.env.local"');
-    expect(script).toContain('export DEV_AUTH_CONVEX_DEPLOYMENT="$CONVEX_DEPLOYMENT"');
-    expect(script).toContain("--local-cloud-port 4417");
-    expect(script).toContain("--local-site-port 4517");
-    expect(script).toContain('bunx convex dev --local --env-file "$lane_env_file"');
-    expect(script).toContain("bunx convex run --no-push devSeed:seedNixSkills");
-    expect(script).toContain("VITE_ENABLE_DEV_AUTH=1");
-    expect(script).toContain("FEATURE_FLAG='1'");
-    expect(script).not.toContain("https://wry-manatee-359.convex.cloud");
-  });
-
-  it("does not enable dev auth by default but still uses lane-local Convex", () => {
-    const script = renderRemoteLaneScript({
-      lane: {
-        convexCloudPort: 4418,
-        convexSitePort: 4518,
-        name: "candidate",
-        outputDir: "/tmp/out/candidate",
-        port: 4318,
-        ref: "worktree",
-      },
-      opts: {
-        devAuth: false,
-        env: {},
-        skipInstall: true,
-        videoDuration: "1",
-      },
-      plan: {
-        outputDir: "/tmp/out",
-      },
-      scenarioText: "export default async function scenario() {}\n",
-    });
-
-    expect(script).toContain("VITE_CONVEX_URL='http://127.0.0.1:4418'");
-    expect(script).toContain("VITE_CONVEX_SITE_URL='http://127.0.0.1:4518'");
-    expect(script).toContain("convex dev --local");
-    expect(script).not.toContain("VITE_ENABLE_DEV_AUTH=1");
-    expect(script).not.toContain("https://wry-manatee-359.convex.cloud");
-  });
+        scenarioText: "export default async function scenario() {}\n",
+      });
+      expect(config).not.toHaveProperty("prepareCommand");
+      expect(config).not.toHaveProperty("proofCommand");
+      expect(script).not.toContain("trap");
+      expect(script).not.toContain("preview_pid");
+      expect(script).not.toContain("dev --local");
+      expect(script).not.toContain(".env.local");
+      expect(script).not.toContain("convex.pid");
+    },
+  );
 });

--- a/specs/ui-proof.md
+++ b/specs/ui-proof.md
@@ -1,27 +1,106 @@
 # UI Proof Runtime
 
-`proof:ui` always verifies a full-stack ClawHub instance. Crabbox lanes start
-local Convex from that lane's checkout, on deterministic lane-specific ports,
-then build and preview the frontend against those local Convex URLs. Local
-Playwright lanes attach to maintainer-started ClawHub instances on localhost or
-a loopback address.
+Remote `proof:ui` lanes prove the full stack from their source and fresh local
+data; there is no shared/production-backend mode. `--mode before-after` compares
+baseline/candidate; `--mode feature` runs the candidate. The optional Crabbox
+runner bootstraps lanes; `--runner local` only attaches to maintainer-started
+loopback instances, keeping baseline/candidate URLs and artifacts separate.
 
-The proof runner must not provide a shared or production-backend mode. UI proof
-is meant to prove the control plane and data plane together: the Git checkout
-controls both frontend and Convex source, and the lane-local Convex URL controls
-the runtime backend/data used by the browser.
+## Isolation and trust
 
-Use `--mode before-after` for baseline-vs-candidate proof and `--mode feature`
-for candidate-only proof. Use `--seed-command` when a scenario needs fixtures.
+Remote lanes use the trusted wrapper's helper/runtime, even for older baselines.
+Push, seed and build run from the lane app root. The remote shell selects source
+and execs the Node lane owner; it does not own background servers or cleanup.
+The local caller may have ignored `.env.local`/`.convex`: syncing must not hydrate
+those files. Reject unsafe `--env` overrides before requesting a lease.
 
-Dev auth must be explicit. The proof runner must not set
-`VITE_ENABLE_DEV_AUTH=1` by default; scenarios that need it should pass
-`--dev-auth` or explicit `--env` values.
+The actual remote wrapper/app roots must reject `.convex`, `.env` and `.env.*`
+(except example/sample/template files) by name, without reading or deleting them.
+Check initially, after source push, and after preparation/seed when they run.
+No cloud auth or operator state is read, copied or sourced. Source/scenarios are
+executable input; this helper is not a sandbox and retains Crabbox's trust boundary.
 
-Crabbox is an optional execution environment, not a prerequisite for visual
-verification. Agents should use `proof:ui` when a Crabbox skill or working
-Crabbox capability is available. Otherwise they should ignore Crabbox and run
-the same temporary scenario with `proof:ui --runner local` against real local
-ClawHub instances. Local before/after evidence requires separate baseline and
-candidate URLs and keeps the results in separate `baseline/` and `candidate/`
-directories so `proof:publish` can publish either execution path.
+Each lane owns fresh mode-0700 state outside source/artifacts: HOME, XDG paths,
+caches, binaries, temporary files, database and storage. The identity and secret
+are fresh; the self-host CLI selection file is mode 0600. Child environments
+inherit only PATH/DISPLAY plus explicit lane settings. Install hooks run before
+credentials exist. Use `bun install --frozen-lockfile`, not the invalid
+`bun --no-env-file install`; runtime invocations retain `--no-env-file`.
+Bun/unzip provisioning remains bounded and noninteractive. `--skip-install`
+skips dependency reinstallation; browser binaries are still installed in the
+fresh private cache, never loaded from an operator browser profile/cache.
+
+## Backend and source readiness
+
+Check installed CLI package metadata for exactly **1.44.0** and invoke its direct
+`bin/main.js`, never copied `.bin` launchers. Smoke verifies its executable version once. The backend release and verified platform ZIP digests live in the
+helper's pin table; never resolve latest or execute an unverified archive.
+
+Pass `--interface 127.0.0.1`, both fixed lane ports and loopback origin/site URLs.
+The pinned backend's
+[config.rs](https://github.com/get-convex/convex-backend/blob/precompiled-2026-08-25-7cce8fb/crates/local_backend/src/config.rs)
+uses that interface for both API and site bind addresses;
+[main.rs](https://github.com/get-convex/convex-backend/blob/precompiled-2026-08-25-7cce8fb/crates/local_backend/src/main.rs)
+uses both addresses to start listeners. Recheck these paths when changing the pin.
+Disable backend beacon telemetry and CLI Sentry (`CI=1`); start no dashboard.
+
+Check all three fixed ports before preparation and again before backend startup.
+Never adopt an occupied listener. Require exact fresh `/instance_name`, then:
+
+```sh
+node <verified-cli> run --push --typecheck disable --codegen disable appMeta:getDeploymentInfo '{}' --env-file <private-file>
+```
+
+Recheck identity and source cleanliness, then run a separate `run --no-push`
+readiness query before seed/build/browser. **Do not use `dev --local` or
+`dev --once`.** CLI 1.44.0's configuring `dev` path writes `.env.local` even with
+explicit self-hosted selection; `run --push` bypasses it. The selection file has
+only self-host URL/admin key. Private HOME also prevents fallback global-auth
+lookup. Keep the app's `local:<fresh-instance>` marker separate from CLI selection.
+
+`--dev-auth` explicitly sets backend `DEV_AUTH_ENABLED` and
+`DEV_AUTH_CONVEX_DEPLOYMENT` via `convex env set`, plus frontend opt-in. Seed gets
+only disposable self-host credentials and the direct CLI/private-file paths;
+build/browser get no admin key. The pinned backend requires its instance secret
+in argv: never log process arguments. Keygen output is private. Other child
+output is bounded and redacted, including split/truncated secrets, before logging.
+
+## Lifecycle and completion
+
+One controller handles backend/preview exit, deadline, INT and TERM. Own process
+groups, not only leaders. Cleanup sends TERM (INT for ffmpeg), waits boundedly,
+then escalates to KILL. An exited leader must get a bounded close/reaping wait
+before its group is probed: macOS can report EPERM between exit and close.
+Closed pipes do not prove descendants are gone; after ESRCH never signal that
+numeric group again. Permission denial fails that record without alternate
+signals, while all other groups are still attempted.
+
+Preserve primary failures alongside cleanup errors. Write redacted diagnostics
+and attempt private-state removal even when shutdown/logging fails. Write
+`bootstrap-summary.json` only after cleanup. Remote success requires both it and
+the UI manifest to pass; completed passing manifests may recover transport errors,
+but screenshots cannot hide missing/failed bootstrap completion. Local attach
+uses only its UI manifest. SIGKILL/host loss still requires outer containment.
+
+## Verification and limits
+
+Focused tests use the real owner with narrow I/O seams and real process-tree
+cleanup without listeners. Avoid dotenv loading and copied launchers:
+
+```sh
+node --input-type=module -e 'import {startVitest} from "vitest/node"; const ctx=await startVitest("test",["scripts/ui-proof.test.mjs","scripts/ui-proof-backend.test.mjs","scripts/ui-proof-runtime.test.mjs","scripts/ui-proof-publish.test.mjs"],{run:true},{envDir:false});await ctx.close();'
+```
+
+The opt-in smoke **starts servers**; use the approved `preview_start`/server
+launcher, never a background shell, with independently verified inputs:
+
+```sh
+node scripts/ui-proof-backend-smoke.mjs --run --cli /verified/convex-1.44.0/package/bin/main.js --backend-archive /verified/convex-local-backend-aarch64-apple-darwin.zip
+```
+
+It proves baseline/candidate source, fresh DB write/read, dev auth off/on/off,
+identity, API/site loopback sockets on macOS, completion and teardown. Supporting
+dependencies still come from the installed snapshot. It does not certify full-app
+build/browser behavior; follow it with real ClawHub UI proof. Parent failure tests
+use disposable malformed-source/missing-query/occupied-port fixtures and signals,
+never operator services, and verify no continuation plus complete teardown.


### PR DESCRIPTION
## Summary

Repair the UI-proof bootstrap's stale `convex dev --local` invocation without borrowing operator configuration or exposing an authenticated backend outside loopback. Convex 1.44.0 rejects that flag, and even self-hosted `dev --once` writes project dotenv. Use a verified standalone backend with `--interface 127.0.0.1` and a non-configuring `convex run --push` instead.

The remote shell now selects source and execs one Node lane owner. That owner handles fresh private state, source push/readiness, opt-in backend dev auth, frontend/proof processes, redacted diagnostics, and bounded cleanup. Both the UI manifest and a post-cleanup bootstrap completion must pass. The attach-only local runner is unchanged.

Simplified the initial implementation by removing generated shell supervision, duplicate cancellation/logging paths, a mock supervisor, and repetitive tests/docs. The final change is **+1,649/-501 across seven files** (net +1,148, versus +1,662 before simplification). `--skip-install` skips dependency reinstall; browser binaries still get a fresh private cache.

## Validation

Validated in a disposable tracked-source copy with a frozen dependency install, genuine Git ancestry, Bun 1.3.10, and Node 24.15.0/npm 11. Operator dotenv, Convex, and auth state were not copied; the original dependency installation was not patched.

- `bun run ci:static` — passed.
- `bun run ci:unit --maxWorkers=8` — 6,269 passed, 3 skipped; the worker budget matches the CI runner size.
- `bun run ci:types-build` — passed, including schema/CLI TypeScript checks and production build.
- Focused UI-proof regressions cover source/target isolation, current CLI arguments, fresh identity/state, dev-auth opt-in, failed startup/readiness, process-group teardown, private diagnostics, and completion reporting.
- `scripts/ui-proof-backend-smoke.mjs` with the exact Convex 1.44.0 CLI and verified Mac arm64 backend archive — baseline/candidate source markers, empty database then write/read, dev auth off/on/off, both loopback sockets, completion, and teardown passed.
- Additional disposable real-backend checks — malformed source prevented continuation; SIGTERM removed private state and closed owned ports.

No Crabbox lease, full-app visual proof, or manual live deployment was run. The fixture smoke proves the backend bootstrap, not full ClawHub browser behavior. Runtime trust boundaries and reproducible proof commands are documented in `specs/ui-proof.md`.

## Provenance

The original full-stack bootstrap was introduced in #2210 (`a66df774f256feca252ceb51d4ff682334520505`); its local-development CLI invocation is no longer supported by the pinned Convex dependency.

## Inspectable runtime evidence

Re-ran the real backend smoke against `af9b09b9bb1440dc66425c898007e825378ea3ec`. Before execution, all seven changed files in the isolated source copy were byte-compared with that commit. The run used the real Convex 1.44.0 CLI and the digest-verified backend, not mocked children or sockets.

Command below uses normalized paths; execution used absolute paths in the isolated source/dependency copy and the supervised local-server launcher:

```bash
node scripts/ui-proof-backend-smoke.mjs --run --cli node_modules/convex/bin/main.js --backend-archive /verified/convex-local-backend-aarch64-apple-darwin.zip
```

Captured runtime output:

```text
Verified source: af9b09b9bb1440dc66425c898007e825378ea3ec (all seven changed files match the committed bytes)
Platform: darwin/arm64; Node v24.15.0
Bun: 1.3.10
Backend archive SHA-256: 98831b0f511f6eed70b0b4dfca62015df57877e08017d2b2979b39d62ae7317b
baseline devAuth=false: source, fresh database, app query, site listener, teardown passed (precompiled-2026-08-25-7cce8fb, CLI 1.44.0)
candidate devAuth=true: source, fresh database, app query, site listener, teardown passed (precompiled-2026-08-25-7cce8fb, CLI 1.44.0)
candidate devAuth=false: source, fresh database, app query, site listener, teardown passed (precompiled-2026-08-25-7cce8fb, CLI 1.44.0)
{"kind":"signal","passed":true,"stateRemoved":true,"portsClosed":true,"continuationRan":true}
{"kind":"malformed-source","passed":true,"stateRemoved":true,"portsClosed":true,"continuationRan":false}
```

The three lane lines come from the committed smoke script: each is printed only after source/readiness assertions, an empty-database check followed by write/read, dev-auth assertions, socket-only `lsof` checks for **both** `127.0.0.1` listeners, successful bootstrap completion, closed ports, and removed private state. The final two lines are additional disposable-fixture checks of the same production owner: actual SIGTERM after readiness, and malformed source that prevents continuation. Both require a failing bootstrap result and successful teardown.

No credentials, private paths, or sensitive backend process arguments are included above. These are backend-bootstrap fixtures, not full ClawHub visual proof. All jobs in [the exact-head CI run](https://github.com/openclaw/clawhub/actions/runs/33228421544) passed, including public and local-auth browser gates.
