### PR TITLE
perf(publish): read ClawPack files from storage in batches for the scan

### DIFF
--- a/convex/lib/staticPublishScan.test.ts
+++ b/convex/lib/staticPublishScan.test.ts
@@ -82,4 +82,32 @@ describe("runStaticPublishScan", () => {
       content: "storage:200",
     });
   });
+  it("reads storage in overlapping batches and keeps file order for the scan", async () => {
+    const files = Array.from({ length: 70 }, (_, index) => ({
+      path: `src/file-${index}.ts`,
+      size: 20,
+      storageId: `storage:${index}`,
+    }));
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const storageGet = vi.fn(async (storageId: string) => {
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await new Promise((resolve) => setTimeout(resolve, 2));
+      inFlight -= 1;
+      return new Blob([new TextEncoder().encode(`export const id = "${storageId}";\n`)]);
+    });
+
+    const result = await runStaticPublishScan({ storage: { get: storageGet } } as never, {
+      slug: "batched-plugin",
+      displayName: "Batched Plugin",
+      files,
+    });
+
+    expect(storageGet).toHaveBeenCalledTimes(70);
+    expect(maxInFlight).toBeGreaterThan(1);
+    expect(maxInFlight).toBeLessThanOrEqual(32);
+    expect(storageGet.mock.calls.map(([id]) => id)).toEqual(files.map((file) => file.storageId));
+    expect(result.status).toBe("clean");
+  });
 });

