### PR TITLE
fix: keep skill hero metadata intact on mobile

### DIFF
--- a/e2e/public-routes-smoke.pw.test.ts
+++ b/e2e/public-routes-smoke.pw.test.ts
@@ -253,7 +253,8 @@ test("skill hero metadata keeps semantic wrap groups on mobile", async ({ page }
 
   const taxonomy = page.getByLabel("Skill metadata");
   const source = taxonomy.locator(".skill-hero-taxonomy-prefix");
-  const category = taxonomy.locator(".skill-category-meta-link").first();
+  const categories = taxonomy.locator(".skill-category-meta-link");
+  const category = categories.first();
   const topics = taxonomy.locator(".skill-hero-topic");
   const creatorName = page.locator(".skill-hero-creator .user-name");
   const creatorHandle = page.locator(".skill-hero-creator .user-handle");
@@ -271,12 +272,36 @@ test("skill hero metadata keeps semantic wrap groups on mobile", async ({ page }
   expect(new Set(taxonomyWeights)).toEqual(new Set(["400"]));
   await expect(creatorHandle).toHaveCSS("font-weight", "400");
   await expect(creatorName).not.toHaveCSS("font-weight", "400");
+  const creatorTypeSizes = await Promise.all(
+    [creatorName, creatorHandle].map(async (locator) =>
+      Number.parseFloat(await locator.evaluate((element) => getComputedStyle(element).fontSize)),
+    ),
+  );
+  expect(creatorTypeSizes[1]).toBeLessThan(creatorTypeSizes[0]!);
+  await expect(creatorHandle).toHaveCSS("font-size", "12px");
+  const creatorColors = await creatorHandle.evaluate((handleElement) => {
+    const nameElement = handleElement.closest(".skill-hero-creator")?.querySelector(".user-name");
+    if (!nameElement) throw new Error("Creator display name is missing");
+    const secondaryProbe = document.createElement("span");
+    secondaryProbe.style.color = "var(--ink-soft)";
+    document.body.append(secondaryProbe);
+    const colors = {
+      handle: getComputedStyle(handleElement).color,
+      name: getComputedStyle(nameElement).color,
+      secondary: getComputedStyle(secondaryProbe).color,
+    };
+    secondaryProbe.remove();
+    return colors;
+  });
+  expect(creatorColors.handle).toBe(creatorColors.secondary);
+  expect(creatorColors.handle).not.toBe(creatorColors.name);
   await expect(taxonomy.locator(".skill-hero-taxonomy-separator").first()).not.toHaveCSS(
     "display",
     "none",
   );
 
   await page.setViewportSize({ width: 600, height: 900 });
+  await expect(topics.first()).toHaveCSS("display", "inline-flex");
   const fittingGroupTops = await Promise.all(
     [source, category, topics.first()].map(async (locator) => (await locator.boundingBox())?.y),
   );
@@ -284,10 +309,67 @@ test("skill hero metadata keeps semantic wrap groups on mobile", async ({ page }
   expect(
     Math.max(...(fittingGroupTops as number[])) - Math.min(...(fittingGroupTops as number[])),
   ).toBeLessThanOrEqual(1);
-  await expect(taxonomy.locator(".skill-hero-taxonomy-separator").first()).toHaveCSS(
-    "display",
-    "none",
-  );
+
+  const mobileSeparatorStyles = await taxonomy
+    .locator(".skill-category-meta-link, .skill-hero-topic")
+    .evaluateAll((elements) =>
+      elements.map((element) => {
+        const style = getComputedStyle(element, "::before");
+        return {
+          backgroundColor: style.backgroundColor,
+          content: style.content,
+          height: style.height,
+          width: style.width,
+        };
+      }),
+    );
+  expect(mobileSeparatorStyles.length).toBeGreaterThanOrEqual(2);
+  expect(
+    mobileSeparatorStyles.every(
+      (style) =>
+        style.content !== "none" &&
+        style.content !== "normal" &&
+        style.width === "1px" &&
+        style.height === "14px" &&
+        style.backgroundColor !== "rgba(0, 0, 0, 0)",
+    ),
+  ).toBe(true);
+
+  await category.evaluate((categoryTemplate) => {
+    const list = categoryTemplate.parentElement;
+    if (!list) throw new Error("Category list is missing");
+    const labels = ["Communication", "Productivity", "Development"];
+    labels.forEach((label, index) => {
+      const categoryItem = index === 0 ? categoryTemplate : categoryTemplate.cloneNode(true);
+      if (!(categoryItem instanceof HTMLAnchorElement)) {
+        throw new Error("Category template is incomplete");
+      }
+      const labelElement = categoryItem.querySelector("span:last-child");
+      if (!labelElement) throw new Error("Category label is missing");
+      categoryItem.href = `/skills?category=${label.toLowerCase()}`;
+      categoryItem.setAttribute("aria-label", `View ${label} skills`);
+      labelElement.textContent = label;
+      if (index > 0) list.append(categoryItem);
+    });
+  });
+  await expect(categories).toHaveCount(3);
+
+  await topics.first().evaluate((topicTemplate) => {
+    const list = topicTemplate.parentElement;
+    if (!list) throw new Error("Topic list is missing");
+    const labels = ["#video-generation", "#creative-production", "#automation-workflows"];
+    labels.forEach((label, index) => {
+      const topicItem = index === 0 ? topicTemplate : topicTemplate.cloneNode(true);
+      if (!(topicItem instanceof HTMLAnchorElement)) {
+        throw new Error("Topic template is incomplete");
+      }
+      topicItem.href = `/topics/${label.slice(1)}`;
+      topicItem.setAttribute("aria-label", `View skills tagged ${label}`);
+      topicItem.textContent = label;
+      if (index > 0) list.append(topicItem);
+    });
+  });
+  await expect(topics).toHaveCount(3);
 
   await page.setViewportSize({ width: 320, height: 900 });
   const wrappedGroupTops = await Promise.all(
@@ -298,12 +380,27 @@ test("skill hero metadata keeps semantic wrap groups on mobile", async ({ page }
     Math.max(...(wrappedGroupTops as number[])) - Math.min(...(wrappedGroupTops as number[])),
   ).toBeGreaterThan(1);
 
-  const semanticUnitLineCounts = await taxonomy
-    .locator(
-      ".skills-sh-sync-source-label, .skill-category-meta-link > span:last-child, .skill-hero-topic",
-    )
-    .evaluateAll((elements) => elements.map((element) => element.getClientRects().length));
-  expect(semanticUnitLineCounts.every((lineCount) => lineCount === 1)).toBe(true);
+  const categoryTops = await categories.evaluateAll((elements) =>
+    elements.map((element) => Math.round(element.getBoundingClientRect().top)),
+  );
+  expect(new Set(categoryTops).size).toBeGreaterThan(1);
+
+  const topicTops = await topics.evaluateAll((elements) =>
+    elements.map((element) => Math.round(element.getBoundingClientRect().top)),
+  );
+  expect(new Set(topicTops).size).toBeGreaterThan(1);
+
+  const semanticUnitStyles = await taxonomy
+    .locator(".skills-sh-sync-source-label, .skill-category-meta-link, .skill-hero-topic")
+    .evaluateAll((elements) =>
+      elements.map((element) => ({
+        rects: element.getClientRects().length,
+        whiteSpace: getComputedStyle(element).whiteSpace,
+      })),
+    );
+  expect(
+    semanticUnitStyles.every((style) => style.rects === 1 && style.whiteSpace === "nowrap"),
+  ).toBe(true);
 
   const overflow = await page.evaluate(() => ({
     clientWidth: document.documentElement.clientWidth,

--- a/e2e/public-routes-smoke.pw.test.ts
+++ b/e2e/public-routes-smoke.pw.test.ts
@@ -242,6 +242,77 @@ for (const route of publicRouteCases()) {
   });
 }
 
+test("skill hero metadata keeps semantic wrap groups on mobile", async ({ page }) => {
+  const errors = trackRuntimeErrors(page);
+  await page.route("**/_vercel/image?**", (route) => route.fulfill({ status: 204 }));
+  await page.setViewportSize({ width: 1280, height: 900 });
+  await page.goto("/skills-sh/skills-101/superpowers/ai-video-generation", {
+    waitUntil: "domcontentloaded",
+  });
+  await waitForHydration(page);
+
+  const taxonomy = page.getByLabel("Skill metadata");
+  const source = taxonomy.locator(".skill-hero-taxonomy-prefix");
+  const category = taxonomy.locator(".skill-category-meta-link").first();
+  const topics = taxonomy.locator(".skill-hero-topic");
+  const creatorName = page.locator(".skill-hero-creator .user-name");
+  const creatorHandle = page.locator(".skill-hero-creator .user-handle");
+
+  await expect(taxonomy).toBeVisible();
+  await expect(source).toContainText("Synced from skills.sh");
+  await expect(category).toBeVisible();
+  await expect(topics.first()).toBeVisible();
+  await expect(creatorName).toBeVisible();
+  await expect(creatorHandle).toBeVisible();
+
+  const taxonomyWeights = await taxonomy
+    .locator(".skills-sh-sync-source-label, .skill-category-meta-link, .skill-hero-topic")
+    .evaluateAll((elements) => elements.map((element) => getComputedStyle(element).fontWeight));
+  expect(new Set(taxonomyWeights)).toEqual(new Set(["400"]));
+  await expect(creatorHandle).toHaveCSS("font-weight", "400");
+  await expect(creatorName).not.toHaveCSS("font-weight", "400");
+  await expect(taxonomy.locator(".skill-hero-taxonomy-separator").first()).not.toHaveCSS(
+    "display",
+    "none",
+  );
+
+  await page.setViewportSize({ width: 600, height: 900 });
+  const fittingGroupTops = await Promise.all(
+    [source, category, topics.first()].map(async (locator) => (await locator.boundingBox())?.y),
+  );
+  expect(fittingGroupTops.every((top) => top !== undefined)).toBe(true);
+  expect(
+    Math.max(...(fittingGroupTops as number[])) - Math.min(...(fittingGroupTops as number[])),
+  ).toBeLessThanOrEqual(1);
+  await expect(taxonomy.locator(".skill-hero-taxonomy-separator").first()).toHaveCSS(
+    "display",
+    "none",
+  );
+
+  await page.setViewportSize({ width: 320, height: 900 });
+  const wrappedGroupTops = await Promise.all(
+    [source, category, topics.first()].map(async (locator) => (await locator.boundingBox())?.y),
+  );
+  expect(wrappedGroupTops.every((top) => top !== undefined)).toBe(true);
+  expect(
+    Math.max(...(wrappedGroupTops as number[])) - Math.min(...(wrappedGroupTops as number[])),
+  ).toBeGreaterThan(1);
+
+  const semanticUnitLineCounts = await taxonomy
+    .locator(
+      ".skills-sh-sync-source-label, .skill-category-meta-link > span:last-child, .skill-hero-topic",
+    )
+    .evaluateAll((elements) => elements.map((element) => element.getClientRects().length));
+  expect(semanticUnitLineCounts.every((lineCount) => lineCount === 1)).toBe(true);
+
+  const overflow = await page.evaluate(() => ({
+    clientWidth: document.documentElement.clientWidth,
+    scrollWidth: document.documentElement.scrollWidth,
+  }));
+  expect(overflow.scrollWidth).toBeLessThanOrEqual(overflow.clientWidth + 1);
+  await expectHealthyPage(page, errors);
+});
+
 test("removed creators route renders not found", async ({ page }) => {
   await stubExternalMediaInVitePreview(page);
   await page.goto("/creators", { waitUntil: "domcontentloaded" });

--- a/src/styles.css
+++ b/src/styles.css
@@ -7060,8 +7060,12 @@ code {
 .skill-detail-page .skill-hero-taxonomy-row,
 .skill-detail-page .skills-sh-sync-source-label,
 .skill-detail-page .skill-category-meta-link,
-.skill-detail-page .skill-hero-topic,
+.skill-detail-page .skill-hero-topic {
+  font-weight: 400;
+}
+
 .skill-detail-page .skill-hero-creator .user-handle {
+  font-size: var(--fs-xs);
   font-weight: 400;
 }
 
@@ -7157,16 +7161,41 @@ code {
 
   /* These groups wrap between items; their labels remain indivisible. */
   .skill-detail-page .skill-hero-taxonomy-prefix,
-  .skill-detail-page .skill-category-meta-link {
+  .skill-detail-page .skill-category-meta-link,
+  .skill-detail-page .skill-hero-topic {
+    flex: 0 0 auto;
     white-space: nowrap;
+  }
+
+  .skill-detail-page .skill-hero-topic {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
   }
 
   .skill-detail-page .skill-hero-taxonomy-separator {
     display: none;
   }
 
+  .skill-detail-page .skill-category-meta-list,
   .skill-detail-page .skill-hero-topic-list {
     display: contents;
+  }
+
+  /* The divider belongs to the following unit, so it cannot wrap by itself. */
+  .skill-detail-page
+    .skill-hero-taxonomy-row:has(.skill-hero-taxonomy-prefix)
+    .skill-category-meta-link:first-child::before,
+  .skill-detail-page .skill-category-meta-link + .skill-category-meta-link::before,
+  .skill-detail-page
+    .skill-hero-taxonomy-row:has(.skill-hero-taxonomy-prefix, .skill-category-meta-link)
+    .skill-hero-topic:first-child::before,
+  .skill-detail-page .skill-hero-topic + .skill-hero-topic::before {
+    content: "";
+    width: 1px;
+    height: 14px;
+    flex: 0 0 auto;
+    background: color-mix(in srgb, var(--ink-soft) 28%, transparent);
   }
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -7057,6 +7057,14 @@ code {
   line-height: 1;
 }
 
+.skill-detail-page .skill-hero-taxonomy-row,
+.skill-detail-page .skills-sh-sync-source-label,
+.skill-detail-page .skill-category-meta-link,
+.skill-detail-page .skill-hero-topic,
+.skill-detail-page .skill-hero-creator .user-handle {
+  font-weight: 400;
+}
+
 .skill-hero-taxonomy-prefix {
   display: inline-flex;
   align-items: center;
@@ -7141,18 +7149,24 @@ code {
 }
 
 @media (max-width: 600px) {
-  .skill-hero-taxonomy-row {
+  .skill-detail-page .skill-hero-taxonomy-row {
     display: flex;
     flex-wrap: wrap;
     row-gap: 10px;
   }
 
-  .skill-hero-taxonomy-separator {
+  /* These groups wrap between items; their labels remain indivisible. */
+  .skill-detail-page .skill-hero-taxonomy-prefix,
+  .skill-detail-page .skill-category-meta-link {
+    white-space: nowrap;
+  }
+
+  .skill-detail-page .skill-hero-taxonomy-separator {
     display: none;
   }
 
-  .skill-hero-topic-list {
-    flex-basis: 100%;
+  .skill-detail-page .skill-hero-topic-list {
+    display: contents;
   }
 }
 


### PR DESCRIPTION
Closes #3554.

## Summary

- restore visible separators between the source, every category, and every topic on mobile while keeping each divider attached to its following semantic unit
- let source, up to three categories, and individual topics wrap independently at 320px without splitting labels or overflowing the page
- keep the creator display name primary while rendering the secondary `@handle` at the 12px caption token, weight 400
- retain the weight-400 taxonomy treatment and unchanged desktop structure
- add focused browser regression coverage for separators, three categories, multiple topics, nowrap units, creator hierarchy, and no overflow

## Verification

- `bun run format:check -- src/styles.css e2e/public-routes-smoke.pw.test.ts`
- `git diff --check`
- `VITE_CONVEX_URL=https://example.invalid bunx vitest run src/components/SkillDetailPageView.test.tsx src/components/SkillDetailPageView.interactions.test.tsx src/__tests__/ui-design-contract.test.ts --maxWorkers=1` (50 passed)
- public-route red check with system Chrome: the production baseline failed the new taxonomy-weight assertion (`520`, expected `400`)
- system-Chrome before/after proof on the real hydrated issue route at 1280px, 600px, and 320px; candidate assertions verified 1x14px separators, independent category wrapping, indivisible units, 12px/400 secondary handle, and zero horizontal overflow
- final structured review: no actionable findings

The candidate screenshots apply the exact final taxonomy CSS from `56244ba1aa18bfacb2356ea8249e7169be2367dd` to the same hydrated public ClawHub route used for the baseline. A local server was not used for the final capture because the required shared dependency target does not contain the current main-branch `@openclaw/krillswitch-react` package, and this low-disk lane prohibits installing or copying dependencies.

## Visual proof

Route: https://clawhub.ai/skills-sh/skills-101/superpowers/ai-video-generation

| Before: desktop | In this PR: desktop |
| --- | --- |
| <img src="https://raw.githubusercontent.com/openclaw/clawhub/qa-artifacts/clawhub-ui-proof/pr-3555/issue-3554-final-56244ba/baseline/desktop-hero-with-separators.png" width="420" alt="Desktop skill hero before"> | <img src="https://raw.githubusercontent.com/openclaw/clawhub/qa-artifacts/clawhub-ui-proof/pr-3555/issue-3554-final-56244ba/candidate/desktop-hero-with-separators.png" width="420" alt="Desktop skill hero in this PR"> |

| Before: mobile groups fit | In this PR: mobile groups fit with separators |
| --- | --- |
| <img src="https://raw.githubusercontent.com/openclaw/clawhub/qa-artifacts/clawhub-ui-proof/pr-3555/issue-3554-final-56244ba/baseline/mobile-groups-fit.png" width="360" alt="Mobile fitting metadata before"> | <img src="https://raw.githubusercontent.com/openclaw/clawhub/qa-artifacts/clawhub-ui-proof/pr-3555/issue-3554-final-56244ba/candidate/mobile-groups-fit.png" width="360" alt="Mobile fitting metadata in this PR"> |

| Before: 320px wrap | In this PR: semantic 320px wrap |
| --- | --- |
| <img src="https://raw.githubusercontent.com/openclaw/clawhub/qa-artifacts/clawhub-ui-proof/pr-3555/issue-3554-final-56244ba/baseline/mobile-narrow-wrap.png" width="320" alt="Narrow mobile metadata before"> | <img src="https://raw.githubusercontent.com/openclaw/clawhub/qa-artifacts/clawhub-ui-proof/pr-3555/issue-3554-final-56244ba/candidate/mobile-narrow-wrap.png" width="320" alt="Narrow mobile metadata in this PR"> |

| Before: source plus three categories and topic | In this PR: independent category wrapping |
| --- | --- |
| <img src="https://raw.githubusercontent.com/openclaw/clawhub/qa-artifacts/clawhub-ui-proof/pr-3555/issue-3554-final-56244ba/baseline/mobile-three-categories.png" width="320" alt="Three-category mobile stress case before"> | <img src="https://raw.githubusercontent.com/openclaw/clawhub/qa-artifacts/clawhub-ui-proof/pr-3555/issue-3554-final-56244ba/candidate/mobile-three-categories.png" width="320" alt="Three-category mobile stress case in this PR"> |

[Raw proof files](https://github.com/openclaw/clawhub/tree/qa-artifacts/clawhub-ui-proof/pr-3555/issue-3554-final-56244ba)
