### PR TITLE
fix(ci): stabilize the UI proof process-tree reaping test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Tests: keep the Vitest localStorage shim working on Node 26, whose native `Storage` global has a non-configurable `length`, so `bun run ci:unit` passes on Node 24 and 26.
 - API/GitHub Actions: authorize human release recovery through v2 approval and the original child-bound parent receipt, fail automated attempts when their exact parent fails, and let admins preview or discard orphaned package publish attempts with a publisher-visible reason.
 - CI: warm and cache the npm packages for local Convex "use node" dependencies and raise the isolated backend's push transport timeout so local-auth browser lanes no longer race a 408-retried external-deps build into a deleted build directory.
+- CI: make the UI proof process-tree reaping test exercise KILL escalation deterministically and assert the reaper's signal sequence, so a TERM that lands before the grandchild ignores it can no longer mask a missing KILL.
 - CI: run the pinned Agent Skills CLI from the Bun lockfile without runtime npm access, retain subprocess failure output, and run first-party CLI coverage before third-party compatibility checks.
 - Docs: repair plugin validation remediation links to the published manifest metadata and runtime session helper sections while preserving valid CLI workflow anchors.
 - Dependencies: pin fast-uri to 3.1.6 to fix host confusion and server-side request forgery advisories in URI normalization.

--- a/scripts/ui-proof-backend.test.mjs
+++ b/scripts/ui-proof-backend.test.mjs
@@ -458,23 +458,31 @@ it("reaps a real process tree whose leader exits while a grandchild holds pipes 
       [
         "-e",
         `
-      require('node:child_process').spawn(process.execPath, ['-e', 'process.on("SIGTERM",()=>{}); setInterval(()=>{},1000)'], {stdio:'inherit'});
-      setTimeout(()=>process.exit(7),100);
+      // Exit only once the grandchild ignores TERM, so cleanup must escalate to KILL.
+      // The grandchild keeps the inherited stderr pipe open after the leader is gone.
+      const grandchild = require('node:child_process').spawn(process.execPath, ['-e', 'process.on("SIGTERM",()=>{}); process.stdout.write("ready"); setInterval(()=>{},1000)'], {stdio:['ignore','pipe','inherit']});
+      grandchild.stdout.once('data', () => process.exit(7));
     `,
       ],
       settings,
     );
     return backend;
   };
-  proof.io.kill = (pid, signal) =>
-    pid === -backend?.pid ? process.kill(pid, signal) : kill(pid, signal);
+  const groupSignals = [];
+  proof.io.kill = (pid, signal) => {
+    if (pid !== -backend?.pid) return kill(pid, signal);
+    groupSignals.push(signal);
+    return process.kill(pid, signal);
+  };
   proof.io.fetchImpl = (_url, { signal }) =>
     new Promise((_, reject) =>
       signal.addEventListener("abort", () => reject(signal.reason), { once: true }),
     );
   await expect(proof.run()).rejects.toThrow("Convex backend exited (7)");
+  expect(groupSignals).toEqual([0, "SIGTERM", 0, "SIGKILL"]);
   // Cleanup resolves on stdio closure, but the SIGKILLed grandchild stays a zombie (still a
   // group member) until init reaps it, so the group can outlive run() by a few milliseconds.
+  // macOS reports EPERM in that window, so keep polling until ESRCH.
   await vi.waitFor(() => expect(() => process.kill(-backend.pid, 0)).toThrow(/ESRCH/), {
     timeout: 2000,
     interval: 10,

--- a/specs/ui-proof.md
+++ b/specs/ui-proof.md
@@ -73,7 +73,9 @@ then escalates to KILL. An exited leader must get a bounded close/reaping wait
 before its group is probed: macOS can report EPERM between exit and close.
 Closed pipes do not prove descendants are gone; after ESRCH never signal that
 numeric group again. Permission denial fails that record without alternate
-signals, while all other groups are still attempted.
+signals, while all other groups are still attempted. KILL is accepted before the
+group disappears: a killed descendant stays in the group as a zombie until init
+reaps it, so proofs of group teardown must poll with a bound, never probe once.
 
 Preserve primary failures alongside cleanup errors. Write redacted diagnostics
 and attempt private-state removal even when shutdown/logging fails. Write


### PR DESCRIPTION
## Summary

`scripts/ui-proof-backend.test.mjs` › "reaps a real process tree whose leader exits while a grandchild holds pipes" failed intermittently on GitHub-hosted ubuntu runners with `expected [Function] to throw an error` (main run 33846708408, PR #3592 run 33861954740; both green on rerun).

The reaper in `scripts/ui-proof-backend.mjs` is correct: the leader is spawned detached, so it owns a session and process group, the grandchild inherits that group, and `release()` always escalates signal 0 → TERM → signal 0 → KILL on `-pgid`. The flake was in the test, and it turned out to hide two separate races:

1. **Assert-before-reap** (the CI failure). The test probed `process.kill(-pgid, 0)` once, synchronously, right after the run rejected. A SIGKILLed grandchild has already been reparented to init and stays in the process group as a zombie until init reaps it, so the group is still visible for a moment (a 200-iteration probe on macOS saw the group visible immediately after KILL in 200/200 tries; macOS reports EPERM in that window, Linux reports success). #3600 landed the fix for this on main while this PR was open: a `vi.waitFor` poll for ESRCH. This PR rebases onto it and keeps that poll.
2. **TERM landing before the handler.** The leader exited on a fixed 100 ms timer. Under load the grandchild's Node runtime had not yet installed its SIGTERM handler, so TERM killed it outright and the test passed without ever exercising KILL escalation. Locally this ordering showed up in 1 of 20 idle iterations once the signal sequence was asserted. This PR fixes it.

## Changes

- The leader now exits only after the grandchild writes a readiness byte, so the grandchild demonstrably ignores TERM and cleanup must escalate to KILL. The grandchild still holds the inherited stderr pipe after the leader is gone, so `close` cannot fire early.
- The test records every signal the reaper sends to the backend group and asserts the exact escalation sequence `[0, SIGTERM, 0, SIGKILL]`, so a TERM that happens to kill the grandchild can no longer mask a missing KILL.
- The ESRCH poll from #3600 is kept, with a note that macOS reports EPERM in the zombie window.
- `specs/ui-proof.md` records that KILL is accepted before the group disappears, so teardown proofs must poll with a bound.
- Changelog entry under Unreleased.

## Proof

Run from the worktree with `VITE_CONVEX_URL=https://example.invalid bun node_modules/vitest/vitest.mjs run scripts/ui-proof-backend.test.mjs -t grandchild`, after rebasing onto main:

| Run | Result |
| --- | --- |
| Fixed test, 20 iterations, idle | 20/20 pass |
| Fixed test, 20 iterations, 64 busy loops on 32 cores (pre-rebase) | 20/20 pass |
| Full `scripts/ui-proof-backend.test.mjs` | 28/28 pass |

Intermediate versions during development failed locally in ways that confirm the diagnosis: asserting the signal sequence with the old 100 ms timer failed 1/20 (`[0, SIGTERM, 0]`, no KILL), and a poll that accepted any error failed 1/20 with `EPERM` on macOS.

Also ran `oxfmt --check` on the touched files. A read-only Codex review of the diff returned no actionable findings.
