### PR TITLE
fix: mobile skill detail hierarchy feels disconnected

### DIFF
--- a/e2e/public-routes-smoke.pw.test.ts
+++ b/e2e/public-routes-smoke.pw.test.ts
@@ -242,6 +242,72 @@ for (const route of publicRouteCases()) {
   });
 }
 
+test("skill detail mobile hierarchy stays coherent at representative widths", async ({ page }) => {
+  await stubExternalMediaInVitePreview(page);
+  const errors = trackRuntimeErrors(page);
+
+  for (const width of [320, 375, 430]) {
+    await page.setViewportSize({ width, height: 1_100 });
+    await page.goto("/vyctorbrzezowski/skills/session-migrate", {
+      waitUntil: "domcontentloaded",
+    });
+    await waitForHydration(page);
+    await expect(page.getByRole("heading", { name: "Session Migrate" }).first()).toBeVisible();
+    await expect(page.locator(".skill-hero-creator-star")).toBeVisible();
+
+    const metrics = await page.evaluate(() => {
+      const detailSurface = document.querySelector<HTMLElement>(
+        ".skill-detail-page .skill-hero-main-extra",
+      );
+      const bookmark = document.querySelector<HTMLElement>(
+        ".skill-hero-creator-star .skill-sidebar-star-action",
+      );
+      const detailTabHeader = document.querySelector<HTMLElement>(
+        ".skill-detail-tabs-card .tab-header",
+      );
+      const detailTab = document.querySelector<HTMLElement>(".skill-detail-tabs-card .tab-button");
+
+      if (!detailSurface || !bookmark || !detailTabHeader || !detailTab) {
+        throw new Error("skill detail mobile surface is incomplete");
+      }
+
+      const detailSurfaceStyle = getComputedStyle(detailSurface);
+      const detailTabHeaderStyle = getComputedStyle(detailTabHeader);
+
+      return {
+        bookmarkHeight: bookmark.getBoundingClientRect().height,
+        detailSurfaceBorderBottom: Number.parseFloat(detailSurfaceStyle.borderBottomWidth),
+        detailSurfaceRadius: Number.parseFloat(detailSurfaceStyle.borderTopLeftRadius),
+        detailTabFlexWrap: detailTabHeaderStyle.flexWrap,
+        detailTabHeight: detailTab.getBoundingClientRect().height,
+        scrollWidth: document.documentElement.scrollWidth,
+        viewportWidth: document.documentElement.clientWidth,
+      };
+    });
+
+    expect(metrics.bookmarkHeight).toBeGreaterThanOrEqual(44);
+    expect(metrics.detailSurfaceBorderBottom).toBeGreaterThanOrEqual(1);
+    expect(metrics.detailSurfaceRadius).toBeGreaterThan(0);
+    expect(metrics.detailTabFlexWrap).toBe("nowrap");
+    expect(metrics.detailTabHeight).toBeGreaterThanOrEqual(44);
+    expect(metrics.scrollWidth).toBeLessThanOrEqual(metrics.viewportWidth + 1);
+
+    const detailTabs = page.locator(".skill-detail-tabs-card");
+    const versionsTab = detailTabs.getByRole("tab", { name: "Versions" });
+    await versionsTab.click();
+    await expect(versionsTab).toHaveAttribute("aria-selected", "true");
+    await detailTabs.getByRole("tab", { name: "SKILL.md" }).click();
+
+    const masterTabs = page.locator(".detail-mobile-master-tabs");
+    const statsTab = masterTabs.getByRole("tab", { name: "Stats & details" });
+    await statsTab.click();
+    await expect(statsTab).toHaveAttribute("aria-selected", "true");
+    await masterTabs.getByRole("tab", { name: "SKILL.md" }).click();
+  }
+
+  await expectHealthyPage(page, errors);
+});
+
 test("removed creators route renders not found", async ({ page }) => {
   await stubExternalMediaInVitePreview(page);
   await page.goto("/creators", { waitUntil: "domcontentloaded" });

--- a/src/styles.css
+++ b/src/styles.css
@@ -8803,7 +8803,7 @@ a.skills-sh-security-audit-row:focus-visible {
   }
 
   .skill-detail-page .detail-mobile-install {
-    margin-top: 14px;
+    margin-top: 0;
   }
 
   .detail-mobile-install .skill-install-command-card {
@@ -8843,6 +8843,11 @@ a.skills-sh-security-audit-row:focus-visible {
   .detail-mobile-install .skill-install-command-card > * {
     position: relative;
     z-index: 1;
+  }
+
+  .skill-detail-page .detail-mobile-install .skill-install-command-card::before,
+  .skill-detail-page .detail-mobile-install .skill-install-command-card::after {
+    content: none;
   }
 
   .detail-mobile-install .skill-install-command-header {
@@ -8979,6 +8984,15 @@ a.skills-sh-security-audit-row:focus-visible {
     gap: 14px;
   }
 
+  .skill-detail-page .skill-hero-main-extra {
+    display: grid;
+    gap: 0;
+    overflow: hidden;
+    border: var(--detail-mobile-surface-border);
+    border-radius: var(--detail-mobile-surface-radius);
+    background: var(--detail-mobile-surface-bg);
+  }
+
   .plugin-detail-page .skill-hero-main-extra {
     gap: var(--space-5);
   }
@@ -9019,7 +9033,8 @@ a.skills-sh-security-audit-row:focus-visible {
   }
 
   .skill-detail-page .skill-hero-creator-star .skill-sidebar-star-action {
-    min-height: 0;
+    min-height: 44px;
+    padding-inline: 4px;
     justify-content: flex-end;
   }
 
@@ -9044,6 +9059,10 @@ a.skills-sh-security-audit-row:focus-visible {
     min-width: 0;
   }
 
+  .skill-detail-page .detail-mobile-master-tabs {
+    gap: 0;
+  }
+
   .detail-mobile-master-tab-list {
     display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -9051,6 +9070,10 @@ a.skills-sh-security-audit-row:focus-visible {
     min-width: 0;
     width: 100%;
     border-bottom: 1px solid var(--line);
+  }
+
+  .skill-detail-page .detail-mobile-master-tab-list {
+    border-top: 1px solid var(--line);
   }
 
   .detail-mobile-master-tab {
@@ -9110,6 +9133,22 @@ a.skills-sh-security-audit-row:focus-visible {
     min-width: 0;
   }
 
+  .skill-detail-page .detail-mobile-master-panel-content {
+    gap: 0;
+  }
+
+  .skill-detail-page .detail-mobile-tabs {
+    margin-top: 0;
+  }
+
+  .skill-detail-page .skill-detail-tabs-card.detail-mobile-tabs {
+    gap: 0;
+    overflow: visible;
+    border: 0;
+    border-radius: 0;
+    background: transparent;
+  }
+
   .detail-mobile-master-stats {
     display: grid;
     gap: 0;
@@ -9123,8 +9162,9 @@ a.skills-sh-security-audit-row:focus-visible {
 
   .skill-detail-page .skill-detail-tabs-card.detail-mobile-tabs .tab-header {
     gap: 8px;
-    padding: 10px var(--detail-mobile-surface-padding);
-    border-bottom: 0;
+    flex-wrap: nowrap;
+    padding: 8px var(--detail-mobile-surface-padding);
+    border-bottom: 1px solid var(--line);
     overflow-x: auto;
     background: transparent;
   }
@@ -9132,7 +9172,7 @@ a.skills-sh-security-audit-row:focus-visible {
   .skill-detail-page .skill-detail-tabs-card.detail-mobile-tabs .tab-button {
     flex: 0 0 auto;
     justify-content: center;
-    min-height: 32px;
+    min-height: 44px;
     margin: 0;
     padding: 0 10px;
     border: 1px solid color-mix(in srgb, var(--line) 82%, transparent);
@@ -20271,7 +20311,7 @@ body:has(.browse-page-borderless-header) .navbar {
     -webkit-line-clamp: 2;
   }
 
-  :is(.skill-detail-page, .plugin-detail-page) .detail-mobile-tabs.tab-card {
+  .plugin-detail-page .detail-mobile-tabs.tab-card {
     gap: 0;
     overflow: hidden;
     border: var(--detail-mobile-surface-border);
@@ -20283,7 +20323,7 @@ body:has(.browse-page-borderless-header) .navbar {
     overflow: visible;
   }
 
-  :is(.skill-detail-page, .plugin-detail-page) .detail-mobile-tabs .tab-header {
+  .plugin-detail-page .detail-mobile-tabs .tab-header {
     gap: 16px;
     padding: 0 var(--detail-mobile-surface-padding);
     overflow-x: auto;
@@ -20301,7 +20341,7 @@ body:has(.browse-page-borderless-header) .navbar {
     justify-content: center;
   }
 
-  :is(.skill-detail-page, .plugin-detail-page) .detail-mobile-tabs .tab-body {
+  .plugin-detail-page .detail-mobile-tabs .tab-body {
     gap: 16px;
     padding: var(--detail-mobile-surface-padding);
     border: 0;


### PR DESCRIPTION
Closes #3558

## What Problem This Solves

Fixes an issue where users opening a skill detail page on a narrow phone would see the creator action, install area, primary navigation, and content tabs as disconnected surfaces with undersized controls and wrapped secondary tabs.

## Why This Change Was Made

This PR proposes one skill-specific mobile surface from install through content, with a closed outline, consistent separators, 44 px bookmark and secondary-tab targets, and a single horizontally scrollable secondary-tab row. It preserves the desktop layout, skill icon, and existing hero taxonomy typography/wrapping.

## User Impact

Skill detail pages should read as one coherent hierarchy at 320–430 px without document-level horizontal overflow, while desktop behavior remains unchanged.

## Evidence

| Before — 375 px | After — 375 px |
| --- | --- |
| <img src="https://raw.githubusercontent.com/openclaw/clawhub/qa-artifacts/clawhub-ui-proof/pr-3559/20260830-mobile-skill-detail-a0a0199/baseline/375.png" width="375" alt="Mobile skill detail before at 375 px"> | <img src="https://raw.githubusercontent.com/openclaw/clawhub/qa-artifacts/clawhub-ui-proof/pr-3559/20260830-mobile-skill-detail-a0a0199/candidate/375.png" width="375" alt="Mobile skill detail after at 375 px"> |

[Full before/after proof at 320, 375, 430, and 1280 px](https://github.com/openclaw/clawhub/tree/qa-artifacts/clawhub-ui-proof/pr-3559/20260830-mobile-skill-detail-a0a0199)

- `playwright ... --grep 'skill detail mobile hierarchy stays coherent'` — passed at 320, 375, and 430 px, including real tab interaction and overflow checks.
- `bunx vitest run src/__tests__/ui-design-contract.test.ts` — 21 passed.
- `bunx vitest run src/components/SkillDetailPageView.test.tsx` — 3 passed.
- `bun run ci:static` — passed.
- `bun run ci:unit` — 6,243 passed; 27 unrelated local-runtime failures (26 from `react-dom/server` resolution in the shared dependency symlink, 1 Mermaid timeout).
- `bun run ci:types-build` — all four typechecks passed; final Vite build blocked by missing `tsex/tsconfig.json` in the same shared dependency runtime.
- `autoreview --mode local` — clean, no actionable findings.
