### PR TITLE
fix(ci): stop local-auth lanes racing the Convex external-deps build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,6 +221,14 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-playwright-
 
+      - name: Cache npm packages for local Convex external dependencies
+        uses: actions/cache@v6
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-local-auth-npm-${{ hashFiles('bun.lock', 'convex.json') }}
+          restore-keys: |
+            ${{ runner.os }}-local-auth-npm-
+
       - name: Install Playwright browsers
         run: bunx playwright install chromium
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixes
 
+- CI: warm and cache the npm packages for local Convex "use node" dependencies and raise the isolated backend's push transport timeout so local-auth browser lanes no longer race a 408-retried external-deps build into a deleted build directory.
 - CI: run the pinned Agent Skills CLI from the Bun lockfile without runtime npm access, retain subprocess failure output, and run first-party CLI coverage before third-party compatibility checks.
 - Docs: repair plugin validation remediation links to the published manifest metadata and runtime session helper sections while preserving valid CLI workflow anchors.
 - Dependencies: pin fast-uri to 3.1.6 to fix host confusion and server-side request forgery advisories in URI normalization.

--- a/scripts/playwright-local-auth-config.test.ts
+++ b/scripts/playwright-local-auth-config.test.ts
@@ -1,11 +1,24 @@
+/* @vitest-environment node */
+
 import { describe, expect, it } from "vitest";
 import {
+  buildLocalAuthBackendEnv,
   buildLocalAuthTrendingSnapshotArgs,
   resolveLocalAuthDeployment,
+  resolveLocalAuthExternalNodeDependencies,
   resolveLocalAuthRunnerConfig,
 } from "./playwright-local-auth-config";
 
 describe("playwright local-auth runner config", () => {
+  it("sets the backend transport timeout and bounded, cache-preferring npm fetches", () => {
+    expect(buildLocalAuthBackendEnv()).toEqual({
+      HTTP_SERVER_TIMEOUT_SECONDS: "900",
+      npm_config_prefer_offline: "true",
+      npm_config_fetch_timeout: "60000",
+      npm_config_fetch_retries: "5",
+    });
+  });
+
   it("defaults local-auth Convex to the anonymous deployment marker", () => {
     expect(resolveLocalAuthDeployment(undefined, null)).toBe("anonymous:anonymous-agent");
     expect(resolveLocalAuthDeployment(undefined, undefined)).toBe("anonymous:anonymous-agent");
@@ -94,4 +107,76 @@ describe("playwright local-auth runner config", () => {
       },
     });
   });
+});
+
+describe("local-auth external Node dependencies", () => {
+  function resolveFromFiles(files: Record<string, unknown>) {
+    return resolveLocalAuthExternalNodeDependencies({
+      readFile: (path) => {
+        if (!(path in files)) throw new Error(`Missing file: ${path}`);
+        return JSON.stringify(files[path]);
+      },
+    });
+  }
+
+  it("pins explicit package names to their installed versions, including scoped packages", () => {
+    expect(
+      resolveFromFiles({
+        "convex.json": { node: { externalPackages: ["sharp", "@example/native"] } },
+        "node_modules/sharp/package.json": { version: "0.35.3" },
+        "node_modules/@example/native/package.json": { version: "1.2.3" },
+      }),
+    ).toEqual([
+      { name: "sharp", version: "0.35.3" },
+      { name: "@example/native", version: "1.2.3" },
+    ]);
+  });
+
+  it.each([
+    { externalPackages: ["*"] },
+    { externalPackages: ["sharp", "*"] },
+    { externalPackages: ["sharp", 42] },
+    { externalPackages: [null] },
+    { externalPackages: [""] },
+    { externalPackages: "sharp" },
+  ])("skips non-explicit external package lists: $externalPackages", (node) => {
+    expect(
+      resolveFromFiles({
+        "convex.json": { node },
+        "node_modules/sharp/package.json": { version: "0.35.3" },
+      }),
+    ).toEqual([]);
+  });
+
+  it("returns no dependencies when convex.json is missing", () => {
+    expect(resolveFromFiles({})).toEqual([]);
+  });
+
+  it.each([{}, { node: {} }, null])(
+    "returns no dependencies without externalPackages: %j",
+    (config) => {
+      expect(resolveFromFiles({ "convex.json": config })).toEqual([]);
+    },
+  );
+
+  it("skips a missing package.json while resolving the other installed packages", () => {
+    expect(
+      resolveFromFiles({
+        "convex.json": { node: { externalPackages: ["missing", "sharp"] } },
+        "node_modules/sharp/package.json": { version: "0.35.3" },
+      }),
+    ).toEqual([{ name: "sharp", version: "0.35.3" }]);
+  });
+
+  it.each([{}, { version: 42 }, { version: "" }, null])(
+    "skips packages without a version: %j",
+    (pkg) => {
+      expect(
+        resolveFromFiles({
+          "convex.json": { node: { externalPackages: ["sharp"] } },
+          "node_modules/sharp/package.json": pkg,
+        }),
+      ).toEqual([]);
+    },
+  );
 });

