### PR TITLE
fix: scope plugin runtime identities to publishers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixes
 
+- API: scope code-plugin runtime identity claims to the owning publisher so community and official packages can retain their manifest ids under distinct scoped names, while rejecting same-owner collisions during publication, transfer, restore, and administrative repair.
 - UI proof: supervise isolated loopback backend and browser proof together without writing project dotenv, preserving diagnostics and private-state cleanup on failure.
 - CI: authenticate weekly design-audit pull request mutations with the Barnacle GitHub App while retaining the workflow token for branch publication and clean-audit closure.
 - API: record skipped and failed skill evaluation outcomes without passing worker tokens to internal mutations.

--- a/convex/packages.public.test.ts
+++ b/convex/packages.public.test.ts
@@ -2283,6 +2283,9 @@ function makeInsertReleaseCtx(
                   const runtimeId = filters.get("runtimeId");
                   const matches = runtimePackages.filter((pkg) => pkg.runtimeId === runtimeId);
                   return {
+                    async *[Symbol.asyncIterator]() {
+                      yield* matches;
+                    },
                     collect: vi.fn().mockResolvedValue(matches),
                     unique: vi.fn().mockResolvedValue(matches[0] ?? null),
                   };
@@ -2558,6 +2561,9 @@ function makeTransferPackageOwnerCtx(options?: {
               withIndex: vi.fn(() => ({
                 unique: vi.fn().mockResolvedValue(pkg),
                 collect: vi.fn().mockResolvedValue(pkg ? [pkg] : []),
+                async *[Symbol.asyncIterator]() {
+                  if (pkg) yield pkg;
+                },
               })),
             };
           }

--- a/convex/packages.runtimeIdentity.test.ts
+++ b/convex/packages.runtimeIdentity.test.ts
@@ -1,0 +1,253 @@
+/// <reference types="vite/client" />
+/* @vitest-environment edge-runtime */
+
+import { convexTest } from "convex-test";
+import { describe, expect, it } from "vitest";
+import { internal } from "./_generated/api";
+import type { Id } from "./_generated/dataModel";
+import schema from "./schema";
+
+const modules = import.meta.glob("./**/*.ts");
+type Backend = ReturnType<typeof convexTest>;
+type Owner = { ownerUserId: Id<"users">; ownerPublisherId?: Id<"publishers"> };
+
+async function fixture() {
+  const t = convexTest({ schema, modules, transactionLimits: true });
+  const owners = await t.run(async (ctx) => {
+    const admin = await ctx.db.insert("users", { role: "admin", handle: "operator" });
+    const user = await ctx.db.insert("users", { handle: "community" });
+    const personal = await ctx.db.insert("publishers", {
+      kind: "user",
+      handle: "community",
+      displayName: "Community",
+      linkedUserId: user,
+      createdAt: 1,
+      updatedAt: 1,
+    });
+    const org = await ctx.db.insert("publishers", {
+      kind: "org",
+      handle: "canonical",
+      displayName: "Canonical",
+      createdAt: 1,
+      updatedAt: 1,
+    });
+    const secondOrg = await ctx.db.insert("publishers", {
+      kind: "org",
+      handle: "another",
+      displayName: "Another",
+      createdAt: 1,
+      updatedAt: 1,
+    });
+    return {
+      admin,
+      community: { ownerUserId: user, ownerPublisherId: personal },
+      legacy: { ownerUserId: user },
+      canonical: { ownerUserId: admin, ownerPublisherId: org },
+      another: { ownerUserId: admin, ownerPublisherId: secondOrg },
+    };
+  });
+  return { t, ...owners };
+}
+
+async function publish(
+  t: Backend,
+  actorUserId: Id<"users">,
+  owner: Owner,
+  name: string,
+  options: { runtimeId?: string; version?: string; pending?: boolean } = {},
+) {
+  return await t.mutation(internal.packages.insertReleaseInternal, {
+    actorUserId,
+    ...owner,
+    name,
+    displayName: name,
+    family: "code-plugin",
+    version: options.version ?? "1.0.0",
+    runtimeId: options.runtimeId ?? "voice",
+    publicationStatus: options.pending ? "pending" : "published",
+    changelog: "Initial release",
+    tags: ["latest"],
+    summary: "Voice plugin",
+    files: [],
+    integritySha256: "a".repeat(64),
+    sha256hash: "b".repeat(64),
+    extractedPluginManifest: { id: options.runtimeId ?? "voice" },
+  });
+}
+
+describe("owner-scoped package runtime identity", () => {
+  it("separates organizations even when the uploader is the same", async () => {
+    const { t, admin, canonical, another } = await fixture();
+    await publish(t, admin, canonical, "@canonical/voice-provider");
+    await expect(publish(t, admin, another, "@another/voice-provider")).resolves.toMatchObject({
+      ok: true,
+    });
+  });
+
+  it("keeps one organization namespace when a different admin uploads", async () => {
+    const { t, admin, canonical } = await fixture();
+    await publish(t, admin, canonical, "@canonical/voice-one");
+    const secondAdmin = await t.run(async (ctx) => ctx.db.insert("users", { role: "admin" }));
+    await expect(
+      publish(t, secondAdmin, { ...canonical, ownerUserId: secondAdmin }, "@canonical/voice-two"),
+    ).rejects.toThrow("already claimed");
+  });
+
+  it("publishes different owners' same runtime without changing either artifact identity", async () => {
+    const { t, admin, community, canonical } = await fixture();
+    const original = await publish(t, admin, community, "@community/voice-tools");
+    const before = await t.run(async (ctx) => ctx.db.get(original.releaseId));
+    const official = await publish(t, admin, canonical, "@canonical/voice-provider");
+    const rows = await t.run(async (ctx) => ({
+      community: await ctx.db.get(original.packageId),
+      canonical: await ctx.db.get(official.packageId),
+      originalRelease: await ctx.db.get(original.releaseId),
+    }));
+    expect(rows.community).toMatchObject({
+      name: "@community/voice-tools",
+      runtimeId: "voice",
+      ...community,
+    });
+    expect(rows.canonical).toMatchObject({
+      name: "@canonical/voice-provider",
+      runtimeId: "voice",
+      ...canonical,
+    });
+    expect(rows.originalRelease).toEqual(before);
+  });
+
+  it.each(["personal-first", "legacy-first"])(
+    "keeps personal and legacy user ownership in one namespace (%s)",
+    async (order) => {
+      const { t, admin, community, legacy } = await fixture();
+      const [first, second] =
+        order === "personal-first" ? [community, legacy] : [legacy, community];
+      await publish(t, admin, first, "@community/voice-one");
+      await expect(publish(t, admin, second, "@community/voice-two")).rejects.toThrow(
+        "already claimed",
+      );
+    },
+  );
+
+  it("retains package ownership and runtime immutability", async () => {
+    const { t, admin, community, canonical } = await fixture();
+    await publish(t, admin, community, "@community/voice-tools");
+    await expect(
+      publish(t, admin, canonical, "@community/voice-tools", { version: "1.0.1" }),
+    ).rejects.toThrow("belongs to another publisher");
+    await expect(
+      publish(t, admin, community, "@community/voice-tools", {
+        version: "1.0.1",
+        runtimeId: "different",
+      }),
+    ).rejects.toThrow("runtime id changes are not allowed");
+  });
+
+  it("rejects a transfer into an occupied owner namespace without changing ownership", async () => {
+    const { t, admin, community, canonical } = await fixture();
+    const first = await publish(t, admin, community, "@community/voice-tools");
+    await publish(t, admin, canonical, "@canonical/voice-provider");
+    await expect(
+      t.mutation(internal.packages.transferPackageOwnerInternal, {
+        actorUserId: admin,
+        name: "@community/voice-tools",
+        ...canonical,
+        reason: "Move publisher namespace",
+      }),
+    ).rejects.toThrow("already claimed");
+    expect(await t.run(async (ctx) => ctx.db.get(first.packageId))).toMatchObject(community);
+  });
+
+  it("rejects undelete after another package in the same owner namespace claims the runtime", async () => {
+    const { t, admin, community } = await fixture();
+    const original = await publish(t, admin, community, "@community/voice-old");
+    await t.mutation(internal.packages.softDeletePackageInternal, {
+      userId: admin,
+      name: "@community/voice-old",
+    });
+    await publish(t, admin, community, "@community/voice-new");
+    await expect(
+      t.mutation(internal.packages.restorePackageInternal, {
+        userId: admin,
+        name: "@community/voice-old",
+      }),
+    ).rejects.toThrow("already claimed");
+    const rows = await t.run(async (ctx) => [
+      await ctx.db.get(original.packageId),
+      await ctx.db.get(original.releaseId),
+    ]);
+    expect(rows.every((row) => typeof row?.softDeletedAt === "number")).toBe(true);
+  });
+
+  it("restores a community package without disturbing another publisher's runtime claim", async () => {
+    const { t, admin, community, canonical } = await fixture();
+    const original = await publish(t, admin, community, "@community/voice-tools");
+    await t.mutation(internal.packages.softDeletePackageInternal, {
+      userId: admin,
+      name: "@community/voice-tools",
+    });
+    await publish(t, admin, canonical, "@canonical/voice-provider");
+    await t.mutation(internal.packages.restorePackageInternal, {
+      userId: admin,
+      name: "@community/voice-tools",
+    });
+    const restored = await t.run(async (ctx) => ctx.db.get(original.packageId));
+    expect(restored).toMatchObject({
+      ...community,
+      runtimeId: "voice",
+    });
+    expect(restored?.softDeletedAt).toBeUndefined();
+  });
+
+  it("scopes an admin runtime repair by owner and rejects same-owner collisions", async () => {
+    const { t, admin, community, canonical } = await fixture();
+    await publish(t, admin, community, "@community/voice-tools");
+    const repaired = await publish(t, admin, canonical, "@canonical/voice-provider", {
+      runtimeId: "wrong-id",
+    });
+    await t.mutation(internal.packages.repairPackageIdentityInternal, {
+      actorUserId: admin,
+      name: "@canonical/voice-provider",
+      nextRuntimeId: "voice",
+      reason: "Correct registry identity",
+    });
+    expect(await t.run(async (ctx) => ctx.db.get(repaired.packageId))).toMatchObject({
+      runtimeId: "voice",
+    });
+    await publish(t, admin, canonical, "@canonical/other-provider", { runtimeId: "other" });
+    await expect(
+      t.mutation(internal.packages.repairPackageIdentityInternal, {
+        actorUserId: admin,
+        name: "@canonical/other-provider",
+        nextRuntimeId: "voice",
+        reason: "Conflicting repair",
+      }),
+    ).rejects.toThrow("already claimed");
+  });
+
+  it.each(["first release", "older release"])(
+    "rechecks a staged %s after the package identity was administratively changed",
+    async (kind) => {
+      const { t, admin, community } = await fixture();
+      if (kind === "older release") {
+        await publish(t, admin, community, "@community/staged", { version: "2.0.0" });
+      }
+      const staged = await publish(t, admin, community, "@community/staged", { pending: true });
+      await t.mutation(internal.packages.repairPackageIdentityInternal, {
+        actorUserId: admin,
+        name: "@community/staged",
+        nextRuntimeId: "repaired",
+        reason: "Move existing claim",
+      });
+      await publish(t, admin, community, "@community/other");
+      await expect(
+        t.mutation(internal.packages.publishPendingReleaseInternal, {
+          releaseId: staged.releaseId,
+        }),
+      ).rejects.toThrow("already claimed");
+      expect(await t.run(async (ctx) => ctx.db.get(staged.releaseId))).toMatchObject({
+        publicationStatus: "pending",
+      });
+    },
+  );
+});

--- a/convex/packages.ts
+++ b/convex/packages.ts
@@ -819,6 +819,39 @@ function getRequestedPackageOwnerKey(args: {
   return args.ownerPublisherId ? `publisher:${args.ownerPublisherId}` : `user:${args.ownerUserId}`;
 }
 
+async function getRuntimeIdentityOwnerKey(
+  ctx: DbReaderCtx,
+  owner: Pick<PackageDoc, "ownerUserId" | "ownerPublisherId">,
+) {
+  if (!owner.ownerPublisherId) return `user:${owner.ownerUserId}`;
+  const publisher = await ctx.db.get(owner.ownerPublisherId);
+  // A personal publisher and its pre-publisher user records are one namespace.
+  return publisher?.kind === "user" && publisher.linkedUserId
+    ? `user:${publisher.linkedUserId}`
+    : `publisher:${owner.ownerPublisherId}`;
+}
+
+async function assertPackageRuntimeIdAvailable(
+  ctx: DbReaderCtx,
+  identity: Pick<PackageDoc, "ownerUserId" | "ownerPublisherId" | "runtimeId"> & {
+    _id?: Id<"packages">;
+  },
+) {
+  if (!identity.runtimeId) return;
+  const ownerKey = await getRuntimeIdentityOwnerKey(ctx, identity);
+  const candidates = ctx.db
+    .query("packages")
+    .withIndex("by_runtime_id", (q) => q.eq("runtimeId", identity.runtimeId));
+  for await (const candidate of candidates) {
+    if (candidate._id === identity._id || candidate.softDeletedAt) continue;
+    if ((await getRuntimeIdentityOwnerKey(ctx, candidate)) === ownerKey) {
+      throw new ConvexError(
+        `Plugin id "${identity.runtimeId}" is already claimed by another package in this publisher namespace`,
+      );
+    }
+  }
+}
+
 function derivePackagePublisherChannel(args: {
   requestedChannel?: PackageChannel;
   currentChannel?: PackageChannel;
@@ -5976,6 +6009,8 @@ async function restorePackageDoc(
     );
   }
 
+  if (pkg.family === "code-plugin") await assertPackageRuntimeIdAvailable(ctx, pkg);
+
   const releases = await ctx.db
     .query("packageReleases")
     .withIndex("by_package", (q) => q.eq("packageId", pkg._id))
@@ -9858,6 +9893,10 @@ async function patchPackageOwnerWithAudit(
     updatedAt: now,
   };
 
+  if (args.pkg.family === "code-plugin") {
+    await assertPackageRuntimeIdAvailable(ctx, { ...args.pkg, ...nextPackageFields });
+  }
+
   await ctx.db.patch(args.pkg._id, nextPackageFields);
   await upsertPackageSearchDigest(ctx, {
     ...extractPackageDigestFields(args.pkg),
@@ -10102,16 +10141,7 @@ export const repairPackageIdentityInternal = internalMutation({
     if (typeof args.nextRuntimeId === "string") {
       const nextRuntimeId = args.nextRuntimeId.trim();
       if (!nextRuntimeId) throw new ConvexError("Runtime id required");
-      const runtimeCollisions = await ctx.db
-        .query("packages")
-        .withIndex("by_runtime_id", (q) => q.eq("runtimeId", nextRuntimeId))
-        .collect();
-      const runtimeCollision = runtimeCollisions.find(
-        (candidate) => candidate._id !== pkg._id && !candidate.softDeletedAt,
-      );
-      if (runtimeCollision) {
-        throw new ConvexError(`Plugin id "${nextRuntimeId}" is already claimed by another package`);
-      }
+      await assertPackageRuntimeIdAvailable(ctx, { ...pkg, runtimeId: nextRuntimeId });
       patch.runtimeId = nextRuntimeId;
       metadata.previousRuntimeId = pkg.runtimeId;
       metadata.nextRuntimeId = nextRuntimeId;
@@ -11247,6 +11277,14 @@ export const publishPendingReleaseInternal = internalMutation({
       candidateVersion: release.version,
       requestedTags: stringArrayPendingField(metadata, "tags") ?? release.distTags ?? [],
     });
+    // Staging does not freeze ownership or administrative identity repairs.
+    // Recheck the effective claim in the transaction that makes it public.
+    if (packageFamily === "code-plugin") {
+      await assertPackageRuntimeIdAvailable(ctx, {
+        ...pkg,
+        runtimeId: release.runtimeId,
+      });
+    }
     const scanStatus = resolvePackageReleaseScanStatus(release);
     const releaseVerification = release.verification
       ? { ...release.verification, scanStatus }
@@ -11529,7 +11567,6 @@ export const insertReleaseInternal = internalMutation({
       publisherOfficial,
     });
     const nextIsOfficial = nextChannel === "official";
-    const nextRuntimeIdLabel = typeof args.runtimeId === "string" ? args.runtimeId : "<unknown>";
     const nextVersionLabel = typeof args.version === "string" ? args.version : "<unknown>";
     if (existing) {
       const existingOwnerKey = getPackageOwnerKey(existing, {
@@ -11561,18 +11598,12 @@ export const insertReleaseInternal = internalMutation({
       );
     }
     if (args.family === "code-plugin" && args.runtimeId) {
-      const runtimeCollisions = await ctx.db
-        .query("packages")
-        .withIndex("by_runtime_id", (q) => q.eq("runtimeId", args.runtimeId))
-        .collect();
-      const runtimeCollision = runtimeCollisions.find(
-        (candidate) => candidate._id !== existing?._id && !candidate.softDeletedAt,
-      );
-      if (runtimeCollision) {
-        throw new ConvexError(
-          `Plugin id "${nextRuntimeIdLabel}" is already claimed by another package`,
-        );
-      }
+      await assertPackageRuntimeIdAvailable(ctx, {
+        _id: existing?._id,
+        ownerUserId: args.ownerUserId,
+        ownerPublisherId: args.ownerPublisherId ?? existing?.ownerPublisherId,
+        runtimeId: args.runtimeId,
+      });
     }
 
     const createdNewParent = !existing;

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -157,6 +157,11 @@ to keep out of public issues.
 ### Before Publishing a Plugin
 
 - Pick an owner that matches the package scope.
+- A code plugin's manifest `id` must be unique within that publisher's packages.
+  Different publishers can distribute the same runtime id under distinct scoped
+  package names. Choose the explicit scoped name to install a community package;
+  known bare OpenClaw aliases select the official package. One OpenClaw
+  installation still uses one plugin for each runtime id.
 - Include `openclaw.plugin.json`. Code plugins also need `package.json` with
   `openclaw.compat.pluginApi` and `openclaw.build.openclawVersion`.
 - To show a custom plugin catalog icon on the homepage and plugin list pages,

--- a/specs/plans/plugins.md
+++ b/specs/plans/plugins.md
@@ -133,7 +133,7 @@ Package rules:
 
 - one package belongs to exactly one family
 - one code-plugin package maps to exactly one plugin id
-- one plugin id maps to exactly one live code-plugin package identity
+- within one publisher namespace, one plugin id maps to exactly one live code-plugin package identity; different publishers may distribute distinct packages with the same manifest id
 - if a publisher wants multiple code plugins, they publish multiple packages
 - package display casing can be preserved for UI, but uniqueness and routing
   must use the canonical normalized package key
@@ -141,6 +141,27 @@ Package rules:
   the oldest publish wins unless a moderator explicitly intervenes
 - plugin id transfer or replacement must be an explicit moderated workflow, not
   an accidental publish collision
+
+Runtime identity belongs to the artifact and is not a global package-name claim.
+Scoped package names and canonical official aliases select the distribution;
+the manifest id remains unchanged and still identifies the plugin in one
+OpenClaw installation. This does not permit installing two packages with the
+same runtime id into the same installation. Personal publisher records and
+their linked legacy user records share a namespace; organization namespaces
+remain distinct even when one user uploads for both. Publication, pending
+publication finalization, owner transfer, undelete, and administrative runtime
+repair validate this owner-scoped claim transactionally. Existing package
+ownership checks and per-package runtime-id immutability still apply.
+
+Follow-up: administrative runtime repair can leave historical release manifests
+inconsistent with the parent package identity. Reproduction: repair a parent
+from id `voice` to `voice-next`, publish another same-owner package claiming
+`voice`, then quarantine a malicious latest release on the repaired package.
+The existing quarantine fallback may restore an older release's `voice` id.
+This predates owner-scoped claims. Keep security quarantine operational; do not
+add a table trigger that throws on this fallback and rolls back quarantine.
+An identity-aware historical-release repair/fallback design remains separate
+work; this change neither rewrites archives nor changes quarantine behavior.
 
 Current OpenClaw evidence supports this:
 
@@ -846,7 +867,7 @@ Policy integration:
 - decide shared package identity model across skills/code plugins/bundle plugins
 - decide canonical internal package key vs public route/CLI locator rules
 - decide canonical package-name normalization rules and reserved-name policy
-- add global code-plugin `pluginId` uniqueness rules and transfer policy
+- add publisher-scoped code-plugin `pluginId` uniqueness rules and transfer policy
 - separate `pluginApiVersion` semver validation from publisher-defined package
   version validation
 - require semver package versions for code-plugin publishing

--- a/specs/slug-routing.md
+++ b/specs/slug-routing.md
@@ -114,6 +114,12 @@ This means official OpenClaw aliases are reserved before skills at the root.
 That is intentional: `https://clawhub.ai/codex` must show the official OpenClaw
 Codex plugin even if a skill named `codex` exists.
 
+Plugin manifest runtime ids do not determine these routes. Different publisher
+namespaces may distribute packages with the same runtime id. Explicit scoped
+package names keep resolving to their original publisher, while a known bare
+OpenClaw alias selects the canonical official package. Moving a bare alias does
+not rename a community manifest, rewrite its archives, or transfer its owner.
+
 Publisher handle creation and rename paths reserve the full official alias set.
 This prevents new profiles from taking over those top-level plugin shortcuts.
 


### PR DESCRIPTION
A scoped community plugin could reserve its manifest runtime ID globally and prevent another publisher from releasing a distinct package. Runtime claims now belong to the publisher namespace, so community and official packages keep their existing names, owners, manifest IDs, versions, and archive bytes. Bare official aliases and explicit scoped package routing are unchanged; this does not allow two plugins with the same runtime ID in one OpenClaw installation.

One shared validator replaces the duplicated global guards and checks publication, staged finalization (including non-latest versions), owner transfers, undelete, and administrative runtime repair. Personal publishers and linked legacy user records share a namespace; separate organizations remain distinct even with the same uploader. Existing package ownership checks, per-package runtime immutability, and security scanning stay intact.

Validation: 377 focused tests passed, including fail-before/pass-after regressions; real isolated Convex proof passed 28 calls plus both scoped HTTP reads. Static checks and the complete types/production-build gate passed; final structured review is clean. The bounded full coverage run had 6,286 passes, three skips, and one unchanged setup-worktree fixture timeout; that fixture passed unchanged on a focused rerun in 7.45 seconds. The timeout remains recorded and is waived as a host timing flake, not reported as a green full run.

Named follow-up in the plugin specification: administrative runtime repairs can leave older release manifests inconsistent, and quarantine fallback can restore that older identity. This existing issue is not changed here; no collision trigger is added that could roll back security quarantine. Production code delta: +54/-23; no schema, configuration, archive, or OpenClaw client changes.


Exact final backend proof (synthetic metadata using existing seed functions, actual Convex transactions and HTTP reads; this is not a scanner or archive-publication certificate):

```json
{
  "result": "pass",
  "testedCommit": "ae495f5660bdeb412df3ba108b587c8e62c4e608",
  "completedAt": "2026-08-31T08:03:50Z",
  "deployment": "isolated local Convex",
  "source": {
    "path": "convex/packages.ts",
    "sha256": "ab64088c8f2d0dd03e7a3e1be38467315f05e71b5d76d82278494976a4c173d5"
  },
  "functionCalls": 28,
  "scopedHttpReads": 2,
  "communityUnchangedAfterCanonicalPublish": true,
  "sameUploaderDifferentOrganizations": true,
  "publicScopedReadsPreserveRuntimeIdentity": true,
  "calls": [
    [
      "devSeed:seedOrgDeletionFixture",
      "success"
    ],
    [
      "devSeed:seedOrgDeletionFixture",
      "success"
    ],
    [
      "packages:getPackageByNameInternal",
      "success"
    ],
    [
      "packages:getPackageByNameInternal",
      "success"
    ],
    [
      "packages:insertReleaseInternal",
      "success"
    ],
    [
      "packages:getPackageByNameInternal",
      "success"
    ],
    [
      "packages:insertReleaseInternal",
      "success"
    ],
    [
      "packages:getPackageByNameInternal",
      "success"
    ],
    [
      "packages:getPackageByNameInternal",
      "success"
    ],
    [
      "packages:insertReleaseInternal",
      "rejected_same_owner_collision"
    ],
    [
      "packages:transferPackageOwnerInternal",
      "rejected_same_owner_collision"
    ],
    [
      "packages:getPackageByNameInternal",
      "success"
    ],
    [
      "packages:softDeletePackageInternal",
      "success"
    ],
    [
      "packages:insertReleaseInternal",
      "success"
    ],
    [
      "packages:restorePackageInternal",
      "rejected_same_owner_collision"
    ],
    [
      "packages:getPackageByNameInternal",
      "success"
    ],
    [
      "packages:softDeletePackageInternal",
      "success"
    ],
    [
      "packages:restorePackageInternal",
      "success"
    ],
    [
      "packages:getPackageByNameInternal",
      "success"
    ],
    [
      "packages:insertReleaseInternal",
      "success"
    ],
    [
      "packages:insertReleaseInternal",
      "success"
    ],
    [
      "packages:repairPackageIdentityInternal",
      "success"
    ],
    [
      "packages:repairPackageIdentityInternal",
      "rejected_same_owner_collision"
    ],
    [
      "packages:insertReleaseInternal",
      "success"
    ],
    [
      "packages:insertReleaseInternal",
      "success"
    ],
    [
      "packages:repairPackageIdentityInternal",
      "success"
    ],
    [
      "packages:insertReleaseInternal",
      "success"
    ],
    [
      "packages:publishPendingReleaseInternal",
      "rejected_same_owner_collision"
    ]
  ]
}
```

Maintainer disposition: Peter explicitly requested the owner/name namespace policy so the bare name selects the canonical official plugin while community distributions remain owner-scoped. The existing routing already selects official aliases first; this change removes the global manifest-ID collision without rewriting community archives.

Scale follow-up: introduce an indexed normalized-owner/runtime claim when addressing registry partition growth. The current `by_runtime_id` iterator can still read the complete shared-runtime partition and perform owner lookups; iteration does not bound total reads. The previous global guard already collected that partition, and allowing distinct owners can increase its future size. No current scale outage was established. The schema/index redesign is deferred under the maintainer instruction to avoid further noncritical release corrections, with Convex transaction read limits remaining fail-closed. This is a deferred scale risk, not a claim that the iterator solved it.
