### PR TITLE
fix: abort hung Hermit content-rights proxy fetches

### DIFF
--- a/convex/httpApiV1/contentRightsV1.test.ts
+++ b/convex/httpApiV1/contentRightsV1.test.ts
@@ -1,9 +1,35 @@
 /* @vitest-environment node */
 
-import { describe, expect, it, vi } from "vitest";
-import { proxyHermitContentRightsRequest } from "./contentRightsV1";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  HERMIT_CONTENT_RIGHTS_FETCH_TIMEOUT_MS,
+  proxyHermitContentRightsRequest,
+} from "./contentRightsV1";
+
+function hangUntilAborted(_input: unknown, init?: RequestInit) {
+  return new Promise<Response>((_resolve, reject) => {
+    const signal = init?.signal;
+    if (!signal) return;
+    signal.addEventListener(
+      "abort",
+      () => {
+        reject(
+          signal.reason instanceof Error
+            ? signal.reason
+            : new DOMException("The operation was aborted.", "AbortError"),
+        );
+      },
+      { once: true },
+    );
+  });
+}
 
 describe("ClawHub content rights Hermit proxy", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
   it("reads a case using the existing shared ClawHub-Hermit token", async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(JSON.stringify({ case: { caseId: "CHR-000007" }, files: [], events: [] }), {
@@ -27,6 +53,7 @@ describe("ClawHub content rights Hermit proxy", () => {
       {
         method: "GET",
         headers: { Authorization: "Bearer shared-token" },
+        signal: expect.any(AbortSignal),
       },
     );
   });
@@ -63,6 +90,7 @@ describe("ClawHub content rights Hermit proxy", () => {
     expect(response.status).toBe(201);
     const forwarded = fetchMock.mock.calls[0]?.[1] as RequestInit;
     expect(forwarded.method).toBe("POST");
+    expect(forwarded.signal).toBeInstanceOf(AbortSignal);
     expect(forwarded.body).toBeInstanceOf(FormData);
     const forwardedBody = forwarded.body as FormData;
     expect(forwardedBody.get("actor")).toBe("users:admin");
@@ -82,5 +110,47 @@ describe("ClawHub content rights Hermit proxy", () => {
     );
 
     expect(response.status).toBe(503);
+  });
+
+  it("returns 502 when a hung Hermit GET exceeds the fetch timeout", async () => {
+    vi.useFakeTimers();
+    // Node's AbortSignal.timeout is native and ignores fake timers. Drive abort via setTimeout.
+    vi.spyOn(AbortSignal, "timeout").mockImplementation((ms) => {
+      const controller = new AbortController();
+      setTimeout(() => {
+        controller.abort(
+          new DOMException("The operation was aborted due to timeout", "TimeoutError"),
+        );
+      }, ms);
+      return controller.signal;
+    });
+    let usedSignal: AbortSignal | undefined;
+    const fetchMock = vi.fn((_input: unknown, init?: RequestInit) => {
+      usedSignal = init?.signal ?? undefined;
+      return hangUntilAborted(_input, init);
+    });
+
+    const pending = proxyHermitContentRightsRequest(
+      new Request("https://clawhub.ai/api/v1/content-rights/CHR-000007"),
+      "users:admin",
+      {
+        baseUrl: "https://forms.openclaw.ai",
+        serviceToken: "shared-token",
+        fetch: fetchMock,
+      },
+    );
+
+    await Promise.resolve();
+    expect(usedSignal).toBeInstanceOf(AbortSignal);
+    expect(usedSignal?.aborted).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(HERMIT_CONTENT_RIGHTS_FETCH_TIMEOUT_MS - 1);
+    expect(usedSignal?.aborted).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(1);
+    const response = await pending;
+    expect(response.status).toBe(502);
+    expect(usedSignal?.aborted).toBe(true);
+    expect(await response.text()).toBe("Hermit content rights service unavailable");
   });
 });

--- a/convex/httpApiV1/contentRightsV1.ts
+++ b/convex/httpApiV1/contentRightsV1.ts
@@ -14,6 +14,9 @@ type ProxyDependencies = {
   fetch: typeof fetch;
 };
 
+// Admin Hermit proxy: do not hold the Convex action if forms.openclaw.ai stalls.
+export const HERMIT_CONTENT_RIGHTS_FETCH_TIMEOUT_MS = 10_000;
+
 const hermitCasePath = (caseId: string, correspondence = false) =>
   `/api/clawhub-content-rights/cases/${encodeURIComponent(caseId)}${
     correspondence ? "/correspondence" : ""
@@ -48,6 +51,7 @@ export async function proxyHermitContentRightsRequest(
         await dependencies.fetch(`${baseUrl}${hermitCasePath(caseId)}`, {
           method: "GET",
           headers,
+          signal: AbortSignal.timeout(HERMIT_CONTENT_RIGHTS_FETCH_TIMEOUT_MS),
         }),
       );
     }
@@ -59,6 +63,7 @@ export async function proxyHermitContentRightsRequest(
           method: "POST",
           headers,
           body: form,
+          signal: AbortSignal.timeout(HERMIT_CONTENT_RIGHTS_FETCH_TIMEOUT_MS),
         }),
       );
     }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where staff using the admin content-rights proxy would hang the Convex action when `forms.openclaw.ai` (or `HERMIT_CONTENT_RIGHTS_BASE_URL`) accepted the TCP connection and never finished the GET case or POST correspondence response. The proxy called `fetch` with no abort signal. A stalled Hermit host held the action until the platform limit.

The same hang class was already closed for public OG metadata fetches in [PR #3471](https://github.com/openclaw/clawhub/pull/3471) and for registry discovery in [PR #3378](https://github.com/openclaw/clawhub/pull/3378). The admin Hermit proxy did not get that deadline.

## Why This Change Was Made

Both Hermit `fetch` calls now pass `AbortSignal.timeout(10_000)`. Ten seconds is long enough for an admin form POST with attachments, and short enough that a silent Hermit host cannot pin a Convex action. The existing catch path still returns HTTP 502 `Hermit content rights service unavailable`. Missing `CLAWHUB_BAN_APPEALS_TOKEN` is still 503 and never contacts Hermit.

## User Impact

Staff content-rights GET and correspondence POST fail closed after 10 seconds when Hermit stalls, instead of sitting on the action until Convex kills it. Successful Hermit replies are unchanged.

## Evidence

Live `bun` on Darwin arm64, Node v26.7.0, worktree `/tmp/clawhub-F005` at `6a6c06597ae17451c8aa47254e6a967119df2ab4`. Script `/tmp/clawhub-f005-proof.mjs` starts a local `node:http` server that never writes a response, then:

1. `fetch(hangUrl)` with no signal against an 800ms harness
2. `fetch(hangUrl, { signal: AbortSignal.timeout(400) })`
3. Production `proxyHermitContentRightsRequest` with a never-settling `fetch` that rejects only when `init.signal` aborts

```console
$ bun /tmp/clawhub-f005-proof.mjs
timeout_ms 10000
hang_url http://127.0.0.1:61333/hang
unpatched_fetch Error HARNESS_TIMEOUT elapsed_ms 808
timeout_fetch TimeoutError The operation timed out. elapsed_ms 405
proxy_status 502 proxy_body Hermit content rights service unavailable elapsed_ms 10004
```

Without a signal, the mute origin is still waiting when the 800ms harness fires. `AbortSignal.timeout(400)` aborts in 405ms. The product proxy, using the 10s constant, returns 502 at 10004ms instead of hanging.

The untimeouted fetches landed in [3c9d4f12109bfd9b3ef8a42033228770f1bbe1d1](https://github.com/openclaw/clawhub/commit/3c9d4f12109bfd9b3ef8a42033228770f1bbe1d1) (`origin/main` blame on `convex/httpApiV1/contentRightsV1.ts` GET around line 48 and POST around line 58), shipped today in [#3493](https://github.com/openclaw/clawhub/pull/3493).

## Real behavior proof

- **Behavior or issue addressed:** Admin content-rights Hermit proxy now aborts a stalled `forms.openclaw.ai` fetch after 10 seconds and returns 502 instead of holding the Convex action.
- **Real environment tested:** macOS Darwin 25.6.0 arm64, Node v26.7.0, bun 1.3.14, worktree `/tmp/clawhub-F005` on `6a6c06597ae17451c8aa47254e6a967119df2ab4`. Proof used a local mute `node:http` server plus production `proxyHermitContentRightsRequest`.
- **Exact steps or command run after this patch:** From `/tmp/clawhub-F005`, ran `bun /tmp/clawhub-f005-proof.mjs`. That process listened on an ephemeral port, issued an unbounded `fetch` against the mute server, issued `fetch` with `AbortSignal.timeout(400)`, then called the production proxy with a `fetch` that only rejects when the abort signal fires.
- **Evidence after fix:** terminal output copied above. Unbounded `fetch` hit `HARNESS_TIMEOUT` at 808ms. `AbortSignal.timeout(400)` printed `TimeoutError The operation timed out.` at 405ms. The product proxy printed `proxy_status 502` and `Hermit content rights service unavailable` at 10004ms.
- **Observed result after fix:** A mute Hermit-style origin no longer holds the proxy. The 10s `AbortSignal.timeout` fires, and staff get HTTP 502 from the existing unavailable path.
- **What was not tested:** A live stall on forms.openclaw.ai. Windows. A real admin token against production Hermit.

## Notes

Same hang class as OG metadata in [PR #3471](https://github.com/openclaw/clawhub/pull/3471) (1.5s). This admin proxy uses 10s because correspondence POST can carry attachments.

Allow edits from maintainers is enabled.

## Tracker

Ref #3671

That issue stays open if this PR is closed without landing on main.
