### PR TITLE
docs: repair published plugin validation anchors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixes
 
+- Dependencies: pin fast-uri to 3.1.6 to fix host confusion and server-side request forgery advisories in URI normalization.
 - GitHub Actions: accept complete release inventories in parent authorization receipts up to the backend's 64 KiB limit while retaining 8 KiB identity and recovery limits.
 - API: preserve inspector findings when workspace cleanup fails, report the failing stage, and keep cleanup failures publication-blocking.
 - API: bound runtime-identity checks to the owning publisher, reject collisions during personal-principal recovery, and prevent malicious-release quarantine from restoring a historical runtime identity that was administratively replaced.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixes
 
+- Docs: repair plugin validation remediation links to the published manifest metadata and runtime session helper sections while preserving valid CLI workflow anchors.
 - Dependencies: pin fast-uri to 3.1.6 to fix host confusion and server-side request forgery advisories in URI normalization.
 - GitHub Actions: accept complete release inventories in parent authorization receipts up to the backend's 64 KiB limit while retaining 8 KiB identity and recovery limits.
 - API: preserve inspector findings when workspace cleanup fails, report the failing stage, and keep cleanup failures publication-blocking.

--- a/bun.lock
+++ b/bun.lock
@@ -175,7 +175,7 @@
     "brace-expansion": "5.0.9",
     "dompurify": "3.4.13",
     "esbuild": "0.28.1",
-    "fast-uri": "3.1.5",
+    "fast-uri": "3.1.6",
     "js-yaml": "4.3.1",
     "nanoid": "3.3.18",
     "next": "16.2.11",
@@ -1317,7 +1317,7 @@
 
     "fast-string-width": ["fast-string-width@3.0.2", "", { "dependencies": { "fast-string-truncated-width": "^3.0.2" } }, "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg=="],
 
-    "fast-uri": ["fast-uri@3.1.5", "", {}, "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw=="],
+    "fast-uri": ["fast-uri@3.1.6", "", {}, "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q=="],
 
     "fast-wrap-ansi": ["fast-wrap-ansi@0.2.2", "", { "dependencies": { "fast-string-width": "^3.0.2" } }, "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q=="],
 

--- a/docs/plugin-validation-fixes.md
+++ b/docs/plugin-validation-fixes.md
@@ -66,7 +66,7 @@ npm package, version, entrypoints, or OpenClaw metadata.
 - Add `package.json` with `name`, `version`, and `type`.
 - Add an `openclaw` block when the package ships an OpenClaw plugin.
 - Use [Building plugins](/plugins/building-plugins) for a minimal package