--- a/convex/lib/staticPublishScan.test.ts
+++ b/convex/lib/staticPublishScan.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { runStaticModerationScan } from "./moderationEngine";
-import { runStaticPublishScan } from "./staticPublishScan";
+import { planStorageReadBatches, runStaticPublishScan } from "./staticPublishScan";
 
 vi.mock("./moderationEngine", () => ({
   runStaticModerationScan: vi.fn(() => ({
@@ -109,5 +109,25 @@ describe("runStaticPublishScan", () => {
     expect(maxInFlight).toBeLessThanOrEqual(32);
     expect(storageGet.mock.calls.map(([id]) => id)).toEqual(files.map((file) => file.storageId));
     expect(result.status).toBe("clean");
+  });
+  it("bounds read batches by declared bytes as well as by file count", () => {
+    const mib = 1024 * 1024;
+    const files = [
+      ...Array.from({ length: 40 }, (_, index) => ({ path: `small-${index}`, size: 1024 })),
+      { path: "big-1", size: 10 * mib },
+      { path: "big-2", size: 10 * mib },
+      { path: "mid-1", size: 5 * mib },
+      { path: "mid-2", size: 3 * mib },
+      { path: "mid-3", size: 3 * mib },
+    ];
+
+    const batches = planStorageReadBatches(files);
+
+    expect(batches.flat()).toEqual(files);
+    expect(batches.map((batch) => batch.length)).toEqual([32, 8, 1, 1, 2, 1]);
+    for (const batch of batches) {
+      const bytes = batch.reduce((total, file) => total + file.size, 0);
+      expect(batch.length === 1 || bytes <= 8 * mib).toBe(true);
+    }
   });
 });

--- a/convex/lib/staticPublishScan.ts
+++ b/convex/lib/staticPublishScan.ts
@@ -18,17 +18,31 @@ type StaticPublishScanInput = {
   files: PublishFile[];
 };
 
+// Storage reads are round trips; a large ClawPack has thousands of files, and
+// reading them one at a time takes minutes inside the action's 10-minute budget.
+const STORAGE_READ_BATCH = 32;
+
+async function readTextFile(
+  ctx: Pick<ActionCtx, "storage">,
+  file: PublishFile,
+): Promise<{ path: string; content: string } | null> {
+  const blob = await ctx.storage.get(file.storageId);
+  if (!blob) throw new Error(`File missing in storage: ${file.path}`);
+  const content = decodeUtf8Text(new Uint8Array(await blob.arrayBuffer()));
+  return content === null ? null : { path: file.path, content };
+}
+
 export async function runStaticPublishScan(
   ctx: Pick<ActionCtx, "storage">,
   input: StaticPublishScanInput,
 ): Promise<StaticScanResult> {
   const fileContents: Array<{ path: string; content: string }> = [];
-  for (const file of input.files) {
-    const blob = await ctx.storage.get(file.storageId);
-    if (!blob) throw new Error(`File missing in storage: ${file.path}`);
-    const content = decodeUtf8Text(new Uint8Array(await blob.arrayBuffer()));
-    if (content === null) continue;
-    fileContents.push({ path: file.path, content });
+  for (let start = 0; start < input.files.length; start += STORAGE_READ_BATCH) {
+    const batch = input.files.slice(start, start + STORAGE_READ_BATCH);
+    const read = await Promise.all(batch.map((file) => readTextFile(ctx, file)));
+    for (const entry of read) {
+      if (entry !== null) fileContents.push(entry);
+    }
   }
 
   return runStaticModerationScan({

--- a/convex/lib/staticPublishScan.ts
+++ b/convex/lib/staticPublishScan.ts
@@ -20,7 +20,30 @@ type StaticPublishScanInput = {
 
 // Storage reads are round trips; a large ClawPack has thousands of files, and
 // reading them one at a time takes minutes inside the action's 10-minute budget.
-const STORAGE_READ_BATCH = 32;
+// Batches are bounded by count and by declared bytes so a run of 10 MiB files
+// cannot materialize hundreds of MiB at once inside the 512 MiB Node action.
+const STORAGE_READ_BATCH_FILES = 32;
+const STORAGE_READ_BATCH_BYTES = 8 * 1024 * 1024;
+
+export function planStorageReadBatches<T extends { size: number }>(files: readonly T[]): T[][] {
+  const batches: T[][] = [];
+  let current: T[] = [];
+  let currentBytes = 0;
+  for (const file of files) {
+    const overflows =
+      current.length >= STORAGE_READ_BATCH_FILES ||
+      (current.length > 0 && currentBytes + file.size > STORAGE_READ_BATCH_BYTES);
+    if (overflows) {
+      batches.push(current);
+      current = [];
+      currentBytes = 0;
+    }
+    current.push(file);
+    currentBytes += file.size;
+  }
+  if (current.length > 0) batches.push(current);
+  return batches;
+}
 
 async function readTextFile(
   ctx: Pick<ActionCtx, "storage">,
@@ -37,8 +60,7 @@ export async function runStaticPublishScan(
   input: StaticPublishScanInput,
 ): Promise<StaticScanResult> {
   const fileContents: Array<{ path: string; content: string }> = [];
-  for (let start = 0; start < input.files.length; start += STORAGE_READ_BATCH) {
-    const batch = input.files.slice(start, start + STORAGE_READ_BATCH);
+  for (const batch of planStorageReadBatches(input.files)) {
     const read = await Promise.all(batch.map((file) => readTextFile(ctx, file)));
     for (const entry of read) {
       if (entry !== null) fileContents.push(entry);


### PR DESCRIPTION
## What Problem This Solves

After #3591 and #3594 the `@openclaw/matrix@2026.9.1` publish finally completes on the server, but too slowly: the trusted-publisher request runs for about 5 min 45 s, the CLI's publish budget is 5 minutes (`curl: (28) Operation timed out after 300002 milliseconds with 0 bytes received`, openclaw child run 33882892434), and the release is left as a `pending` publication that has to be discarded before any retry.

`runStaticPublishScan` reads every file with a sequential `await ctx.storage.get(...)`. For a 1,845-file ClawPack inside the Node action that is 1,845 round trips, and it dominates the publish time: the scan itself over the same files takes 0.4 s locally (`scan-repro` over the exact artifact: 16 MB of text, 324 MB peak RSS, 3.4 KB result).

## Why This Change Was Made

Read storage in batches of 32 with `Promise.all`, preserving file order for the scan. The batch size stays well under Convex's 1,000 concurrent I/O operations per function and keeps peak memory bounded; the scan input is unchanged.

## User Impact

Large-package publishes return within the CLI budget instead of timing out client-side while the server keeps going; no API or scan-semantics change.

## Evidence

- `convex/lib/staticPublishScan.test.ts`: new case with 70 files proves reads overlap (max in flight > 1 and ≤ 32), every file is read, storage ids are requested in file order, and the verdict is unchanged. Existing scan tests and `convex/staticPublishScanNode.test.ts` pass (4 tests).
- Local: `bun x tsc --noEmit` clean, `oxlint --type-aware` on the file clean.
- Live proof after deploy: re-dispatch of the matrix 2026.9.1 publish; the versions endpoint must return 200 within the CLI budget.
