### PR TITLE
fix(http): keep fetch timeout through the response body

### DIFF
--- a/packages/clawhub/src/http.test.ts
+++ b/packages/clawhub/src/http.test.ts
@@ -58,6 +58,37 @@ function createAbortingFetchMock() {
   });
 }
 
+function createStalledBodyFetch(options?: {
+  ok?: boolean;
+  status?: number;
+  headers?: Record<string, string>;
+}) {
+  return vi.fn(async (_url: string, init?: RequestInit) => {
+    const signal = init?.signal;
+    const hang = () =>
+      new Promise<never>((_resolve, reject) => {
+        if (!(signal instanceof AbortSignal)) return;
+        const abort = () => {
+          reject(signal.reason instanceof Error ? signal.reason : new Error("aborted"));
+        };
+        if (signal.aborted) {
+          abort();
+          return;
+        }
+        signal.addEventListener("abort", abort, { once: true });
+      });
+    const headers = new Headers(options?.headers);
+    return {
+      ok: options?.ok ?? true,
+      status: options?.status ?? 200,
+      headers,
+      json: hang,
+      text: hang,
+      arrayBuffer: hang,
+    };
+  });
+}
+
 describe("detectHttpRuntime", () => {
   it("detects bun and node runtimes explicitly", () => {
     expect(detectHttpRuntime({ bun: "1.2.3" } as unknown as NodeJS.ProcessVersions)).toBe("bun");
@@ -566,5 +597,90 @@ describe("node http client", () => {
       }),
     ).rejects.toThrow(/timed out after 300s/i);
     expect(longTimeouts.setTimeoutImpl.mock.calls[0]?.[1]).toBe(300_000);
+  });
+
+  describe("stalled response body", () => {
+    function createShortTimeouts() {
+      const setTimeoutImpl = vi.fn((callback: () => void, _ms?: number) =>
+        setTimeout(callback, 50),
+      );
+      return {
+        setTimeoutImpl: setTimeoutImpl as unknown as typeof setTimeout,
+        clearTimeoutImpl: clearTimeout,
+      };
+    }
+
+    it(
+      "aborts apiRequest when json never completes after headers",
+      { timeout: 5_000 },
+      async () => {
+        const fetchImpl = createStalledBodyFetch();
+        const client = createNodeClient({
+          fetchImpl: fetchImpl as unknown as typeof fetch,
+          ...createShortTimeouts(),
+        });
+        await expect(
+          client.apiRequest("https://example.com", {
+            method: "GET",
+            path: "/x",
+            retryCount: 0,
+          }),
+        ).rejects.toThrow(/Request timed out after 15s/);
+      },
+    );
+
+    it(
+      "aborts fetchText when the text body never completes after headers",
+      { timeout: 5_000 },
+      async () => {
+        const fetchImpl = createStalledBodyFetch();
+        const client = createNodeClient({
+          fetchImpl: fetchImpl as unknown as typeof fetch,
+          ...createShortTimeouts(),
+        });
+        await expect(client.fetchText("https://example.com", { path: "/x" })).rejects.toThrow(
+          /Request timed out after 15s/,
+        );
+      },
+    );
+
+    it(
+      "aborts downloadZip when arrayBuffer never completes after headers",
+      { timeout: 5_000 },
+      async () => {
+        const fetchImpl = createStalledBodyFetch();
+        const client = createNodeClient({
+          fetchImpl: fetchImpl as unknown as typeof fetch,
+          ...createShortTimeouts(),
+        });
+        await expect(client.downloadZip("https://example.com", { slug: "demo" })).rejects.toThrow(
+          /Request timed out after 15s/,
+        );
+      },
+    );
+
+    it(
+      "times out a stalled 429 body instead of retrying Retry-After",
+      { timeout: 5_000 },
+      async () => {
+        const fetchImpl = createStalledBodyFetch({
+          ok: false,
+          status: 429,
+          headers: { "Retry-After": "120" },
+        });
+        const client = createNodeClient({
+          fetchImpl: fetchImpl as unknown as typeof fetch,
+          ...createShortTimeouts(),
+        });
+        await expect(
+          client.apiRequest("https://example.com", {
+            method: "GET",
+            path: "/x",
+            retryCount: 0,
+          }),
+        ).rejects.toThrow(/Request timed out after 15s/);
+        expect(fetchImpl).toHaveBeenCalledTimes(1);
+      },
+    );
   });
 });