--- a/scripts/playwright-local-auth-config.ts
+++ b/scripts/playwright-local-auth-config.ts
@@ -10,6 +10,7 @@ const DEFAULT_PLAYWRIGHT_RETRIES = "1";
 const LOCAL_AUTH_TRENDING_SNAPSHOT_ID = "local-auth-canonical-trending-v1";
 const DAY_MS = 24 * 60 * 60 * 1_000;
 const SNAPSHOT_RETENTION_MS = 2 * DAY_MS;
+const LOCAL_AUTH_BACKEND_HTTP_TIMEOUT_SECONDS = 900;
 
 type RunnerEnv = Record<string, string | undefined>;
 
@@ -19,6 +20,56 @@ export type LocalAuthRunnerConfig = {
   convexUrl: string;
   playwrightArgs: string[];
 };
+
+export function buildLocalAuthBackendEnv() {
+  // A 300s backend 408 makes the CLI retry into the executor's shared build_deps directory.
+  // 900s exceeds its 605s build_deps cap, so a stuck install hits the executor timeout first.
+  return {
+    HTTP_SERVER_TIMEOUT_SECONDS: String(LOCAL_AUTH_BACKEND_HTTP_TIMEOUT_SECONDS),
+    npm_config_prefer_offline: "true",
+    npm_config_fetch_timeout: "60000",
+    npm_config_fetch_retries: "5",
+  };
+}
+
+export function resolveLocalAuthExternalNodeDependencies({
+  readFile,
+}: {
+  readFile: (path: string) => string;
+}): Array<{ name: string; version: string }> {
+  let externalPackages: unknown;
+  try {
+    const config = JSON.parse(readFile("convex.json")) as {
+      node?: { externalPackages?: unknown };
+    } | null;
+    externalPackages = config?.node?.externalPackages;
+  } catch {
+    return [];
+  }
+  if (
+    !Array.isArray(externalPackages) ||
+    !externalPackages.every(
+      (name): name is string => typeof name === "string" && name !== "*" && name.length > 0,
+    )
+  ) {
+    return [];
+  }
+
+  const dependencies: Array<{ name: string; version: string }> = [];
+  for (const name of externalPackages) {
+    try {
+      const pkg = JSON.parse(readFile(join("node_modules", name, "package.json"))) as {
+        version?: unknown;
+      } | null;
+      if (typeof pkg?.version === "string" && pkg.version.length > 0) {
+        dependencies.push({ name, version: pkg.version });
+      }
+    } catch {
+      // Missing installed packages are left for the normal Convex push to resolve.
+    }
+  }
+  return dependencies;
+}
 
 export function buildLocalAuthTrendingSnapshotArgs(now: number) {
   const windowEndDay = Math.floor(now / DAY_MS);

--- a/scripts/playwright-local-auth-workflow.test.ts
+++ b/scripts/playwright-local-auth-workflow.test.ts
@@ -6,6 +6,7 @@ import { parse as parseYaml } from "yaml";
 type WorkflowStep = {
   name?: string;
   run?: string;
+  with?: { path?: string; key?: string };
 };
 
 describe("playwright local-auth workflow", () => {
@@ -41,5 +42,11 @@ describe("playwright local-auth workflow", () => {
     expect(localAuthStep?.run).toContain("/sys/fs/cgroup/cpu.stat");
     expect(localAuthStep?.run).toContain("/proc/pressure/memory");
     expect(localAuthStep?.run).toContain("trap report_runner_pressure EXIT");
+
+    const npmCacheStep = job.steps.find(
+      (step) => step.name === "Cache npm packages for local Convex external dependencies",
+    );
+    expect(npmCacheStep?.with?.path).toBe("~/.npm");
+    expect(npmCacheStep?.with?.key).toContain("local-auth-npm");
   });
 });

--- a/scripts/run-playwright-local-auth.ts
+++ b/scripts/run-playwright-local-auth.ts
@@ -5,9 +5,11 @@ import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync 
 import { createServer } from "node:net";
 import { join } from "node:path";
 import {
+  buildLocalAuthBackendEnv,
   buildLocalAuthTrendingSnapshotArgs,
   createLocalAuthTempDir,
   resolveLocalAuthDeployment,
+  resolveLocalAuthExternalNodeDependencies,
   resolveLocalAuthRunnerConfig,
 } from "./playwright-local-auth-config";
 
@@ -204,9 +206,14 @@ function getLocalUrlPort(url: string, label: string) {
   return port;
 }
 
-function spawnManaged(command: string, args: string[], env: NodeJS.ProcessEnv) {
+function spawnManaged(
+  command: string,
+  args: string[],
+  env: NodeJS.ProcessEnv,
+  cwd = process.cwd(),
+) {
   const child = spawn(command, args, {
-    cwd: process.cwd(),
+    cwd,
     detached: process.platform !== "win32",
     env,
     stdio: "inherit",
@@ -318,6 +325,64 @@ async function runRequired(command: string, args: string[], env: NodeJS.ProcessE
       else reject(new Error(`${command} failed with exit code ${code}.`));
     });
   });
+}
+
+async function warmLocalAuthExternalNodeDependencies(env: NodeJS.ProcessEnv) {
+  const dependencies = resolveLocalAuthExternalNodeDependencies({
+    readFile: (path) => readFileSync(path, "utf8"),
+  });
+  if (dependencies.length === 0) return;
+
+  console.log(
+    `Warming the npm cache for local Convex external Node dependencies: ${dependencies.map(({ name, version }) => `${name}@${version}`).join(", ")}`,
+  );
+  const startedAt = Date.now();
+  let child: ChildProcess | undefined;
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    const warmupDir = join(tempDir, "external-deps-warmup");
+    mkdirSync(warmupDir, { recursive: true });
+    writeFileSync(
+      join(warmupDir, "package.json"),
+      JSON.stringify({
+        name: "clawhub-local-auth-external-deps",
+        version: "0.0.0",
+        private: true,
+        dependencies: Object.fromEntries(dependencies.map(({ name, version }) => [name, version])),
+      }),
+    );
+    const warmupChild = spawnManaged(
+      "npm",
+      ["install", "--no-audit", "--no-fund", "--no-package-lock", "--ignore-scripts"],
+      env,
+      warmupDir,
+    );
+    child = warmupChild;
+    await new Promise<void>((resolve, reject) => {
+      timeout = setTimeout(
+        () => reject(new Error(`timed out after ${START_TIMEOUT_MS}ms`)),
+        START_TIMEOUT_MS,
+      );
+      warmupChild.once("error", (error) => {
+        managedChildren.delete(warmupChild);
+        reject(error);
+      });
+      warmupChild.once("exit", (code, signal) => {
+        if (code === 0) resolve();
+        else reject(new Error(`npm exited with ${signal ? `signal ${signal}` : `code ${code}`}`));
+      });
+    });
+    console.log(
+      `External dependency warmup finished in ${((Date.now() - startedAt) / 1_000).toFixed(1)}s.`,
+    );
+  } catch (error) {
+    if (child?.pid) await stopManagedChild(child);
+    console.log(
+      `External dependency warmup failed (${error instanceof Error ? error.message : String(error)}); the local backend will install them during the first push.`,
+    );
+  } finally {
+    clearTimeout(timeout);
+  }
 }
 
 function runBuffered(command: string, args: string[], env: NodeJS.ProcessEnv) {
@@ -475,6 +540,7 @@ async function main() {
   );
   const e2eEnv: NodeJS.ProcessEnv = {
     ...process.env,
+    ...buildLocalAuthBackendEnv(),
     TMPDIR: tempDir,
     AUTH_GITHUB_ID: process.env.AUTH_GITHUB_ID ?? "local-dev",
     AUTH_GITHUB_SECRET: process.env.AUTH_GITHUB_SECRET ?? "local-dev",
@@ -524,6 +590,8 @@ async function main() {
       "",
     ].join("\n"),
   );
+
+  await warmLocalAuthExternalNodeDependencies(e2eEnv);
 
   console.log(`Starting local Convex at ${convexUrl} with isolated e2e state.`);
   const convexArgs = [

--- a/specs/ci.md
+++ b/specs/ci.md
@@ -70,6 +70,18 @@ local Convex process and temporarily moves aside `.env.local` plus
 `.convex/local/default`, then restores them afterward. Stop any already-running
 local Convex process before running it.
 
+The first push builds the external dependencies for Convex `"use node"` functions
+from their installed package versions. A slow cold npm install can exceed the
+backend's default 300-second HTTP timeout: its 408 response prompts a CLI retry
+while the executor keeps building, and overlapping builds corrupt the shared
+`build_deps` directory. The isolated runner sets `HTTP_SERVER_TIMEOUT_SECONDS=900`,
+above the executor's unchanged 605-second dependency-build cap, so that cap fails
+the build before a transport retry can overlap it. Before starting the backend,
+it warms npm's cache with a bounded, best-effort install; warmup and backend both
+use `npm_config_prefer_offline=true`, `npm_config_fetch_timeout=60000`, and
+`npm_config_fetch_retries=5`. CI restores and saves `~/.npm` keyed by `bun.lock`
+and `convex.json`. Action execution limits are not raised.
+
 The full `bun run test:e2e` suite includes token-backed CLI flows. Keep that for
 local or secret-backed validation; PR CI should not require a developer auth
 token or a local global ClawHub config.

--- a/specs/plugin-inspector-reliability.md
+++ b/specs/plugin-inspector-reliability.md
@@ -31,6 +31,8 @@ backend storage volume, with a short path for Unix sockets. The runner owns and
 removes only that scratch directory and its isolated backend state; it restores
 pre-existing local state. Builds and browsers run as awaited managed children
 so signal handlers can stop them; signal and normal-exit cleanup share one run.
+The backend's HTTP transport timeout for the initial push is raised so a slow
+external-deps build cannot be retried into the executor's shared build directory.
 No test timeout or backend execution limit is raised.
 
 The earlier generated-card browser failure included one-second execution


### PR DESCRIPTION
## Problem

The `playwright-local-auth / *` lanes failed intermittently with:

```text
✖ Error fetching POST http://127.0.0.1:3210/api/deploy2/start_push 408 Request Timeout
…
400 Bad Request: InvalidExternalModules: … ENOENT: no such file or directory, stat '/tmp/clawhub-pw-XXXX/.tmpYYYY/build_deps/node_modules.zip'
```

Seen on run 33846708408 (attempts 1–2, `moderation-malicious`), run 33849286983 (#3591), and earlier on #3584 / #3586.

## Root cause

This is not backend readiness and not a CLI temp-dir cleanup. The first push to the fresh isolated backend has to build the `"use node"` external package (`convex.json` → `node.externalPackages: ["sharp"]`). The backend's node executor does that by running `npm install sharp@0.35.3` inside the push request:

1. The Convex backend times out every HTTP request after `HTTP_SERVER_TIMEOUT_SECONDS` (default 300) and answers **408**, cancelling the push future. The executor keeps running the `npm install` it already started, and the cancelled push never stores the package, so the cache stays empty.
2. The Convex CLI treats 408 as retryable and immediately re-sends `start_push`, so the backend issues a **second** `build_deps`. The executor builds every request in one fixed `<tmp>/build_deps` directory and starts each build with `rm -rf` of it (`npm-packages/node-executor/src/build_deps.ts` in get-convex/convex-backend). Overlapping builds therefore delete each other's `node_modules.zip`; whichever request is live when that happens gets the unretryable `InvalidExternalModules … ENOENT` and the lane fails.
3. On the Blacksmith runners that cold `npm install` takes 5–20+ minutes (locally with an empty npm cache it takes ~10 s). Every CI job, including the passing ones, shows one 408 exactly 5:01 after `Preparing Convex functions...`; the passing runs simply won the race on the retry (e.g. `inspector-version`: 408 at 07:37:31, retry ready 14 s later; `old-cli-publish`: 408 at 07:36:08, retry ready 3.28 min later).

The executor also caps a single `build_deps` at `NODE_ACTION_USER_TIMEOUT_SECS + 5 = 605 s`; that is a backend execution limit and is deliberately left unchanged.

## Fix (owner: the lane driver + CI job)

- `scripts/run-playwright-local-auth.ts` passes `HTTP_SERVER_TIMEOUT_SECONDS=900` to the isolated backend (the Convex CLI forwards its env to `convex-local-backend`). No 408 means no retry and no overlapping build; a pathological install now fails with the executor's own 605 s timeout instead of corrupting the shared build directory.
- Before starting the backend, the driver warms the npm cache with a bounded, best-effort `npm install --no-audit --no-fund --no-package-lock --ignore-scripts` of the exact external packages the CLI will request (names from `convex.json`, versions from the installed `package.json`, mirroring the CLI's pinning). Failure or timeout only logs a warning; the backend then installs as before.
- The backend's npm (and the warmup) run with `npm_config_prefer_offline=true`, `npm_config_fetch_timeout=60000`, `npm_config_fetch_retries=5`, so a warm cache needs no registry round-trips and a hung registry connection is abandoned after 60 s instead of npm's 5-minute default.
- `.github/workflows/ci.yml`: the shard job restores/saves `~/.npm` (`actions/cache@v6`, keyed on `bun.lock` + `convex.json`, prefix restore key), so the warmup is a cache hit on every run after the first.
- Specs: `specs/ci.md` documents the mechanism and mitigation; `specs/plugin-inspector-reliability.md` distinguishes the transport timeout from the unchanged execution limits. Changelog entry under Unreleased.

## Regression tests

- `scripts/playwright-local-auth-config.test.ts`: backend env knobs; external-dependency resolution (explicit names pinned to installed versions incl. scoped packages, `"*"`/invalid entries → none, missing `convex.json`/package.json handled).
- `scripts/playwright-local-auth-workflow.test.ts`: asserts the `~/.npm` cache step in the shard job.

## Evidence

Local, this branch, `moderation-malicious` spec (`PATH` with Node 24 for the backend executor):

- Empty npm cache (`npm_config_cache` pointed at a fresh dir): `External dependency warmup finished in 6.6s.` → `Convex functions ready! (12.45s)` → `1 passed`.
- Warm cache with **all network blocked** (`npm_config_proxy`/`https_proxy` → `http://127.0.0.1:9`, real registry URL so cache keys match): `External dependency warmup finished in 1.1s.` → `Convex functions ready! (11.47s)` → `1 passed`. The backend's `build_deps` install resolved entirely from the cache.
- Interrupting the driver during warmup: warmup child terminated (`npm exited with signal SIGTERM`), warning logged, exit 130, port 3210 freed.

Gates: `bunx vitest run scripts/playwright-local-auth-*.test.ts` (29 passed), `bun run ci:static`, `bunx tsc --noEmit`, `bun run ci:unit` (481 files / 6356 tests, run under Node 24 because Node 26 trips an unrelated `vitest.setup.ts` Storage shim locally), Codex autoreview (scoped-clean, P0–P2).

## CI on this PR (run 33900242516)

All eight `playwright-local-auth / *` lanes passed on the first attempt. `moderation-malicious` (the lane that failed on main) now logs:

```text
Cache not found for input keys: Linux-local-auth-npm-…     ← first run, cold ~/.npm
Warming the npm cache for local Convex external Node dependencies: sharp@0.35.3
External dependency warmup finished in 1.3s.
- Preparing Convex functions...
✔ 17:23:19 Convex functions ready! (19.32s)                ← no 408, no retry
  1 passed (57.0s)
```

Lane wall time dropped from 4–11 minutes (every previous run spent 5+ minutes in the 408 retry) to 1–2 minutes. The `~/.npm` cache is saved from this run, so later runs hit the cache directly.

The `unit` job failed once in an unrelated timing race (`scripts/ui-proof-backend.test.mjs` process-group reaping assertion) and was re-run; it is tracked separately.
