### PR TITLE
fix: sanitize static publish scan metadata

### DIFF
--- a/convex/packages.public.test.ts
+++ b/convex/packages.public.test.ts
@@ -12935,6 +12935,14 @@ describe("packages public queries", () => {
           categories: ["security"],
           topics: ["Manifest Topic"],
           contracts: { tools: ["demoTool"] },
+          channelConfigs: {
+            inline: {
+              schema: {
+                $schema: "http://json-schema.org/draft-07/schema#",
+                type: "object",
+              },
+            },
+          },
         }),
       ],
       [
@@ -13047,6 +13055,23 @@ describe("packages public queries", () => {
       expect.objectContaining({
         status: "suspicious",
         reasonCodes: expect.arrayContaining(["suspicious.dangerous_exec"]),
+      }),
+    );
+    expect(ctx.runAction).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          pluginManifest: expect.objectContaining({
+            channelConfigs: {
+              inline: {
+                schema: {
+                  dollar_schema: "http://json-schema.org/draft-07/schema#",
+                  type: "object",
+                },
+              },
+            },
+          }),
+        }),
       }),
     );
     expect(ctx.scheduler.runAfter).toHaveBeenNthCalledWith(

--- a/convex/packages.ts
+++ b/convex/packages.ts
@@ -1010,6 +1010,7 @@ async function runStaticPublishScanInNode(
     internalRefs.staticPublishScanNode.runStaticPublishScanInternal,
     stripUndefinedForStoredAttempt({
       ...input,
+      metadata: toConvexSafeJsonValue(input.metadata),
       files: input.files.map(({ path, size, storageId, contentType }) => ({
         path,
         size,


### PR DESCRIPTION
## Summary

- normalize package metadata before crossing the Convex action boundary into the Node static scanner
- add a regression assertion for a valid plugin manifest containing a JSON Schema `$schema` key

## Why

Publishing an exact ClawPack with a channel config schema currently fails before release insertion with:

`Field name $schema starts with a '$', which is reserved.`

The package publish path already sanitizes extracted manifests before database storage, but the new Node-runtime scan hop receives the raw metadata first. This applies the same existing `toConvexSafeJsonValue` normalization at that boundary. Package files remain unchanged and are still scanned from storage; only the duplicate structured metadata projection is normalized.

## Tests

- `bunx vitest run convex/packages.public.test.ts --testNamePattern 'scans plugin publishes and forwards scan status to insertReleaseInternal'`
- `bun run ci:static`
- `bun run ci:types-build`
- `npx --yes -p node@24 -c 'bun run ci:unit'` (6,334 passed, 3 skipped)
