### PR TITLE
fix(publish): carry scan metadata as JSON across the Node action boundary

### DIFF
--- a/convex/packages.public.test.ts
+++ b/convex/packages.public.test.ts
@@ -12,7 +12,6 @@ import {
 } from "./lib/recommendationScore";
 import { buildPackageInventoryDigest } from "./lib/skills";
 import { buildDeterministicPackageZip } from "./lib/skillZip";
-import { runStaticPublishScan } from "./lib/staticPublishScan";
 import {
   backfillLatestPackageScanStatusInternal,
   backfillPackageReleaseScansInternal,
@@ -79,6 +78,7 @@ import {
   searchForViewerInternal,
   searchPublic,
 } from "./packages";
+import { runStaticPublishScanInternal } from "./staticPublishScanNode";
 
 vi.mock("@convex-dev/auth/server", () => ({
   getAuthUserId: vi.fn(),
@@ -511,17 +511,40 @@ function makePackageManifestStorage() {
 
 type PublishScanStorage = { storage: { get: (storageId: string) => Promise<Blob | null> } };
 
+// Convex rejects action arguments whose object keys start with `$` (package.json
+// `$schema` is the production case); mirror that rule so the mock fails the way
+// the real boundary would.
+function assertConvexValueKeys(value: unknown, path = "args"): void {
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => assertConvexValueKeys(item, `${path}[${index}]`));
+    return;
+  }
+  if (value && typeof value === "object") {
+    for (const [key, nested] of Object.entries(value)) {
+      if (key.startsWith("$")) {
+        throw new Error(`Field name ${key} at ${path} starts with a '$', which is reserved.`);
+      }
+      assertConvexValueKeys(nested, `${path}.${key}`);
+    }
+  }
+}
+
+type StaticScanHandler = (ctx: unknown, args: unknown) => Promise<unknown>;
+
 // Publish actions hop to the Node runtime for the moderation scan; run the real
-// scan against the calling ctx's storage (`ctx.runAction(...)` binds `this`) so
-// scan verdicts stay observable, and answer every other action (the package
-// inspector) with the supplied result.
+// action handler against the calling ctx's storage (`ctx.runAction(...)` binds
+// `this`) so scan verdicts stay observable, and answer every other action (the
+// package inspector) with the supplied result.
 function makePublishRunActionMock(
   inspectorResult: () => unknown = makeCleanPackageInspectorResult,
 ) {
   return vi.fn(async function (this: PublishScanStorage, ref: unknown, args: unknown) {
     const name = getFunctionName(ref as FunctionReference<"action">);
     if (name === "staticPublishScanNode:runStaticPublishScanInternal") {
-      return await runStaticPublishScan(this as never, args as never);
+      assertConvexValueKeys(args);
+      const handler = (runStaticPublishScanInternal as unknown as { _handler: StaticScanHandler })
+        ._handler;
+      return await handler(this, args);
     }
     return inspectorResult();
   });
@@ -12905,6 +12928,7 @@ describe("packages public queries", () => {
       [
         "storage:package",
         JSON.stringify({
+          $schema: "https://json.schemastore.org/package.json",
           name: "demo-plugin",
           keywords: [
             "one",

--- a/convex/packages.ts
+++ b/convex/packages.ts
@@ -1009,7 +1009,12 @@ async function runStaticPublishScanInNode(
     ctx,
     internalRefs.staticPublishScanNode.runStaticPublishScanInternal,
     stripUndefinedForStoredAttempt({
-      ...input,
+      slug: input.slug,
+      displayName: input.displayName,
+      summary: input.summary,
+      // JSON string, not a Convex object: manifests carry `$schema` keys, which
+      // Convex values reject, and the scan must see the metadata unchanged.
+      metadataJson: input.metadata === undefined ? undefined : JSON.stringify(input.metadata),
       files: input.files.map(({ path, size, storageId, contentType }) => ({
         path,
         size,

--- a/convex/staticPublishScanNode.test.ts
+++ b/convex/staticPublishScanNode.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import type { ActionCtx } from "./_generated/server";
+import { REASON_CODES } from "./lib/moderationReasonCodes";
 import { runStaticPublishScanInternal } from "./staticPublishScanNode";
 
 type Handler = (ctx: ActionCtx, args: unknown) => Promise<unknown>;
@@ -14,13 +15,23 @@ describe("runStaticPublishScanInternal", () => {
     )._handler({ storage: { get: storageGet } } as unknown as ActionCtx, {
       slug: "demo-plugin",
       displayName: "Demo Plugin",
-      metadata: { packageJson: { name: "demo-plugin", version: "1.0.0" } },
+      // `$schema` is exactly what Convex values reject as an object key; the
+      // JSON transport must deliver it, and the shortener URL, to the scan intact.
+      metadataJson: JSON.stringify({
+        packageJson: {
+          $schema: "https://json.schemastore.org/package.json",
+          name: "demo-plugin",
+          version: "1.0.0",
+          homepage: "https://bit.ly/demo-plugin",
+        },
+      }),
       files: [{ path: "dist/index.js", size: 27, storageId: "storage:1" }],
     })) as { status: string; reasonCodes: string[]; engineVersion: string; checkedAt: number };
 
     expect(storageGet).toHaveBeenCalledWith("storage:1");
     expect(result.status).toBe("suspicious");
     expect(result.reasonCodes).toContain("suspicious.dynamic_code_execution");
+    expect(result.reasonCodes).toContain(REASON_CODES.SUSPICIOUS_INSTALL_SOURCE);
     expect(typeof result.engineVersion).toBe("string");
     expect(result.checkedAt).toBeGreaterThan(0);
   });

--- a/convex/staticPublishScanNode.ts
+++ b/convex/staticPublishScanNode.ts
@@ -11,8 +11,9 @@ export const runStaticPublishScanInternal = internalAction({
     slug: v.string(),
     displayName: v.string(),
     summary: v.optional(v.string()),
-    frontmatter: v.optional(v.any()),
-    metadata: v.optional(v.any()),
+    // Manifests travel as a JSON string: Convex values reject `$`-prefixed keys
+    // such as package.json `$schema`, and the scan needs the metadata byte-exact.
+    metadataJson: v.optional(v.string()),
     files: v.array(
       v.object({
         path: v.string(),
@@ -22,5 +23,9 @@ export const runStaticPublishScanInternal = internalAction({
       }),
     ),
   },
-  handler: async (ctx, args) => await runStaticPublishScan(ctx, args),
+  handler: async (ctx, { metadataJson, ...input }) =>
+    await runStaticPublishScan(ctx, {
+      ...input,
+      metadata: metadataJson === undefined ? undefined : (JSON.parse(metadataJson) as unknown),
+    }),
 });


### PR DESCRIPTION
## What Problem This Solves

The first production publish after #3591 (`@openclaw/matrix@2026.9.1`, openclaw child run 33867813179) failed inside `publishPackageForTrustedPublisherInternal` with:

```
Uncaught Error: Field name $schema starts with a '$', which is reserved.
```

#3591 moved the moderation scan into a `"use node"` internal action. That turned the scan input into Convex action arguments, and Convex values cannot carry object keys starting with `$`. The publish metadata includes the extracted `package.json`, and matrix's `package.json` declares `"$schema"`, so the hop itself now rejected the publish before the scan ran. Before #3591 the scan was an in-process call with no serialization, which is why no existing test or deploy caught it.

## Why This Change Was Made

Carry the manifests across the boundary as a JSON string (`metadataJson`) and parse them inside the Node action. The scan reads metadata as a JSON blob (env-name discovery and the shortener-URL check stringify it), so a string round-trip keeps the input byte-exact, whereas stripping `$` keys would silently change what the scan sees. The unused `frontmatter` argument is dropped: neither caller passes it and `runStaticPublishScan` already defaults it.

## User Impact

Publishing any package whose `package.json`, plugin manifest, or bundle manifest carries a `$schema` (or any other `$`-prefixed key) works again. No CLI, API, or stored-shape change.

## Evidence

- `convex/packages.public.test.ts`: the `runAction` mock now runs the real `runStaticPublishScanInternal` handler behind a Convex-style reserved-key check, and the "scans plugin publishes" fixture's `package.json` carries `$schema`. With the production helper reverted to pass raw `metadata`, that test fails with the exact production message (`Field name $schema at args.metadata.packageJson starts with a '$', which is reserved.`); with this change it passes.
- `convex/staticPublishScanNode.test.ts`: metadata with `$schema` plus a `bit.ly` homepage crosses the transport and the scan still reports `suspicious.install_source`, proving the JSON round-trip preserves scan semantics.
- Local: `bun x tsc --noEmit` clean; `vitest run convex/packages.public.test.ts convex/lib/staticPublishScan.test.ts convex/staticPublishScanNode.test.ts` → 369 passed; `oxlint --type-aware`, `oxfmt --check`, `bun run deadcode:ci` clean; independent Codex review: see PR thread.
- Live proof after deploy: the matrix 2026.9.1 publish re-dispatch from the openclaw release tag; the versions endpoint must return 200.

Production LOC: net +6 (JSON transport line and comment in the helper, parse in the action, one arg removed).