-  example and [Plugin manifest](/plugins/manifest#manifest-versus-packagejson)
+  example and [Plugin manifest](/plugins/manifest#manifest-versus-package.json)
   for the package versus manifest split.
 - Rerun `clawhub package validate <path-to-plugin>`.
 
@@ -80,7 +80,7 @@ metadata.
   `openclaw.runtimeExtensions`.
 - Add compatibility and install metadata when the package will be published or
   installed through ClawHub.
-- See [package.json fields that affect discovery](/plugins/manifest#packagejson-fields-that-affect-discovery).
+- See [package.json fields that affect discovery](/plugins/manifest#package.json-fields-that-affect-discovery).
 - Rerun `clawhub package validate <path-to-plugin>`.
 
 ### package-openclaw-entry-missing
@@ -93,7 +93,7 @@ entrypoint.
   JavaScript.
 - Keep all entrypoint paths inside the package directory.
 - See [Plugin entry points](/plugins/sdk-entrypoints) and
-  [package.json fields that affect discovery](/plugins/manifest#packagejson-fields-that-affect-discovery).
+  [package.json fields that affect discovery](/plugins/manifest#package.json-fields-that-affect-discovery).
 - Rerun `clawhub package validate <path-to-plugin>`.
 
 ### package-entrypoint-missing
@@ -117,7 +117,7 @@ ClawHub cannot tell how the package should be installed or updated.
 - Set `openclaw.install.defaultChoice` when more than one install source is
   available.
 - Use `openclaw.install.minHostVersion` for the minimum OpenClaw host version.
-- See [package.json fields that affect discovery](/plugins/manifest#packagejson-fields-that-affect-discovery).
+- See [package.json fields that affect discovery](/plugins/manifest#package.json-fields-that-affect-discovery).
 - Rerun `clawhub package validate <path-to-plugin>`.
 
 ### package-plugin-api-compat-missing
@@ -129,7 +129,7 @@ The package does not declare the OpenClaw plugin API range it supports.
   against.
 - Keep this separate from the package version. The package version describes the
   plugin release; `openclaw.compat.pluginApi` describes the host API contract.
-- See [package.json fields that affect discovery](/plugins/manifest#packagejson-fields-that-affect-discovery).
+- See [package.json fields that affect discovery](/plugins/manifest#package.json-fields-that-affect-discovery).
 - Rerun `clawhub package validate <path-to-plugin>`.
 
 ### package-min-host-version-drift
@@ -142,7 +142,7 @@ the package was built against.
   used during release.
 - Align the minimum host version with the host version range the package
   actually supports.
-- See [package.json fields that affect discovery](/plugins/manifest#packagejson-fields-that-affect-discovery).
+- See [package.json fields that affect discovery](/plugins/manifest#package.json-fields-that-affect-discovery).
 - Rerun `clawhub package validate <path-to-plugin>`.
 
 ### package-manifest-version-drift
@@ -165,7 +165,7 @@ OpenClaw package metadata.
 - Keep native plugin metadata in `openclaw.plugin.json`.
 - Keep package entrypoints, compatibility, install, setup, and catalog metadata
   in supported `package.json#openclaw` fields.
-- See [package.json fields that affect discovery](/plugins/manifest#packagejson-fields-that-affect-discovery).
+- See [package.json fields that affect discovery](/plugins/manifest#package.json-fields-that-affect-discovery).
 - Rerun `clawhub package validate <path-to-plugin>`.
 
 ## Published artifact
@@ -278,7 +278,7 @@ The plugin still uses the deprecated whole-session-store helper
 - Avoid loading, mutating, and saving the whole session store object.
 - Keep `loadSessionStore(...)` only while your declared compatibility range
   still supports older OpenClaw versions that require it.
-- See [Runtime API](/plugins/sdk-runtime#agent-session-state) and
+- See [Runtime API](/plugins/sdk-runtime#runtime-namespaces) and
   [Plugin SDK subpaths](/plugins/sdk-subpaths).
 - Rerun `clawhub package validate <path-to-plugin>`.
 
@@ -293,7 +293,7 @@ The plugin still uses a deprecated whole-session-store write helper such as
 - Avoid loading, mutating, and saving the whole session store object.
 - Keep whole-store write helpers only while your declared compatibility range
   still supports older OpenClaw versions that require them.
-- See [Runtime API](/plugins/sdk-runtime#agent-session-state) and
+- See [Runtime API](/plugins/sdk-runtime#runtime-namespaces) and
   [Plugin SDK subpaths](/plugins/sdk-subpaths).
 - Rerun `clawhub package validate <path-to-plugin>`.
 
@@ -309,7 +309,7 @@ The plugin still uses deprecated session file-path helpers such as
 - Use transcript identity or target helpers when the code is preparing a
   transcript operation.
 - Do not persist or depend on legacy transcript file paths.
-- See [Runtime API](/plugins/sdk-runtime#agent-session-state) and
+- See [Runtime API](/plugins/sdk-runtime#runtime-namespaces) and
   [Plugin SDK subpaths](/plugins/sdk-subpaths).
 - Rerun `clawhub package validate <path-to-plugin>`.
 
@@ -325,7 +325,7 @@ The plugin still uses the deprecated transcript file target helper
 - Avoid reading or constructing legacy transcript file targets directly.
 - Keep the legacy helper only while your declared compatibility range still
   supports older OpenClaw versions that require it.
-- See [Runtime API](/plugins/sdk-runtime#agent-session-state) and
+- See [Runtime API](/plugins/sdk-runtime#runtime-namespaces) and
   [Plugin SDK subpaths](/plugins/sdk-subpaths).
 - Rerun `clawhub package validate <path-to-plugin>`.
 
@@ -341,7 +341,7 @@ The plugin still uses deprecated low-level transcript helpers such as
   correct transaction boundaries and identity handling.
 - Keep low-level transcript helpers only while your declared compatibility range
   still supports older OpenClaw versions that require them.
-- See [Runtime API](/plugins/sdk-runtime#agent-session-state) and
+- See [Runtime API](/plugins/sdk-runtime#runtime-namespaces) and
   [Plugin SDK subpaths](/plugins/sdk-subpaths).
 - Rerun `clawhub package validate <path-to-plugin>`.
 

--- a/package.json
+++ b/package.json
@@ -192,7 +192,7 @@
     "brace-expansion": "5.0.9",
     "dompurify": "3.4.13",
     "esbuild": "0.28.1",
-    "fast-uri": "3.1.5",
+    "fast-uri": "3.1.6",
     "js-yaml": "4.3.1",
     "nanoid": "3.3.18",
     "next": "16.2.11",

--- a/specs/openclaw-docs-extraction.md
+++ b/specs/openclaw-docs-extraction.md
@@ -44,3 +44,36 @@ in OpenClaw unless the owner explicitly asks for a separate extraction:
 For this slice, the ClawHub repo owns the new canonical source file. The
 OpenClaw worktree was read-only, so replacing OpenClaw sections with short links
 is left to the OpenClaw-side worker.
+
+## Published anchor contract
+
+ClawHub owns incoming links in `docs/`; OpenClaw owns plugin target content and
+`scripts/docs-link-audit.mts`; `openclaw/docs` owns the published renderer in
+`scripts/docs-site/mdx-ish.mjs`. Repair links in their canonical source, never
+in a generated mirror. The sync step rewrites relative page paths but preserves
+fragments, so it cannot reconcile renderer differences.
+
+The 2026-09-02 audit of ClawHub `d40547056deee00781721daa24cbc73c497cf2ba`
+found 12 stale links in `docs/plugin-validation-fixes.md`. The published manifest
+IDs are `manifest-versus-package.json` and
+`package.json-fields-that-affect-discovery`. Session and transcript helpers live
+under `runtime-namespaces` in the runtime reference, not `agent-session-state`.
+Keep the precise published section links rather than dropping their fragments
+or choosing checker-only spellings.
+
+At that audit, the publisher used `markdown-it@15.0.0` and
+`markdown-it-anchor@9.2.1`, while the core auditor pinned `mint@4.2.808`.
+Mint predicts hyphens instead of dots for the manifest IDs and counts repeated
+CLI GitHub Actions headings as `github-actions`, `github-actions-2`, and
+`github-actions-3`; the publisher emits `github-actions`, `github-actions-1`,
+and `github-actions-2`. Preserve the live-valid `#github-actions-1` links in
+`docs/cli.md` and `docs/publishing.md`: changing them to `-2` sends readers to
+the wrong section.
+
+Renderer/auditor parity belongs to the core auditor and publisher owners, not
+ClawHub link rewrites. With the 12 source repairs, the pinned Mint audit still
+reports nine renderer-only findings (seven manifest links and two CLI links).
+A parity fix must validate published IDs without hiding genuinely missing
+anchors, with regression coverage for punctuation, duplicate heading order,
+and unique target ownership. Recheck real rendered navigation when either
+renderer or its dependencies change.


### PR DESCRIPTION
## Summary

Repair 12 stale links in canonical ClawHub plugin-validation guidance without changing valid links to satisfy an incompatible anchor checker. Seven manifest references now use the published renderer’s dotted `package.json` IDs; five session/transcript references point to the existing Runtime namespaces section. The two `#github-actions-1` references in the CLI and publishing guides remain unchanged and continue to target the intended skill/catalog workflow section.

Record the published-anchor ownership contract in the extraction spec and add release-note context. ClawHub owns incoming documentation; OpenClaw core owns plugin reference content and the anchor auditor; the docs publishing repository owns rendering. No mirrored documentation is edited.

Include a minimal CI prerequisite: update the existing `fast-uri` override and lockfile resolution from 3.1.5 to patched 3.1.6. The unchanged baseline failed the required audit on GHSA-5jgf-p345-68v8, GHSA-f65p-4m7j-42xc, GHSA-fph4-wmhf-6fwf, and GHSA-jqff-g426-hqxp. No audit suppressions or CI gates are changed.

## Root cause and reader-visible behavior

| References | Old fragment | Published destination |
| --- | --- | --- |
| 1 manifest/package split link | `manifest-versus-packagejson` | `manifest-versus-package.json` |
| 6 package discovery links | `packagejson-fields-that-affect-discovery` | `package.json-fields-that-affect-discovery` |
| 5 session/transcript links | `agent-session-state` | `runtime-namespaces` |

The publisher uses `markdown-it@15.0.0` / `markdown-it-anchor@9.2.1`, while the audited core command pins `mint@4.2.808`. Mint predicts hyphenated manifest fragments and duplicate heading suffixes `base/-2/-3`; the publisher emits dotted manifest fragments and `base/-1/-2`. After these source repairs, that pinned Mint comparison still has nine renderer-only mismatches, not nine broken published targets. Fixing auditor parity is separate from rewriting already-valid reader links.

## Validation

Live Chromium navigation on `docs.openclaw.ai` confirmed that the three old destination IDs are absent, each replacement ID is unique and scrolls into view, and the Runtime namespaces agent accordion contains the session and transcript helpers. Clicking the existing links in both the CLI and publishing pages reaches the intended GitHub Actions catalog-workflow section. This verifies the existing live destinations, not deployment of this unmerged source patch.

A comparison using the actual published renderer and pinned Mint parser checks 21 relevant source links: zero invalid published targets, with the nine documented Mint-only differences. Exact-diff assertions verify that the guidance changes contain only the 12 intended substitutions and that the CLI/publishing files remain byte-identical.

The final candidate passes the following with repository-pinned Bun 1.3.10:

- `bun run docs:list`
- `bun run ci:static` (the four advisories are cleared; existing audit ignores are unchanged)
- `bunx tsc -p packages/schema/tsconfig.json --noEmit`
- `bunx tsc -p packages/clawhub/tsconfig.json --noEmit`
- `bun run ci:packages` (558 tests)
- `bun run ci:types-build`
- Installed-package checks for all four patched URI parsing cases plus Ajv relative-reference resolution
- Exact documentation replacement/unchanged-file assertions and `git diff --check`

The broader unit, HTTP, and browser suites run in PR CI before merge. No app UI, public API, audit policy, or CI limits are changed.

## Attached head-bound behavior evidence

Captured from the clean PR head `81ba33508db3f33e666d5ec709f66b6beea4e571` after the CI run. This directly addresses the proof-only request in the automated review; it is actual execution output, not a claim inferred from green CI. No code or dependency changed after the reviewed head.

The browser trace visits the existing live reference destinations and clicks both preserved CLI source links. The source/renderer trace separately proves that this head's 12 repaired source links target those published IDs. It does **not** claim that the unmerged ClawHub guide was already deployed. The URI checks execute this checkout's installed 3.1.6 package and Ajv on synthetic test inputs; the absolute local install path is redacted.

<details>
<summary>Real Chromium navigation trace: missing old IDs, unique visible replacements, runtime helpers, and preserved workflow clicks</summary>

```json
{
  "result": "PASS",
  "head": "81ba33508db3f33e666d5ec709f66b6beea4e571",
  "browser": "Isolated Chromium 152.0.7977.65",
  "checks": [
    {
      "kind": "repaired-target",
      "httpStatus": 200,
      "before": {
        "url": "https://docs.openclaw.ai/plugins/manifest#manifest-versus-packagejson",
        "id": "manifest-versus-packagejson",
        "exists": false,
        "unique": 0,
        "visible": false,
        "scrollY": 0
      },
      "after": {
        "url": "https://docs.openclaw.ai/plugins/manifest#manifest-versus-package.json",
        "id": "manifest-versus-package.json",
        "exists": true,
        "unique": 1,
        "text": "Manifest versus package.json",
        "nextText": "The two files serve different jobs:",
        "top": 176.1875,
        "visible": true,
        "scrollY": 52718
      }
    },
    {
      "kind": "repaired-target",
      "before": {
        "url": "https://docs.openclaw.ai/plugins/manifest#packagejson-fields-that-affect-discovery",
        "id": "packagejson-fields-that-affect-discovery",
        "exists": false,
        "unique": 0,
        "visible": false,
        "scrollY": 52772
      },
      "after": {
        "url": "https://docs.openclaw.ai/plugins/manifest#package.json-fields-that-affect-discovery",
        "id": "package.json-fields-that-affect-discovery",
        "exists": true,
        "unique": 1,
        "text": "package.json fields that affect discovery",
        "nextText": "Some pre-runtime plugin metadata intentionally lives in package.json under the openclaw block instead of openclaw.plugin.json. openclaw.bundle and openclaw.bundle.json are not OpenClaw plugin contracts; native plugins must use openclaw.plugin.json plus the supported package.json#openclaw fields below.",
        "top": 190.09375,
        "visible": true,
        "scrollY": 53146
      }
    },
    {
      "kind": "repaired-target",
      "httpStatus": 200,
      "before": {
        "url": "https://docs.openclaw.ai/plugins/sdk-runtime#agent-session-state",
        "id": "agent-session-state",
        "exists": false,
        "unique": 0,
        "visible": false,
        "scrollY": 0
      },
      "after": {
        "url": "https://docs.openclaw.ai/plugins/sdk-runtime#runtime-namespaces",
        "id": "runtime-namespaces",
        "exists": true,
        "unique": 1,
        "text": "Runtime namespaces",
        "nextText": "api.runtime.agent\nAgent identity, directories, and session management.\ntypescriptCopy code// Resolve the agent's working directory (agentId is required)const agentDir = api.runtime.agent.resolveAgentDir(cfg, agentId); // Resolve agent workspaceconst workspaceDir = api.runtime.agent.resolveAgentWorkspaceDir(cfg, agentId); // Get agent identityconst identity = api.runtime.agent.resolveAgentIdentity(cfg); // Get default thinking levelconst thinking ",
        "top": 190.71875,
        "visible": true,
        "scrollY": 5487
      }
    },
    {
      "kind": "runtime-content",
      "accordion": "api.runtime.agent",
      "open": true,
      "sessionAndTranscriptHelpers": true
    },
    {
      "kind": "preserved-source-click",
      "source": "/clawhub/cli",
      "href": "#github-actions-1",
      "after": {
        "url": "https://docs.openclaw.ai/clawhub/cli#github-actions-1",
        "id": "github-actions-1",
        "exists": true,
        "unique": 1,
        "text": "GitHub Actions",
        "nextText": "ClawHub ships an official reusable workflow at\n/.github/workflows/skill-publish.yml\nfor skill repos and catalog repos.",
        "top": 199.921875,
        "visible": true,
        "scrollY": 7665
      },
      "headings": [
        "github-actions",
        "github-actions-1",
        "github-actions-2"
      ]
    },
    {
      "kind": "preserved-source-click",
      "source": "/clawhub/publishing",
      "href": "/clawhub/cli#github-actions-1",
      "after": {
        "url": "https://docs.openclaw.ai/clawhub/cli#github-actions-1",
        "id": "github-actions-1",
        "exists": true,
        "unique": 1,
        "text": "GitHub Actions",
        "nextText": "ClawHub ships an official reusable workflow at\n/.github/workflows/skill-publish.yml\nfor skill repos and catalog repos.",
        "top": 196.921875,
        "visible": true,
        "scrollY": 7668
      },
      "headings": [
        "github-actions",
        "github-actions-1",
        "github-actions-2"
      ]
    }
  ]
}
```

</details>

<details>
<summary>Exact source-to-renderer trace: all 12 repairs and the preserved duplicate-heading contract</summary>

```json
{
  "head": "81ba33508db3f33e666d5ec709f66b6beea4e571",
  "coreTargetSource": "41419be40bbb17e5eed318992c8e3bf1aee6199b",
  "publisherRendererSource": "ce570c3c635cb0ace2cbc3883bb0a9832cb46683",
  "result": "PASS: 21 source links checked; 0 invalid publisher targets; 9 Mint failures",
  "repairedSourceReferences": [
    {
      "file": "plugin-validation-fixes.md",
      "line": 69,
      "target": "/plugins/manifest#manifest-versus-package.json",
      "publisher": true,
      "mint": false
    },
    {
      "file": "plugin-validation-fixes.md",
      "line": 83,
      "target": "/plugins/manifest#package.json-fields-that-affect-discovery",
      "publisher": true,
      "mint": false
    },
    {
      "file": "plugin-validation-fixes.md",
      "line": 96,
      "target": "/plugins/manifest#package.json-fields-that-affect-discovery",
      "publisher": true,
      "mint": false
    },
    {
      "file": "plugin-validation-fixes.md",
      "line": 120,
      "target": "/plugins/manifest#package.json-fields-that-affect-discovery",
      "publisher": true,
      "mint": false
    },
    {
      "file": "plugin-validation-fixes.md",
      "line": 132,
      "target": "/plugins/manifest#package.json-fields-that-affect-discovery",
      "publisher": true,
      "mint": false
    },
    {
      "file": "plugin-validation-fixes.md",
      "line": 145,
      "target": "/plugins/manifest#package.json-fields-that-affect-discovery",
      "publisher": true,
      "mint": false
    },
    {
      "file": "plugin-validation-fixes.md",
      "line": 168,
      "target": "/plugins/manifest#package.json-fields-that-affect-discovery",
      "publisher": true,
      "mint": false
    },
    {
      "file": "plugin-validation-fixes.md",
      "line": 281,
      "target": "/plugins/sdk-runtime#runtime-namespaces",
      "publisher": true,
      "mint": true
    },
    {
      "file": "plugin-validation-fixes.md",
      "line": 296,
      "target": "/plugins/sdk-runtime#runtime-namespaces",
      "publisher": true,
      "mint": true
    },
    {
      "file": "plugin-validation-fixes.md",
      "line": 312,
      "target": "/plugins/sdk-runtime#runtime-namespaces",
      "publisher": true,
      "mint": true
    },
    {
      "file": "plugin-validation-fixes.md",
      "line": 328,
      "target": "/plugins/sdk-runtime#runtime-namespaces",
      "publisher": true,
      "mint": true
    },
    {
      "file": "plugin-validation-fixes.md",
      "line": 344,
      "target": "/plugins/sdk-runtime#runtime-namespaces",
      "publisher": true,
      "mint": true
    }
  ],
  "cliDuplicateIds": {
    "publisher": [
      "github-actions",
      "github-actions-1",
      "github-actions-2"
    ],
    "mint": [
      "github-actions",
      "github-actions-2",
      "github-actions-3"
    ]
  }
}
```

</details>

<details>
<summary>Installed fast-uri and Ajv behavior output</summary>

```text
Runtime: 1.3.10
Installed fast-uri: node_modules/fast-uri/index.js (version 3.1.6)
PASS GHSA-5jgf-p345-68v8: scheme-relative IDN host canonicalization
PASS GHSA-f65p-4m7j-42xc: malformed IPv6 rejection; valid IPv6 preserved
PASS GHSA-fph4-wmhf-6fwf: nested hostname escapes stay inert
PASS GHSA-jqff-g426-hqxp: malformed decoded schemes rejected; valid schemes preserved
PASS Ajv relative schema reference resolution and validation
```

These assertions cover scheme-relative IDN canonicalization; malformed IPv6 rejection while preserving valid IPv6; nested hostname escapes remaining inert; malformed decoded schemes being rejected while valid schemes remain valid; and Ajv resolving a relative schema reference and accepting/rejecting the expected values. The synthetic cases do not issue network requests.

</details>
