### PR TITLE
perf(ci): run required gates in parallel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7.0.1
+        with:
+          fetch-depth: 2
 
       - uses: ./.github/actions/setup-bun
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,10 @@ env:
   VITE_CONVEX_URL: https://example.invalid
 
 jobs:
-  pr-gates:
-    name: pr-gates
-    runs-on: blacksmith-8vcpu-ubuntu-2404
-    timeout-minutes: 45
+  static:
+    name: static
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
 
     steps:
       - uses: actions/checkout@v7.0.1
@@ -31,18 +31,6 @@ jobs:
 
       - name: Static checks
         run: bun run ci:static
-
-      - name: Unit coverage
-        run: bun run ci:unit
-
-      - name: Package checks
-        run: bun run ci:packages
-
-      - name: Typecheck and build
-        run: bun run ci:types-build
-
-      - name: HTTP e2e
-        run: bun run ci:e2e-http
 
   claws-openclaw-contract:
     name: claws-openclaw-contract
@@ -80,75 +68,71 @@ jobs:
           OPENCLAW_CLAWS_CHECKOUT: ${{ github.workspace }}/.artifacts/openclaw-contract
         run: bunx vitest run scripts/claws-feed-openclaw-e2e.test.ts --maxWorkers=1
 
-  static:
-    name: static
-    runs-on: ubuntu-latest
-    needs: pr-gates
-    if: ${{ always() }}
-    timeout-minutes: 5
-
-    steps:
-      - name: Mirror pr-gates result
-        env:
-          PR_GATES_RESULT: ${{ needs.pr-gates.result }}
-        run: |
-          test "$PR_GATES_RESULT" = "success"
-
   unit:
     name: unit
-    runs-on: ubuntu-latest
-    needs: pr-gates
-    if: ${{ always() }}
+    runs-on: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 5
 
     steps:
-      - name: Mirror pr-gates result
-        env:
-          PR_GATES_RESULT: ${{ needs.pr-gates.result }}
+      - uses: actions/checkout@v7.0.1
+
+      - uses: ./.github/actions/setup-bun
+
+      - name: Record runner capacity
         run: |
-          test "$PR_GATES_RESULT" = "success"
+          printf 'logical_cpus='
+          nproc
+          printf 'memory_total_kib='
+          awk '/^MemTotal:/ { print $2 }' /proc/meminfo
+          if [[ -r /sys/fs/cgroup/cpu.max ]]; then
+            printf 'cpu_max='
+            cat /sys/fs/cgroup/cpu.max
+          fi
+          if [[ -r /sys/fs/cgroup/cpu.stat ]]; then
+            cat /sys/fs/cgroup/cpu.stat
+          fi
+
+      - name: Unit coverage
+        run: bun run ci:unit
 
   packages:
     name: packages
-    runs-on: ubuntu-latest
-    needs: pr-gates
-    if: ${{ always() }}
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
 
     steps:
-      - name: Mirror pr-gates result
-        env:
-          PR_GATES_RESULT: ${{ needs.pr-gates.result }}
-        run: |
-          test "$PR_GATES_RESULT" = "success"
+      - uses: actions/checkout@v7.0.1
+
+      - uses: ./.github/actions/setup-bun
+
+      - name: Package checks
+        run: bun run ci:packages
 
   types-build:
     name: types-build
-    runs-on: ubuntu-latest
-    needs: pr-gates
-    if: ${{ always() }}
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
 
     steps:
-      - name: Mirror pr-gates result
-        env:
-          PR_GATES_RESULT: ${{ needs.pr-gates.result }}
-        run: |
-          test "$PR_GATES_RESULT" = "success"
+      - uses: actions/checkout@v7.0.1
+
+      - uses: ./.github/actions/setup-bun
+
+      - name: Typecheck and build
+        run: bun run ci:types-build
 
   e2e-http:
     name: e2e-http
-    runs-on: ubuntu-latest
-    needs: pr-gates
-    if: ${{ always() }}
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
 
     steps:
-      - name: Mirror pr-gates result
-        env:
-          PR_GATES_RESULT: ${{ needs.pr-gates.result }}
-        run: |
-          test "$PR_GATES_RESULT" = "success"
+      - uses: actions/checkout@v7.0.1
+
+      - uses: ./.github/actions/setup-bun
+
+      - name: HTTP e2e
+        run: bun run ci:e2e-http
 
   playwright-smoke:
     name: playwright-smoke

