### PR TITLE
fix: let staff stop stuck signal scans

### DIFF
--- a/convex/publisherAbuse.test.ts
+++ b/convex/publisherAbuse.test.ts
@@ -664,6 +664,7 @@ describe("publisher abuse dry-run persistence", () => {
       ).resolves.toEqual({
         latestRun: null,
         latestSignalRun: null,
+        latestSignalRunIsCurrentModel: false,
         pendingItems: [],
         pendingPotentialBanCandidateItems: [],
         pendingReviewItems: [],
@@ -730,6 +731,7 @@ describe("publisher abuse dry-run persistence", () => {
     await expect(listDashboardHandler({ db }, {})).resolves.toEqual({
       latestRun: null,
       latestSignalRun: null,
+      latestSignalRunIsCurrentModel: false,
       pendingItems: [],
       pendingPotentialBanCandidateItems: [],
       pendingReviewItems: [],
@@ -847,6 +849,7 @@ describe("publisher abuse dry-run persistence", () => {
     await expect(listDashboardHandler({ db }, {})).resolves.toEqual({
       latestRun: null,
       latestSignalRun: null,
+      latestSignalRunIsCurrentModel: false,
       pendingItems: [],
       pendingPotentialBanCandidateItems: [],
       pendingReviewItems: [],
@@ -914,7 +917,7 @@ describe("publisher abuse dry-run persistence", () => {
     expect(db.get).not.toHaveBeenCalled();
   });
 
-  it("keeps resumable legacy and synchronizing signal scans visible", async () => {
+  it("keeps signal history visible without making old runs active", async () => {
     vi.mocked(requireUser).mockResolvedValue({
       userId: "users:moderator",
       user: { _id: "users:moderator", role: "moderator" },
@@ -944,7 +947,23 @@ describe("publisher abuse dry-run persistence", () => {
       updatedAt: 400,
       temporalPipelinePhase: "synchronizing",
     };
+    const pressureRun = {
+      ...legacySignalRun,
+      _id: "publisherAbuseScoreRuns:pressure",
+      modelVersion: "publisher-abuse-pressure.v4",
+      startedAt: 100,
+      updatedAt: 100,
+      temporalPipelinePhase: undefined,
+    };
+    const staleTaggedV1Run = {
+      ...legacySignalRun,
+      _id: "publisherAbuseScoreRuns:stale-v1",
+      temporalPipelineKind: "signals",
+      startedAt: 500,
+      updatedAt: 500,
+    };
     let currentModelRun: typeof synchronizingRun | null = null;
+    let taggedSignalRun: typeof staleTaggedV1Run | null = null;
     const db = {
       get: vi.fn(async () => null),
       query: vi.fn((table: string) => {
@@ -965,7 +984,9 @@ describe("publisher abuse dry-run persistence", () => {
               return {
                 order: () => ({
                   first: async () => {
-                    if (indexName === "by_temporal_pipeline_kind_and_started_at") return null;
+                    if (indexName === "by_temporal_pipeline_kind_and_started_at") {
+                      return taggedSignalRun;
+                    }
                     if (
                       indexName ===
                       "by_model_version_and_temporal_pipeline_kind_and_phase_started_at"
@@ -978,6 +999,9 @@ describe("publisher abuse dry-run persistence", () => {
                     }
                     if (constraints.modelVersion === "publisher-abuse-temporal.v2") {
                       return currentModelRun;
+                    }
+                    if (constraints.modelVersion === "publisher-abuse-pressure.v4") {
+                      return pressureRun;
                     }
                     return constraints.modelVersion === "publisher-abuse-temporal.v1"
                       ? newerDiagnosticRun
@@ -999,63 +1023,37 @@ describe("publisher abuse dry-run persistence", () => {
 
     await expect(listDashboardHandler({ db }, {})).resolves.toEqual(
       expect.objectContaining({
-        latestRun: expect.objectContaining({ _id: legacySignalRun._id }),
+        latestRun: expect.objectContaining({ _id: pressureRun._id }),
         latestSignalRun: expect.objectContaining({ _id: legacySignalRun._id }),
+        latestSignalRunIsCurrentModel: false,
       }),
+    );
+    await expect(publisherAbuse.getRunningPublisherAbuseSignalRun({ db } as never)).resolves.toBe(
+      null,
     );
 
     currentModelRun = synchronizingRun;
     await expect(listDashboardHandler({ db }, {})).resolves.toEqual(
       expect.objectContaining({
         latestSignalRun: expect.objectContaining({ _id: synchronizingRun._id }),
+        latestSignalRunIsCurrentModel: true,
       }),
     );
-  });
+    await expect(
+      publisherAbuse.getRunningPublisherAbuseSignalRun({ db } as never),
+    ).resolves.toMatchObject({ _id: synchronizingRun._id });
 
-  it("never treats a tagged old-model signal run as the active running scan", async () => {
-    vi.mocked(requireUser).mockResolvedValue({
-      userId: "users:moderator",
-      user: { _id: "users:moderator", role: "moderator" },
-    } as never);
-    const staleTaggedV1Run = {
-      _id: "publisherAbuseScoreRuns:stale-v1",
-      modelVersion: "publisher-abuse-temporal.v1",
-      status: "running",
-      phase: "collecting",
-      trigger: "cron",
-      temporalPipelineKind: "signals",
-      temporalPipelinePhase: "collecting",
-      startedAt: 500,
-      updatedAt: 500,
-    };
-    const db = {
-      get: vi.fn(async () => null),
-      query: vi.fn((table: string) => {
-        if (table === "publisherAbuseScoreRuns") {
-          return {
-            withIndex: (indexName: string) => ({
-              order: () => ({
-                first: async () =>
-                  // Only the tagged-signals lookup finds the stale v1 run; every
-                  // model-version and legacy-phase lookup returns nothing.
-                  indexName === "by_temporal_pipeline_kind_and_started_at"
-                    ? staleTaggedV1Run
-                    : null,
-              }),
-            }),
-          };
-        }
-        if (table === "publisherAbuseReviewNominations") {
-          return makePublisherAbuseNominationCountQuery([]);
-        }
-        if (table === "publisherAbuseSignals") return makePublisherAbuseSignalCountQuery([]);
-        if (table === "officialPublishers") return makeEmptyOfficialPublishersQuery();
-        throw new Error(`unexpected table ${table}`);
-      }),
-    };
-
+    currentModelRun = null;
+    taggedSignalRun = staleTaggedV1Run;
     await expect(listDashboardHandler({ db }, {})).resolves.toEqual(
-      expect.objectContaining({ latestRun: null, latestSignalRun: null }),
+      expect.objectContaining({
+        latestRun: expect.objectContaining({ _id: pressureRun._id }),
+        latestSignalRun: expect.objectContaining({ _id: staleTaggedV1Run._id }),
+        latestSignalRunIsCurrentModel: false,
+      }),
+    );
+    await expect(publisherAbuse.getRunningPublisherAbuseSignalRun({ db } as never)).resolves.toBe(
+      null,
     );
   });
 
@@ -1201,6 +1199,7 @@ describe("publisher abuse dry-run persistence", () => {
     await expect(listDashboardHandler({ db }, {})).resolves.toEqual({
       latestRun: null,
       latestSignalRun: null,
+      latestSignalRunIsCurrentModel: false,
       pendingItems: [],
       pendingPotentialBanCandidateItems: [],
       pendingReviewItems: [],
@@ -1293,6 +1292,7 @@ describe("publisher abuse dry-run persistence", () => {
     await expect(listDashboardHandler({ db }, {})).resolves.toEqual({
       latestRun: null,
       latestSignalRun: null,
+      latestSignalRunIsCurrentModel: false,
       pendingItems: [],
       pendingPotentialBanCandidateItems: [],
       pendingReviewItems: [],

--- a/convex/publisherAbuse.test.ts
+++ b/convex/publisherAbuse.test.ts
@@ -1012,6 +1012,53 @@ describe("publisher abuse dry-run persistence", () => {
     );
   });
 
+  it("never treats a tagged old-model signal run as the active running scan", async () => {
+    vi.mocked(requireUser).mockResolvedValue({
+      userId: "users:moderator",
+      user: { _id: "users:moderator", role: "moderator" },
+    } as never);
+    const staleTaggedV1Run = {
+      _id: "publisherAbuseScoreRuns:stale-v1",
+      modelVersion: "publisher-abuse-temporal.v1",
+      status: "running",
+      phase: "collecting",
+      trigger: "cron",
+      temporalPipelineKind: "signals",
+      temporalPipelinePhase: "collecting",
+      startedAt: 500,
+      updatedAt: 500,
+    };
+    const db = {
+      get: vi.fn(async () => null),
+      query: vi.fn((table: string) => {
+        if (table === "publisherAbuseScoreRuns") {
+          return {
+            withIndex: (indexName: string) => ({
+              order: () => ({
+                first: async () =>
+                  // Only the tagged-signals lookup finds the stale v1 run; every
+                  // model-version and legacy-phase lookup returns nothing.
+                  indexName === "by_temporal_pipeline_kind_and_started_at"
+                    ? staleTaggedV1Run
+                    : null,
+              }),
+            }),
+          };
+        }
+        if (table === "publisherAbuseReviewNominations") {
+          return makePublisherAbuseNominationCountQuery([]);
+        }
+        if (table === "publisherAbuseSignals") return makePublisherAbuseSignalCountQuery([]);
+        if (table === "officialPublishers") return makeEmptyOfficialPublishersQuery();
+        throw new Error(`unexpected table ${table}`);
+      }),
+    };
+
+    await expect(listDashboardHandler({ db }, {})).resolves.toEqual(
+      expect.objectContaining({ latestRun: null, latestSignalRun: null }),
+    );
+  });
+
   it("counts only visible publisher abuse nominations on the dashboard", async () => {
     vi.mocked(requireUser).mockResolvedValue({
       userId: "users:moderator",

--- a/convex/publisherAbuse.ts
+++ b/convex/publisherAbuse.ts
@@ -2840,7 +2840,10 @@ function newerPublisherAbuseRun(left: ScoreRun | null, right: ScoreRun | null) {
   return right.startedAt > left.startedAt ? right : left;
 }
 
-async function getLatestPublisherAbuseScoreRunForModel(ctx: QueryCtx, modelVersion: string) {
+async function getLatestPublisherAbuseScoreRunForModel(
+  ctx: Pick<QueryCtx | MutationCtx, "db">,
+  modelVersion: string,
+) {
   return await ctx.db
     .query("publisherAbuseScoreRuns")
     .withIndex("by_model_version_and_started_at", (q) => q.eq("modelVersion", modelVersion))
@@ -2848,7 +2851,7 @@ async function getLatestPublisherAbuseScoreRunForModel(ctx: QueryCtx, modelVersi
     .first();
 }
 
-async function getLatestPublisherAbuseSignalRun(ctx: QueryCtx) {
+export async function getLatestPublisherAbuseSignalRun(ctx: Pick<QueryCtx | MutationCtx, "db">) {
   const legacyTemporalPhases = [
     "collecting",
     "downloads_percentiles",
@@ -2889,10 +2892,19 @@ async function getLatestPublisherAbuseSignalRun(ctx: QueryCtx) {
     currentModelRun.temporalPipelinePhase
       ? currentModelRun
       : null;
+  // An old tagged run cannot be resumed by the current worker and must not lock
+  // the dashboard control that starts its replacement.
+  const compatibleTaggedRun =
+    taggedRun?.modelVersion === PUBLISHER_TEMPORAL_ABUSE_MODEL_VERSION ? taggedRun : null;
   return [untaggedCurrentModelRun, ...legacyRuns].reduce<ScoreRun | null>(
     newerPublisherAbuseRun,
-    taggedRun,
+    compatibleTaggedRun,
   );
+}
+
+export async function getRunningPublisherAbuseSignalRun(ctx: Pick<QueryCtx | MutationCtx, "db">) {
+  const run = await getLatestPublisherAbuseSignalRun(ctx);
+  return run && run.status === "running" ? run : null;
 }
 
 async function getRecentResolvedPublisherAbuseReviewItems(

--- a/convex/publisherAbuse.ts
+++ b/convex/publisherAbuse.ts
@@ -91,7 +91,6 @@ const FAILED_SCORE_RUN_AUTOBAN_SKIP_NOTE =
 const PUBLISHER_ABUSE_AUTOBAN_SETTING_KEY = "publisherAbuseAutobanEnabled" as const;
 const PUBLISHER_TEMPORAL_ABUSE_MODEL_PREFIX = "publisher-abuse-temporal.";
 const LEGACY_PUBLISHER_TEMPORAL_ABUSE_MODEL_VERSIONS = ["publisher-abuse-temporal.v1"] as const;
-
 type TriageStatus = Doc<"publisherAbuseReviewNominations">["status"];
 type ScoreRun = Doc<"publisherAbuseScoreRuns">;
 type ScoreDoc = Doc<"publisherAbuseScores">;
@@ -260,11 +259,11 @@ export const listReviewDashboard = query({
         getPublisherAbuseReviewNominationCountSummary(ctx),
         getPublisherAbuseSignalCountSummary(ctx),
       ]);
-    const latestRun = newerPublisherAbuseRun(latestPressureRun, latestSignalRun);
-
     return {
-      latestRun: latestRun ? summarizePublisherAbuseRun(latestRun) : null,
+      latestRun: latestPressureRun ? summarizePublisherAbuseRun(latestPressureRun) : null,
       latestSignalRun: latestSignalRun ? summarizePublisherAbuseRun(latestSignalRun) : null,
+      latestSignalRunIsCurrentModel:
+        latestSignalRun?.modelVersion === PUBLISHER_TEMPORAL_ABUSE_MODEL_VERSION,
       pendingItems: [],
       pendingPotentialBanCandidateItems: [],
       pendingReviewItems: [],
@@ -463,6 +462,7 @@ function emptyPublisherAbuseReviewDashboard() {
   return {
     latestRun: null,
     latestSignalRun: null,
+    latestSignalRunIsCurrentModel: false,
     pendingItems: [],
     pendingPotentialBanCandidateItems: [],
     pendingReviewItems: [],
@@ -2892,19 +2892,17 @@ export async function getLatestPublisherAbuseSignalRun(ctx: Pick<QueryCtx | Muta
     currentModelRun.temporalPipelinePhase
       ? currentModelRun
       : null;
-  // An old tagged run cannot be resumed by the current worker and must not lock
-  // the dashboard control that starts its replacement.
-  const compatibleTaggedRun =
-    taggedRun?.modelVersion === PUBLISHER_TEMPORAL_ABUSE_MODEL_VERSION ? taggedRun : null;
   return [untaggedCurrentModelRun, ...legacyRuns].reduce<ScoreRun | null>(
     newerPublisherAbuseRun,
-    compatibleTaggedRun,
+    taggedRun,
   );
 }
 
 export async function getRunningPublisherAbuseSignalRun(ctx: Pick<QueryCtx | MutationCtx, "db">) {
   const run = await getLatestPublisherAbuseSignalRun(ctx);
-  return run && run.status === "running" ? run : null;
+  return run?.status === "running" && run.modelVersion === PUBLISHER_TEMPORAL_ABUSE_MODEL_VERSION
+    ? run
+    : null;
 }
 
 async function getRecentResolvedPublisherAbuseReviewItems(

--- a/convex/publisherAbuseOwnerSynchrony.test.ts
+++ b/convex/publisherAbuseOwnerSynchrony.test.ts
@@ -669,6 +669,7 @@ describe("publisher abuse owner synchrony signal", () => {
     });
     const ctx = {
       db: {
+        get: vi.fn(async () => ({ status: "running" })),
         query: vi.fn(() => ({
           withIndex: () => ({ first: async () => existing }),
         })),
@@ -697,5 +698,31 @@ describe("publisher abuse owner synchrony signal", () => {
       lastSeenAt: now,
       seenCount: 3,
     });
+  });
+
+  it("does not write synchrony evidence after its scan is canceled", async () => {
+    const query = vi.fn();
+    const insert = vi.fn();
+    const patch = vi.fn();
+    const ctx = {
+      db: {
+        get: vi.fn(async () => ({ status: "failed" })),
+        query,
+        insert,
+        patch,
+      },
+    };
+
+    await expect(
+      upsertPublisherAbuseOwnerSynchronySignalInternalHandler(ctx as unknown as MutationCtx, {
+        runId: "publisherAbuseScoreRuns:canceled" as Id<"publisherAbuseScoreRuns">,
+        candidate: candidate(),
+        now: 1_700_000_000_000,
+      }),
+    ).resolves.toBeNull();
+
+    expect(query).not.toHaveBeenCalled();
+    expect(insert).not.toHaveBeenCalled();
+    expect(patch).not.toHaveBeenCalled();
   });
 });

--- a/convex/publisherAbuseOwnerSynchrony.ts
+++ b/convex/publisherAbuseOwnerSynchrony.ts
@@ -382,6 +382,10 @@ export async function upsertPublisherAbuseOwnerSynchronySignalInternalHandler(
   },
 ) {
   const { candidate } = args;
+  if (args.runId) {
+    const run = await ctx.db.get(args.runId);
+    if (run?.status !== "running") return null;
+  }
   const existing = await ctx.db
     .query("publisherAbuseSignals")
     .withIndex("by_owner_key_and_signal_type", (q) =>

--- a/convex/publisherAbuseTemporalScan.test.ts
+++ b/convex/publisherAbuseTemporalScan.test.ts
@@ -1,21 +1,23 @@
 /* @vitest-environment node */
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Doc, Id } from "./_generated/dataModel";
 import type { ActionCtx, MutationCtx } from "./_generated/server";
-import { assertModerator, requireUserFromAction } from "./lib/access";
+import { assertModerator, requireUser, requireUserFromAction } from "./lib/access";
 import {
   DEFAULT_PUBLISHER_ABUSE_MODEL_CONFIG,
   PUBLISHER_TEMPORAL_ABUSE_MODEL_VERSION,
   type SkillTemporalAbuseScore,
 } from "./lib/publisherAbuseScoring";
-import type { TemporalSkillCandidate } from "./publisherAbuse";
+import { getRunningPublisherAbuseSignalRun, type TemporalSkillCandidate } from "./publisherAbuse";
 import {
   advanceScheduledTemporalCandidatesInternalHandler,
+  cancelPublisherAbuseSignalScanHandler,
   getOrStartScheduledTemporalScanInternalHandler,
   markScheduledTemporalScanFailedInternalHandler,
   recordScheduledTemporalScanFailureInternalHandler,
   percentileIndex,
   pruneExpiredTemporalScanRowsInternalHandler,
+  PUBLISHER_ABUSE_SIGNAL_SCAN_CANCELED_MESSAGE,
   readScheduledTemporalCandidatesPageInternalHandler,
   runScheduledTemporalPublisherAbuseScanInternalHandler,
   startPublisherAbuseSignalScanHandler,
@@ -26,8 +28,14 @@ import {
 
 vi.mock("./lib/access", () => ({
   assertModerator: vi.fn(),
+  requireUser: vi.fn(),
   requireUserFromAction: vi.fn(),
 }));
+
+vi.mock("./publisherAbuse", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./publisherAbuse")>();
+  return { ...actual, getRunningPublisherAbuseSignalRun: vi.fn() };
+});
 
 function temporalScore(overrides: Partial<SkillTemporalAbuseScore> = {}): SkillTemporalAbuseScore {
   return {
@@ -1135,5 +1143,99 @@ describe("scheduled temporal publisher abuse scan", () => {
     ).resolves.toEqual({ samplesDeleted: 1, candidatesDeleted: 1, hasMore: false });
     expect(ctx.db.delete).toHaveBeenCalledTimes(2);
     expect(scheduler.runAfter).not.toHaveBeenCalled();
+  });
+});
+
+describe("cancel publisher abuse signal scan", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("cancels the running signals scan for a moderator and records the actor", async () => {
+    const actorUserId = "users:moderator" as Id<"users">;
+    vi.mocked(requireUser).mockResolvedValue({
+      userId: actorUserId,
+      user: { _id: actorUserId, role: "moderator" },
+    } as never);
+    const run = temporalRun({
+      _id: "publisherAbuseScoreRuns:running" as Id<"publisherAbuseScoreRuns">,
+      status: "running",
+      temporalPipelinePhase: "classifying",
+    });
+    vi.mocked(getRunningPublisherAbuseSignalRun).mockResolvedValue(run);
+    const patch = vi.fn(async () => null);
+    const insert = vi.fn(async () => "auditLogs:1" as Id<"auditLogs">);
+
+    await expect(
+      cancelPublisherAbuseSignalScanHandler({ db: { patch, insert } } as unknown as MutationCtx, {
+        runId: run._id,
+      }),
+    ).resolves.toEqual({ ok: true, canceled: true, runId: run._id });
+
+    expect(assertModerator).toHaveBeenCalledWith(
+      expect.objectContaining({ _id: actorUserId, role: "moderator" }),
+    );
+    expect(patch).toHaveBeenCalledWith(
+      run._id,
+      expect.objectContaining({
+        status: "failed",
+        temporalScanComplete: false,
+        canceledAt: expect.any(Number),
+        errorMessage: PUBLISHER_ABUSE_SIGNAL_SCAN_CANCELED_MESSAGE,
+        nextTransientRetryAt: undefined,
+      }),
+    );
+    expect(insert).toHaveBeenCalledWith(
+      "auditLogs",
+      expect.objectContaining({
+        actorUserId,
+        action: "publisher_abuse.signal_scan.cancel",
+        targetId: run._id,
+      }),
+    );
+  });
+
+  it("refuses to cancel for non-moderators and writes nothing", async () => {
+    vi.mocked(requireUser).mockResolvedValue({
+      userId: "users:viewer" as Id<"users">,
+      user: { _id: "users:viewer", role: "user" },
+    } as never);
+    vi.mocked(assertModerator).mockImplementation(() => {
+      throw new Error("Forbidden");
+    });
+    const patch = vi.fn();
+    const insert = vi.fn();
+
+    await expect(
+      cancelPublisherAbuseSignalScanHandler({ db: { patch, insert } } as unknown as MutationCtx, {
+        runId: "publisherAbuseScoreRuns:running" as Id<"publisherAbuseScoreRuns">,
+      }),
+    ).rejects.toThrow("Forbidden");
+    expect(getRunningPublisherAbuseSignalRun).not.toHaveBeenCalled();
+    expect(patch).not.toHaveBeenCalled();
+    expect(insert).not.toHaveBeenCalled();
+  });
+
+  it("does not cancel a replacement scan after the confirmed run finishes", async () => {
+    vi.mocked(requireUser).mockResolvedValue({
+      userId: "users:moderator" as Id<"users">,
+      user: { _id: "users:moderator", role: "moderator" },
+    } as never);
+    vi.mocked(getRunningPublisherAbuseSignalRun).mockResolvedValue(
+      temporalRun({
+        _id: "publisherAbuseScoreRuns:replacement" as Id<"publisherAbuseScoreRuns">,
+        status: "running",
+      }),
+    );
+    const patch = vi.fn();
+    const insert = vi.fn();
+
+    await expect(
+      cancelPublisherAbuseSignalScanHandler({ db: { patch, insert } } as unknown as MutationCtx, {
+        runId: "publisherAbuseScoreRuns:confirmed" as Id<"publisherAbuseScoreRuns">,
+      }),
+    ).resolves.toEqual({ ok: true, canceled: false });
+    expect(patch).not.toHaveBeenCalled();
+    expect(insert).not.toHaveBeenCalled();
   });
 });

--- a/convex/publisherAbuseTemporalScan.ts
+++ b/convex/publisherAbuseTemporalScan.ts
@@ -2,8 +2,8 @@ import { v } from "convex/values";
 import { internal } from "./_generated/api";
 import type { Doc, Id } from "./_generated/dataModel";
 import type { ActionCtx, MutationCtx, QueryCtx } from "./_generated/server";
-import { action, internalAction, internalMutation, internalQuery } from "./functions";
-import { assertModerator, requireUserFromAction } from "./lib/access";
+import { action, internalAction, internalMutation, internalQuery, mutation } from "./functions";
+import { assertModerator, requireUser, requireUserFromAction } from "./lib/access";
 import { toDayKey } from "./lib/leaderboards";
 import {
   classifySkillTemporalAbuseScore,
@@ -17,6 +17,7 @@ import {
 import { RETENTION_STANDARD_BATCH_SIZE } from "./lib/retentionPolicy";
 import {
   archiveTemporalPublisherAbuseSignals,
+  getRunningPublisherAbuseSignalRun,
   type TemporalSkillCandidate,
 } from "./publisherAbuse";
 import { scanPublisherAbuseOwnerSynchronyPage } from "./publisherAbuseOwnerSynchrony";
@@ -30,6 +31,9 @@ const TEMPORAL_SCAN_HEARTBEAT_TIMEOUT_MS = 15 * 60 * 1000;
 const TEMPORAL_SCAN_RETRY_BASE_DELAY_MS = 30 * 1000;
 const TEMPORAL_SCAN_RETRY_MAX_DELAY_MS = 5 * 60 * 1000;
 const MAX_TEMPORAL_SCAN_FAILURE_ATTEMPTS = 5;
+
+export const PUBLISHER_ABUSE_SIGNAL_SCAN_CANCELED_MESSAGE =
+  "Signal scan canceled by staff before it finished.";
 
 const temporalCohortBandValidator = v.union(v.literal("p95"), v.literal("p99"));
 const temporalScoreValidator = v.object({
@@ -1227,6 +1231,50 @@ export async function startPublisherAbuseSignalScanHandler(
 export const startPublisherAbuseSignalScan = action({
   args: {},
   handler: startPublisherAbuseSignalScanHandler,
+});
+
+type CancelPublisherAbuseSignalScanResult =
+  | { ok: true; canceled: true; runId: Id<"publisherAbuseScoreRuns"> }
+  | { ok: true; canceled: false };
+
+export async function cancelPublisherAbuseSignalScanHandler(
+  ctx: MutationCtx,
+  args: { runId: Id<"publisherAbuseScoreRuns"> },
+): Promise<CancelPublisherAbuseSignalScanResult> {
+  const { user } = await requireUser(ctx);
+  assertModerator(user);
+
+  const run = await getRunningPublisherAbuseSignalRun(ctx);
+  if (!run || run._id !== args.runId) {
+    return { ok: true, canceled: false };
+  }
+
+  const now = Date.now();
+  await ctx.db.patch(run._id, {
+    status: "failed",
+    temporalScanComplete: false,
+    canceledAt: now,
+    errorMessage: PUBLISHER_ABUSE_SIGNAL_SCAN_CANCELED_MESSAGE,
+    nextTransientRetryAt: undefined,
+    updatedAt: now,
+  });
+  await ctx.db.insert("auditLogs", {
+    actorUserId: user._id,
+    action: "publisher_abuse.signal_scan.cancel",
+    targetType: "publisherAbuseScoreRun",
+    targetId: run._id,
+    metadata: {
+      modelVersion: run.modelVersion,
+      phase: run.temporalPipelinePhase ?? run.phase,
+    },
+    createdAt: now,
+  });
+  return { ok: true, canceled: true, runId: run._id };
+}
+
+export const cancelPublisherAbuseSignalScan = mutation({
+  args: { runId: v.id("publisherAbuseScoreRuns") },
+  handler: cancelPublisherAbuseSignalScanHandler,
 });
 
 export async function pruneExpiredTemporalScanRowsInternalHandler(

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -3824,6 +3824,8 @@ const publisherAbuseScoreRuns = defineTable({
     }),
   ),
   errorMessage: v.optional(v.string()),
+  // Distinguishes an intentional stop from a scan failure in the staff UI.
+  canceledAt: v.optional(v.number()),
   transientErrorCount: v.optional(v.number()),
   lastTransientError: v.optional(v.string()),
   lastTransientErrorAt: v.optional(v.number()),

--- a/specs/security-moderation.md
+++ b/specs/security-moderation.md
@@ -79,7 +79,11 @@ See also: [acceptable-usage.md](./acceptable-usage.md) for the marketplace polic
   already active return that run without starting a competing worker. Stale
   recovery continues the same durable run instead of replacing it, and
   cursor-guarded writes prevent overlapping late workers from duplicating work.
-  Explicitly bounded previews remain diagnostic-only.
+  Explicitly bounded previews remain diagnostic-only. Moderators can cancel the
+  displayed running signal scan without deleting recorded evidence. Cancellation
+  uses the shared terminal state so scheduled work stops, records the actor, and
+  is a no-op if that exact run has already finished or been replaced. A signal run
+  from an older model must not lock the control that starts its replacement.
   New scan indexes must ship in a staging-only release before any function
   queries them. Keep the indexes marked `staged: true`, deploy that schema,
   and wait until Convex reports every index ready. Only a later release may

--- a/src/routes/-management.test.tsx
+++ b/src/routes/-management.test.tsx
@@ -1040,7 +1040,63 @@ describe("Management", () => {
       expect(startSignalScan).toHaveBeenCalledWith({});
     });
     expect(startScoreScan).not.toHaveBeenCalled();
-    expect(screen.getByText("Checks every active skill")).toBeTruthy();
+  });
+
+  it("cancels a running signal scan from the Signals tab after confirmation", async () => {
+    searchState = { view: "abuse", tab: "signals" };
+    const cancelScan = vi.fn(async () => ({
+      ok: true,
+      canceled: true,
+      runId: "publisherAbuseScoreRuns:running",
+    }));
+    useMutationMock.mockImplementation((mutation) =>
+      getFunctionName(mutation) === "publisherAbuseTemporalScan:cancelPublisherAbuseSignalScan"
+        ? cancelScan
+        : vi.fn(),
+    );
+    useQueryMock.mockImplementation((query, args) => {
+      if (args === "skip") return undefined;
+      const name = getFunctionName(query);
+      if (name === "skills:listRecentVersions") return [];
+      if (name === "skills:listReportedSkills") return [];
+      if (name === "skills:listDuplicateCandidates") return [];
+      if (name === "publisherAbuse:listReviewDashboard") {
+        return {
+          latestRun: null,
+          latestSignalRun: {
+            _id: "publisherAbuseScoreRuns:running",
+            status: "running",
+            temporalPipelineKind: "signals",
+            temporalPipelinePhase: "classifying",
+            scannedPublishers: 3,
+            temporalSampleSize: 3,
+            transientErrorCount: 0,
+          },
+          pendingItems: [],
+          pendingPotentialBanCandidateItems: [],
+          pendingReviewItems: [],
+          recentResolvedItems: [],
+          signalCount: 0,
+          signalCountHasMore: false,
+        };
+      }
+      if (name === "users:list") return { items: [], total: 0 };
+      return undefined;
+    });
+
+    render(<Management />);
+
+    expect(screen.getByRole("button", { name: "Scanning signals" })).toHaveProperty(
+      "disabled",
+      true,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Cancel scan" }));
+    expect(cancelScan).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole("button", { name: "Cancel scan now" }));
+
+    await waitFor(() => {
+      expect(cancelScan).toHaveBeenCalledWith({ runId: "publisherAbuseScoreRuns:running" });
+    });
   });
 
   it("shows a focused signal scan summary without unrelated scoring or auto-ban controls", () => {
@@ -1075,11 +1131,10 @@ describe("Management", () => {
 
     expect(screen.getByText("Latest signal scan")).toBeTruthy();
     expect(screen.getByText("70,679 skills checked")).toBeTruthy();
-    expect(screen.getByText("Manual review only")).toBeTruthy();
-    expect(screen.getByText("Signals never auto-ban publishers.")).toBeTruthy();
     expect(screen.queryByText("Scored")).toBeNull();
     expect(screen.queryByText("Auto-ban is off")).toBeNull();
     expect(screen.queryByLabelText("Publisher abuse auto-ban")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Cancel scan" })).toBeNull();
   });
 
   it("shows the terminal signal scan error after five failed attempts", () => {

--- a/src/routes/-management.test.tsx
+++ b/src/routes/-management.test.tsx
@@ -1044,11 +1044,13 @@ describe("Management", () => {
 
   it("cancels a running signal scan from the Signals tab after confirmation", async () => {
     searchState = { view: "abuse", tab: "signals" };
-    const cancelScan = vi.fn(async () => ({
-      ok: true,
-      canceled: true,
-      runId: "publisherAbuseScoreRuns:running",
-    }));
+    let scanStatus: "running" | "failed" = "running";
+    let canceledAt: number | undefined;
+    const cancelScan = vi.fn(async () => {
+      scanStatus = "failed";
+      canceledAt = 1_700_000_000_000;
+      return { ok: true, canceled: true, runId: "publisherAbuseScoreRuns:running" };
+    });
     useMutationMock.mockImplementation((mutation) =>
       getFunctionName(mutation) === "publisherAbuseTemporalScan:cancelPublisherAbuseSignalScan"
         ? cancelScan
@@ -1063,9 +1065,11 @@ describe("Management", () => {
       if (name === "publisherAbuse:listReviewDashboard") {
         return {
           latestRun: null,
+          latestSignalRunIsCurrentModel: true,
           latestSignalRun: {
             _id: "publisherAbuseScoreRuns:running",
-            status: "running",
+            status: scanStatus,
+            canceledAt,
             temporalPipelineKind: "signals",
             temporalPipelinePhase: "classifying",
             scannedPublishers: 3,
@@ -1084,7 +1088,7 @@ describe("Management", () => {
       return undefined;
     });
 
-    render(<Management />);
+    const { rerender } = render(<Management />);
 
     expect(screen.getByRole("button", { name: "Scanning signals" })).toHaveProperty(
       "disabled",
@@ -1097,6 +1101,51 @@ describe("Management", () => {
     await waitFor(() => {
       expect(cancelScan).toHaveBeenCalledWith({ runId: "publisherAbuseScoreRuns:running" });
     });
+    rerender(<Management />);
+    expect(screen.getByText("Canceled")).toBeTruthy();
+  });
+
+  it("lets staff replace an outdated running signal scan", () => {
+    searchState = { view: "abuse", tab: "signals" };
+    useQueryMock.mockImplementation((query, args) => {
+      if (args === "skip") return undefined;
+      const name = getFunctionName(query);
+      if (name === "skills:listRecentVersions") return [];
+      if (name === "skills:listReportedSkills") return [];
+      if (name === "skills:listDuplicateCandidates") return [];
+      if (name === "publisherAbuse:listReviewDashboard") {
+        return {
+          latestRun: null,
+          latestSignalRunIsCurrentModel: false,
+          latestSignalRun: {
+            _id: "publisherAbuseScoreRuns:outdated",
+            status: "running",
+            temporalPipelinePhase: "classifying",
+            temporalSampleSize: 60_600,
+            transientErrorCount: 1,
+            lastTransientError: "Old worker stopped.",
+          },
+          pendingItems: [],
+          pendingPotentialBanCandidateItems: [],
+          pendingReviewItems: [],
+          recentResolvedItems: [],
+          signalCount: 0,
+          signalCountHasMore: false,
+        };
+      }
+      if (name === "users:list") return { items: [], total: 0 };
+      return undefined;
+    });
+
+    render(<Management />);
+
+    expect(screen.getByText("Outdated")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Rescan signals" })).toHaveProperty(
+      "disabled",
+      false,
+    );
+    expect(screen.queryByRole("button", { name: "Cancel scan" })).toBeNull();
+    expect(screen.queryByText(/Retrying after/)).toBeNull();
   });
 
   it("shows a focused signal scan summary without unrelated scoring or auto-ban controls", () => {
@@ -1171,7 +1220,7 @@ describe("Management", () => {
     expect(screen.getByText("Query exceeded the document read limit.")).toBeTruthy();
   });
 
-  it("does not show a retry warning for a completed signal scan", () => {
+  it("shows retry progress for the current running signal scan", () => {
     searchState = { view: "abuse", tab: "signals" };
     useQueryMock.mockImplementation((query, args) => {
       if (args === "skip") return undefined;
@@ -1182,8 +1231,9 @@ describe("Management", () => {
       if (name === "publisherAbuse:listReviewDashboard") {
         return {
           latestRun: null,
+          latestSignalRunIsCurrentModel: true,
           latestSignalRun: {
-            status: "completed",
+            status: "running",
             scannedPublishers: 120,
             scoredPublishers: 12,
             transientErrorCount: 1,
@@ -1201,7 +1251,7 @@ describe("Management", () => {
 
     render(<Management />);
 
-    expect(screen.queryByText("Retrying after 1 of 5 failed attempts")).toBeNull();
+    expect(screen.getByText("Retrying after 1 of 5 failed attempts")).toBeTruthy();
   });
 
   it("shows the number of skills processed by a running signal scan", () => {
@@ -1215,6 +1265,7 @@ describe("Management", () => {
       if (name === "publisherAbuse:listReviewDashboard") {
         return {
           latestRun: null,
+          latestSignalRunIsCurrentModel: true,
           latestSignalRun: {
             status: "running",
             scannedPublishers: 0,

--- a/src/routes/-management/AbusePage.tsx
+++ b/src/routes/-management/AbusePage.tsx
@@ -2,6 +2,7 @@ import { Link } from "@tanstack/react-router";
 import { useQuery } from "convex/react";
 import {
   Ban,
+  CircleStop,
   Copy,
   ExternalLink,
   Power,
@@ -58,8 +59,10 @@ export function AbusePage({
   signalItems,
   signalLoadedCount,
   signalPageStatus,
+  signalScanCancelPending,
   tab,
   onBanOwner,
+  onCancelSignalScan,
   onChangeNotes,
   onChangeSearch,
   onChangeTab,
@@ -90,8 +93,10 @@ export function AbusePage({
   signalItems: PublisherAbuseSignalEntry[];
   signalLoadedCount: number;
   signalPageStatus: string;
+  signalScanCancelPending: boolean;
   tab: PublisherAbuseTab;
   onBanOwner: (item: PublisherAbuseReviewItem) => void;
+  onCancelSignalScan: (runId: Id<"publisherAbuseScoreRuns">) => void;
   onChangeNotes: (value: string) => void;
   onChangeSearch: (value: string) => void;
   onChangeTab: (value: PublisherAbuseTab) => void;
@@ -248,8 +253,17 @@ export function AbusePage({
   const autobanToggleLabel = autobanEnabled ? "Turn off auto-ban" : "Turn on auto-ban";
   const AutobanStatusIcon = autobanEnabled ? ShieldCheck : ShieldOff;
   const scanRunning = displayedRun?.status === "running";
-  const scanStatusClass =
-    displayedRun?.status === "completed"
+  const runningSignalRunId =
+    tab === "signals" && latestSignalRun?.status === "running" ? latestSignalRun._id : null;
+  const scanCanceled =
+    displayedRun?.status === "failed" && (displayedRun.canceledAt ?? null) !== null;
+  const signalScanCanceledAt =
+    tab === "signals" && latestSignalRun?.status === "failed"
+      ? (latestSignalRun.canceledAt ?? null)
+      : null;
+  const scanStatusClass = scanCanceled
+    ? "is-canceled"
+    : displayedRun?.status === "completed"
       ? "is-complete"
       : displayedRun?.status === "failed"
         ? "is-failed"
@@ -269,7 +283,7 @@ export function AbusePage({
           </p>
         </div>
         <div
-          className="pa-run"
+          className={tab === "signals" ? "pa-run pa-run-signals" : "pa-run"}
           aria-label={tab === "signals" ? "Signal scan status" : "Publisher scan status"}
         >
           <div className="pa-run-state">
@@ -279,7 +293,9 @@ export function AbusePage({
             <strong className={`pa-run-status ${scanStatusClass}`}>
               <span className="pa-run-status-dot" aria-hidden="true" />
               {displayedRun
-                ? formatPublisherAbuseRunStatus(displayedRun.status)
+                ? scanCanceled
+                  ? "Canceled"
+                  : formatPublisherAbuseRunStatus(displayedRun.status)
                 : dashboardLoaded
                   ? "No scans yet"
                   : "Loading"}
@@ -300,12 +316,7 @@ export function AbusePage({
               </div>
             ) : null}
           </dl>
-          {tab === "signals" ? (
-            <div className="pa-scan-policy">
-              <strong>Manual review only</strong>
-              <span>Signals never auto-ban publishers.</span>
-            </div>
-          ) : (
+          {tab !== "signals" ? (
             <div className="pa-autoban" aria-label="Publisher abuse auto-ban">
               <span className={autobanEnabled ? "pa-autoban-status is-on" : "pa-autoban-status"}>
                 <AutobanStatusIcon size={14} />
@@ -322,27 +333,51 @@ export function AbusePage({
                 {admin ? autobanToggleLabel : "Admins only"}
               </Button>
             </div>
-          )}
+          ) : null}
           <div className="pa-rescan">
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              disabled={scanRunning}
-              aria-label={tab === "signals" && scanRunning ? "Scanning signals" : undefined}
-              onClick={onRefresh}
-            >
-              <RefreshCcw className={scanRunning ? "pa-scan-spin" : undefined} size={14} />
-              {scanRunning ? "Scanning…" : tab === "signals" ? "Rescan signals" : "Run new scan"}
-            </Button>
-            <span className="pa-rescan-hint">
-              {tab === "signals" ? "Checks every active skill" : "Re-scores every publisher"}
-            </span>
+            <div className="pa-rescan-actions">
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                disabled={scanRunning}
+                aria-label={tab === "signals" && scanRunning ? "Scanning signals" : undefined}
+                onClick={onRefresh}
+              >
+                <RefreshCcw className={scanRunning ? "pa-scan-spin" : undefined} size={14} />
+                {scanRunning ? "Scanning…" : tab === "signals" ? "Rescan signals" : "Run new scan"}
+              </Button>
+              {runningSignalRunId ? (
+                <Button
+                  type="button"
+                  variant="destructive"
+                  size="sm"
+                  loading={signalScanCancelPending}
+                  onClick={() => onCancelSignalScan(runningSignalRunId)}
+                >
+                  {signalScanCancelPending ? "Canceling…" : "Cancel scan"}
+                </Button>
+              ) : null}
+            </div>
+            {tab !== "signals" ? (
+              <span className="pa-rescan-hint">Re-scores every publisher</span>
+            ) : null}
           </div>
         </div>
       </header>
 
-      {tab === "signals" && latestSignalRun?.status === "failed" ? (
+      {signalScanCanceledAt !== null ? (
+        <div className="pa-scan-canceled" role="status">
+          <CircleStop aria-hidden="true" size={18} />
+          <div>
+            <strong>Signal scan canceled</strong>
+            <span>
+              Canceled {formatShortTimestamp(signalScanCanceledAt)}. Signals already recorded are
+              kept — start a new scan when you're ready.
+            </span>
+          </div>
+        </div>
+      ) : tab === "signals" && latestSignalRun?.status === "failed" ? (
         <div className="pa-scan-failure" role="alert">
           <XCircle aria-hidden="true" size={18} />
           <div>

--- a/src/routes/-management/AbusePage.tsx
+++ b/src/routes/-management/AbusePage.tsx
@@ -252,24 +252,28 @@ export function AbusePage({
     : "Auto-ban loading";
   const autobanToggleLabel = autobanEnabled ? "Turn off auto-ban" : "Turn on auto-ban";
   const AutobanStatusIcon = autobanEnabled ? ShieldCheck : ShieldOff;
-  const scanRunning = displayedRun?.status === "running";
-  const runningSignalRunId =
-    tab === "signals" && latestSignalRun?.status === "running" ? latestSignalRun._id : null;
+  const signalScanCurrent = dashboard?.latestSignalRunIsCurrentModel ?? false;
+  const scanRunning =
+    displayedRun?.status === "running" && (tab !== "signals" || signalScanCurrent);
+  const runningSignalRunId = tab === "signals" && scanRunning ? latestSignalRun?._id : null;
+  const scanOutdated =
+    tab === "signals" && latestSignalRun?.status === "running" && !signalScanCurrent;
   const scanCanceled =
     displayedRun?.status === "failed" && (displayedRun.canceledAt ?? null) !== null;
   const signalScanCanceledAt =
     tab === "signals" && latestSignalRun?.status === "failed"
       ? (latestSignalRun.canceledAt ?? null)
       : null;
-  const scanStatusClass = scanCanceled
-    ? "is-canceled"
-    : displayedRun?.status === "completed"
-      ? "is-complete"
-      : displayedRun?.status === "failed"
-        ? "is-failed"
-        : displayedRun?.status === "running"
-          ? "is-running"
-          : "is-idle";
+  const scanStatusClass =
+    scanCanceled || scanOutdated
+      ? "is-canceled"
+      : displayedRun?.status === "completed"
+        ? "is-complete"
+        : displayedRun?.status === "failed"
+          ? "is-failed"
+          : displayedRun?.status === "running"
+            ? "is-running"
+            : "is-idle";
 
   return (
     <section className="pa" aria-labelledby="pa-title">
@@ -295,7 +299,9 @@ export function AbusePage({
               {displayedRun
                 ? scanCanceled
                   ? "Canceled"
-                  : formatPublisherAbuseRunStatus(displayedRun.status)
+                  : scanOutdated
+                    ? "Outdated"
+                    : formatPublisherAbuseRunStatus(displayedRun.status)
                 : dashboardLoaded
                   ? "No scans yet"
                   : "Loading"}
@@ -391,7 +397,10 @@ export function AbusePage({
             </span>
           </div>
         </div>
-      ) : tab === "signals" && latestSignalRun?.status === "running" && signalFailureCount > 0 ? (
+      ) : tab === "signals" &&
+        signalScanCurrent &&
+        latestSignalRun?.status === "running" &&
+        signalFailureCount > 0 ? (
         <div className="pa-scan-retrying" role="status">
           <RefreshCcw aria-hidden="true" size={18} />
           <div>

--- a/src/routes/management.tsx
+++ b/src/routes/management.tsx
@@ -284,6 +284,9 @@ export function Management() {
   const startPublisherAbuseSignalScan = useAction(
     api.publisherAbuseTemporalScan.startPublisherAbuseSignalScan,
   );
+  const cancelPublisherAbuseSignalScan = useMutation(
+    api.publisherAbuseTemporalScan.cancelPublisherAbuseSignalScan,
+  );
 
   const [selectedDuplicate, setSelectedDuplicate] = useState("");
   const [selectedOwner, setSelectedOwner] = useState<Id<"users"> | "">("");
@@ -301,6 +304,7 @@ export function Management() {
   );
   const [publisherAbuseSearch, setPublisherAbuseSearch] = useState("");
   const [publisherAbuseNotes, setPublisherAbuseNotes] = useState("");
+  const [signalScanCancelPending, setSignalScanCancelPending] = useState(false);
   const [selectedPublisherAbuseNominationId, setSelectedPublisherAbuseNominationId] =
     useState<Id<"publisherAbuseReviewNominations"> | null>(null);
   const {
@@ -624,6 +628,27 @@ export function Management() {
     });
   };
 
+  const requestCancelPublisherAbuseSignalScan = (runId: Id<"publisherAbuseScoreRuns">) => {
+    if (signalScanCancelPending) return;
+    setConfirmRequest({
+      title: "Cancel the running signal scan?",
+      body: "Stops the in-progress scan and keeps every signal already recorded. You can start a new scan whenever you're ready.",
+      confirmLabel: "Cancel scan now",
+      destructive: true,
+      onConfirm: () => {
+        setSignalScanCancelPending(true);
+        void cancelPublisherAbuseSignalScan({ runId })
+          .then((result) =>
+            toast.success(
+              result.canceled ? "Signal scan canceled." : "No running signal scan to cancel.",
+            ),
+          )
+          .catch((error) => toast.error(formatMutationError(error)))
+          .finally(() => setSignalScanCancelPending(false));
+      },
+    });
+  };
+
   const requestMarkPublisherAbuseNominationReviewed = (item: PublisherAbuseReviewItem) => {
     const label = item.nomination.handleSnapshot;
     const note = publisherAbuseNotes.trim() || undefined;
@@ -746,8 +771,10 @@ export function Management() {
             signalItems={filteredPublisherAbuseSignals}
             signalLoadedCount={publisherAbuseSignalItems.length}
             signalPageStatus={publisherAbuseSignalPageStatus}
+            signalScanCancelPending={signalScanCancelPending}
             tab={publisherAbuseTab}
             onBanOwner={banPublisherAbuseOwner}
+            onCancelSignalScan={requestCancelPublisherAbuseSignalScan}
             onChangeNotes={setPublisherAbuseNotes}
             onChangeSearch={setPublisherAbuseSearch}
             onChangeTab={(nextTab) => {

--- a/src/styles.css
+++ b/src/styles.css
@@ -14717,9 +14717,12 @@ a.skills-sh-security-audit-row:focus-visible {
   background: color-mix(in srgb, var(--panel) 70%, transparent);
 }
 
+.pa-run-signals {
+  grid-template-columns: minmax(140px, auto) minmax(140px, auto) 1fr;
+}
+
 .pa-run-state,
 .pa-run-meta,
-.pa-scan-policy,
 .pa-autoban,
 .pa-rescan {
   padding: var(--space-3) var(--space-4);
@@ -14780,6 +14783,14 @@ a.skills-sh-security-audit-row:focus-visible {
   background: currentColor;
 }
 
+.pa-run-status.is-canceled {
+  color: var(--ink-soft);
+}
+
+.pa-run-status.is-canceled .pa-run-status-dot {
+  background: currentColor;
+}
+
 .pa-autoban {
   display: grid;
   align-content: center;
@@ -14810,6 +14821,12 @@ a.skills-sh-security-audit-row:focus-visible {
   border-left: 1px solid var(--line);
 }
 
+.pa-rescan-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
 .pa-rescan-hint {
   font-size: var(--fs-xs);
   color: var(--ink-soft);
@@ -14833,23 +14850,6 @@ a.skills-sh-security-audit-row:focus-visible {
   font-size: var(--fs-sm);
   font-weight: 650;
   font-variant-numeric: tabular-nums;
-}
-
-.pa-scan-policy {
-  display: grid;
-  align-content: center;
-  gap: 2px;
-  border-left: 1px solid var(--line);
-}
-
-.pa-scan-policy strong {
-  font-size: var(--fs-sm);
-  font-weight: 650;
-}
-
-.pa-scan-policy span {
-  color: var(--ink-soft);
-  font-size: var(--fs-xs);
 }
 
 .pa-scan-spin {
@@ -14897,6 +14897,33 @@ a.skills-sh-security-audit-row:focus-visible {
   border-color: color-mix(in srgb, var(--oc-status-warning-fg) 30%, var(--line));
   background: var(--oc-status-warning-bg);
   color: var(--oc-status-warning-fg);
+}
+
+.pa-scan-canceled {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-2);
+  padding: var(--space-3) var(--space-4);
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, var(--panel) 70%, transparent);
+  color: var(--ink);
+}
+
+.pa-scan-canceled svg {
+  flex: none;
+  color: var(--ink-soft);
+}
+
+.pa-scan-canceled > div {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+
+.pa-scan-canceled span {
+  overflow-wrap: anywhere;
+  color: var(--ink-soft);
+  font-size: var(--fs-sm);
 }
 
 .pa-tabs {
@@ -15585,7 +15612,6 @@ a.skills-sh-security-audit-row:focus-visible {
     grid-template-columns: 1fr 1fr;
   }
 
-  .pa-scan-policy,
   .pa-autoban {
     border-top: 1px solid var(--line);
     border-left: 0;
@@ -15593,6 +15619,10 @@ a.skills-sh-security-audit-row:focus-visible {
 
   .pa-rescan {
     border-top: 1px solid var(--line);
+  }
+
+  .pa-run-signals .pa-rescan {
+    grid-column: 1 / -1;
   }
 }
 
@@ -15607,7 +15637,6 @@ a.skills-sh-security-audit-row:focus-visible {
   }
 
   .pa-run-meta,
-  .pa-scan-policy,
   .pa-autoban,
   .pa-rescan {
     border-top: 1px solid var(--line);
@@ -15616,6 +15645,11 @@ a.skills-sh-security-audit-row:focus-visible {
 
   .pa-rescan [data-slot="button"] {
     width: 100%;
+    min-height: 44px;
+  }
+
+  .pa-run-signals .pa-rescan {
+    grid-column: auto;
   }
 
   .pa-score,


### PR DESCRIPTION
Signal scans could leave the staff page stuck on **Scanning**, with no way to stop them. Old scan data could also block a new run, and a canceled run looked like a failure.

This PR lets moderators stop only the exact scan they can see, keeps the evidence already recorded, and prevents workers from writing after the stop. Old scans now show as **Outdated**, while canceled scans show a neutral state with **Rescan** available.

## How cancellation works

This shows the path from an active scan to a safe stop or replacement.

<img src="https://github.com/user-attachments/assets/955afcdb-c0f6-480d-8531-5fc3fbcba046" alt="Signal scan cancellation checks the exact current run, preserves evidence, writes an audit record, and allows a replacement scan" width="100%">

*What this explains: only the current visible scan can be canceled; finished, replaced, and outdated scans follow safe no-change or rescan paths.*

## Change breakdown

| Part | Files | +LOC | -LOC |
| --- | ---: | ---: | ---: |
| Implementation | 7 | +230 | -61 |
| Tests and fixtures | 5 | +299 | -13 |
| **Total** | **12** | **+529** | **-74** |

## Proof

Same local-admin fixture, light theme, Signals route, and viewports on both sides. The direct-base frontend uses the same canceled-run record from the isolated development backend so the old failure treatment can be compared; the base schema cannot store the new `canceledAt` field itself.

| Before: direct base | After: PR |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/c7778729-f89e-4759-bb74-025651ebfe53" alt="Desktop direct base shows cancellation as a red failure and includes the redundant manual-review block" width="100%"> | <img src="https://github.com/user-attachments/assets/d65016fb-b320-4a6c-a9b8-5107ef0a8f33" alt="Desktop PR shows cancellation as a neutral stopped state with Rescan and no policy block" width="100%"> |
| <img src="https://github.com/user-attachments/assets/28c96566-9e80-4bb4-a08f-4995a6dfedee" alt="Mobile direct base shows cancellation as a red failure and stacks the redundant policy copy" width="100%"> | <img src="https://github.com/user-attachments/assets/4d2ff1d0-7bc7-49fb-b57b-b6ac98dc0bb2" alt="Mobile PR shows a compact neutral canceled state and keeps the Signals table usable" width="100%"> |

The real staff flow takes 11 seconds: **Rescan → Run signal scan → Cancel scan → confirm → Canceled**.

https://github.com/user-attachments/assets/828e384e-1770-4d41-8aed-8433caa12f34

The isolated development database then contained:

```text
run_status: failed (canceledAt set)
retry_at: null
saved_signals: 3
audit: publisher_abuse.signal_scan.cancel (same run ID)
```

## How to verify

1. Sign in as a moderator and open **Management → Publisher abuse → Signals**.
2. Start a signal scan, choose **Cancel scan**, then confirm.
3. Expect **Canceled**, the existing signals still listed, and **Rescan signals** enabled.
