### PR TITLE
fix(deps): bound inspector memory during publication

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,7 @@
         "@monaco-editor/react": "4.7.0",
         "@openclaw/carapace": "git+https://github.com/openclaw/carapace.git#v0.6.1",
         "@openclaw/krillswitch-react": "0.0.1",
-        "@openclaw/plugin-inspector": "0.3.22",
+        "@openclaw/plugin-inspector": "0.3.23",
         "@radix-ui/react-avatar": "1.2.6",
         "@radix-ui/react-dialog": "1.1.23",
         "@radix-ui/react-dropdown-menu": "2.1.24",
@@ -109,7 +109,7 @@
       },
       "dependencies": {
         "@clack/prompts": "1.7.0",
-        "@openclaw/plugin-inspector": "0.3.22",
+        "@openclaw/plugin-inspector": "0.3.23",
         "arktype": "2.2.3",
         "commander": "15.0.0",
         "croner": "10.0.1",
@@ -459,7 +459,7 @@
 
     "@openclaw/krillswitch-react": ["@openclaw/krillswitch-react@0.0.1", "", { "dependencies": { "@openclaw/krillswitch-core": "0.0.1" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0" } }, "sha512-hFlq6txC+W6Dfab4nHdezCU7Axaxjw1hXwdj3skriZiC0lOEuc3++fKJsnUEFpFqjQbsdDs1ZNrknGV9w16bPg=="],
 
-    "@openclaw/plugin-inspector": ["@openclaw/plugin-inspector@0.3.22", "", { "dependencies": { "semver": "^7.8.5", "tar": "^7.5.22" }, "bin": { "plugin-inspector": "src/cli.js" } }, "sha512-OfOaBPTyLgwHSjwqX/sSjukLjuH/sMI4bq/s6mwP0D+66hV24HG26zV9Gqm+p+OZSQe4OUwZSHR1WTzzh86BcQ=="],
+    "@openclaw/plugin-inspector": ["@openclaw/plugin-inspector@0.3.23", "", { "dependencies": { "semver": "^7.8.5", "tar": "^7.5.22" }, "bin": { "plugin-inspector": "src/cli.js" } }, "sha512-nTrLGKI5VpptBebuGO3erUyIGTcPQAxyhyDUUU1TAJV3Roc5tXOgqBR0Wf+XSRJUB+5TbCdSBnn+M7gn7RaqmQ=="],
 
     "@oslojs/asn1": ["@oslojs/asn1@1.0.0", "", { "dependencies": { "@oslojs/binary": "1.0.0" } }, "sha512-zw/wn0sj0j0QKbIXfIlnEcTviaCzYOY3V5rAyjR6YtOByFtJiT574+8p9Wlach0lZH9fddD4yb9laEAIl4vXQA=="],
 

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "@monaco-editor/react": "4.7.0",
     "@openclaw/carapace": "git+https://github.com/openclaw/carapace.git#v0.6.1",
     "@openclaw/krillswitch-react": "0.0.1",
-    "@openclaw/plugin-inspector": "0.3.22",
+    "@openclaw/plugin-inspector": "0.3.23",
     "@radix-ui/react-avatar": "1.2.6",
     "@radix-ui/react-dialog": "1.1.23",
     "@radix-ui/react-dropdown-menu": "2.1.24",

--- a/packages/clawhub/package.json
+++ b/packages/clawhub/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@clack/prompts": "1.7.0",
-    "@openclaw/plugin-inspector": "0.3.22",
+    "@openclaw/plugin-inspector": "0.3.23",
     "arktype": "2.2.3",
     "commander": "15.0.0",
     "croner": "10.0.1",


### PR DESCRIPTION
Pin the backend and CLI to `@openclaw/plugin-inspector@0.3.23` to consume the bounded-memory comment masking repair in https://github.com/openclaw/plugin-inspector/pull/64. The old implementation reached 610,828,288 bytes peak RSS while inspecting one retained 14,006,143-byte JavaScript asset on Node.js 20.20.2; the repaired implementation used 134,512,640 bytes and produced the identical inspection output.

The consumer change is limited to two exact version pins and their Bun lockfile resolution. No backend source, scan verdicts, capability checks, authorization, schemas, or OpenClaw release artifacts change. The original generic production error does not itself prove an OOM, and backend publication recovery still needs a normal-gated live attempt after deployment.

Existing upstream real-input proof, retained in PR64:

```text
asset SHA256: d711f760d14db992cdd6c5a1013bf819dc6207b4ce51b8d5d1a820ae8a189855
Node.js 20.20.2; asset bytes: 14,006,143
before peak RSS: 610,828,288 bytes; after: 134,512,640 bytes
inspection output SHA256 unchanged:
8cc61407019ad62d679039b666fe1fc0cbd28ff40c5697da1ca80e9053c567d6
plugin code executed: no
```

The upstream bounded-heap regression failed before the repair and passed afterward; all 239 upstream tests passed. Consumer validation passed: Bun1.3.10 frozen install; ci:static; ci:packages (558 source/artifact tests);16 focused backend/pin-routing tests; schema and CLI noEmit checks; scoped review clean. All59 installed inspector files match the published archive. Registry signatures, all attestations, and exact release-workflow/source/run identity verified for Release33359141916 attempt1 at source19512a12323eab2fff783820ffd20c3c04040964; archive SHA2560e7e68df73ac6dd5c186379244b5a3fa4f92ad93e7f828385bd39e9507e44745. Production deployment is separate and requires successful Deploy Test at the exact merged SHA plus publication-batch quiescence.