--- a/scripts/ci-workflow.test.ts
+++ b/scripts/ci-workflow.test.ts
@@ -7,7 +7,12 @@ type WorkflowJob = {
   "runs-on": string;
   "timeout-minutes": number;
   needs?: string;
-  steps: Array<{ name?: string; run?: string; uses?: string }>;
+  steps: Array<{
+    name?: string;
+    run?: string;
+    uses?: string;
+    with?: Record<string, number | string>;
+  }>;
 };
 
 describe("CI workflow", () => {
@@ -32,6 +37,12 @@ describe("CI workflow", () => {
     }
 
     expect(workflow.jobs.unit["runs-on"]).toBe("blacksmith-32vcpu-ubuntu-2404");
+    expect(workflow.jobs.unit.steps).toContainEqual(
+      expect.objectContaining({
+        uses: "actions/checkout@v7.0.1",
+        with: { "fetch-depth": 2 },
+      }),
+    );
     for (const name of ["static", "packages", "types-build", "e2e-http"]) {
       expect(workflow.jobs[name]["runs-on"]).toBe("ubuntu-24.04");
     }

--- a/scripts/ci-workflow.test.ts
+++ b/scripts/ci-workflow.test.ts
@@ -1,0 +1,45 @@
+/* @vitest-environment node */
+import { readFile } from "node:fs/promises";
+import { describe, expect, it } from "vitest";
+import { parse as parseYaml } from "yaml";
+
+type WorkflowJob = {
+  "runs-on": string;
+  "timeout-minutes": number;
+  needs?: string;
+  steps: Array<{ name?: string; run?: string; uses?: string }>;
+};
+
+describe("CI workflow", () => {
+  it("runs required gates in parallel with one CPU-sized Blacksmith lane", async () => {
+    const workflow = parseYaml(await readFile(".github/workflows/ci.yml", "utf8")) as {
+      jobs: Record<string, WorkflowJob>;
+    };
+    const requiredGates = {
+      static: "bun run ci:static",
+      unit: "bun run ci:unit",
+      packages: "bun run ci:packages",
+      "types-build": "bun run ci:types-build",
+      "e2e-http": "bun run ci:e2e-http",
+    };
+
+    expect(workflow.jobs["pr-gates"]).toBeUndefined();
+    for (const [name, command] of Object.entries(requiredGates)) {
+      const job = workflow.jobs[name];
+      expect(job.needs).toBeUndefined();
+      expect(job["timeout-minutes"]).toBe(5);
+      expect(job.steps).toContainEqual(expect.objectContaining({ run: command }));
+    }
+
+    expect(workflow.jobs.unit["runs-on"]).toBe("blacksmith-32vcpu-ubuntu-2404");
+    for (const name of ["static", "packages", "types-build", "e2e-http"]) {
+      expect(workflow.jobs[name]["runs-on"]).toBe("ubuntu-24.04");
+    }
+
+    const capacityStep = workflow.jobs.unit.steps.find(
+      (step) => step.name === "Record runner capacity",
+    );
+    expect(capacityStep?.run).toContain("nproc");
+    expect(capacityStep?.run).toContain("/sys/fs/cgroup/cpu.stat");
+  });
+});

--- a/specs/ci.md
+++ b/specs/ci.md
@@ -4,9 +4,8 @@ Pull requests are validated by `.github/workflows/ci.yml`.
 
 ## PR Checks
 
-The `CI` workflow keeps the public required status checks stable while bundling
-the short non-browser gates into one Blacksmith runner registration. The
-`pr-gates` job runs the actual command steps for:
+The `CI` workflow runs the non-browser gates as independent jobs so their wall
+times overlap and each required check reports its own failure:
 
 - `static` runs peer dependency validation, dependency audit, formatting, lint,
   and dead-code checks.
@@ -21,10 +20,12 @@ the short non-browser gates into one Blacksmith runner registration. The
   window fits the five-second CI budget. Longer rate limits and deterministic
   client errors such as a missing repository fail immediately.
 
-The `static`, `unit`, `packages`, `types-build`, and `e2e-http` jobs are
-hosted-runner compatibility mirrors of `pr-gates` so existing branch protection
-rules do not need to change. Inspect the `pr-gates` step logs for the exact
-failing command.
+The CPU-heavy `unit` job uses one 32-vCPU Blacksmith registration and records
+the runner's actual CPU, memory, and cgroup allocation before coverage. The
+short `static`, `packages`, `types-build`, and `e2e-http` jobs run on GitHub-hosted
+Ubuntu runners, so this parallel layout keeps the same one-Blacksmith-registration
+budget as the former serial `pr-gates` job. Every non-browser gate has a
+five-minute timeout to enforce the pull-request feedback target.
 
 - `playwright-smoke` builds the app and runs a chromium browser smoke against the
   public read backend.


### PR DESCRIPTION
## Summary

- replace the serial `pr-gates` bundle with five independently required jobs
- give unit coverage an 8-logical-CPU Blacksmith runner while keeping short gates on GitHub-hosted runners
- add five-minute budgets, runner-capacity telemetry, workflow regression tests, and updated CI intent

## Audit

Across the last 100 CI runs, successful workflows had a 9:00 median and 11:56 p90. The serial `pr-gates` job was the critical path: unit coverage alone had a 6:02 median, then static, package, build, and HTTP gates ran after it.

PR #3550's 30-minute run was a singular degraded Blacksmith instance, not a deadlock: checkout/setup/static were already 4–7x slower than normal and unit files kept completing until the PR merge cancelled the run.

## Validation

- `bun run ci:static`
- `bun run ci:unit` — 6,304 passed, 3 skipped
- autoreview — clean (0.98)
- exact-head CI: 3m34s created-to-updated, all green
  - unit: 1m36s job / 84.74s coverage
  - static: 54s
  - packages: 1m03s
  - types-build: 48s
  - e2e-http: 53s

Proof: https://github.com/openclaw/clawhub/actions/runs/33424207191
