### PR TITLE
Remove misleading severity labels from Signals

### DIFF
--- a/src/routes/-management.test.tsx
+++ b/src/routes/-management.test.tsx
@@ -988,6 +988,29 @@ describe("Management", () => {
     expect(screen.queryByText("Loading publisher abuse nominations…")).toBeNull();
   });
 
+  it("uses Signal-first loading placeholders on the Signals tab", () => {
+    searchState = { view: "abuse", tab: "signals" };
+    usePaginatedQueryMock.mockImplementation((query, args) => ({
+      results: [],
+      status:
+        getFunctionName(query) === "publisherAbuse:listSignalsPage" && args !== "skip"
+          ? "LoadingFirstPage"
+          : "Exhausted",
+      loadMore: vi.fn(),
+    }));
+
+    render(<Management />);
+
+    const loadingStatus = screen.getByRole("status", {
+      name: "Loading publisher abuse signals",
+    });
+    const loadingRow = loadingStatus.closest("tr");
+    expect(loadingRow?.querySelectorAll("td")).toHaveLength(4);
+    expect(
+      loadingStatus.parentElement?.querySelector(".pa-table-skeleton-bar")?.getAttribute("style"),
+    ).toBe("width: 148px;");
+  });
+
   it("starts a manual publisher abuse scan without exposing force-new", async () => {
     const startScan = vi.fn(async () => ({
       ok: true,

--- a/src/routes/-management.test.tsx
+++ b/src/routes/-management.test.tsx
@@ -517,13 +517,11 @@ describe("Management", () => {
     expect(screen.getByRole("tab", { name: /All flagged 2/ })).toBeTruthy();
     expect(screen.getByRole("tab", { name: /Resolved 0/ })).toBeTruthy();
     expect(screen.getByRole("columnheader", { name: "Signal" })).toBeTruthy();
-    expect(screen.getByRole("columnheader", { name: "Severity" })).toBeTruthy();
     expect(screen.getByRole("columnheader", { name: "Subject" })).toBeTruthy();
     expect(screen.getByRole("columnheader", { name: "Evidence" })).toBeTruthy();
     expect(screen.queryByRole("columnheader", { name: "Status" })).toBeNull();
     expect(screen.queryByRole("columnheader", { name: "Actions" })).toBeNull();
     expect(screen.getByText("High install/download ratio")).toBeTruthy();
-    expect(screen.getByText("High")).toBeTruthy();
     expect(screen.getByText("Ratio Skill")).toBeTruthy();
     expect(screen.getByText("@ratio-owner / ratio-skill")).toBeTruthy();
     expect(screen.queryByRole("link", { name: "Open skill Ratio Skill" })).toBeNull();

--- a/src/routes/-management/AbusePage.tsx
+++ b/src/routes/-management/AbusePage.tsx
@@ -493,7 +493,7 @@ export function AbusePage({
               <tbody>
                 {!loaded ? (
                   <PublisherAbuseTableSkeletonRows
-                    columns={5}
+                    columnWidths={[72, 148, 64, 124, 92]}
                     label="Loading publisher abuse nominations"
                   />
                 ) : items.length === 0 ? (
@@ -848,11 +848,11 @@ function formatAbuseTabCountLabel(count: number, hasMore: boolean | undefined) {
 }
 
 function PublisherAbuseTableSkeletonRows({
-  columns,
+  columnWidths,
   label,
   rows = 5,
 }: {
-  columns: number;
+  columnWidths: readonly number[];
   label: string;
   rows?: number;
 }) {
@@ -864,7 +864,7 @@ function PublisherAbuseTableSkeletonRows({
           className="pa-skeleton-row"
           aria-hidden={rowIndex === 0 ? undefined : true}
         >
-          {Array.from({ length: columns }, (_column, columnIndex) => (
+          {columnWidths.map((baseWidth, columnIndex) => (
             <td key={columnIndex}>
               {rowIndex === 0 && columnIndex === 0 ? (
                 <span className="sr-only" role="status" aria-label={label}>
@@ -874,7 +874,7 @@ function PublisherAbuseTableSkeletonRows({
               <span
                 className="pa-table-skeleton-bar"
                 style={{
-                  width: publisherAbuseSkeletonWidth(columnIndex, rowIndex),
+                  width: publisherAbuseSkeletonWidth(baseWidth, rowIndex),
                 }}
               />
             </td>
@@ -885,10 +885,8 @@ function PublisherAbuseTableSkeletonRows({
   );
 }
 
-function publisherAbuseSkeletonWidth(columnIndex: number, rowIndex: number) {
-  const widths = [72, 148, 64, 124, 92, 84, 92, 100, 100];
-  const base = widths[columnIndex] ?? 96;
-  return Math.max(48, base - (rowIndex % 3) * 14);
+function publisherAbuseSkeletonWidth(baseWidth: number, rowIndex: number) {
+  return Math.max(48, baseWidth - (rowIndex % 3) * 14);
 }
 
 function PublisherAbuseSignalsTable({
@@ -920,7 +918,10 @@ function PublisherAbuseSignalsTable({
         </thead>
         <tbody>
           {!loaded ? (
-            <PublisherAbuseTableSkeletonRows columns={4} label="Loading publisher abuse signals" />
+            <PublisherAbuseTableSkeletonRows
+              columnWidths={[148, 148, 64, 92]}
+              label="Loading publisher abuse signals"
+            />
           ) : items.length === 0 ? (
             <tr className="pa-empty-row">
               <td colSpan={4}>

--- a/src/routes/-management/AbusePage.tsx
+++ b/src/routes/-management/AbusePage.tsx
@@ -912,7 +912,6 @@ function PublisherAbuseSignalsTable({
       <table className="pa-table pa-signals-table">
         <thead>
           <tr>
-            <th>Severity</th>
             <th>Signal</th>
             <th>Subject</th>
             <th className="pa-num">Evidence</th>
@@ -921,10 +920,10 @@ function PublisherAbuseSignalsTable({
         </thead>
         <tbody>
           {!loaded ? (
-            <PublisherAbuseTableSkeletonRows columns={5} label="Loading publisher abuse signals" />
+            <PublisherAbuseTableSkeletonRows columns={4} label="Loading publisher abuse signals" />
           ) : items.length === 0 ? (
             <tr className="pa-empty-row">
-              <td colSpan={5}>
+              <td colSpan={4}>
                 <strong>{emptyState.title}</strong>
                 {emptyState.body}
               </td>
@@ -940,14 +939,6 @@ function PublisherAbuseSignalsTable({
                   className={selected ? "is-selected" : undefined}
                   onClick={() => onSelectSignal(item)}
                 >
-                  <td>
-                    <Badge
-                      variant={publisherAbuseSignalSeverityVariant(item.signal.signalType)}
-                      size="sm"
-                    >
-                      {formatPublisherAbuseSignalSeverity(item.signal.signalType)}
-                    </Badge>
-                  </td>
                   <td>
                     <button
                       type="button"
@@ -1022,9 +1013,6 @@ function PublisherAbuseSignalInspector({ item }: { item: PublisherAbuseSignalEnt
           Publisher abuse signal evidence with links to the skill and publisher.
         </SheetDescription>
         <div className="pa-pills">
-          <Badge variant={publisherAbuseSignalSeverityVariant(item.signal.signalType)} size="sm">
-            {formatPublisherAbuseSignalSeverity(item.signal.signalType)}
-          </Badge>
           <Badge variant="compact">Seen {formatWholeNumber(item.signal.seenCount)} times</Badge>
         </div>
         <div className="pa-idline">
@@ -1691,18 +1679,6 @@ function describePublisherAbuseSignalType(signalType: string) {
     return "Several already-anomalous skills under this publisher have nearly identical download trends and similarly sized peaks.";
   }
   return "Stored publisher traffic anomaly visible to staff.";
-}
-
-function formatPublisherAbuseSignalSeverity(signalType: string) {
-  if (signalType === "high_install_download_ratio") return "High";
-  return "Watch";
-}
-
-function publisherAbuseSignalSeverityVariant(
-  signalType: string,
-): NonNullable<BadgeProps["variant"]> {
-  if (signalType === "high_install_download_ratio") return "warning";
-  return "review";
 }
 
 function formatPublisherAbuseStatus(status: string) {


### PR DESCRIPTION
The Signals table labels nearly every result as `Watch` and one signal type as `High`, but those labels do not represent a real risk ranking. This makes the page look more decisive than the detector is and distracts staff from the evidence they should review.

This PR removes the Severity column and the matching badge in signal details. It also gives the loading state the same Signal-first, four-column layout as the loaded table.

## Proof

| Before: direct base | After: PR |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/9144b7f9-1145-4506-a7d6-dd52d97ce234" alt="Direct base Signals table with a Severity column and High and Watch badges" width="100%"> | <img src="https://github.com/user-attachments/assets/a5837b22-ebe5-4233-96ad-6d17764477d2" alt="PR Signals table showing signal names and evidence without severity badges" width="100%"> |

Same local staff account, seeded records, cloud development backend, dark theme, and 1265 x 712 viewport. Signal names, evidence and dates remain visible.

### Loading: desktop

**Before: direct base**

<img src="https://github.com/user-attachments/assets/4cf99faf-372b-4a17-9cf4-5881ae6fb03b" alt="Before: desktop loading table starts with a narrow Severity placeholder" width="100%">

**After: PR**

<img src="https://github.com/user-attachments/assets/b6236939-a0b9-46ff-9af7-2b9d4328bcc6" alt="After: desktop loading table starts with Signal and has four aligned columns" width="100%">

### Loading: mobile

| Before: direct base | After: PR |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/30b8c2b6-81f0-4084-a0af-647b49073577" alt="Before: mobile loading table starts with Severity" width="100%"> | <img src="https://github.com/user-attachments/assets/69a122cc-3eb6-49a4-90b0-f9571f4e18be" alt="After: mobile loading table starts with Signal" width="100%"> |

Loading captures use the same disposable local Convex backend and local admin, with server replies briefly held to expose the real loading state. Desktop: 1440 x 900; mobile: 390 x 844. The table scrolls horizontally on mobile without widening the page. Also checked at 768px and after replies resumed into the empty state; no browser errors or page overflow. No production data was used for these captures.

## How to verify

1. Open Management > Publisher abuse as a staff user.
2. Select Signals and open a result. Evidence remains; `Watch` and `High` badges are gone.
3. Reload with a slow connection. Loading has four columns starting with Signal.

## Validation and review

Head `58bdc18ef1e5a016d291053ae74b63982d17c9d9`: two native review passes and one independent cold review completed with no actionable findings, no review fixes, and no open decisions.

- Fresh app, schema and CLI TypeScript checks; 38 management tests passed.
- Matched local-browser loading/empty proof passed at 1440, 768 and 390px; production build passed.
- Exact-head GitHub CI passed, including static, unit, types-build, packages and browser checks.

The earlier local `ci:static` attempt stopped on four `fast-uri@3.1.5` advisories already present in the base dependency graph. This PR does not change dependencies or claim to fix those advisories.
