### PR TITLE
fix(cli): stage ClawPacks above the public edge limit

### DIFF
--- a/packages/clawhub/src/cli/commands/packages.test.ts
+++ b/packages/clawhub/src/cli/commands/packages.test.ts
@@ -2374,7 +2374,7 @@ describe("package commands", () => {
     }
   });
 
-  it("stages ClawPack tarballs over the multipart publish budget", async () => {
+  it("stages ClawPack tarballs over the public edge multipart budget", async () => {
     const workdir = await makeTmpWorkdir();
     try {
       const packName = "oversized-plugin-1.0.0.tgz";

--- a/packages/clawhub/src/cli/commands/packages.ts
+++ b/packages/clawhub/src/cli/commands/packages.ts
@@ -82,6 +82,8 @@ const LEGACY_DOT_DIR = ".clawdhub";
 const DOT_IGNORE = ".clawhubignore";
 const LEGACY_DOT_IGNORE = ".clawdhubignore";
 const PACKAGE_PUBLISH_RETRY_COUNT = 5;
+// Keep inline ClawPack requests below the clawhub.ai hosting edge's body limit.
+const MAX_PACKAGE_EDGE_MULTIPART_BYTES = 4 * 1024 * 1024;
 const PACKAGE_PUBLISH_POLL_INTERVAL_MS = 5_000;
 const DEFAULT_PACKAGE_PUBLISH_WAIT_TIMEOUT_SECONDS = 30 * 60;
 // ClawHub unpacks and stores a ClawPack inside one HTTP action before it
@@ -1026,7 +1028,14 @@ export async function cmdPublishPackage(
       form.set("payload", payloadJson);
 
       if (plan.clawpackOnDisk) {
-        if (isPackageMultipartTooLarge(payloadJson, "clawpack", [plan.clawpackOnDisk])) {
+        if (
+          isPackageMultipartTooLarge(
+            payloadJson,
+            "clawpack",
+            [plan.clawpackOnDisk],
+            MAX_PACKAGE_EDGE_MULTIPART_BYTES,
+          )
+        ) {
           const staged = await uploadClawPackToStorage(
             registry,
             publishToken,
@@ -2441,6 +2450,7 @@ function isPackageMultipartTooLarge(
   payloadJson: string,
   fileFieldName: "files" | "clawpack",
   files: PackageFile[],
+  maxBytes = MAX_PACKAGE_MULTIPART_BYTES,
 ) {
   return (
     estimatePackageMultipartUploadBytes({
@@ -2451,7 +2461,7 @@ function isPackageMultipartTooLarge(
         size: file.bytes.byteLength,
         type: file.contentType,
       })),
-    }) > MAX_PACKAGE_MULTIPART_BYTES
+    }) > maxBytes
   );
 }
 

--- a/specs/security-moderation.md
+++ b/specs/security-moderation.md
@@ -364,6 +364,9 @@ See also: [acceptable-usage.md](./acceptable-usage.md) for the marketplace polic
   clear ClawHub validation error before hitting Convex's 20MB HTTP action body
   cap. ClawPack tarballs keep the 120MB package tarball cap through staged
   storage uploads.
+- The CLI stages ClawPack requests whose estimated multipart size exceeds 4MB
+  so public publishes remain below the hosting edge's lower request-body limit.
+  This client threshold is intentionally lower than the backend's 18MB cap.
 - For tarball uploads, ClawHub stores the uploaded tarball, derives its
   artifact hashes and npm metadata, and derives package file metadata from the
   tarball contents.


### PR DESCRIPTION
## Summary

- stage ClawPack uploads when their estimated multipart request exceeds the public edge's 4 MiB request budget
- preserve the existing 18 MiB backend direct-upload limit and inline fast path for smaller packages
- cover the previously untested 4–18 MiB range that caused valid package publishes to receive `413 Request Entity Too Large`

Fixes [#3577](https://github.com/openclaw/clawhub/issues/3577).

## Real behavior proof

The baseline [`@shopify/ai-toolkit@1.8.0` workflow](https://github.com/Shopify/Shopify-AI-Toolkit/actions/runs/33650721342/job/100316932136) sent its 8,032,797-byte ClawPack inline and failed at the public edge with `413 Request Entity Too Large`.

Using the same artifact (`sha256:629149712be4621c42d9b211ae3ab3f63d9e44b3fbe1737ba2513e32b8ff10cb`), the public `https://clawhub.ai/api/cli/upload-url` route issued a staged-upload ticket and the complete 8 MB binary upload succeeded:

```text
ticket_http=200
upload_host=wry-manatee-359.convex.cloud
upload_ticket_received=true
upload_http=200
upload_bytes=8032797
storage_id_received=true
```

The CLI built from [this PR's head](https://github.com/openclaw/clawhub/commit/70d5a44f016bd4ce0b147fd7c624b667da0eaef6) then published that artifact through `--registry https://clawhub.ai`. The proof request deliberately overrode the payload version to `1.8.0-proof`, avoiding a synthetic release. After staging the 8 MB artifact, the small final package request crossed the public edge and reached backend ClawPack identity validation:

```text
PR_HEAD=70d5a44f016bd4ce0b147fd7c624b667da0eaef6
REGISTRY=https://clawhub.ai
ARTIFACT_BYTES=8032797
ARTIFACT_SHA256=629149712be4621c42d9b211ae3ab3f63d9e44b3fbe1737ba2513e32b8ff10cb
Error: ClawPack package.json version must match 1.8.0-proof
    at publishPackageImpl (../convex/packages.ts:8777:2)
EXIT_STATUS=1
```

That intentional application-level rejection can only occur after ticket issuance, binary storage upload, final metadata submission, and server-side parsing of the staged tarball. The after-fix path therefore traversed the real public setup without a `413`, while creating no test package or version.

## Tests

- `bun run --cwd packages/clawhub test:src -- src/cli/commands/packages.test.ts` (108 passed)
- `bun run ci:packages` (558 passed across ClawHub, artifact, and admin suites)
- `VITE_CONVEX_URL=https://example.invalid bun run ci:unit` (6,320 passed, 3 skipped)
- `bunx tsc -p packages/schema/tsconfig.json --noEmit`
- `bunx tsc -p packages/clawhub/tsconfig.json --noEmit`
- `bun run format:check`
- `bunx oxlint packages/clawhub/src/cli/commands/packages.ts packages/clawhub/src/cli/commands/packages.test.ts`

`bun run ci:static` could not complete in the Shopify development environment because its `bun audit` request was redirected to a corporate package proxy that returned HTTP 405. The full formatting check and focused lint passed; CI can run the complete static gate against the public registry.
<!-- github-gate:idempotency=github-gate:publish_pr_body:e2dfc97dbb4b0f2639b9e41a -->