### PR TITLE
fix(search): rank matching curated results first

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1085,7 +1085,7 @@
 
     "brace-expansion": ["brace-expansion@5.0.9", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg=="],
 
-    "browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
+    "browserslist": ["browserslist@4.28.8", "", { "dependencies": { "baseline-browser-mapping": "^2.11.12", "caniuse-lite": "^1.0.30001809", "electron-to-chromium": "^1.5.402", "node-releases": "^2.0.53", "update-browserslist-db": "^1.3.0" }, "bin": { "browserslist": "cli.js" } }, "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA=="],
 
     "caniuse-lite": ["caniuse-lite@1.0.30001793", "", {}, "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA=="],
 
@@ -1273,7 +1273,7 @@
 
     "dot-prop": ["dot-prop@10.1.0", "", { "dependencies": { "type-fest": "^5.0.0" } }, "sha512-MVUtAugQMOff5RnBy2d9N31iG0lNwg1qAoAOn7pOK5wf94WIaE3My2p3uwTQuvS2AcqchkcR3bHByjaM0mmi7Q=="],
 
-    "electron-to-chromium": ["electron-to-chromium@1.5.368", "", {}, "sha512-7RckJJK4uESJF9PxvfMWd3TGqIiieUTG4HxnKaKuIpGbcr+r2ZEB3g2gAhCP3Fqm42vJSzLfgab9eva/C4/XVw=="],
+    "electron-to-chromium": ["electron-to-chromium@1.5.416", "", {}, "sha512-K6bvB2BjnNrugtIih6ewlbBI9DXa976jIdiIlRLHhBoEI9a4JaQjjHyF+A1IQI543aQYR4LnmOrT/K5fZj0aPA=="],
 
     "engine.io": ["engine.io@6.6.8", "", { "dependencies": { "@types/cors": "^2.8.12", "@types/node": ">=10.0.0", "@types/ws": "^8.5.12", "accepts": "~1.3.4", "base64id": "2.0.0", "cookie": "~0.7.2", "cors": "~2.8.5", "debug": "~4.4.1", "engine.io-parser": "~5.2.1", "ws": "~8.20.1" } }, "sha512-2agL3ueZhqxoVrfmntO8yuVj+uNSlIOnhykYHk3Cq0ShYPdUjjUiSJrQvXjq01I9jAuI0Zl2YO8Evv5Mqytm5g=="],
 
@@ -1633,7 +1633,7 @@
 
     "nitro": ["nitro@3.0.260610-beta", "", { "dependencies": { "consola": "^3.4.2", "crossws": "^0.4.6", "db0": "^0.3.4", "env-runner": "^0.1.12", "h3": "2.0.1-rc.22", "hookable": "^6.1.1", "nf3": "^0.3.17", "ocache": "^0.1.5", "ofetch": "2.0.0-alpha.3", "ohash": "^2.0.11", "rolldown": "^1.1.0", "srvx": "^0.11.16", "unenv": "2.0.0-rc.24", "unstorage": "2.0.0-alpha.7" }, "peerDependencies": { "@vercel/queue": "^0.3.0", "dotenv": "*", "giget": "*", "jiti": "^2.7.0", "rollup": "^4.61.1", "vite": "^7 || ^8", "xml2js": "^0.6.2", "zephyr-agent": "^0.2.0" }, "optionalPeers": ["@vercel/queue", "dotenv", "giget", "jiti", "rollup", "vite", "xml2js", "zephyr-agent"], "bin": { "nitro": "dist/cli/index.mjs" } }, "sha512-KPb4L5yaF/Rx/xoGMpgHRJvZhbhGiqbRKOwwPLCH9jKTKTsEUHLjnJas85AeCzaswqa8Wi52eQBtRsODC4PS0Q=="],
 
-    "node-releases": ["node-releases@2.0.47", "", {}, "sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og=="],
+    "node-releases": ["node-releases@2.0.54", "", {}, "sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ=="],
 
     "normalize-path": ["normalize-path@3.0.0", "", {}, "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="],
 
@@ -1961,7 +1961,7 @@
 
     "unstorage": ["unstorage@2.0.0-alpha.7", "", { "peerDependencies": { "@azure/app-configuration": "^1.11.0", "@azure/cosmos": "^4.9.1", "@azure/data-tables": "^13.3.2", "@azure/identity": "^4.13.0", "@azure/keyvault-secrets": "^4.10.0", "@azure/storage-blob": "^12.31.0", "@capacitor/preferences": "^6 || ^7 || ^8", "@deno/kv": ">=0.13.0", "@netlify/blobs": "^6.5.0 || ^7.0.0 || ^8.1.0 || ^9.0.0 || ^10.0.0", "@planetscale/database": "^1.19.0", "@upstash/redis": "^1.36.2", "@vercel/blob": ">=0.27.3", "@vercel/functions": "^2.2.12 || ^3.0.0", "@vercel/kv": "^1.0.1", "aws4fetch": "^1.0.20", "chokidar": "^4 || ^5", "db0": ">=0.3.4", "idb-keyval": "^6.2.2", "ioredis": "^5.9.3", "lru-cache": "^11.2.6", "mongodb": "^6 || ^7", "ofetch": "*", "uploadthing": "^7.7.4" }, "optionalPeers": ["@azure/app-configuration", "@azure/cosmos", "@azure/data-tables", "@azure/identity", "@azure/keyvault-secrets", "@azure/storage-blob", "@capacitor/preferences", "@deno/kv", "@netlify/blobs", "@planetscale/database", "@upstash/redis", "@vercel/blob", "@vercel/functions", "@vercel/kv", "aws4fetch", "chokidar", "db0", "idb-keyval", "ioredis", "lru-cache", "mongodb", "ofetch", "uploadthing"] }, "sha512-ELPztchk2zgFJnakyodVY3vJWGW9jy//keJ32IOJVGUMyaPydwcA1FtVvWqT0TNRch9H+cMNEGllfVFfScImog=="],
 
-    "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
+    "update-browserslist-db": ["update-browserslist-db@1.3.2", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw=="],
 
     "use-callback-ref": ["use-callback-ref@1.3.3", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg=="],
 
@@ -2102,6 +2102,10 @@
     "babel-dead-code-elimination/@babel/parser": ["@babel/parser@7.29.7", "", { "dependencies": { "@babel/types": "^7.29.7" }, "bin": "./bin/babel-parser.js" }, "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg=="],
 
     "babel-dead-code-elimination/@babel/traverse": ["@babel/traverse@7.29.7", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/generator": "^7.29.7", "@babel/helper-globals": "^7.29.7", "@babel/parser": "^7.29.7", "@babel/template": "^7.29.7", "@babel/types": "^7.29.7", "debug": "^4.3.1" } }, "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw=="],
+
+    "browserslist/baseline-browser-mapping": ["baseline-browser-mapping@2.11.20", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-H0ulySigv6icDJ1F7SjtdCD6PrhTpdYCmP0CactWy1+ekh0AFd0o1Wn5T8b+hnTmdBx19u9yhL6wvCylXMY7zw=="],
+
+    "browserslist/caniuse-lite": ["caniuse-lite@1.0.30001810", "", {}, "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg=="],
 
     "conf/semver": ["semver@7.8.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-wnilbGyMxzbY7dNOl7jpKbLSjcfeweJWU5j4+u5qW+6/wuGD9KzIGOyZnQVSBM9E7DtWaaH3CyHkppYrKYoxwg=="],
 

--- a/convex/httpApiV1.handlers.test.ts
+++ b/convex/httpApiV1.handlers.test.ts
@@ -12391,23 +12391,41 @@ describe("httpApiV1 handlers", () => {
     }
   });
 
-  it("plugins search sorts by rank tier before score without exposing rank metadata", async () => {
+  it("plugins search keeps matching official and featured results first across families", async () => {
     const runQuery = vi.fn((_, args: Record<string, unknown>) => {
       if (args.family === "code-plugin") {
         return [
           {
+            score: 10,
+            rankTier: 1,
+            package: makeCatalogItem("name-plugin", { family: "code-plugin", updatedAt: 100 }),
+          },
+          {
             score: 20,
             rankTier: 3,
-            package: makeCatalogItem("summary-plugin", { family: "code-plugin", updatedAt: 100 }),
+            package: {
+              ...makeCatalogItem("featured-summary-plugin", {
+                family: "code-plugin",
+                updatedAt: 75,
+              }),
+              featuredAt: 75,
+            },
           },
         ];
       }
       if (args.family === "bundle-plugin") {
         return [
           {
-            score: 10,
-            rankTier: 1,
-            package: makeCatalogItem("name-plugin", { family: "bundle-plugin", updatedAt: 50 }),
+            score: 15,
+            rankTier: 2,
+            package: {
+              ...makeCatalogItem("official-topic-plugin", {
+                family: "bundle-plugin",
+                updatedAt: 50,
+              }),
+              channel: "official",
+              isOfficial: true,
+            },
           },
         ];
       }
@@ -12417,14 +12435,15 @@ describe("httpApiV1 handlers", () => {
 
     const response = await __handlers.pluginsGetRouterV1Handler(
       makeCtx({ runQuery, runMutation }),
-      new Request("https://example.com/api/v1/plugins/search?q=plugin&limit=2"),
+      new Request("https://example.com/api/v1/plugins/search?q=plugin&limit=3"),
     );
 
     expect(response.status).toBe(200);
     const body = await response.json();
     expect(body.results.map((entry: { package: { name: string } }) => entry.package.name)).toEqual([
+      "official-topic-plugin",
+      "featured-summary-plugin",
       "name-plugin",
-      "summary-plugin",
     ]);
     expect(body.results[0]).not.toHaveProperty("rankTier");
     expect(body.results[0]).not.toHaveProperty("matchReason");

--- a/convex/httpApiV1/packagesV1.ts
+++ b/convex/httpApiV1/packagesV1.ts
@@ -64,6 +64,7 @@ import {
   MAX_PUBLISH_TOTAL_BYTES,
 } from "../lib/publishLimits";
 import { compareRecommendationStats } from "../lib/recommendationScore";
+import { isCuratedSearchResult } from "../lib/searchRanking";
 import {
   getPublicSkillVersionAccessBlock,
   getPublicSkillVersionDownloadBlock,
@@ -873,6 +874,7 @@ type CatalogListItem = {
   createdAt: number;
   updatedAt: number;
   latestVersion?: string | null;
+  featuredAt?: number;
   verificationTier?: string | null;
   stats?: { downloads: number; installs: number; stars: number; versions: number };
 };
@@ -1178,6 +1180,18 @@ function compareCatalogItemsForSort(
 
 function compareCatalogSearchEntries(a: CatalogSearchEntry, b: CatalogSearchEntry) {
   return (
+    Number(
+      isCuratedSearchResult({
+        isOfficial: b.package.isOfficial,
+        featured: typeof b.package.featuredAt === "number",
+      }),
+    ) -
+      Number(
+        isCuratedSearchResult({
+          isOfficial: a.package.isOfficial,
+          featured: typeof a.package.featuredAt === "number",
+        }),
+      ) ||
     (a.rankTier ?? Number.POSITIVE_INFINITY) - (b.rankTier ?? Number.POSITIVE_INFINITY) ||
     b.score - a.score ||
     Number(b.package.isOfficial) - Number(a.package.isOfficial) ||

--- a/convex/lib/canonicalSkillSearch.test.ts
+++ b/convex/lib/canonicalSkillSearch.test.ts
@@ -88,24 +88,24 @@ describe("canonical mixed skill search ranking", () => {
     expect(summary).toMatchObject({ tier: 4 });
   });
 
-  it("uses official and featured only after lexical relevance is tied", () => {
-    const betterLexical = candidate("clawhub:better", {
+  it("orders matching official and featured skills before community matches", () => {
+    const community = candidate("clawhub:community", {
       relevance: { tier: 1, lexicalScore: 96, semanticScore: 0 },
     });
     const official = candidate("clawhub:official", {
-      relevance: { tier: 1, lexicalScore: 95, semanticScore: 0 },
+      relevance: { tier: 3, lexicalScore: 60, semanticScore: 0 },
       official: true,
-      featured: true,
     });
-    const tiedCommunity = candidate("clawhub:community", {
-      relevance: { tier: 1, lexicalScore: 95, semanticScore: 0 },
+    const featured = candidate("clawhub:featured", {
+      relevance: { tier: 4, lexicalScore: 40, semanticScore: 0 },
+      featured: true,
     });
 
     expect(
-      [official, betterLexical, tiedCommunity]
+      [featured, community, official]
         .sort(compareCanonicalSkillSearchCandidates)
         .map((row) => row.id),
-    ).toEqual(["clawhub:better", "clawhub:official", "clawhub:community"]);
+    ).toEqual(["clawhub:official", "clawhub:featured", "clawhub:community"]);
   });
 
   it("uses rolling adoption, bookmarks, and freshness for comparable matches", () => {

--- a/convex/lib/canonicalSkillSearch.ts
+++ b/convex/lib/canonicalSkillSearch.ts
@@ -1,3 +1,4 @@
+import { isCuratedSearchResult } from "./searchRanking";
 import { tokenize } from "./searchText";
 
 export type CanonicalSkillSearchDocument = {
@@ -100,6 +101,8 @@ export function compareCanonicalSkillSearchCandidates(
   right: CanonicalSkillSearchCandidate,
 ) {
   return (
+    Number(isCuratedSearchResult({ isOfficial: right.official, featured: right.featured })) -
+      Number(isCuratedSearchResult({ isOfficial: left.official, featured: left.featured })) ||
     left.relevance.tier - right.relevance.tier ||
     right.relevance.lexicalScore - left.relevance.lexicalScore ||
     right.relevance.semanticScore - left.relevance.semanticScore ||

--- a/convex/lib/searchRanking.test.ts
+++ b/convex/lib/searchRanking.test.ts
@@ -31,6 +31,7 @@ describe("verificationRank", () => {
 describe("hasStrongTrustSignal", () => {
   it("accepts official packages and strong verification", () => {
     expect(hasStrongTrustSignal(community({ isOfficial: true }))).toBe(true);
+    expect(hasStrongTrustSignal(community({ featured: true }))).toBe(true);
     expect(hasStrongTrustSignal(community({ verificationTier: "provenance-verified" }))).toBe(true);
     expect(hasStrongTrustSignal(community({ verificationTier: "rebuild-verified" }))).toBe(true);
   });
@@ -130,6 +131,20 @@ describe("compareRankedSearchKeys", () => {
         { name: "official", key: official },
       ]),
     ).toEqual(["official", "adopted"]);
+  });
+
+  it("ranks curated matches ahead of stronger community matches", () => {
+    const featured = rankedSearchKey({ rankTier: 2, score: 20 }, community({ featured: true }));
+    const communityExact = rankedSearchKey(
+      { rankTier: 0, score: 200 },
+      community({ installs: 90_000 }),
+    );
+    expect(
+      sortKeys([
+        { name: "community-exact", key: communityExact },
+        { name: "featured", key: featured },
+      ]),
+    ).toEqual(["featured", "community-exact"]);
   });
 
   it("prefers adoption magnitude before text score within a tier", () => {

--- a/convex/lib/searchRanking.ts
+++ b/convex/lib/searchRanking.ts
@@ -12,6 +12,7 @@ type SearchTextMatch = {
 
 export type SearchTrustSignals = {
   isOfficial: boolean;
+  featured?: boolean;
   verificationTier?:
     | "structural"
     | "source-linked"
@@ -21,6 +22,12 @@ export type SearchTrustSignals = {
   downloads?: number | null;
   installs?: number | null;
 };
+
+export function isCuratedSearchResult(
+  signals: Pick<SearchTrustSignals, "isOfficial" | "featured">,
+): boolean {
+  return signals.isOfficial || Boolean(signals.featured);
+}
 
 export function verificationRank(tier: SearchTrustSignals["verificationTier"]): number {
   if (tier === "rebuild-verified") return 4;
@@ -35,7 +42,7 @@ export function verificationRank(tier: SearchTrustSignals["verificationTier"]): 
 // source chain. source-linked and structural are self-serve, so they must not
 // open the exact-match squat gate.
 export function hasStrongTrustSignal(signals: SearchTrustSignals): boolean {
-  return signals.isOfficial || verificationRank(signals.verificationTier) >= 3;
+  return isCuratedSearchResult(signals) || verificationRank(signals.verificationTier) >= 3;
 }
 
 const ADOPTION_BUCKET_MAX = 6;
@@ -50,6 +57,7 @@ export function adoptionBucket(signals: SearchTrustSignals): number {
 }
 
 type RankedSearchKey = {
+  curated: boolean;
   tier: number;
   adoption: number;
   score: number;
@@ -66,6 +74,7 @@ export function rankedSearchKey(
   const adoption = adoptionBucket(signals);
   const demoteExact = match.rankTier === 0 && adoption === 0 && !hasStrongTrustSignal(signals);
   return {
+    curated: isCuratedSearchResult(signals),
     tier: demoteExact ? 1 : match.rankTier,
     adoption,
     score: match.score,
@@ -74,7 +83,12 @@ export function rankedSearchKey(
 
 /** Ascending sort: better entries first. Callers append surface tie-breakers. */
 export function compareRankedSearchKeys(a: RankedSearchKey, b: RankedSearchKey): number {
-  return a.tier - b.tier || b.adoption - a.adoption || b.score - a.score;
+  return (
+    Number(b.curated) - Number(a.curated) ||
+    a.tier - b.tier ||
+    b.adoption - a.adoption ||
+    b.score - a.score
+  );
 }
 
 // Collection guard: a demoted exact match must not satisfy "enough results"

--- a/convex/packages.public.test.ts
+++ b/convex/packages.public.test.ts
@@ -1360,6 +1360,7 @@ function makeDigestCtx(options: {
   }>;
   exactPackages?: Array<Record<string, unknown>>;
   exactDigests?: Array<Record<string, unknown>>;
+  officialDigests?: Array<Record<string, unknown>>;
   publisherDocs?: Record<string, Record<string, unknown>>;
   publisherMemberships?: Record<string, "owner" | "admin" | "publisher">;
   highlightedBadges?: Array<Record<string, unknown>>;
@@ -1758,6 +1759,28 @@ function makeDigestCtx(options: {
                   );
                   return {
                     take: vi.fn().mockResolvedValue(matches),
+                  };
+                }
+                if (options.officialDigests !== undefined && indexName.includes("_official_")) {
+                  let family = "";
+                  const queryBuilder = {
+                    eq: (field: string, value: string | undefined) => {
+                      if (field === "family") family = value ?? "";
+                      return queryBuilder;
+                    },
+                    gte: () => queryBuilder,
+                    lt: () => queryBuilder,
+                  };
+                  builder?.(queryBuilder);
+                  const matches = (options.officialDigests ?? []).filter(
+                    (digest) => !family || digest.family === family,
+                  );
+                  return {
+                    take: vi.fn(async (limit: number) => matches.slice(0, limit)),
+                    order: vi.fn(() => ({
+                      paginate: getPaginate(table),
+                      take: vi.fn(async (limit: number) => matches.slice(0, limit)),
+                    })),
                   };
                 }
                 if (indexName.includes("_family_")) {
@@ -5133,8 +5156,14 @@ describe("packages public queries", () => {
     expect(result.map((entry) => entry.package.name)).toEqual(["react-exact"]);
   });
 
-  it("does not let official status make unrelated packages eligible for search", async () => {
+  it("does not let official or featured status make unrelated packages eligible for search", async () => {
+    const featured = makeDigest("featured-nostr", {
+      displayName: "Featured Nostr",
+      summary: "Protocol integration.",
+    });
     const { ctx } = makeDigestCtx({
+      highlightedBadges: [{ packageId: featured.packageId, at: 100 }],
+      exactDigests: [featured],
       pages: [
         {
           page: [
@@ -5143,6 +5172,7 @@ describe("packages public queries", () => {
               isOfficial: true,
               summary: "Protocol integration.",
             }),
+            featured,
           ],
           isDone: true,
           continueCursor: "",
@@ -5229,24 +5259,22 @@ describe("packages public queries", () => {
     expect(result).toEqual([]);
   });
 
-  it("orders lexical matches before summary-only matches without exposing rank metadata", async () => {
+  it("orders matching official packages before stronger community matches", async () => {
+    const community = makeDigest("email", {
+      displayName: "Email",
+      summary: "Mailbox tools.",
+    });
+    const agentMail = makeDigest("agentmail", {
+      displayName: "AgentMail",
+      isOfficial: true,
+      summary: "Official email plugin and email channel for OpenClaw.",
+      topics: ["email", "inbox"],
+    });
     const { ctx } = makeDigestCtx({
+      officialDigests: [agentMail],
       pages: [
         {
-          page: [
-            makeDigest("official-helper", {
-              displayName: "Official Helper",
-              isOfficial: true,
-              summary: "Ghost CMS integration.",
-              updatedAt: 100,
-            }),
-            makeDigest("ghost-tools", {
-              displayName: "Ghost Tools",
-              isOfficial: false,
-              summary: "CMS helper.",
-              updatedAt: 1,
-            }),
-          ],
+          page: [community],
           isDone: true,
           continueCursor: "",
         },
@@ -5254,13 +5282,42 @@ describe("packages public queries", () => {
     });
 
     const result = await searchPublicHandler(ctx, {
-      query: "ghost",
+      query: "email",
+      limit: 2,
+    });
+
+    expect(result.map((entry) => entry.package.name)).toEqual(["agentmail", "email"]);
+    expect(result[0]).not.toHaveProperty("rankTier");
+    expect(result[0]).not.toHaveProperty("matchReason");
+  });
+
+  it("orders matching featured packages before stronger community matches", async () => {
+    const community = makeDigest("email", {
+      displayName: "Email",
+      summary: "Mailbox tools.",
+    });
+    const featured = makeDigest("agentmail", {
+      displayName: "AgentMail",
+      summary: "Email inboxes for agents.",
+    });
+    const { ctx } = makeDigestCtx({
+      highlightedBadges: [{ packageId: featured.packageId, at: 100 }],
+      exactDigests: [community, featured],
+      pages: [
+        {
+          page: [community, featured],
+          isDone: true,
+          continueCursor: "",
+        },
+      ],
+    });
+
+    const result = await searchPublicHandler(ctx, {
+      query: "email",
       limit: 10,
     });
 
-    expect(result.map((entry) => entry.package.name)).toEqual(["ghost-tools", "official-helper"]);
-    expect(result[0]).not.toHaveProperty("rankTier");
-    expect(result[0]).not.toHaveProperty("matchReason");
+    expect(result.map((entry) => entry.package.name)).toEqual(["agentmail", "email"]);
   });
 
   it("allows org collaborators to search their private packages", async () => {
@@ -5348,7 +5405,12 @@ describe("packages public queries", () => {
       ]),
     );
     expect(new Set(indexNames)).toEqual(
-      new Set(["by_active_topic_updated", "by_active_category_updated", "by_active_updated"]),
+      new Set([
+        "by_active_topic_updated",
+        "by_active_category_updated",
+        "by_active_official_updated",
+        "by_active_updated",
+      ]),
     );
   });
 
@@ -6127,8 +6189,14 @@ describe("packages public queries", () => {
     });
 
     expect(result.map((entry) => entry.package.name)).toEqual(["api-demo"]);
-    expect(tableNames).toEqual(["packagePluginCategorySearchDigest"]);
-    expect(indexNames).toEqual(["by_active_category_updated"]);
+    expect(tableNames).toEqual([
+      "packagePluginCategorySearchDigest",
+      "packagePluginCategorySearchDigest",
+    ]);
+    expect(indexNames).toEqual([
+      "by_active_official_category_updated",
+      "by_active_category_updated",
+    ]);
   });
 
   it("uses topic digests for topic-filtered search", async () => {
@@ -6398,8 +6466,9 @@ describe("packages public queries", () => {
 
     expect(result).toEqual([]);
     expect(paginate).toHaveBeenCalledTimes(6);
-    expect(take).toHaveBeenCalledTimes(1);
+    expect(take).toHaveBeenCalledTimes(2);
     expect(take).toHaveBeenCalledWith(20);
+    expect(take).toHaveBeenCalledWith(200);
   });
 
   it("recalls exact author topics without an explicit topic filter", async () => {
@@ -6479,7 +6548,7 @@ describe("packages public queries", () => {
 
     expect(result).toEqual([]);
     expect(paginate).not.toHaveBeenCalled();
-    expect(take).toHaveBeenCalledTimes(3);
+    expect(take).toHaveBeenCalledTimes(4);
     expect(take).toHaveBeenCalledWith(20);
     expect(take).toHaveBeenCalledWith(50);
   });
@@ -6505,7 +6574,7 @@ describe("packages public queries", () => {
     });
 
     expect(result.map((entry) => entry.package.name)).toEqual(["demo-plugin"]);
-    expect(take).toHaveBeenCalledTimes(3);
+    expect(take).toHaveBeenCalledTimes(4);
     expect(ctx.db.query).toHaveBeenCalledWith("packageSearchDigest");
   });
 
@@ -6532,7 +6601,7 @@ describe("packages public queries", () => {
     });
 
     expect(result.map((entry) => entry.package.name)).toEqual(["runtime-demo"]);
-    expect(take).toHaveBeenCalledTimes(3);
+    expect(take).toHaveBeenCalledTimes(4);
     expect(ctx.db.query).toHaveBeenCalledWith("packageSearchDigest");
   });
 
@@ -6596,7 +6665,7 @@ describe("packages public queries", () => {
     });
 
     expect(result.map((entry) => entry.package.name)).toEqual(["demo-prefix"]);
-    expect(take).toHaveBeenCalledTimes(3);
+    expect(take).toHaveBeenCalledTimes(4);
     expect(ctx.db.query).toHaveBeenCalledWith("packageSearchDigest");
   });
 
@@ -6651,7 +6720,7 @@ describe("packages public queries", () => {
     });
 
     expect(result.map((entry) => entry.package.name)).toEqual(["alpha", "beta"]);
-    expect(take).toHaveBeenCalledTimes(3);
+    expect(take).toHaveBeenCalledTimes(4);
     expect(take).toHaveBeenCalledWith(20);
     expect(take).toHaveBeenCalledWith(50);
   });
@@ -6749,7 +6818,7 @@ describe("packages public queries", () => {
 
     expect(result).toEqual([]);
     expect(paginate).not.toHaveBeenCalled();
-    expect(take).toHaveBeenCalledTimes(3);
+    expect(take).toHaveBeenCalledTimes(4);
     expect(take).toHaveBeenCalledWith(20);
     expect(take).toHaveBeenCalledWith(200);
   });

--- a/convex/packages.ts
+++ b/convex/packages.ts
@@ -1900,11 +1900,13 @@ function packageSearchMatch(
 
 function packageTrustSignals(pkg: {
   isOfficial: boolean;
+  featuredAt?: number;
   verificationTier?: PackageDigestLike["verificationTier"] | null;
   stats?: { downloads: number; installs: number; stars: number } | null;
 }): SearchTrustSignals {
   return {
     isOfficial: pkg.isOfficial,
+    featured: typeof pkg.featuredAt === "number",
     verificationTier: pkg.verificationTier,
     downloads: pkg.stats?.downloads,
     installs: pkg.stats?.installs,
@@ -1915,6 +1917,7 @@ function comparePackageSearchMatches<
   T extends PackageSearchMatch & {
     package: {
       isOfficial: boolean;
+      featuredAt?: number;
       updatedAt: number;
       verificationTier?: PackageDigestLike["verificationTier"] | null;
       stats?: { downloads: number; installs: number; stars: number } | null;
@@ -4930,39 +4933,61 @@ async function searchPackagesImpl(
     !args.family && !experimentalClawsEnabled()
       ? ([...STABLE_PACKAGE_FAMILIES] as PackageFamily[])
       : [args.family];
-  const buildSearchDigestQuery = (family: PackageFamily | undefined) =>
+  const buildSearchDigestQuery = (
+    family: PackageFamily | undefined,
+    isOfficial = args.isOfficial,
+  ) =>
     topic
       ? buildPackageTopicDigestQuery(ctx, {
           topic,
           family,
           channel: args.channel,
-          isOfficial: args.isOfficial,
+          isOfficial,
         })
       : category
         ? buildPackagePluginCategoryDigestQuery(ctx, {
             category,
             family,
             channel: args.channel,
-            isOfficial: args.isOfficial,
+            isOfficial,
           })
         : buildPackageDigestQuery(ctx, {
             family,
             channel: args.channel,
-            isOfficial: args.isOfficial,
+            isOfficial,
           });
   const matches: Array<PackageSearchMatch & { package: PublicPackageListItem }> = [];
   const seen = new Set<string>();
-  const directDigests =
+  const shouldRecallOfficial =
+    args.isOfficial === undefined && args.channel !== "community" && args.channel !== "private";
+  const [highlightedEntries, officialDigestGroups, directDigests] = await Promise.all([
+    fetchHighlightedPackageEntries(ctx, { ...args, category, topic }),
+    shouldRecallOfficial
+      ? Promise.all(
+          searchFamilies.map(async (family) =>
+            buildSearchDigestQuery(family, true).order("desc").take(MAX_PUBLIC_LIST_PAGE_SIZE),
+          ),
+        )
+      : Promise.resolve([]),
     category && !topic
-      ? []
-      : (
-          await Promise.all(
-            searchFamilies.map(
-              async (family) => await resolveDirectPackageSearchDigests(ctx, queryText, family),
-            ),
-          )
-        ).flat();
-  for (const digest of directDigests) {
+      ? Promise.resolve([])
+      : Promise.all(
+          searchFamilies.map(
+            async (family) => await resolveDirectPackageSearchDigests(ctx, queryText, family),
+          ),
+        ).then((results) => results.flat()),
+  ]);
+  const featuredAtByPackage = new Map(
+    highlightedEntries.map(({ digest, featuredAt }) => [String(digest.packageId), featuredAt]),
+  );
+  // Curated recall is still subject to the same filters and text matcher below.
+  // It only ensures Official and Featured matches are present before the result limit is applied.
+  const candidateDigests = [
+    ...highlightedEntries.map(({ digest }) => digest),
+    ...officialDigestGroups.flat().filter((digest) => digest.isOfficial),
+    ...directDigests,
+  ];
+  for (const digest of candidateDigests) {
     if (!(await canViewPackage(digest))) continue;
     if (!digestMatchesSearchFilters(digest, { ...args, topic })) continue;
     const match = packageSearchMatch(digest, queryText);
@@ -4970,7 +4995,11 @@ async function searchPackagesImpl(
     seen.add(digest.packageId);
     matches.push({
       ...match,
-      package: await toPublicPackageListItem(ctx, digest),
+      package: await toPublicPackageListItem(
+        ctx,
+        digest,
+        featuredAtByPackage.get(String(digest.packageId)),
+      ),
     });
   }
 
@@ -4992,7 +5021,11 @@ async function searchPackagesImpl(
         seen.add(digest.packageId);
         matches.push({
           ...match,
-          package: await toPublicPackageListItem(ctx, digest),
+          package: await toPublicPackageListItem(
+            ctx,
+            digest,
+            featuredAtByPackage.get(String(digest.packageId)),
+          ),
         });
       }
     };

--- a/convex/search.test.ts
+++ b/convex/search.test.ts
@@ -327,6 +327,34 @@ describe("search helpers", () => {
     );
   });
 
+  it("recalls matching curated skills before the display limit is applied", async () => {
+    const community = makeSkillDoc({
+      id: "skills:email",
+      slug: "email",
+      displayName: "Email",
+      summary: "Mailbox tools.",
+    });
+    const official = makeSkillDoc({
+      id: "skills:agentmail",
+      slug: "agentmail",
+      displayName: "AgentMail",
+      summary: "Official email inboxes for agents.",
+      official: true,
+    });
+    const unrelatedOfficial = makeSkillDoc({
+      id: "skills:nostr",
+      slug: "nostr",
+      displayName: "Nostr",
+      summary: "Protocol integration.",
+      official: true,
+    });
+    const ctx = makeDirectPrefixCtx([community, official, unrelatedOfficial]);
+
+    const result = await directPrefixSkillMatchesHandler(ctx, { query: "email" });
+
+    expect(result.map((entry) => entry.skill.slug)).toEqual(["agentmail", "email"]);
+  });
+
   it("exact mode bypasses vector and fallback recall", async () => {
     const exactEntry = {
       skill: makePublicSkill({
@@ -3159,11 +3187,13 @@ function makePublicSkill(params: {
   categories?: string[];
   topics?: string[];
   official?: boolean;
+  featured?: boolean;
   createdAt?: number;
   githubScanStatus?: "pending" | "clean" | "suspicious" | "malicious" | "not-run";
 }) {
   const badges: Record<string, { byUserId: string; at: number }> = {};
   if (params.official) badges.official = { byUserId: "users:curator", at: 1 };
+  if (params.featured) badges.highlighted = { byUserId: "users:curator", at: 1 };
   return {
     _id: params.id,
     _creationTime: 1,
@@ -3207,6 +3237,8 @@ function makeSkillDoc(params: {
   stars?: number;
   categories?: string[];
   topics?: string[];
+  official?: boolean;
+  featured?: boolean;
   inferredCategories?: string[];
   inferredFromVersionId?: string;
   latestVersionId?: string;
@@ -3448,6 +3480,18 @@ function makeDirectPrefixCtx(skills: Array<ReturnType<typeof makeSkillDoc>>) {
     },
     db: {
       query: vi.fn((table: string) => {
+        if (table === "curatedSkillSearchDigest") {
+          const curated = digestRows.filter(
+            (digest) => digest.badges.official || digest.badges.highlighted,
+          );
+          return {
+            withIndex: () => ({
+              order: () => ({
+                take: vi.fn(async (limit: number) => curated.slice(0, limit)),
+              }),
+            }),
+          };
+        }
         if (table === "skillTopicSearchDigest") {
           return {
             withIndex: (

--- a/convex/search.ts
+++ b/convex/search.ts
@@ -32,6 +32,7 @@ import {
   getOwnerPublisher,
   getPublisherByHandle,
 } from "./lib/publishers";
+import { isCuratedSearchResult } from "./lib/searchRanking";
 import {
   matchesAllTokens,
   matchesExactTokens,
@@ -107,6 +108,13 @@ type PublicSearchResult = SkillSearchEntry & {
   score: number;
   semanticScore: number;
 };
+
+function isCuratedSkillSearchEntry(entry: SkillSearchEntry): boolean {
+  return isCuratedSearchResult({
+    isOfficial: Boolean(entry.owner?.official || entry.skill.badges?.official),
+    featured: isSkillHighlighted(entry.skill),
+  });
+}
 
 const EXACT_SLUG_BOOST = 2.5;
 const SLUG_TOKEN_BOOST = 1.4;
@@ -576,6 +584,7 @@ const nativeSkillSearch = {
       .filter((entry): entry is SearchResult => Boolean(entry?.skill))
       .sort(
         (a, b) =>
+          Number(isCuratedSkillSearchEntry(b)) - Number(isCuratedSkillSearchEntry(a)) ||
           a.candidateRelevance.tier - b.candidateRelevance.tier ||
           b.candidateRelevance.lexicalScore - a.candidateRelevance.lexicalScore ||
           b.candidateRelevance.semanticScore - a.candidateRelevance.semanticScore ||
@@ -1244,6 +1253,50 @@ export const directPrefixSkillMatches = internalQuery({
         matchesCatalogFilters(skill, categorySlug, topic)
       );
     };
+    const matchesCuratedRecallFilters = (digest: Doc<"skillSearchDigest">) => {
+      const skill = digestToHydratableSkill(digest);
+      const relevance = classifyCanonicalSkillSearchMatch(args.query, {
+        identities: [digest.slug],
+        name: digest.displayName,
+        slug: digest.slug,
+        taxonomy: [...(digest.categories ?? []), ...(digest.topics ?? [])],
+        summary: digest.summary ?? null,
+      });
+      return (
+        relevance !== null &&
+        !shouldExcludeSkillFromPublicBrowse(skill) &&
+        (!args.highlightedOnly || isSkillHighlighted(skill)) &&
+        matchesNativeSearchEligibility(skill, args) &&
+        matchesCatalogFilters(skill, categorySlug, topic)
+      );
+    };
+    const loadCuratedDigests = async () => {
+      const rows = await (
+        args.nonSuspiciousOnly
+          ? ctx.db
+              .query("curatedSkillSearchDigest")
+              .withIndex("by_nonsuspicious_updated", (q) =>
+                q.eq("softDeletedAt", undefined).eq("isSuspicious", false),
+              )
+          : ctx.db
+              .query("curatedSkillSearchDigest")
+              .withIndex("by_active_updated", (q) => q.eq("softDeletedAt", undefined))
+      )
+        .order("desc")
+        .take(MAX_FILTERED_DIRECT_SKILL_SCAN_CANDIDATES);
+      const digests = await Promise.all(
+        rows.map((row) =>
+          ctx.db
+            .query("skillSearchDigest")
+            .withIndex("by_skill", (q) => q.eq("skillId", row.skillId))
+            .unique(),
+        ),
+      );
+      return digests.filter(
+        (digest): digest is Doc<"skillSearchDigest"> =>
+          digest !== null && matchesCuratedRecallFilters(digest),
+      );
+    };
     const needsExpandedRecall = Boolean(
       categorySlug ||
       topic ||
@@ -1313,6 +1366,7 @@ export const directPrefixSkillMatches = internalQuery({
         matches: matchesDirectRecallFilters,
       });
     const [
+      curatedDigests,
       slugDigests,
       displayNameDigests,
       slugFirstTokenDigests,
@@ -1321,6 +1375,7 @@ export const directPrefixSkillMatches = internalQuery({
       ftSlugDigests,
       exactTopicDigestPages,
     ] = await Promise.all([
+      loadCuratedDigests(),
       collectDirectCandidates(
         () =>
           args.nonSuspiciousOnly
@@ -1478,6 +1533,7 @@ export const directPrefixSkillMatches = internalQuery({
           all.findIndex((candidate) => candidate.skillId === digest.skillId) === index,
       );
     const digests = [
+      ...curatedDigests,
       ...slugDigests,
       ...displayNameDigests,
       ...slugFirstTokenDigests,

--- a/convex/skills.packageCatalog.test.ts
+++ b/convex/skills.packageCatalog.test.ts
@@ -111,6 +111,7 @@ function makeCtx(
         firstByIndex?: Record<string, unknown>;
         indexNames?: string[];
         missingRecommendedScores?: boolean;
+        curatedDigests?: Array<Record<string, unknown>>;
       }
     | string[] = {},
 ) {
@@ -124,7 +125,7 @@ function makeCtx(
     string | null,
     { page: Array<Record<string, unknown>>; isDone: boolean; continueCursor: string }
   >();
-  const allDigests = pages.flatMap((page) => page.page);
+  const allDigests = [...pages.flatMap((page) => page.page), ...(options.curatedDigests ?? [])];
   let cursor: string | null = null;
   for (const page of pages) {
     pageByCursor.set(cursor, page);
@@ -180,7 +181,10 @@ function makeCtx(
               order: () => ({
                 paginate: async ({ cursor: pageCursor }: { cursor: string | null }) =>
                   pageByCursor.get(pageCursor) ?? { page: [], isDone: true, continueCursor: "" },
-                take: async () => [],
+                take: async (limit: number) =>
+                  table === "curatedSkillSearchDigest"
+                    ? (options.curatedDigests ?? []).slice(0, limit)
+                    : [],
               }),
               first: async () =>
                 options.firstByIndex?.[indexName] ??
@@ -1023,7 +1027,7 @@ describe("skills package catalog queries", () => {
 
     expect(result.map((entry) => entry.package.name)).toEqual(["calendar-demo"]);
     expect(indexNames).toContain("by_active_topic_updated");
-    expect(indexNames).not.toContain("by_active_updated");
+    expect(indexNames).toContain("by_active_updated");
   });
 
   it("uses author topics as skill package search evidence", async () => {
@@ -1078,7 +1082,7 @@ describe("skills package catalog queries", () => {
     expect(result).toEqual([]);
   });
 
-  it("does not let official status make unrelated skills eligible for package search", async () => {
+  it("does not let official or featured status make unrelated skills eligible for package search", async () => {
     const result = await searchPackageCatalogPublicHandler(
       makeCtx([
         {
@@ -1086,6 +1090,11 @@ describe("skills package catalog queries", () => {
             makeDigest("official-skill", {
               badges: { official: { byUserId: "users:admin", at: 1 } },
               displayName: "Official Skill",
+              summary: "General integration.",
+            }),
+            makeDigest("featured-skill", {
+              badges: { highlighted: { byUserId: "users:admin", at: 1 } },
+              displayName: "Featured Skill",
               summary: "General integration.",
             }),
           ],
@@ -1102,34 +1111,47 @@ describe("skills package catalog queries", () => {
     expect(result).toEqual([]);
   });
 
-  it("returns skill package match metadata and orders name matches before summary matches", async () => {
+  it("returns skill package match metadata and orders matching curated skills first", async () => {
+    const official = makeDigest("official-helper", {
+      badges: { official: { byUserId: "users:admin", at: 1 } },
+      displayName: "Official Helper",
+      summary: "Ghost CMS integration.",
+      updatedAt: 100,
+    });
+    const featured = makeDigest("featured-helper", {
+      badges: { highlighted: { byUserId: "users:admin", at: 1 } },
+      displayName: "Featured Helper",
+      summary: "Ghost CMS integration.",
+      updatedAt: 50,
+    });
     const result = await searchPackageCatalogPublicHandler(
-      makeCtx([
-        {
-          page: [
-            makeDigest("official-helper", {
-              badges: { official: { byUserId: "users:admin", at: 1 } },
-              displayName: "Official Helper",
-              summary: "Ghost CMS integration.",
-              updatedAt: 100,
-            }),
-            makeDigest("ghost-tools", {
-              displayName: "Ghost Tools",
-              summary: "CMS helper.",
-              updatedAt: 1,
-            }),
-          ],
-          isDone: true,
-          continueCursor: "",
-        },
-      ]),
+      makeCtx(
+        [
+          {
+            page: [
+              makeDigest("ghost-tools", {
+                displayName: "Ghost Tools",
+                summary: "CMS helper.",
+                updatedAt: 1,
+              }),
+            ],
+            isDone: true,
+            continueCursor: "",
+          },
+        ],
+        { curatedDigests: [official, featured] },
+      ),
       {
         query: "ghost",
         limit: 5,
       },
     );
 
-    expect(result.map((entry) => entry.package.name)).toEqual(["ghost-tools", "official-helper"]);
+    expect(result.map((entry) => entry.package.name)).toEqual([
+      "official-helper",
+      "featured-helper",
+      "ghost-tools",
+    ]);
     expect(result[0]).not.toHaveProperty("rankTier");
     expect(result[0]).not.toHaveProperty("matchReason");
   });

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -6341,6 +6341,7 @@ type PublicSkillCatalogItem = {
   createdAt: number;
   updatedAt: number;
   latestVersion: string | null;
+  featuredAt?: number;
   verificationTier: null;
   stats: { downloads: number; installs: number; stars: number; versions: number };
 };
@@ -6470,6 +6471,9 @@ async function toPublicSkillCatalogItem(
     createdAt: digest.createdAt,
     updatedAt: digest.updatedAt,
     latestVersion: latestVersion?.version ?? null,
+    ...(digest.badges?.highlighted?.at === undefined
+      ? {}
+      : { featuredAt: digest.badges.highlighted.at }),
     verificationTier: null,
     stats: {
       // CLAW-561 changes presentation only. Download indexes and ranking remain
@@ -6663,13 +6667,14 @@ function skillCatalogSearchMatch(
   return { rankTier, score };
 }
 
-// Skills have no verification tiers, so official flag + adoption are the
+// Skills have no verification tiers, so curated status + adoption are the
 // only trust signals feeding the shared squat gate.
 function skillTrustSignals(
-  pkg: Pick<PublicSkillCatalogItem, "isOfficial" | "stats">,
+  pkg: Pick<PublicSkillCatalogItem, "isOfficial" | "featuredAt" | "stats">,
 ): SearchTrustSignals {
   return {
     isOfficial: pkg.isOfficial,
+    featured: typeof pkg.featuredAt === "number",
     downloads: pkg.stats.downloads,
     installs: pkg.stats.installs,
   };
@@ -6677,7 +6682,7 @@ function skillTrustSignals(
 
 function compareSkillCatalogSearchMatches<
   T extends SkillCatalogSearchMatch & {
-    package: Pick<PublicSkillCatalogItem, "isOfficial" | "updatedAt" | "stats">;
+    package: Pick<PublicSkillCatalogItem, "isOfficial" | "featuredAt" | "updatedAt" | "stats">;
   },
 >(a: T, b: T) {
   return (
@@ -6852,6 +6857,30 @@ async function searchPackageCatalogImpl(ctx: QueryCtx, args: SkillPackageCatalog
   const targetCount = Math.max(1, Math.min(args.limit ?? 20, 100));
   const matches: Array<SkillCatalogSearchMatch & { package: PublicSkillCatalogItem }> = [];
   const seen = new Set<string>();
+
+  // Curated rows have their own bounded projection, so recall them before the
+  // result quota can be filled by recent community matches. Eligibility still
+  // comes exclusively from the normal filters and text matcher below.
+  const curatedDigests = await ctx.db
+    .query("curatedSkillSearchDigest")
+    .withIndex("by_active_updated", (q) => q.eq("softDeletedAt", undefined))
+    .order("desc")
+    .take(MAX_SKILL_CATALOG_SEARCH_PAGE_SIZE);
+  for (const curatedDigest of curatedDigests) {
+    const digest = await ctx.db
+      .query("skillSearchDigest")
+      .withIndex("by_skill", (q) => q.eq("skillId", curatedDigest.skillId))
+      .unique();
+    if (!digest || !isCuratedSkillDigest(digest) || !skillCatalogMatchesFilters(digest, filters)) {
+      continue;
+    }
+    const match = skillCatalogSearchMatch(digest, queryText);
+    if (!match || seen.has(digest.skillId)) continue;
+    const catalogItem = await toPublicSkillCatalogItem(ctx, digest);
+    if (!catalogItem) continue;
+    seen.add(digest.skillId);
+    matches.push({ ...match, package: catalogItem });
+  }
 
   const exactSkill = await resolveSkillBySlugOrAlias(ctx, queryText);
   if (exactSkill.skill) {

--- a/specs/search-relevance.md
+++ b/specs/search-relevance.md
@@ -6,18 +6,18 @@ ClawHub search is a retrieval surface, not a browse fallback. A package, plugin,
 - exact or token-prefix match in taxonomy fields such as categories and author topics;
 - token-prefix match in exploratory fields such as summary, using a minimum query-token length for every query token to avoid short-query noise.
 
-Trust and business signals are not relevance signals. They must not make an otherwise unrelated item eligible for search. Package/plugin search may use its documented adoption tie-breaks; canonical mixed skill search follows the stricter source-neutral contract below.
+Trust and business signals are not relevance signals. They must not make an otherwise unrelated item eligible for search. After eligibility is established from query evidence, Official and Featured items form a curated result group that is ordered before community results. Package/plugin search may use its documented adoption tie-breaks inside each group; canonical mixed skill search follows the stricter source-neutral contract below.
 
 Generic fallback categories such as `other` are browse groupings, not search evidence.
 
-Search ranking should be lexicographic before it is numeric:
+Search ranking should first separate matching results into curated (Official or Featured) and community groups. Within each group, ranking should be lexicographic before it is numeric:
 
 1. exact full field match in name, slug, normalized package name, or runtime id;
 2. lexical field match in name, slug, normalized package name, display name, or runtime id;
 3. category or topic match;
 4. summary match;
 
-Numeric scores, trust state, popularity, and recency may order results inside those broad tiers, but must not make a weaker-evidence match eligible for a stronger tier.
+Numeric scores, popularity, and recency may order results inside those broad tiers. Curated status may place a weaker-evidence match before a stronger community match, but it must never make an otherwise unrelated item eligible.
 
 ## Canonical mixed skill search
 
@@ -25,7 +25,7 @@ Numeric scores, trust state, popularity, and recency may order results inside th
 
 - Candidate retrieval is bounded and indexed. Native lexical/vector recall and external exact, prefix, first-token, and full-text recall are merged before one final ordering pass; no full-corpus scan is allowed.
 - Shared relevance tiers are exact identity/name, exact token, prefix token, taxonomy, summary/content, then semantic-only recall. Semantic recall can add a candidate but can never displace a lexical candidate from a stronger tier.
-- Official and Featured may reorder only candidates with the same relevance evidence. Within comparable relevance, use ClawHub-observed rolling 60-day installs, then rolling Bookmarks and freshness.
+- Matching Official and Featured candidates form one curated group ahead of community candidates. Within each group, preserve relevance ordering, then use ClawHub-observed rolling 60-day installs, rolling Bookmarks, and freshness.
 - Lifetime ClawHub downloads, lifetime OpenClaw installs, skills.sh lifetime installs, GitHub stars, scanner status, and cross-source percentile normalization have zero ordering weight. They may still be returned as clearly labeled metadata.
 - Native public-browse/installability checks and external `active && publicVisible && installable && observed-only && !tombstoned` checks run before ranking. Upstream scanner observations remain source metadata, not a ClawHub verdict.
 - The canonical result includes a ClawHub route, source link, publisher/official metadata, install reference, source identity, trust metadata, rolling metrics, and the native rendering payload when applicable. HTTP, CLI, and web consumers preserve the action order by default.
@@ -37,7 +37,7 @@ External install references use `skills-sh:<owner>/<repo>/<slug>` and their cano
 The exact-match tier is authority, and authority must be earned (issue #3054). An exact full-field
 match claims tier 1 only when the item carries at least one signal that is expensive to fake:
 
-- the curated `official` flag,
+- the curated `official` or `featured` flag,
 - provenance or rebuild verification (self-serve tiers such as structural or source-linked do not
   qualify), or
 - measurable adoption (identity-deduped downloads plus installs).
@@ -48,8 +48,9 @@ long-adopted alternatives; display names are not even unique. Demoted items stil
 score inside the lexical tier, so fresh legitimate packages stay discoverable while they earn
 signal.
 
-Within a tier, a log-scale adoption bucket orders results before the raw text-match score, then the
-existing tie-breakers apply (official, verification tier, stars, installs, downloads, recency).
+Within each curated/community group and relevance tier, a log-scale adoption bucket orders results
+before the raw text-match score, then the existing tie-breakers apply (official, verification tier,
+stars, installs, downloads, recency).
 Log-scale bucketing rewards magnitude, not vanity deltas, and identity-deduped download metering
 (`specs/download-metering.md`) keeps buckets costly to inflate.
 


### PR DESCRIPTION
## Summary

- recall matching Official and Featured entries before short result limits are applied
- sort matching curated entries ahead of community entries across plugin, skill, canonical, and HTTP aggregation paths
- retain the existing text-evidence and visibility/filter eligibility rules, so unrelated curated entries stay excluded
- update the durable search relevance contract
- refresh the transitive `browserslist` lock entry to clear newly published high-severity audit findings that blocked the required static gate

## Validation

- `bunx vitest run convex/lib/searchRanking.test.ts convex/lib/canonicalSkillSearch.test.ts convex/skills.packageCatalog.test.ts convex/packages.public.test.ts convex/httpApiV1.handlers.test.ts convex/search.test.ts` (948 passed)
- `bun run ci:static`
- `bun run ci:unit` (6,307 passed, 3 skipped)
- `bun run ci:types-build`
- `bun run ci:e2e-http`
- `bun run ci:playwright-smoke` (17 passed)
- `.agents/skills/autoreview/scripts/autoreview --base origin/main` (clean)
