### PR TITLE
fix: simplify plugin list columns

### DIFF
--- a/src/__tests__/packages-route.test.tsx
+++ b/src/__tests__/packages-route.test.tsx
@@ -913,6 +913,8 @@ describe("plugins route", () => {
 
     expect(screen.getByRole("main").className).toContain("plugins-browse-page");
     expect(screen.getByText("1.2k")).toBeTruthy();
+    expect(document.querySelector(".browse-list-head")?.textContent).toBe("PluginDownloads");
+    expect(document.querySelector(".skill-list-item-taxonomy")).toBeNull();
   });
 
   it("renders the browse shell while the route loader is pending", async () => {
@@ -925,6 +927,8 @@ describe("plugins route", () => {
     expect(screen.getByRole("heading", { name: "Plugins" })).toBeTruthy();
     expect(screen.getByRole("status", { name: "Loading results" })).toBeTruthy();
     expect(screen.queryByText("Loading results")).toBeNull();
+    expect(document.querySelector(".browse-list-head")?.textContent).toBe("PluginDownloads");
+    expect(document.querySelector(".skill-list-item-taxonomy")).toBeNull();
   });
 
   it("keeps plugin count copy hidden on non-first browse pages", async () => {

--- a/src/__tests__/skills-index.claw591.test.tsx
+++ b/src/__tests__/skills-index.claw591.test.tsx
@@ -442,7 +442,7 @@ describe("SkillsIndex", () => {
 
     expect(screen.getByText("Japanese Conversation Scorer")).toBeTruthy();
     expect(screen.queryByText("24h installs")).toBeNull();
-    expect(screen.getByText("Popularity")).toBeTruthy();
+    expect(screen.getByText("Downloads")).toBeTruthy();
     expect(action).not.toHaveBeenCalled();
   });
 

--- a/src/__tests__/ui-design-contract.test.ts
+++ b/src/__tests__/ui-design-contract.test.ts
@@ -172,6 +172,17 @@ describe("restored UI design contract", () => {
     );
   });
 
+  it("keeps metric headers visible when responsive category columns collapse", () => {
+    const css = styles();
+
+    for (const query of ["(max-width: 960px)", "(max-width: 760px)"]) {
+      const responsive = cssMediaContaining(css, query, [
+        ".browse-page .browse-list-head-category",
+      ]);
+      expect(responsive).not.toContain(".browse-page .browse-list-head-label:nth-of-type(3)");
+    }
+  });
+
   it("keeps dashboard package names inside their rows and attention cards", () => {
     const css = styles();
 

--- a/src/components/PluginListItem.test.tsx
+++ b/src/components/PluginListItem.test.tsx
@@ -40,9 +40,15 @@ describe("PluginListItem", () => {
     expect(screen.getByText("#local-models")).toBeTruthy();
     expect(screen.getByText("#inference")).toBeTruthy();
     expect(screen.queryByText("#routing")).toBeNull();
-    expect(screen.getByText("Models")).toBeTruthy();
+    expect(screen.queryByText("Models")).toBeNull();
     expect(screen.getByLabelText("Topics")).toBeTruthy();
-    expect(screen.getByLabelText("Category")).toBeTruthy();
+    expect(screen.queryByLabelText("Category")).toBeNull();
+  });
+
+  it("keeps the category badge on plugin cards", () => {
+    render(<PluginListItem item={makePlugin({ categories: ["models"] })} variant="card" />);
+
+    expect(screen.getByLabelText("Category").textContent).toContain("Models");
   });
 
   it("renders category labels when topics are unavailable", () => {

--- a/src/components/PluginListItem.tsx
+++ b/src/components/PluginListItem.tsx
@@ -52,10 +52,6 @@ export function PluginListItem({
   const taxonomy = getPluginTaxonomyDisplay(item);
   const categories = getPluginCategories(item);
   const primaryCategory = categories[0] ?? null;
-  const categoryLabel = categories
-    .slice(0, 3)
-    .map((category) => category.label)
-    .join(", ");
   const pluginHref = href ?? buildPluginDetailHref(item.name, { ownerHandle: item.ownerHandle });
   const displayName = presentationTitle(item.displayName, item.name);
 
@@ -116,11 +112,7 @@ export function PluginListItem({
   }
 
   return (
-    <Link
-      to={pluginHref}
-      className="skill-list-item skill-list-item-with-taxonomy"
-      aria-label={`Plugin: ${displayName}`}
-    >
+    <Link to={pluginHref} className="skill-list-item" aria-label={`Plugin: ${displayName}`}>
       <MarketplaceIcon
         kind="plugin"
         label={displayName}
@@ -143,9 +135,6 @@ export function PluginListItem({
         <p className="skill-list-item-summary">
           {truncateText(item.summary ?? "Plugin package for agent workflows.", 80)}
         </p>
-      </div>
-      <div className="skill-list-item-taxonomy" aria-label="Category">
-        {categoryLabel ? <span className="skill-list-item-category">{categoryLabel}</span> : null}
       </div>
       <div className="skill-list-item-meta">
         <span className="skill-list-item-meta-item">

--- a/src/components/skeletons/BrowseResultsSkeleton.test.tsx
+++ b/src/components/skeletons/BrowseResultsSkeleton.test.tsx
@@ -11,6 +11,9 @@ describe("BrowseResultsSkeleton", () => {
 
       const loadingResults = screen.getByRole("status", { name: "Loading results" });
       if (variant === "list") {
+        expect(loadingResults.querySelector(".browse-list-head-stat")?.textContent).toBe(
+          "Downloads",
+        );
         expect(loadingResults.querySelector(".browse-list-head-icon-spacer")).not.toBeNull();
         expect(loadingResults.querySelectorAll(".browse-results-skeleton-icon")).toHaveLength(2);
         expect(loadingResults.querySelector(".skill-list-item-no-icon")).toBeNull();

--- a/src/components/skeletons/BrowseResultsSkeleton.tsx
+++ b/src/components/skeletons/BrowseResultsSkeleton.tsx
@@ -6,6 +6,7 @@ type BrowseResultsSkeletonProps = {
   showIcon?: boolean;
   variant?: "list" | "grid";
   showColumnHead?: boolean;
+  showCategoryColumn?: boolean;
 };
 
 export function BrowseResultsSkeleton({
@@ -14,6 +15,7 @@ export function BrowseResultsSkeleton({
   showIcon = true,
   variant = "list",
   showColumnHead = true,
+  showCategoryColumn = true,
 }: BrowseResultsSkeletonProps) {
   if (variant === "grid") {
     return (
@@ -53,13 +55,23 @@ export function BrowseResultsSkeleton({
     <div className="browse-list-stack" role="status" aria-label="Loading results">
       {showColumnHead ? (
         <div
-          className={`browse-list-head${showIcon ? "" : " browse-list-head-no-icon"}`}
+          className={`browse-list-head${
+            showCategoryColumn
+              ? showIcon
+                ? ""
+                : " browse-list-head-no-icon"
+              : showIcon
+                ? " browse-list-head-simple"
+                : " browse-list-head-simple-no-icon"
+          }`}
           aria-hidden="true"
         >
           {showIcon ? <span className="browse-list-head-icon-spacer" /> : null}
           <span className="browse-list-head-label">{label}</span>
-          <span className="browse-list-head-label browse-list-head-category">Category</span>
-          <span className="browse-list-head-label browse-list-head-stat">Popularity</span>
+          {showCategoryColumn ? (
+            <span className="browse-list-head-label browse-list-head-category">Category</span>
+          ) : null}
+          <span className="browse-list-head-label browse-list-head-stat">Downloads</span>
         </div>
       ) : null}
       <div className="results-list">
@@ -67,9 +79,9 @@ export function BrowseResultsSkeleton({
           <div
             // biome-ignore lint/suspicious/noArrayIndexKey: static skeleton placeholder count
             key={i}
-            className={`skill-list-item skill-list-item-has-creator browse-results-skeleton-row${
-              showIcon ? "" : " skill-list-item-no-icon"
-            }`}
+            className={`skill-list-item browse-results-skeleton-row${
+              showCategoryColumn ? " skill-list-item-has-creator" : ""
+            }${showIcon ? "" : showCategoryColumn ? " skill-list-item-no-icon" : " skill-list-item-simple-no-icon"}`}
           >
             {showIcon ? (
               <Skeleton className="browse-results-skeleton-icon h-[27px] w-[27px] shrink-0 rounded-[var(--oc-radius-inset)]" />
@@ -81,9 +93,11 @@ export function BrowseResultsSkeleton({
               </div>
               <Skeleton className="h-4 w-80 max-w-full" />
             </div>
-            <div className="skill-list-item-taxonomy">
-              <Skeleton className="h-4 w-24" />
-            </div>
+            {showCategoryColumn ? (
+              <div className="skill-list-item-taxonomy">
+                <Skeleton className="h-4 w-24" />
+              </div>
+            ) : null}
             <div className="skill-list-item-meta">
               <Skeleton className="h-4 w-24 browse-results-skeleton-updated" />
               <Skeleton className="h-4 w-14" />

--- a/src/routes/plugins/index.tsx
+++ b/src/routes/plugins/index.tsx
@@ -367,7 +367,7 @@ function PluginsIndexPending() {
           disabled
         />
         <div className="browse-results">
-          <BrowseResultsSkeleton label="Plugin" />
+          <BrowseResultsSkeleton label="Plugin" showCategoryColumn={false} />
         </div>
       </div>
     </main>
@@ -738,7 +738,11 @@ function PluginsIndex() {
         />
         <div className="browse-results">
           {isLoading ? (
-            <BrowseResultsSkeleton label="Plugin" variant={effectiveView} />
+            <BrowseResultsSkeleton
+              label="Plugin"
+              variant={effectiveView}
+              showCategoryColumn={false}
+            />
           ) : apiError ? (
             <div className="empty-state">
               <PackageSearch size={22} className="empty-state-icon" aria-hidden="true" />
@@ -775,11 +779,10 @@ function PluginsIndex() {
             </div>
           ) : (
             <div className="browse-list-stack">
-              <div className="browse-list-head" aria-hidden="true">
+              <div className="browse-list-head browse-list-head-simple" aria-hidden="true">
                 <span className="browse-list-head-icon-spacer" />
                 <span className="browse-list-head-label">Plugin</span>
-                <span className="browse-list-head-label">Category</span>
-                <span className="browse-list-head-label browse-list-head-stat">Popularity</span>
+                <span className="browse-list-head-label browse-list-head-stat">Downloads</span>
               </div>
               <div className="results-list">
                 {visibleItems.map((item) => (

--- a/src/routes/skills/-SkillsResults.tsx
+++ b/src/routes/skills/-SkillsResults.tsx
@@ -308,7 +308,7 @@ export function SkillsResults({
               <span className="browse-list-head-label browse-list-head-category">Category</span>
             )}
             <span className="browse-list-head-label browse-list-head-stat">
-              {showTrendingLayout ? "24h downloads" : "Popularity"}
+              {showTrendingLayout ? "24h downloads" : "Downloads"}
             </span>
           </div>
           <div className="results-list">

--- a/src/styles.css
+++ b/src/styles.css
@@ -17467,6 +17467,10 @@ a.agentic-risk-finding-title:focus-visible {
   grid-template-columns: auto minmax(0, 1fr) 190px;
 }
 
+.browse-list-head-simple-no-icon {
+  grid-template-columns: minmax(0, 1fr) 190px;
+}
+
 .browse-list-head-publishers {
   grid-template-columns: minmax(0, 1fr) minmax(160px, auto);
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -17804,7 +17804,7 @@ a.agentic-risk-finding-title:focus-visible {
   }
 
   .browse-page .skill-list-item-taxonomy,
-  .browse-page .browse-list-head-label:nth-of-type(3) {
+  .browse-page .browse-list-head-category {
     display: none;
   }
 
@@ -20180,7 +20180,7 @@ body:has(.browse-page-borderless-header) .navbar {
   }
 
   .browse-page .browse-list-head-icon-spacer,
-  .browse-page .browse-list-head-label:nth-of-type(3) {
+  .browse-page .browse-list-head-category {
     display: none;
   }
 


### PR DESCRIPTION
## Summary

- remove the Category column from plugin list rows and loading skeletons
- rename the plugin and non-Trending skills metric header to Downloads
- preserve plugin grid-card category badges and category filtering
- keep the Downloads heading visible at responsive list breakpoints

## Validation

- `bunx vitest run src/components/PluginListItem.test.tsx src/components/skeletons/BrowseResultsSkeleton.test.tsx src/__tests__/packages-route.test.tsx src/__tests__/skills-index.claw591.test.tsx src/__tests__/ui-design-contract.test.ts`
- `bun run ci:static`
- `VITE_CONVEX_URL=https://example.invalid bun run ci:unit` (6,308 passed, 3 skipped)
- `bun run ci:types-build`
- `.agents/skills/autoreview/scripts/autoreview --mode local --parallel-tests 'bunx vitest run src/components/PluginListItem.test.tsx src/components/skeletons/BrowseResultsSkeleton.test.tsx src/__tests__/packages-route.test.tsx src/__tests__/skills-index.claw591.test.tsx src/__tests__/ui-design-contract.test.ts'`

## Visual proof

- Playwright feature proof passed against the real local ClawHub instance at `http://127.0.0.1:3017`
- covered Plugins at 1280px and 960px, plus the Featured Skills list at 1280px
- screenshots and assertions are attached in the ClawHub UI Proof comment below
