### PR TITLE
improve: remove skill icons from detail headers

### DIFF
--- a/specs/plugin-skill-detail-polish-iteration.md
+++ b/specs/plugin-skill-detail-polish-iteration.md
@@ -30,6 +30,7 @@ This note preserves the complete UI direction established during the June 2026 d
 - Follow categories with a vertical separator and up to five topics.
 - Render topics lowercase, prefixed with `#`, and muted.
 - Keep category/topic typography compact and muted.
+- Skill detail heroes are title-first: do not render a skill presentation icon in the title row, even when legacy or hosted icon metadata exists. Category icons remain in taxonomy metadata; creator avatars and icons outside the hero title keep their existing surfaces.
 - Use a 36 px desktop detail title with deliberate breathing room below the taxonomy row.
 - Render the summary at 14 px, muted/approximately 82% opacity, clamped to two lines.
 - Use `Read more`, not `See more`, to expand the hero summary.

--- a/src/components/SkillDetailPageView.test.tsx
+++ b/src/components/SkillDetailPageView.test.tsx
@@ -102,8 +102,10 @@ describe("SkillDetailPageView", () => {
     expect(taxonomy?.querySelector(".skill-hero-taxonomy-separator")).toBeTruthy();
   });
 
-  it("renders the supplied title icon", () => {
-    const icon = `/api/v1/skill-icons/${"a".repeat(64)}`;
+  it.each([
+    ["legacy", "brain"],
+    ["hosted", `/api/v1/skill-icons/${"a".repeat(64)}`],
+  ])("omits the title icon for %s skill icon data", (_kind, icon) => {
     const { container } = render(
       <TooltipProvider>
         <SkillDetailPageView
@@ -112,11 +114,13 @@ describe("SkillDetailPageView", () => {
             ...makeMinimalProps().skill,
             icon,
           }}
+          categories={[{ slug: "development", label: "Development", icon: "wrench", keywords: [] }]}
         />
       </TooltipProvider>,
     );
 
-    expect(container.querySelector(".marketplace-icon img")?.getAttribute("src")).toBe(icon);
+    expect(container.querySelector(".skill-hero-title-row .marketplace-icon")).toBeNull();
+    expect(container.querySelector(".skill-hero-taxonomy-row .skill-category-icon")).toBeTruthy();
   });
 });
 

--- a/src/components/SkillDetailPageView.tsx
+++ b/src/components/SkillDetailPageView.tsx
@@ -26,7 +26,6 @@ import { DetailHero, DetailPageShell, DETAIL_HERO_TOPIC_LIMIT } from "./DetailPa
 import { DetailSecuritySummaryLabel } from "./DetailSecuritySummary";
 import { useDownloadsSidebarMetricBlock } from "./DownloadsMetricCard";
 import { InlineCodeSummary } from "./InlineCodeSummary";
-import { MarketplaceIcon } from "./MarketplaceIcon";
 import { SidebarMetadata } from "./SidebarMetadata";
 import { buildSkillHref } from "./skillDetailUtils";
 import { SkillCommandLineCard } from "./SkillInstallSurface";
@@ -499,15 +498,6 @@ export function SkillDetailPageView({
                     </div>
                   ) : null}
                   <div className="skill-hero-title-row">
-                    {skill.icon ? (
-                      <MarketplaceIcon
-                        kind="skill"
-                        label={displayName}
-                        imageUrl={skill.icon}
-                        skill={skill}
-                        size="md"
-                      />
-                    ) : null}
                     <h1 className="skill-page-title">{displayName}</h1>
                     {showTitleBadges ? (
                       <div className="skill-title-badges">


### PR DESCRIPTION
Closes #3556

## What Problem This Solves

Skill detail pages give the hero title different visual weight when optional legacy or hosted icon metadata is present. The extra leading icon also duplicates category presentation already available in the taxonomy row.

## Why This Change Was Made

This PR removes the skill icon render branch from the shared detail-page owner. Category icons, creator avatars, listing and search icons, related-skill icons, plugin pages, and other marketplace surfaces remain unchanged.

Focused regression coverage exercises both legacy and hosted skill icon values while confirming that taxonomy category icons still render.

## User Impact

Native and skills.sh-backed skill detail pages now use the same title-first hero treatment on desktop and mobile.

## Evidence

- `VITE_CONVEX_URL=https://example.invalid bun run test -- src/components/SkillDetailPageView.test.tsx src/components/SkillsShCatalogDetail.test.tsx` — 11 tests passed.
- `bun run ci:static` — passed.
- App, schema, CLI, and admin TypeScript checks — passed.
- Real desktop and mobile checks in system Chrome covered `session-migrate` and the skills.sh `ai-video-generation` detail page.

Before/after screenshots are attached below.
