### PR TITLE
fix: large ClawPack publishes time out after the upload succeeds

### DIFF
--- a/convex/httpApiV1.handlers.test.ts
+++ b/convex/httpApiV1.handlers.test.ts
@@ -16395,6 +16395,83 @@ describe("httpApiV1 handlers", () => {
     expect(payload?.files?.map((file) => file.path)).toContain("dist/index.js");
   });
 
+  it("multipart ClawPack publish stores extracted files in bounded concurrent batches", async () => {
+    vi.mocked(getOptionalApiTokenUserId).mockResolvedValue("users:1" as never);
+    vi.mocked(requirePackagePublishAuth).mockResolvedValue({
+      kind: "user",
+      userId: "users:1",
+      user: { _id: "users:1", handle: "p" },
+    } as never);
+    const runMutation = vi.fn().mockResolvedValue(okRate());
+    const runAction = vi
+      .fn()
+      .mockResolvedValue({ ok: true, packageId: "pkg:1", releaseId: "rel:1" });
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const storageStore = vi.fn(async (_blob: Blob) => {
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await new Promise((resolve) => setTimeout(resolve, 1));
+      inFlight -= 1;
+      return `storage:${storageStore.mock.calls.length}`;
+    });
+    const fileCount = 40;
+    const pack = npmPackFixture({
+      "package/package.json": JSON.stringify({ name: "demo-plugin", version: "1.0.0" }),
+      "package/openclaw.plugin.json": JSON.stringify({ id: "demo.plugin" }),
+      ...Object.fromEntries(
+        Array.from({ length: fileCount }, (_, index) => [
+          `package/dist/chunk-${String(index).padStart(3, "0")}.js`,
+          `export const chunk = ${index};\n`,
+        ]),
+      ),
+    });
+    const form = new FormData();
+    form.set(
+      "payload",
+      JSON.stringify({
+        name: "demo-plugin",
+        family: "code-plugin",
+        version: "1.0.0",
+        changelog: "init",
+      }),
+    );
+    form.append(
+      "clawpack",
+      new File([bytesToArrayBuffer(pack)], "demo-plugin-1.0.0.tgz", {
+        type: "application/octet-stream",
+      }),
+    );
+
+    const response = await __handlers.publishPackageV1Handler(
+      makeCtx({ runAction, runMutation, storage: { store: storageStore } }),
+      new Request("https://example.com/api/v1/packages", {
+        method: "POST",
+        headers: { Authorization: "Bearer clh_test" },
+        body: form,
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    // One tarball store plus every extracted file; batches overlap but stay bounded.
+    expect(storageStore).toHaveBeenCalledTimes(fileCount + 3);
+    expect(maxInFlight).toBeGreaterThan(1);
+    expect(maxInFlight).toBeLessThanOrEqual(16);
+    const actionCall = runAction.mock.calls[0] as [
+      unknown,
+      { payload?: { files?: Array<{ path: string }> } },
+    ];
+    const chunkPaths = actionCall[1].payload?.files
+      ?.map((file) => file.path)
+      .filter((path) => path.startsWith("dist/"));
+    expect(chunkPaths).toEqual(
+      Array.from(
+        { length: fileCount },
+        (_, index) => `dist/chunk-${String(index).padStart(3, "0")}.js`,
+      ),
+    );
+  });
+
   it("multipart Claw publish accepts an npm pack without a plugin manifest", async () => {
     vi.stubEnv("CLAWHUB_EXPERIMENTAL_CLAWS", "1");
     vi.mocked(getOptionalApiTokenUserId).mockResolvedValue("users:1" as never);

--- a/convex/httpApiV1/packagesV1.ts
+++ b/convex/httpApiV1/packagesV1.ts
@@ -1351,15 +1351,33 @@ async function storeClawPackFile(
   };
 }
 
+// Convex actions have a tight memory ceiling, so bound in-flight Blob copies by
+// bytes as well as count. Storing thousands of small files one at a time
+// otherwise pushes large ClawPacks past clients' publish request timeouts.
+const CLAWPACK_STORE_BATCH_BYTES = 8 * 1024 * 1024;
+const CLAWPACK_STORE_BATCH_FILES = 16;
+
 async function storeClawPackFiles(
   ctx: ActionCtx,
   entries: Array<{ path: string; bytes: Uint8Array }>,
 ) {
   const files: StoredPackagePublishFile[] = [];
-  // Convex HTTP actions have a tight memory ceiling; avoid concurrent Blob work.
+  let batch: Array<{ path: string; bytes: Uint8Array }> = [];
+  let batchBytes = 0;
+  const flush = async () => {
+    files.push(...(await Promise.all(batch.map((entry) => storeClawPackFile(ctx, entry)))));
+    batch = [];
+    batchBytes = 0;
+  };
   for (const entry of entries) {
-    files.push(await storeClawPackFile(ctx, entry));
+    const overflows =
+      batch.length >= CLAWPACK_STORE_BATCH_FILES ||
+      batchBytes + entry.bytes.byteLength > CLAWPACK_STORE_BATCH_BYTES;
+    if (batch.length > 0 && overflows) await flush();
+    batch.push(entry);
+    batchBytes += entry.bytes.byteLength;
   }
+  if (batch.length > 0) await flush();
   return files;
 }
 

--- a/packages/clawhub/src/cli/commands/packages.test.ts
+++ b/packages/clawhub/src/cli/commands/packages.test.ts
@@ -2365,6 +2365,7 @@ describe("package commands", () => {
         expect.objectContaining({
           path: "/api/v1/packages",
           retryCount: 0,
+          timeoutMs: 5 * 60_000,
         }),
         expect.anything(),
       );

--- a/packages/clawhub/src/cli/commands/packages.ts
+++ b/packages/clawhub/src/cli/commands/packages.ts
@@ -83,6 +83,10 @@ const LEGACY_DOT_IGNORE = ".clawdhubignore";
 const PACKAGE_PUBLISH_RETRY_COUNT = 5;
 const PACKAGE_PUBLISH_POLL_INTERVAL_MS = 5_000;
 const DEFAULT_PACKAGE_PUBLISH_WAIT_TIMEOUT_SECONDS = 30 * 60;
+// ClawHub unpacks and stores a ClawPack inside one HTTP action before it
+// answers the publish request, so large packages need far more than the
+// default upload timeout; 5 minutes matches the front-end function budget.
+const PACKAGE_PUBLISH_REQUEST_TIMEOUT_MS = 5 * 60_000;
 const AUTHOR_REMEDIATION_DOCS_BASE = "https://docs.openclaw.ai/clawhub/plugin-validation-fixes";
 const LEGACY_AUTHOR_REMEDIATION_SUMMARIES = {
   "channel-env-vars":
@@ -1075,6 +1079,7 @@ export async function cmdPublishPackage(
           token: publishToken,
           form,
           retryCount: trustedToolingBoundary ? 0 : PACKAGE_PUBLISH_RETRY_COUNT,
+          timeoutMs: PACKAGE_PUBLISH_REQUEST_TIMEOUT_MS,
         },
         ApiV1PackagePublishResponseSchema,
       );

--- a/packages/clawhub/src/http.bun.test.ts
+++ b/packages/clawhub/src/http.bun.test.ts
@@ -209,6 +209,21 @@ describe("bun http client", () => {
     expect(args.some((arg) => arg.includes("file=@/tmp/clawhub-upload-abc/dist/demo.txt"))).toBe(
       true,
     );
+    expect(args.slice(args.indexOf("--max-time"), args.indexOf("--max-time") + 2)).toEqual([
+      "--max-time",
+      "120",
+    ]);
+
+    await client.apiRequestForm<{ ok: boolean }>("https://registry.example", {
+      method: "POST",
+      path: "/upload",
+      form: new FormData(),
+      timeoutMs: 300_000,
+    });
+    const [, longArgs] = spawnImpl.mock.calls[1] as [string, string[]];
+    expect(
+      longArgs.slice(longArgs.indexOf("--max-time"), longArgs.indexOf("--max-time") + 2),
+    ).toEqual(["--max-time", "300"]);
   });
 
   it("keeps binary upload bearer tokens out of curl arguments", async () => {

--- a/packages/clawhub/src/http.test.ts
+++ b/packages/clawhub/src/http.test.ts
@@ -550,5 +550,21 @@ describe("node http client", () => {
       }),
     ).rejects.toThrow(/timed out after 120s/i);
     expect(setTimeoutImpl.mock.calls[0]?.[1]).toBe(120_000);
+
+    const longTimeouts = createImmediateTimeouts();
+    const longTimeoutClient = createNodeClient({
+      fetchImpl: createAbortingFetchMock() as unknown as typeof fetch,
+      setTimeoutImpl: longTimeouts.setTimeoutImpl as unknown as typeof setTimeout,
+      clearTimeoutImpl: longTimeouts.clearTimeoutImpl,
+    });
+    await expect(
+      longTimeoutClient.apiRequestForm("https://example.com", {
+        method: "POST",
+        path: "/upload",
+        form: new FormData(),
+        timeoutMs: 300_000,
+      }),
+    ).rejects.toThrow(/timed out after 300s/i);
+    expect(longTimeouts.setTimeoutImpl.mock.calls[0]?.[1]).toBe(300_000);
   });
 });

--- a/packages/clawhub/src/http.ts
+++ b/packages/clawhub/src/http.ts
@@ -49,9 +49,16 @@ type RequestArgs =
       acceptedStatuses?: number[];
     };
 
+type FormRequestOptions = {
+  method: "POST";
+  token?: string;
+  form: FormData;
+  retryCount?: number;
+  timeoutMs?: number;
+};
 type FormRequestArgs =
-  | { method: "POST"; path: string; token?: string; form: FormData; retryCount?: number }
-  | { method: "POST"; url: string; token?: string; form: FormData; retryCount?: number };
+  | (FormRequestOptions & { path: string })
+  | (FormRequestOptions & { url: string });
 
 type TextRequestArgs = { path: string; token?: string } | { url: string; token?: string };
 type BinaryUploadArgs = {
@@ -244,7 +251,7 @@ export function createHttpClient(options: HttpClientOptions = {}): HttpClient {
           headers,
           body: args.form,
         },
-        UPLOAD_TIMEOUT_MS,
+        args.timeoutMs ?? UPLOAD_TIMEOUT_MS,
       );
       if (!response.ok) {
         throwHttpStatusError(
@@ -813,7 +820,7 @@ async function fetchJsonFormViaCurl(
       "--show-error",
       "--location",
       "--max-time",
-      String(UPLOAD_TIMEOUT_SECONDS),
+      String(Math.ceil((args.timeoutMs ?? UPLOAD_TIMEOUT_MS) / 1000)),
       "--write-out",
       CURL_WRITE_OUT_FORMAT,
       "-X",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where publishing a large ClawPack (thousands of files, several MB) through `clawhub package publish` fails with `Network request failed: the request timed out. curl: (28) Operation timed out after 120002 milliseconds with 0 bytes received` even though the upload itself succeeds. After #3584 routed `@openclaw/matrix@2026.9.1` (5.5 MB, 1,843 files) through the upload-url flow, the OpenClaw release publish reached ClawHub but the publish request timed out (openclaw/openclaw run 33833703657, job 100904763980).

## Why This Change Was Made

`POST /api/v1/packages` unpacks the staged tarball and stores every extracted file with `ctx.storage.store` one at a time inside the Convex HTTP action before answering, so a 1,843-file package takes longer than the CLI's generic 120 s `UPLOAD_TIMEOUT_MS`. Two owner-level changes: `storeClawPackFiles` now stores files in batches bounded by 8 MiB and 16 files (order preserved), keeping the memory ceiling the old sequential comment protected while cutting wall time by roughly the batch width; and CLI form requests accept an optional `timeoutMs`, with the package publish POST using a 5 minute budget (the Vercel function budget in front of Convex) instead of the generic upload timeout. Staging uploads and other form requests keep 120 s.

## User Impact

Large plugin packages publish reliably from the CLI and from the reusable `package-publish.yml` workflow; smaller packages are unaffected. No API contract changes.

## Evidence

- `convex/httpApiV1.handlers.test.ts` "multipart ClawPack publish stores extracted files in bounded concurrent batches": on the sequential loop it fails with `expected 1 to be greater than 1`; with the fix it passes, with max in-flight ≤ 16 and file order preserved.
- `packages/clawhub/src/http.test.ts` and `http.bun.test.ts`: `timeoutMs` honored on the fetch runtime (300 s timer) and curl runtime (`--max-time 300`), default 120 s unchanged.
- `packages/clawhub/src/cli/commands/packages.test.ts`: the publish POST passes `timeoutMs: 300000`.
- Local: `bun run ci:static`, root `tsc --noEmit`, package `tsc` for `packages/schema` and `packages/clawhub`, full `convex/httpApiV1.handlers.test.ts`, `bun run --cwd packages/clawhub verify`, and Codex autoreview (results in the PR comment thread).
- Live proof after deploy: re-run of the OpenClaw selected-scope ClawHub publish for `@openclaw/matrix@2026.9.1`; success is `https://clawhub.ai/api/v1/packages/%40openclaw%2Fmatrix/versions/2026.9.1` returning 200.