--- a/packages/clawhub/src/http.ts
+++ b/packages/clawhub/src/http.ts
@@ -211,20 +211,22 @@ export function createHttpClient(options: HttpClientOptions = {}): HttpClient {
         headers["Content-Type"] = "application/json";
         body = JSON.stringify(args.body ?? {});
       }
-      const response = await fetchWithTimeout(deps, url, {
-        method: args.method,
-        headers,
-        body,
-      });
-      if (!response.ok && !isAcceptedStatus(response.status, args.acceptedStatuses)) {
-        throwHttpStatusError(
-          response.status,
-          await readResponseTextSafe(response),
-          response.headers,
-          deps.now,
-        );
-      }
-      return (await response.json()) as unknown;
+      return await fetchWithTimeout(
+        deps,
+        url,
+        { method: args.method, headers, body },
+        async (response) => {
+          if (!response.ok && !isAcceptedStatus(response.status, args.acceptedStatuses)) {
+            throwHttpStatusError(
+              response.status,
+              await readResponseTextSafe(response),
+              response.headers,
+              deps.now,
+            );
+          }
+          return (await response.json()) as unknown;
+        },
+      );
     }, args.retryCount);
     if (schema) return parseArk(schema, json, "API response");
     return json as T;
@@ -243,7 +245,7 @@ export function createHttpClient(options: HttpClientOptions = {}): HttpClient {
 
       const headers: Record<string, string> = { Accept: "application/json" };
       if (args.token) headers.Authorization = `Bearer ${args.token}`;
-      const response = await fetchWithTimeout(
+      return await fetchWithTimeout(
         deps,
         url,
         {
@@ -251,17 +253,19 @@ export function createHttpClient(options: HttpClientOptions = {}): HttpClient {
           headers,
           body: args.form,
         },
+        async (response) => {
+          if (!response.ok) {
+            throwHttpStatusError(
+              response.status,
+              await readResponseTextSafe(response),
+              response.headers,
+              deps.now,
+            );
+          }
+          return (await response.json()) as unknown;
+        },
         args.timeoutMs ?? UPLOAD_TIMEOUT_MS,
       );
-      if (!response.ok) {
-        throwHttpStatusError(
-          response.status,
-          await readResponseTextSafe(response),
-          response.headers,
-          deps.now,
-        );
-      }
-      return (await response.json()) as unknown;
     }, args.retryCount);
     if (schema) return parseArk(schema, json, "API response");
     return json as T;
@@ -276,12 +280,13 @@ export function createHttpClient(options: HttpClientOptions = {}): HttpClient {
 
       const headers: Record<string, string> = { Accept: "text/plain" };
       if (args.token) headers.Authorization = `Bearer ${args.token}`;
-      const response = await fetchWithTimeout(deps, url, { method: "GET", headers });
-      const text = await response.text();
-      if (!response.ok) {
-        throwHttpStatusError(response.status, text, response.headers, deps.now);
-      }
-      return text;
+      return await fetchWithTimeout(deps, url, { method: "GET", headers }, async (response) => {
+        const text = await response.text();
+        if (!response.ok) {
+          throwHttpStatusError(response.status, text, response.headers, deps.now);
+        }
+        return text;
+      });
     });
   }
 
@@ -294,16 +299,17 @@ export function createHttpClient(options: HttpClientOptions = {}): HttpClient {
 
       const headers: Record<string, string> = {};
       if (args.token) headers.Authorization = `Bearer ${args.token}`;
-      const response = await fetchWithTimeout(deps, url, { method: "GET", headers });
-      if (!response.ok) {
-        throwHttpStatusError(
-          response.status,
-          await readResponseTextSafe(response),
-          response.headers,
-          deps.now,
-        );
-      }
-      return new Uint8Array(await response.arrayBuffer());
+      return await fetchWithTimeout(deps, url, { method: "GET", headers }, async (response) => {
+        if (!response.ok) {
+          throwHttpStatusError(
+            response.status,
+            await readResponseTextSafe(response),
+            response.headers,
+            deps.now,
+          );
+        }
+        return new Uint8Array(await response.arrayBuffer());
+      });
     });
   }
 
