### PR TITLE
fix: fail closed when a skill archive blob is missing

### DIFF
--- a/convex/downloads.test.ts
+++ b/convex/downloads.test.ts
@@ -460,7 +460,7 @@ describe("downloads helpers", () => {
     expect(runAfter).toHaveBeenCalledTimes(1);
   });
 
-  it("streams stored file chunks, stays deterministic, and skips a Blob that vanishes", async () => {
+  it("streams stored file chunks and stays deterministic", async () => {
     const firstChunk = new Uint8Array(64 * 1024).fill(0x61);
     const secondChunk = new TextEncoder().encode("streamed body\n");
     const releaseSecondChunk = deferred<void>();
@@ -518,7 +518,6 @@ describe("downloads helpers", () => {
           files: [
             { path: "a.txt", storageId: "_storage:skill" },
             { path: "b.txt", storageId: "_storage:notes" },
-            { path: "missing.txt", storageId: "_storage:missing" },
           ],
           softDeletedAt: undefined,
         };
@@ -550,7 +549,9 @@ describe("downloads helpers", () => {
 
     expect(response.status).toBe(200);
     expect(storageGetMetadata).not.toHaveBeenCalled();
-    expect(storageGet).not.toHaveBeenCalled();
+    expect(storageGet).toHaveBeenCalledWith("_storage:skill");
+    expect(storageGet).toHaveBeenCalledWith("_storage:notes");
+    expect(stream).not.toHaveBeenCalled();
 
     const reader = response.body!.getReader();
     const firstArchiveChunk = await reader.read();
@@ -570,7 +571,6 @@ describe("downloads helpers", () => {
     expect(Object.keys(unzipped).sort()).toEqual(["_meta.json", "a.txt", "b.txt"]);
     expect(unzipped["a.txt"]).toEqual(Uint8Array.from([...firstChunk, ...secondChunk]));
     expect(new TextDecoder().decode(unzipped["b.txt"])).toBe("supporting notes\n");
-    expect(storageGet).toHaveBeenCalledWith("_storage:missing");
 
     const repeatResponse = await downloadZipHandler(
       {
@@ -610,6 +610,63 @@ describe("downloads helpers", () => {
       new Request("https://example.com/api/v1/download?slug=demo"),
     );
     expect(new Uint8Array(await repeatResponse.arrayBuffer())).toEqual(responseBytes);
+  });
+
+  it("returns 410 when a skill archive blob is missing from storage", async () => {
+    const runQuery = vi.fn(async (_query: unknown, args: Record<string, unknown>) => {
+      if ("slug" in args) {
+        return {
+          skill: {
+            _id: "skills:1",
+            ownerUserId: "users:1",
+            slug: "demo",
+            tags: {},
+            latestVersionId: "skillVersions:1",
+          },
+          moderationInfo: null,
+        };
+      }
+      if ("versionId" in args) {
+        return {
+          _id: "skillVersions:1",
+          skillId: "skills:1",
+          version: "1.0.0",
+          createdAt: 3,
+          files: [
+            { path: "SKILL.md", storageId: "_storage:1" },
+            { path: "missing.txt", storageId: "_storage:missing" },
+          ],
+          softDeletedAt: undefined,
+        };
+      }
+      return null;
+    });
+    const runMutation = vi.fn(async (_mutation: unknown, args: Record<string, unknown>) => {
+      if (isRateLimitArgs(args)) return okRate();
+      return null;
+    });
+    const runAfter = vi.fn();
+    const storageGet = vi.fn(async (storageId: string) =>
+      storageId === "_storage:1" ? streamingBlob("hello") : null,
+    );
+
+    const response = await downloadZipHandler(
+      {
+        runQuery,
+        runMutation,
+        scheduler: { runAfter },
+        storage: { get: storageGet, getMetadata: vi.fn().mockResolvedValue({}) },
+      } as unknown as ActionCtx,
+      new Request("https://example.com/api/v1/download?slug=demo", {
+        headers: { "cf-connecting-ip": "1.2.3.4" },
+      }),
+    );
+
+    expect(response.status).toBe(410);
+    expect(await response.text()).toBe("Skill archive file missing from storage");
+    expect(response.headers.get("Content-Type")).not.toBe("application/zip");
+    expect(storageGet).toHaveBeenCalledWith("_storage:missing");
+    expect(runAfter).not.toHaveBeenCalled();
   });
 
   it("returns 410 for an explicitly requested revoked version", async () => {

--- a/convex/downloads.ts
+++ b/convex/downloads.ts
@@ -247,10 +247,23 @@ export async function downloadZipHandler(
     });
   }
 
-  const entries = version.files.map((file) => ({
-    path: file.path,
-    openStream: async () => (await ctx.storage.get(file.storageId))?.stream() ?? null,
-  }));
+  const entries: Array<{
+    path: string;
+    openStream: () => Promise<ReadableStream<Uint8Array> | null>;
+  }> = [];
+  for (const file of version.files) {
+    const blob = await ctx.storage.get(file.storageId);
+    if (!blob) {
+      return new Response("Skill archive file missing from storage", {
+        status: 410,
+        headers: mergeHeaders(rate.headers, corsHeaders()),
+      });
+    }
+    entries.push({
+      path: file.path,
+      openStream: async () => blob.stream(),
+    });
+  }
   const zipStream = buildDeterministicZipStream(entries, meta);
 
   await scheduleSkillDownloadMetric(ctx, request, skill._id);


### PR DESCRIPTION
## What Problem This Solves

Public skill ZIP download skipped missing storage blobs and still returned HTTP 200. `clawhub install` treats 200 as success and can write a truncated archive plus origin lock. Sibling download paths already fail closed when a stored file is gone.

## Evidence

terminal output from the patched tree:

```console
$ bunx vitest run convex/downloads.test.ts
 Test Files  1 passed (1)
      Tests  32 passed (32)
```

A missing `ctx.storage.get` now returns 410 `Skill archive file missing from storage` and does not emit a ZIP or a success metric.

## Real behavior proof
Behavior addressed: skill archive download fails closed when any declared blob is missing.
Real environment tested: macOS, bun, patched clawhub worktree.
Exact steps or command run after this patch: bunx vitest run convex/downloads.test.ts
Evidence after fix: terminal output copied below.

```console
$ bunx vitest run convex/downloads.test.ts
 Test Files  1 passed (1)
      Tests  32 passed (32)
```

Observed result after fix: missing blob is 410, not a 200 ZIP.
What was not tested: a live production Convex blob store with a deleted file.

## Tracker

Ref #3668

That issue stays open if this PR is closed without landing on main.
