### PR TITLE
fix(publish): run the static moderation scan in the Node runtime

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -212,6 +212,7 @@ import type * as skillsShMirrorPublic from "../skillsShMirrorPublic.js";
 import type * as skillsShMirrorVisibility from "../skillsShMirrorVisibility.js";
 import type * as skillsShPublicTestFixtures from "../skillsShPublicTestFixtures.js";
 import type * as stars from "../stars.js";
+import type * as staticPublishScanNode from "../staticPublishScanNode.js";
 import type * as statsMaintenance from "../statsMaintenance.js";
 import type * as telemetry from "../telemetry.js";
 import type * as tokens from "../tokens.js";
@@ -431,6 +432,7 @@ declare const fullApi: ApiFromModules<{
   skillsShMirrorVisibility: typeof skillsShMirrorVisibility;
   skillsShPublicTestFixtures: typeof skillsShPublicTestFixtures;
   stars: typeof stars;
+  staticPublishScanNode: typeof staticPublishScanNode;
   statsMaintenance: typeof statsMaintenance;
   telemetry: typeof telemetry;
   tokens: typeof tokens;

--- a/convex/packages.public.test.ts
+++ b/convex/packages.public.test.ts
@@ -1,6 +1,7 @@
 /* @vitest-environment node */
 
 import { getAuthUserId } from "@convex-dev/auth/server";
+import { type FunctionReference, getFunctionName } from "convex/server";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { sha256Hex } from "./lib/clawpack";
 import { verifyOpenClawPublishAuthorization } from "./lib/openClawPublishAuthorization";
@@ -11,6 +12,7 @@ import {
 } from "./lib/recommendationScore";
 import { buildPackageInventoryDigest } from "./lib/skills";
 import { buildDeterministicPackageZip } from "./lib/skillZip";
+import { runStaticPublishScan } from "./lib/staticPublishScan";
 import {
   backfillLatestPackageScanStatusInternal,
   backfillPackageReleaseScansInternal,
@@ -505,6 +507,24 @@ function makePackageManifestStorage() {
     ),
     store: vi.fn(async () => "storage:legacy-zip"),
   };
+}
+
+type PublishScanStorage = { storage: { get: (storageId: string) => Promise<Blob | null> } };
+
+// Publish actions hop to the Node runtime for the moderation scan; run the real
+// scan against the calling ctx's storage (`ctx.runAction(...)` binds `this`) so
+// scan verdicts stay observable, and answer every other action (the package
+// inspector) with the supplied result.
+function makePublishRunActionMock(
+  inspectorResult: () => unknown = makeCleanPackageInspectorResult,
+) {
+  return vi.fn(async function (this: PublishScanStorage, ref: unknown, args: unknown) {
+    const name = getFunctionName(ref as FunctionReference<"action">);
+    if (name === "staticPublishScanNode:runStaticPublishScanInternal") {
+      return await runStaticPublishScan(this as never, args as never);
+    }
+    return inspectorResult();
+  });
 }
 
 function makeCleanPackageInspectorResult() {
@@ -9978,7 +9998,7 @@ describe("packages public queries", () => {
           githubCreatedAt: Date.now() - 20 * 24 * 60 * 60 * 1000,
         }),
       runMutation,
-      runAction: vi.fn(async () => makeCleanPackageInspectorResult()),
+      runAction: makePublishRunActionMock(),
       scheduler: {
         runAfter: vi.fn(),
       },
@@ -10950,6 +10970,7 @@ describe("packages public queries", () => {
         }),
         store: vi.fn(async () => "storage:legacy-zip"),
       },
+      runAction: makePublishRunActionMock(),
     };
 
     try {
@@ -11123,6 +11144,7 @@ describe("packages public queries", () => {
         }),
         store: vi.fn(async () => "storage:legacy-zip"),
       },
