### PR TITLE
fix: align mobile homepage search trigger

### DIFF
--- a/src/__tests__/home-listing-section.test.tsx
+++ b/src/__tests__/home-listing-section.test.tsx
@@ -153,6 +153,8 @@ describe("HomeListingSection", () => {
     expect(divider?.nextElementSibling?.contains(catalogTabs)).toBe(true);
     expect(primary?.lastElementChild?.contains(catalogTabs)).toBe(true);
     expect(toolbar?.lastElementChild?.classList.contains("home-v2-listing-actions")).toBe(true);
+    const searchPanel = document.querySelector(".browse-search-panel");
+    expect(toolbar?.nextElementSibling).toBe(searchPanel);
     expect(Array.from(contentTypeButtons, (button) => button.textContent)).toEqual([
       "Skills",
       "Plugins",
@@ -184,6 +186,13 @@ describe("HomeListingSection", () => {
         ?.getAttribute("src"),
     ).toBe(featuredPlugin.icon);
     expect(document.querySelector(".home-v2-listing-row-stats svg")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Search catalog" }));
+    const searchInput = screen.getByRole("searchbox", { name: "Search plugins" });
+    await waitFor(() => expect(document.activeElement).toBe(searchInput));
+    expect(searchPanel?.hasAttribute("hidden")).toBe(false);
+    expect(searchPanel?.contains(searchInput)).toBe(true);
+    expect(screen.getByRole("button", { name: "Close search" })).toBeTruthy();
   });
 
   it("keeps the initial Skills skeleton iconless", () => {

--- a/src/__tests__/ui-design-contract.test.ts
+++ b/src/__tests__/ui-design-contract.test.ts
@@ -459,12 +459,21 @@ describe("restored UI design contract", () => {
       ".home-v2-listing-primary {",
       ".home-v2-listing-actions {",
     ]);
-    expect(mobileCatalog).toMatch(/\.home-v2-listing-toolbar \{[^}]*flex-direction:\s*column/s);
-    expect(mobileCatalog).toMatch(/\.home-v2-listing-primary \{[^}]*flex-direction:\s*column/s);
+    expect(mobileCatalog).toMatch(/\.home-v2-listing-toolbar \{[^}]*display:\s*grid/s);
+    expect(mobileCatalog).toMatch(
+      /\.home-v2-listing-toolbar \{[^}]*grid-template-columns:\s*auto minmax\(0, 1fr\) auto/s,
+    );
+    expect(mobileCatalog).toMatch(/\.home-v2-listing-primary \{[^}]*display:\s*contents/s);
     expect(mobileCatalog).toMatch(
       /\.home-v2-listing-primary > \.browse-controls-divider \{[^}]*display:\s*none/s,
     );
-    expect(mobileCatalog).toMatch(/\.home-v2-listing-actions \{[^}]*width:\s*100%/s);
+    expect(mobileCatalog).toMatch(/\.home-v2-listing-actions \{[^}]*display:\s*contents/s);
+    expect(mobileCatalog).toMatch(
+      /\.home-v2-listing-actions \.browse-search-trigger \{[^}]*grid-column:\s*3[^}]*grid-row:\s*1/s,
+    );
+    expect(mobileCatalog).toMatch(
+      /\.home-v2-listing-sort \{[^}]*grid-column:\s*1\s*\/\s*-1[^}]*grid-row:\s*2/s,
+    );
     expect(cssRule(css, ".home-v2-listing-row::before")).toContain("border-radius: 0");
   });
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -28860,33 +28860,37 @@ a.home-v2-byos-import:focus-visible svg:last-child {
     margin-bottom: 24px;
   }
   .home-v2-listing-toolbar {
-    flex-direction: column;
-    align-items: stretch;
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr) auto;
+    align-items: center;
     min-height: 0;
-    gap: 14px;
+    gap: 14px 12px;
   }
   .home-v2-listing-primary {
-    flex-direction: column;
-    align-items: stretch;
-    gap: 12px;
-    width: 100%;
+    display: contents;
   }
   .home-v2-listing-primary > .browse-controls-divider {
     display: none;
   }
   .home-v2-listing-kind {
-    align-self: flex-start;
+    grid-column: 1;
+    grid-row: 1;
+    align-self: center;
   }
   .home-v2-listing-actions {
-    width: 100%;
-    margin-left: 0;
+    display: contents;
   }
   .home-v2-listing-actions .browse-search-trigger {
+    grid-column: 3;
+    grid-row: 1;
+    justify-self: end;
     width: 44px;
     height: 44px;
   }
   .home-v2-listing-actions .browse-category-select {
-    flex: 1 1 auto;
+    grid-column: 1 / -1;
+    grid-row: 3;
+    width: 100%;
     max-width: none;
   }
   .home-v2-listing-actions .browse-category-trigger {
@@ -28898,6 +28902,8 @@ a.home-v2-byos-import:focus-visible svg:last-child {
     background: color-mix(in srgb, var(--hv2-surface) 76%, transparent);
   }
   .home-v2-listing-sort {
+    grid-column: 1 / -1;
+    grid-row: 2;
     align-self: auto;
     width: 100%;
     min-height: 36px;


### PR DESCRIPTION
Fixes #3552

## What Problem This Solves

On the homepage at mobile widths, the collapsed catalog search trigger can occupy a row by itself below the discovery tabs. This separates the trigger from the Skills / Plugins selector and leaves unnecessary vertical space in the catalog controls.

## Why This Change Was Made

In this PR, the mobile catalog toolbar uses its existing wrappers as a grid so the same search trigger sits to the right of Skills / Plugins while the discovery tabs remain on the next row. The expanded search panel stays outside the toolbar in its existing position below the tabs; desktop rules and search behavior are unchanged.

## User Impact

If merged, mobile users should get a more compact catalog header without losing search focus, the close control, discovery tabs, category filtering, or the expanded search field position.

## Evidence

Browser comparison at 390 x 844. The baseline is the production page at `https://clawhub.ai/`; the candidate lane uses the same page through a lightweight local HTTP proxy that appends only the mobile toolbar CSS extracted from `13627e5158b43ac766c869bbeca5fae3d6eab1c5`. This branch does not change the toolbar markup.

| Production | In this PR |
| --- | --- |
| <img src="https://raw.githubusercontent.com/openclaw/clawhub/qa-artifacts/clawhub-ui-proof/pr-3553/pr-3553-13627e5-local-proxy/baseline/mobile-collapsed.png" width="390" alt="Production mobile catalog controls with the collapsed search trigger on a separate row"> | <img src="https://raw.githubusercontent.com/openclaw/clawhub/qa-artifacts/clawhub-ui-proof/pr-3553/pr-3553-13627e5-local-proxy/candidate/mobile-collapsed.png" width="390" alt="Proposed mobile catalog controls with the collapsed search trigger beside Skills and Plugins"> |

| Production search open | In this PR, search open |
| --- | --- |
| <img src="https://raw.githubusercontent.com/openclaw/clawhub/qa-artifacts/clawhub-ui-proof/pr-3553/pr-3553-13627e5-local-proxy/baseline/mobile-open-focused.png" width="390" alt="Production mobile search open and focused below the discovery tabs"> | <img src="https://raw.githubusercontent.com/openclaw/clawhub/qa-artifacts/clawhub-ui-proof/pr-3553/pr-3553-13627e5-local-proxy/candidate/mobile-open-focused.png" width="390" alt="Proposed mobile search open and focused below the discovery tabs"> |

Computed geometry confirms that the collapsed trigger and Skills / Plugins share the first row, the discovery tabs remain on the second row, and the opened panel remains below the tabs. The input receives focus and Close search restores the collapsed state. The same placement was checked in dark mode, and the desktop toolbar remains on its existing flex layout.

- Exact-head CI: all required checks passed, including unit, static, types/build, packages, e2e, Playwright, CodeQL, and secret scanning.
- `git diff --check`
- Focused responsive contract and search disclosure coverage are included in the updated tests.
- Full dependency-backed local checks were not run because no compatible existing ClawHub `node_modules` was available; no dependencies were downloaded or reinstalled.
- [Raw UI proof files](https://github.com/openclaw/clawhub/tree/qa-artifacts/clawhub-ui-proof/pr-3553/pr-3553-13627e5-local-proxy)