@@ -319,7 +325,7 @@ export function createHttpClient(options: HttpClientOptions = {}): HttpClient {
       const headers: Record<string, string> = {};
       if (args.contentType) headers["Content-Type"] = args.contentType;
       if (args.token) headers.Authorization = `Bearer ${args.token}`;
-      const response = await fetchWithTimeout(
+      return await fetchWithTimeout(
         deps,
         args.url,
         {
@@ -327,17 +333,19 @@ export function createHttpClient(options: HttpClientOptions = {}): HttpClient {
           headers,
           body: bytesToArrayBuffer(args.bytes),
         },
+        async (response) => {
+          if (!response.ok) {
+            throwHttpStatusError(
+              response.status,
+              await readResponseTextSafe(response),
+              response.headers,
+              deps.now,
+            );
+          }
+          return (await response.json()) as unknown;
+        },
         UPLOAD_TIMEOUT_MS,
       );
-      if (!response.ok) {
-        throwHttpStatusError(
-          response.status,
-          await readResponseTextSafe(response),
-          response.headers,
-          deps.now,
-        );
-      }
-      return (await response.json()) as unknown;
     }, args.retryCount);
     if (schema) return parseArk(schema, json, "API response");
     return json as T;
@@ -355,16 +363,22 @@ export function createHttpClient(options: HttpClientOptions = {}): HttpClient {
 
       const headers: Record<string, string> = {};
       if (args.token) headers.Authorization = `Bearer ${args.token}`;
-      const response = await fetchWithTimeout(deps, url.toString(), { method: "GET", headers });
-      if (!response.ok) {
-        throwHttpStatusError(
-          response.status,
-          await readResponseTextSafe(response),
-          response.headers,
-          deps.now,
-        );
-      }
-      return new Uint8Array(await response.arrayBuffer());
+      return await fetchWithTimeout(
+        deps,
+        url.toString(),
+        { method: "GET", headers },
+        async (response) => {
+          if (!response.ok) {
+            throwHttpStatusError(
+              response.status,
+              await readResponseTextSafe(response),
+              response.headers,
+              deps.now,
+            );
+          }
+          return new Uint8Array(await response.arrayBuffer());
+        },
+      );
     });
   }
 
@@ -478,21 +492,35 @@ function bytesToArrayBuffer(bytes: Uint8Array) {
   return copy.buffer;
 }
 