+      runAction: makePublishRunActionMock(),
     };
 
     try {
@@ -11418,7 +11440,7 @@ describe("packages public queries", () => {
         })
         .mockResolvedValueOnce(null),
       runMutation,
-      runAction: vi.fn(async () => makeCleanPackageInspectorResult()),
+      runAction: makePublishRunActionMock(),
       scheduler: {
         runAfter: vi.fn(async () => {}),
       },
@@ -11720,7 +11742,7 @@ describe("packages public queries", () => {
         .mockResolvedValueOnce(null)
         .mockResolvedValueOnce(null),
       runMutation,
-      runAction: vi.fn(async () => makeCleanPackageInspectorResult()),
+      runAction: makePublishRunActionMock(),
       scheduler: {
         runAfter: vi.fn(),
       },
@@ -11852,7 +11874,7 @@ describe("packages public queries", () => {
         .mockResolvedValueOnce(null)
         .mockResolvedValueOnce(null),
       runMutation,
-      runAction: vi.fn(async () => makeCleanPackageInspectorResult()),
+      runAction: makePublishRunActionMock(),
       scheduler: {
         runAfter: vi.fn(),
       },
@@ -11949,7 +11971,7 @@ describe("packages public queries", () => {
         .mockResolvedValueOnce(trustedPublisher)
         .mockResolvedValueOnce(null),
       runMutation,
-      runAction: vi.fn(async () => makeCleanPackageInspectorResult()),
+      runAction: makePublishRunActionMock(),
       scheduler: {
         runAfter: vi.fn(),
       },
@@ -12078,7 +12100,7 @@ describe("packages public queries", () => {
         .mockResolvedValueOnce(orphanRelease)
         .mockResolvedValueOnce(null),
       runMutation,
-      runAction: vi.fn(async () => makeCleanPackageInspectorResult()),
+      runAction: makePublishRunActionMock(),
       scheduler: {
         runAfter: vi.fn(),
       },
@@ -12187,7 +12209,7 @@ describe("packages public queries", () => {
         .mockResolvedValueOnce(null)
         .mockResolvedValueOnce(null),
       runMutation,
-      runAction: vi.fn(async () => makeCleanPackageInspectorResult()),
+      runAction: makePublishRunActionMock(),
       scheduler: {
         runAfter: vi.fn(),
       },
@@ -12275,7 +12297,7 @@ describe("packages public queries", () => {
           }),
         ),
       runMutation,
-      runAction: vi.fn(async () => makeCleanPackageInspectorResult()),
+      runAction: makePublishRunActionMock(),
       scheduler: {
         runAfter: vi.fn(),
       },
@@ -12355,7 +12377,7 @@ describe("packages public queries", () => {
           status: "blocked",
         }),
       runMutation,
-      runAction: vi.fn(async () => makeCleanPackageInspectorResult()),
+      runAction: makePublishRunActionMock(),
       scheduler: {
         runAfter: vi.fn(),
       },
@@ -12440,7 +12462,7 @@ describe("packages public queries", () => {
         .mockResolvedValueOnce(trustedPublisher)
         .mockResolvedValueOnce(null),
       runMutation,
-      runAction: vi.fn(async () => makeCleanPackageInspectorResult()),
+      runAction: makePublishRunActionMock(),
       scheduler: {
         runAfter: vi.fn(),
       },
@@ -12519,7 +12541,7 @@ describe("packages public queries", () => {
         })
         .mockResolvedValueOnce(null),
       runMutation,
-      runAction: vi.fn(async () => makeCleanPackageInspectorResult()),
+      runAction: makePublishRunActionMock(),
       scheduler: {
         runAfter: vi.fn(),
       },
@@ -12675,7 +12697,7 @@ describe("packages public queries", () => {
           linkedUserId: "users:owner",
         }),
       runMutation,
-      runAction: vi.fn(async () => makeCleanPackageInspectorResult()),
+      runAction: makePublishRunActionMock(),
       scheduler: {
         runAfter: vi.fn(),
       },
@@ -12795,7 +12817,7 @@ describe("packages public queries", () => {
             linkedUserId: "users:owner",
           }),
         runMutation,
-        runAction: vi.fn(async () => makeCleanPackageInspectorResult()),
+        runAction: makePublishRunActionMock(),
         scheduler: {
           runAfter: vi.fn(),
         },
@@ -12945,7 +12967,7 @@ describe("packages public queries", () => {
         }),
         store: vi.fn(async () => "storage:legacy-zip"),
       },
-      runAction: vi.fn(async () => ({
+      runAction: makePublishRunActionMock(() => ({
         status: "pass",
         summary: {
           breakageCount: 0,
@@ -15502,7 +15524,7 @@ describe("packages public queries", () => {
           githubCreatedAt: Date.now() - 20 * 24 * 60 * 60 * 1000,
         }),
       runMutation,
-      runAction: vi.fn(async () => makeCleanPackageInspectorResult()),
+      runAction: makePublishRunActionMock(),
       scheduler: {
         runAfter: vi.fn(),
       },
@@ -15558,7 +15580,7 @@ describe("packages public queries", () => {
           linkedUserId: "users:vincent",
         }),
       runMutation,
-      runAction: vi.fn(async () => makeCleanPackageInspectorResult()),
+      runAction: makePublishRunActionMock(),
       scheduler: {
         runAfter: vi.fn(),
       },
@@ -15619,7 +15641,7 @@ describe("packages public queries", () => {
           githubCreatedAt: Date.now() - 20 * 24 * 60 * 60 * 1000,
         }),
       runMutation,
-      runAction: vi.fn(async () => makeCleanPackageInspectorResult()),
+      runAction: makePublishRunActionMock(),
       scheduler: {
         runAfter: vi.fn(),
       },
@@ -15669,7 +15691,7 @@ describe("packages public queries", () => {
           githubCreatedAt: Date.now() - 20 * 24 * 60 * 60 * 1000,
         }),
       runMutation,
-      runAction: vi.fn(async () => makeCleanPackageInspectorResult()),
+      runAction: makePublishRunActionMock(),
       scheduler: {
         runAfter: vi.fn(),
       },
@@ -15714,7 +15736,7 @@ describe("packages public queries", () => {
           githubCreatedAt: Date.now() - 20 * 24 * 60 * 60 * 1000,
         }),
       runMutation,
-      runAction: vi.fn(async () => makeCleanPackageInspectorResult()),
+      runAction: makePublishRunActionMock(),
       scheduler: {
         runAfter: vi.fn(),
       },
@@ -15760,7 +15782,7 @@ describe("packages public queries", () => {
           githubCreatedAt: Date.now() - 20 * 24 * 60 * 60 * 1000,
         }),
       runMutation,
-      runAction: vi.fn(async () => makeCleanPackageInspectorResult()),
+      runAction: makePublishRunActionMock(),
       scheduler: {
         runAfter: vi.fn(),
       },

--- a/convex/packages.ts
+++ b/convex/packages.ts
@@ -70,6 +70,7 @@ import { requireGitHubAccountAge } from "./lib/githubAccount";
 import { normalizeGitHubRepository } from "./lib/githubActionsOidc";
 import { readGlobalPublicPluginsCount } from "./lib/globalStats";
 import { toDayKey } from "./lib/leaderboards";
+import type { StaticScanResult } from "./lib/moderationEngine";
 import { isOfficialPublisher } from "./lib/officialPublishers";
 import { verifyOpenClawPublishAuthorization } from "./lib/openClawPublishAuthorization";
 import { getPackageReleaseArtifactSha256 } from "./lib/packageArtifacts";
@@ -132,7 +133,6 @@ import {
 import { matchesAllTokens, matchesExploratoryTokenPrefixes, tokenize } from "./lib/searchText";
 import { buildPackageInventoryDigest, hashSkillFiles } from "./lib/skills";
 import { buildDeterministicPackageZip } from "./lib/skillZip";
-import { runStaticPublishScan } from "./lib/staticPublishScan";
 import { PACKAGE_TRENDING_LEADERBOARD_KIND } from "./packageLeaderboards";
 import schema from "./schema";
 
@@ -510,6 +510,9 @@ const internalRefs = internal as unknown as {
   };
   packageInspectorNode: {
     runPackageInspectorForPublishInternal: unknown;
+  };
+  staticPublishScanNode: {
+    runStaticPublishScanInternal: unknown;
   };
   packagePublishTokens: {
     createInternal: unknown;
@@ -988,6 +991,33 @@ async function runActionRef<T>(
   args: unknown,
 ): Promise<T> {
   return (await ctx.runAction(ref as never, args as never)) as T;
+}
+
+// The moderation scan decodes every package file; large ClawPacks exceed the
+// Convex runtime's 64 MiB action ceiling, so it runs in the Node runtime.
+async function runStaticPublishScanInNode(
+  ctx: { runAction: (ref: never, args: never) => Promise<unknown> },
+  input: {
+    slug: string;
+    displayName: string;
+    summary?: string;
+    metadata?: unknown;
+    files: ReadonlyArray<{ path: string; size: number; storageId: string; contentType?: string }>;
+  },
+): Promise<StaticScanResult> {
+  return await runActionRef<StaticScanResult>(
+    ctx,
+    internalRefs.staticPublishScanNode.runStaticPublishScanInternal,
+    stripUndefinedForStoredAttempt({
+      ...input,
+      files: input.files.map(({ path, size, storageId, contentType }) => ({
+        path,
+        size,
+        storageId: storageId as Id<"_storage">,
+        contentType,
+      })),
+    }),
+  );
 }
 
 async function runAfterRef(
@@ -8839,7 +8869,7 @@ async function publishPackageImpl(
     throw new ConvexError(error instanceof Error ? error.message : "Invalid catalog metadata");
   }
   const topics = normalizedTopics.length ? normalizedTopics : undefined;
-  const staticScan = await runStaticPublishScan(ctx, {
+  const staticScan = await runStaticPublishScanInNode(ctx, {
     slug: name,
     displayName,
     summary,
@@ -12409,7 +12439,7 @@ export const scanPackageReleaseStaticallyInternal = internalAction({
       return { ok: true as const, skipped: "missing_package" as const };
     }
 
-    const staticScan = await runStaticPublishScan(ctx, {
+    const staticScan = await runStaticPublishScanInNode(ctx, {
       slug: pkg.name,
       displayName: pkg.displayName,
       summary: pkg.summary,

--- a/convex/staticPublishScanNode.test.ts
+++ b/convex/staticPublishScanNode.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ActionCtx } from "./_generated/server";
+import { runStaticPublishScanInternal } from "./staticPublishScanNode";
+
+type Handler = (ctx: ActionCtx, args: unknown) => Promise<unknown>;
+
+describe("runStaticPublishScanInternal", () => {
+  it("runs the moderation scan against the files it is handed and returns the verdict", async () => {
+    const storageGet = vi.fn(
+      async () => new Blob([new TextEncoder().encode("const token = eval(input);\n")]),
+    );
+    const result = (await (
+      runStaticPublishScanInternal as unknown as { _handler: Handler }
+    )._handler({ storage: { get: storageGet } } as unknown as ActionCtx, {
+      slug: "demo-plugin",
+      displayName: "Demo Plugin",
+      metadata: { packageJson: { name: "demo-plugin", version: "1.0.0" } },
+      files: [{ path: "dist/index.js", size: 27, storageId: "storage:1" }],
+    })) as { status: string; reasonCodes: string[]; engineVersion: string; checkedAt: number };
+
+    expect(storageGet).toHaveBeenCalledWith("storage:1");
+    expect(result.status).toBe("suspicious");
+    expect(result.reasonCodes).toContain("suspicious.dynamic_code_execution");
+    expect(typeof result.engineVersion).toBe("string");
+    expect(result.checkedAt).toBeGreaterThan(0);
+  });
+});

--- a/convex/staticPublishScanNode.ts
+++ b/convex/staticPublishScanNode.ts
@@ -1,0 +1,26 @@
+"use node";
+import { v } from "convex/values";
+import { internalAction } from "./_generated/server";
+import { runStaticPublishScan } from "./lib/staticPublishScan";
+
+// Package publish actions run in the Convex runtime, whose 64 MiB action ceiling
+// dies decoding every file of a large ClawPack for the moderation scan. The
+// Node runtime has 512 MiB, so the scan itself crosses over here unchanged.
+export const runStaticPublishScanInternal = internalAction({
+  args: {
+    slug: v.string(),
+    displayName: v.string(),
+    summary: v.optional(v.string()),
+    frontmatter: v.optional(v.any()),
+    metadata: v.optional(v.any()),
+    files: v.array(
+      v.object({
+        path: v.string(),
+        size: v.number(),
+        storageId: v.id("_storage"),
+        contentType: v.optional(v.string()),
+      }),
+    ),
+  },
+  handler: async (ctx, args) => await runStaticPublishScan(ctx, args),
+});


### PR DESCRIPTION
## What Problem This Solves

Publishing `@openclaw/matrix@2026.9.1` (1,843 files after unpacking) now gets past the Vercel body cap (#3584) and the storage staging budget (#3586), but the trusted-publisher publish action still dies after ~220 s with a redacted Convex error. Live `convex logs` for the failing runs show the isolate for `packages:publishPackageForTrustedPublisherInternal` being killed while `runStaticPublishScan` reads and decodes every file of the ClawPack for the moderation scan. `publishPackageImpl` runs in the default Convex runtime, whose actions are capped at 64 MiB of memory; the full decoded text of a large plugin plus the scan's working set exceeds that, so the publish never reaches `insertReleaseInternal` and the CLI only sees an opaque failure.

## Why This Change Was Made

The scan itself is fine; it is running in the wrong runtime. Convex's Node.js runtime gives actions 512 MiB, so this moves the scan across that boundary and nothing else:

- new `convex/staticPublishScanNode.ts` (`"use node"`) exposes `runStaticPublishScanInternal`, which calls the unchanged `runStaticPublishScan` against the same storage ids.
- `convex/packages.ts` routes both callers (`publishPackageImpl` and `scanPackageReleaseStaticallyInternal`) through `runStaticPublishScanInNode`, a thin `runAction` hop using the existing `runActionRef`/`stripUndefinedForStoredAttempt` conventions. Scan semantics, reason codes, and the stored `staticScan` shape are untouched.
- `convex/_generated/api.d.ts` registers the new module (codegen needs a deployment; the edit matches what `convex codegen` emits).

The action hop is the smallest change that fixes the owner: the publish action stays in the Convex runtime (it needs `ctx.storage`, mutations, and scheduling exactly as before), and only the memory-heavy step crosses over, mirroring how `packageInspectorNode` already runs the package inspector.

## User Impact

Large plugins (thousands of files, tens of MB of source) publish again instead of failing with a redacted server error after several minutes. No CLI, API, or schema change; small packages take the same path with one extra internal action call.

## Evidence

- `convex/staticPublishScanNode.test.ts`: the Node action runs the real scan on the handed files and returns the verdict (reason code + engine version), proving the hop preserves scan output.
- `convex/packages.public.test.ts`: the `runAction` mock now dispatches by function name, running the real scan for the Node ref and answering the inspector otherwise. The pre-existing "scans plugin publishes and forwards scan status" case fails on the old mock (it returned the inspector result as the scan result) and passes with the dispatching mock, so the publish → Node scan → `insertReleaseInternal` wiring is covered end to end.
- Local: `bun x tsc --noEmit`, `vitest run convex/packages.public.test.ts convex/lib/staticPublishScan.test.ts convex/staticPublishScanNode.test.ts` (369 passed), `oxlint`/`oxfmt --check` on touched files, `bun run ci:static`.
- Live proof follows after deploy: re-dispatch of the `@openclaw/matrix@2026.9.1` publish from the openclaw release tag; the versions endpoint must return 200.

Production LOC: +~30 (new Node action module + the `runStaticPublishScanInNode` hop); justified by the runtime boundary (Convex vs Node memory ceiling) that cannot be expressed inside the existing action.
