### PR TITLE
fix(deps): pin inspector extraction lifecycle repair

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,7 @@
         "@monaco-editor/react": "4.7.0",
         "@openclaw/carapace": "git+https://github.com/openclaw/carapace.git#v0.6.1",
         "@openclaw/krillswitch-react": "0.0.1",
-        "@openclaw/plugin-inspector": "0.3.21",
+        "@openclaw/plugin-inspector": "0.3.22",
         "@radix-ui/react-avatar": "1.2.6",
         "@radix-ui/react-dialog": "1.1.23",
         "@radix-ui/react-dropdown-menu": "2.1.24",
@@ -109,7 +109,7 @@
       },
       "dependencies": {
         "@clack/prompts": "1.7.0",
-        "@openclaw/plugin-inspector": "0.3.21",
+        "@openclaw/plugin-inspector": "0.3.22",
         "arktype": "2.2.3",
         "commander": "15.0.0",
         "croner": "10.0.1",
@@ -459,7 +459,7 @@
 
     "@openclaw/krillswitch-react": ["@openclaw/krillswitch-react@0.0.1", "", { "dependencies": { "@openclaw/krillswitch-core": "0.0.1" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0" } }, "sha512-hFlq6txC+W6Dfab4nHdezCU7Axaxjw1hXwdj3skriZiC0lOEuc3++fKJsnUEFpFqjQbsdDs1ZNrknGV9w16bPg=="],
 
-    "@openclaw/plugin-inspector": ["@openclaw/plugin-inspector@0.3.21", "", { "dependencies": { "semver": "^7.8.5", "tar": "^7.5.22" }, "bin": { "plugin-inspector": "src/cli.js" } }, "sha512-EKrsUSI+cYNMi90XECHNbvJ7HrlBS8XXcXFMaw3c64ZVCAVC93dF6f9OgOJ7Mli8XzTnN5vOEhg+K/gKC5l6fg=="],
+    "@openclaw/plugin-inspector": ["@openclaw/plugin-inspector@0.3.22", "", { "dependencies": { "semver": "^7.8.5", "tar": "^7.5.22" }, "bin": { "plugin-inspector": "src/cli.js" } }, "sha512-OfOaBPTyLgwHSjwqX/sSjukLjuH/sMI4bq/s6mwP0D+66hV24HG26zV9Gqm+p+OZSQe4OUwZSHR1WTzzh86BcQ=="],
 
     "@oslojs/asn1": ["@oslojs/asn1@1.0.0", "", { "dependencies": { "@oslojs/binary": "1.0.0" } }, "sha512-zw/wn0sj0j0QKbIXfIlnEcTviaCzYOY3V5rAyjR6YtOByFtJiT574+8p9Wlach0lZH9fddD4yb9laEAIl4vXQA=="],
 

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "@monaco-editor/react": "4.7.0",
     "@openclaw/carapace": "git+https://github.com/openclaw/carapace.git#v0.6.1",
     "@openclaw/krillswitch-react": "0.0.1",
-    "@openclaw/plugin-inspector": "0.3.21",
+    "@openclaw/plugin-inspector": "0.3.22",
     "@radix-ui/react-avatar": "1.2.6",
     "@radix-ui/react-dialog": "1.1.23",
     "@radix-ui/react-dropdown-menu": "2.1.24",

--- a/packages/clawhub/package.json
+++ b/packages/clawhub/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@clack/prompts": "1.7.0",
-    "@openclaw/plugin-inspector": "0.3.21",
+    "@openclaw/plugin-inspector": "0.3.22",
     "arktype": "2.2.3",
     "commander": "15.0.0",
     "croner": "10.0.1",


### PR DESCRIPTION
ClawHub package publication can fail during inspector target extraction when temporary-cache cleanup races unfinished archive writes. Pin the backend and CLI to `@openclaw/plugin-inspector@0.3.22`, which contains the extraction lifecycle repair in https://github.com/openclaw/plugin-inspector/pull/63.

Both manifests and the Bun 1.3.10 lockfile now resolve the same exact published artifact. Its npm signatures, provenance, and all 59 installed file contents were verified. No transitive dependencies, backend source, scan verdicts, capability checks, authorization, or schemas change.

Validation: frozen install; `bun run ci:static`; `bun run ci:packages` (558 source/artifact tests); 16 focused backend inspector and dependency-pin routing tests; schema and CLI TypeScript checks; scoped review clean. Production deployment remains separate and requires a successful Deploy Test run for the exact merged SHA.

The real extraction proof requested in review is retained in the upstream repair and reproduced below. This is existing maintainer evidence, not a new claim that ClawHub production is recovered. The npm release used source `fadd118b47ee9eae2dcc87f35c1cdda591684696` in [Release run 33355897254](https://github.com/openclaw/plugin-inspector/actions/runs/33355897254). Registry signatures and all attestations verified, including exact workflow, tag, source, and run-attempt identity. The published gzip differs from the local candidate only in compression: the complete uncompressed TAR is byte-identical, and all 59 installed files in this consumer match it. Registry archive SHA256: `3ca8cdbe8d49bc93362dbde76eb15e618ae5dd39dc5a065240191bdab5d2f160`.

Captured maintainer proof for `15cf03b7a4cfbe12967df79df5f9fdc2e2b5cabc` (inspector 0.3.22):

The packed candidate's unchanged public `openClawTargets.resolveVersion("2026.8.1")` and `openClawTargets.prepare(...)` flow was run against the live npm registry on 2026-08-31 at 04:03 UTC, using a fresh temporary cache. A fetch observer measured the downloaded bytes without substituting a fixture response. Preparation passed, discovered 57 public registrars, and the second preparation reused the cache. Exactly one archive was downloaded, with SHA256 `43c4b1f81afcd50244c85bcb5686fa6e39f0da6a5941735811b58064b7e0ca10`. The task-owned cache was removed successfully. This is local maintainer evidence, not CI or deployed ClawHub evidence.

The strict-failure proof is a labeled, instrumented regression through the real preparation owner and real tar parser. Its integrity-valid fixture contains a valid directory followed by a checksum-invalid header. It requires the original `TAR_ENTRY_INVALID` / `checksum failure` error, observes callback-based filesystem work at cleanup entry, and verifies an empty cache after rejection. The test drains outstanding callbacks before physically deleting its scratch directory so testing the old implementation does not leave background writes. It does not mock tar or assert its option shape.

```text
node --test --test-name-pattern='failed target extraction' test/openclaw-version.test.js
old source: FAIL — cleanup must not overtake extraction filesystem work
            actual pending filesystem operations: 2; expected: 0
            the original TAR_ENTRY_INVALID assertion had already passed
fixed source: PASS — original strict error retained; pending operations: 0;
              no prepared target or temporary extraction directory remains
```

The retained fixed owner-file run passed all 13 cases; the complete suite passed 237 tests. The canonical Crabpot source smoke passed 60 fixtures with zero breakages. That smoke does not consume an OpenClaw host target; the live preparation above supplies the separate target proof.

This proves the extraction/cleanup ownership repair and successful preparation of the published package. It does not identify the original masked error in ClawHub's deployed environment or claim publication recovery before a live backend attempt.