-async function fetchWithTimeout(
+async function fetchWithTimeout<T>(
   deps: Pick<HttpClientDeps, "fetchImpl" | "setTimeoutImpl" | "clearTimeoutImpl">,
   url: string,
   init: RequestInit,
+  read: (response: Response) => Promise<T>,
   timeoutMs = REQUEST_TIMEOUT_MS,
-): Promise<Response> {
+): Promise<T> {
   const controller = new AbortController();
   const timeoutSeconds = Math.ceil(timeoutMs / 1000);
-  const timeout = deps.setTimeoutImpl(
-    () => controller.abort(new Error(`Request timed out after ${timeoutSeconds}s`)),
-    timeoutMs,
-  );
+  let timeoutError: Error | null = null;
+  // "connect" = waiting on headers; "body" = reading/classifying after headers.
+  let phase: "connect" | "body" = "connect";
+  let timeoutPhase: "connect" | "body" | null = null;
+  const timeout = deps.setTimeoutImpl(() => {
+    timeoutError = new Error(`Request timed out after ${timeoutSeconds}s`);
+    timeoutPhase = phase;
+    controller.abort(timeoutError);
+  }, timeoutMs);
   try {
-    return await deps.fetchImpl(url, { ...init, signal: controller.signal });
+    // Keep abort armed through json/text/arrayBuffer; curl already uses --max-time.
+    const response = await deps.fetchImpl(url, { ...init, signal: controller.signal });
+    phase = "body";
+    return await read(response);
   } catch (error) {
+    // If the deadline fired during body read, prefer timeout over status errors
+    // (e.g. stalled 429/5xx body must not unlock Retry-After past the deadline).
+    if (timeoutError && (getHttpErrorStatus(error) === undefined || timeoutPhase === "body")) {
+      throw timeoutError;
+    }
     if (error instanceof Error) throw error;
     const message =
       typeof error === "object" && error !== null && "message" in error


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `clawhub` Node HTTP calls could hang after the server sent headers if the response body never finished. `clawhub install`, search, whoami, and skill download all go through `createHttpClient` on Node. The timeout aborted only the `fetch()` headers wait. Once headers arrived, `json()`, `text()`, and `arrayBuffer()` had no deadline. The Bun/curl path already bounds the whole transfer with `--max-time`.

Site discovery already keeps its abort armed through JSON parsing after [PR #3378](https://github.com/openclaw/clawhub/pull/3378). The shared HTTP client did not.

## Why This Change Was Made

`fetchWithTimeout` now keeps the abort signal armed until the caller finishes reading the body, then clears the timer. A stalled body fails with `Request timed out after 15s` (120s for uploads) instead of hanging. Successful responses are unchanged. HTTP status errors still surface as status errors when the body arrives. This does not change the curl path.

## User Impact

On Node, a registry that answers headers and then stalls the ZIP or JSON body fails closed on the existing request budget instead of leaving the CLI stuck until the process is killed. Bun/curl behavior is unchanged.

## Evidence

Live `bun` plus undici `fetch` on Darwin arm64, Node v26.7.0, worktree `/tmp/oc-pr-clawhub-F003` at `9d43db7f`. Local `node:http` server calls `writeHead` + `flushHeaders` with `Content-Length: 1000000` and never writes the body. Client uses production `createHttpClient` (`runtime: "node"`, `retryCount: 0`) with a 250ms injected abort.

Without a body deadline, the headers return and `json()` never settles. A 1500ms harness fires first:

```console
$ HARNESS_MS=1500 bun /tmp/clawhub-f003-proof.mjs
error=HARNESS_TIMEOUT
elapsed_ms=1502
```

After the patch, the same stalled body fails on the product timeout:

```console
$ bun /tmp/clawhub-f003-proof.mjs
error=Request timed out after 15s
elapsed_ms=503
```

The stall server is still running when the unpatched client hits the harness. The patched client returns `Request timed out after 15s` in 503ms.

## Real behavior proof

- **Behavior or issue addressed:** Node `clawhub` HTTP now times out when a registry sends headers and never finishes the JSON, text, or ZIP body.
- **Real environment tested:** macOS Darwin 25.6.0 arm64, Node v26.7.0, bun 1.3.14, worktree `/tmp/oc-pr-clawhub-F003` on `9d43db7f` plus this patch. Proof used undici `fetch` and a local `node:http` stall server.
- **Exact steps or command run after this patch:** Started a local server that flushes a 200 JSON header and never writes the body. Ran `bun /tmp/clawhub-f003-proof.mjs` against `createHttpClient({ runtime: "node" }).apiRequest(..., { retryCount: 0 })` with a 250ms abort. Then swapped in the unpatched `http.ts` and ran `HARNESS_MS=1500 bun /tmp/clawhub-f003-proof.mjs`.
- **Evidence after fix:** terminal output copied above. The patched client printed `error=Request timed out after 15s` and `elapsed_ms=503`. The unpatched client printed `error=HARNESS_TIMEOUT` and `elapsed_ms=1502`.
- **Observed result after fix:** A stalled JSON body now fails closed on the request budget. The unpatched client stayed blocked after headers until the 1500ms harness.
- **What was not tested:** A live clawhub.ai stall. Windows. The Bun/curl `--max-time` path (already bounded). Upload 120s budget against a stalled POST body.

## Notes

Same body-timeout contract as `discoverRegistryFromSite` in [PR #3378](https://github.com/openclaw/clawhub/pull/3378). The headers-only `finally { clearTimeout }` landed in [PR #283](https://github.com/openclaw/clawhub/pull/283) (2026-02-14, 196 days). This PR only covers the Node `fetch` client in `packages/clawhub/src/http.ts`.

Allow edits from maintainers is enabled.

## Tracker

Ref #3669

That issue stays open if this PR is closed without landing on main.
