### PR TITLE
fix(publish): complete OpenClaw recovery authorization and retire discarded publish attempts

### DIFF
--- a/.github/scripts/verify-trusted-tooling-identity.cjs
+++ b/.github/scripts/verify-trusted-tooling-identity.cjs
@@ -66,6 +66,8 @@ const RECOVERY_RECEIPT_KEYS = [
   "actor",
   "approvalJob",
   "authorizationRoute",
+  "authorizedChildRunAttempt",
+  "authorizedChildRunId",
   "environment",
   "kind",
   "parentRunAttempt",
@@ -290,10 +292,20 @@ function parseRecoveryApprovalReceipt(raw) {
   const value = parseExactJson(raw, {
     name: "recovery environment approval receipt",
     keys: RECOVERY_RECEIPT_KEYS,
-    version: 1,
+    version: 2,
   });
   const receipt = {
-    version: 1,
+    version: 2,
+    authorizedChildRunId: requireString(
+      value.authorizedChildRunId,
+      "recovery receipt authorizedChildRunId",
+      POSITIVE_INTEGER_PATTERN,
+    ),
+    authorizedChildRunAttempt: requireString(
+      value.authorizedChildRunAttempt,
+      "recovery receipt authorizedChildRunAttempt",
+      POSITIVE_INTEGER_PATTERN,
+    ),
     kind: requireString(value.kind, "recovery receipt kind"),
     repository: requireString(value.repository, "recovery receipt repository", REPOSITORY_PATTERN),
     workflow: requireString(value.workflow, "recovery receipt workflow", WORKFLOW_PATTERN),
@@ -394,8 +406,8 @@ function validateWorkflowRun(identity, run, actor) {
   }
 }
 
-function parentArtifactName(identity) {
-  return `${PARENT_RECEIPT_KIND}-v2-${identity.parentRunId}-${identity.parentRunAttempt}-${identity.runId}-${identity.runAttempt}`;
+function parentArtifactName(identity, child = identity) {
+  return `${PARENT_RECEIPT_KIND}-v2-${identity.parentRunId}-${identity.parentRunAttempt}-${child.runId}-${child.runAttempt}`;
 }
 
 function recoveryArtifactName(identity) {
@@ -425,7 +437,7 @@ function validateArtifactResponse(response, { headSha, name, runId }) {
   }
 }
 
-function validateParentAuthorizationReceipt(identity, receipt) {
+function validateParentAuthorizationReceipt(identity, receipt, child = identity) {
   const checks = [
     ["repository", receipt.repository, identity.parentRepository],
     ["workflow", receipt.workflow, identity.parentWorkflow],
@@ -436,8 +448,8 @@ function validateParentAuthorizationReceipt(identity, receipt) {
     ["head SHA", receipt.headSha, identity.toolingSha],
     ["child repository", receipt.childRepository, identity.repository],
     ["child workflow", receipt.childWorkflow, identity.workflow],
-    ["child run id", receipt.childRunId, identity.runId],
-    ["child run attempt", receipt.childRunAttempt, identity.runAttempt],
+    ["child run id", receipt.childRunId, child.runId],
+    ["child run attempt", receipt.childRunAttempt, child.runAttempt],
     ["child ref", receipt.childRef, identity.ref],
     ["child full ref", receipt.childFullRef, identity.fullRef],
     ["child head SHA", receipt.childHeadSha, identity.sha],
@@ -481,12 +493,15 @@ function validateRecoveryApprovalReceipt(identity, receipt, actor) {
 }
 
 function deriveAuthorizationRoute(identity, run, parentReceipt, recoveryReceipt) {
-  if (!recoveryReceipt) {
+  if (isBotActor(run)) {
+    if (recoveryReceipt) fail("automated ClawHub publication cannot select the recovery route");
     return parentReceipt.authorizationRoute;
   }
   const actor = String(run.actor?.login ?? "");
-  if (isBotActor(run)) {
-    fail("automated ClawHub publication cannot select the recovery route");
+  if (!recoveryReceipt) {
+    fail(
+      `RECOVERY_APPROVAL_RECEIPT_PATH is required for human ClawHub publication (artifact ${recoveryArtifactName(identity)})`,
+    );
   }
   validateRecoveryApprovalReceipt(identity, recoveryReceipt, actor);
   return "explicit-recovery";
@@ -510,7 +525,7 @@ function validateReleaseParentState(route, run) {
   }
 }
 
-function validateReleaseParentRun(identity, receipt, route, run) {
+function validateReleaseParentRun(identity, run) {
   if (!run || typeof run !== "object" || Array.isArray(run)) {
     fail("trusted release parent workflow run response is invalid");
   }
@@ -521,8 +536,8 @@ function validateReleaseParentRun(identity, receipt, route, run) {
     ["run id", String(run.id ?? ""), identity.parentRunId],
     ["run attempt", String(run.run_attempt ?? ""), identity.parentRunAttempt],
     ["workflow path", workflowPath, identity.parentWorkflow],
-    ["head branch", String(run.head_branch ?? ""), receipt.ref],
-    ["head SHA", String(run.head_sha ?? ""), receipt.headSha],
+    ["head branch", String(run.head_branch ?? ""), identity.toolingRef],
+    ["head SHA", String(run.head_sha ?? ""), identity.toolingSha],
     ["event", String(run.event ?? ""), "workflow_dispatch"],
   ];
   for (const [name, actual, expected] of checks) {
@@ -533,13 +548,12 @@ function validateReleaseParentRun(identity, receipt, route, run) {
 
   const normalizedQualifiedRef = normalizeQualifiedWorkflowRef(
     qualifiedRef,
-    receipt.ref,
-    receipt.fullRef,
+    identity.toolingRef,
+    identity.toolingFullRef,
   );
-  if (normalizedQualifiedRef && normalizedQualifiedRef !== receipt.fullRef) {
+  if (normalizedQualifiedRef && normalizedQualifiedRef !== identity.toolingFullRef) {
     fail("trusted release parent workflow path ref mismatch");
   }
-  validateReleaseParentState(route, run);
 }
 
 function validateProtectedTag(identity, tagRef) {
@@ -587,20 +601,22 @@ async function verifyTrustedToolingIdentity({
   );
   validateWorkflowRun(identity, run, actor);
 
-  const expectedParentArtifact = parentArtifactName(identity);
-  const parentArtifacts = await getJson(
-    `repos/${identity.parentRepository}/actions/runs/${identity.parentRunId}/artifacts?name=${encodeURIComponent(expectedParentArtifact)}`,
+  const parentRun = await getJson(
+    `repos/${identity.parentRepository}/actions/runs/${identity.parentRunId}/attempts/${identity.parentRunAttempt}`,
   );
-  validateArtifactResponse(parentArtifacts, {
-    headSha: identity.toolingSha,
-    name: expectedParentArtifact,
-    runId: identity.parentRunId,
-  });
-  const parentReceipt = parseParentAuthorizationReceipt(rawParentReceipt);
-  validateParentAuthorizationReceipt(identity, parentReceipt);
+  validateReleaseParentRun(identity, parentRun);
 
-  let recoveryReceipt;
-  if (rawRecoveryReceipt) {
+  const parentReceipt = parseParentAuthorizationReceipt(rawParentReceipt);
+  const recoveryReceipt = rawRecoveryReceipt
+    ? parseRecoveryApprovalReceipt(rawRecoveryReceipt)
+    : undefined;
+  const authorizationRoute = deriveAuthorizationRoute(
+    identity,
+    run,
+    parentReceipt,
+    recoveryReceipt,
+  );
+  if (recoveryReceipt) {
     const expectedRecoveryArtifact = recoveryArtifactName(identity);
     const recoveryArtifacts = await getJson(
       `repos/${identity.repository}/actions/runs/${identity.runId}/artifacts?name=${encodeURIComponent(expectedRecoveryArtifact)}`,
@@ -610,19 +626,24 @@ async function verifyTrustedToolingIdentity({
       name: expectedRecoveryArtifact,
       runId: identity.runId,
     });
-    recoveryReceipt = parseRecoveryApprovalReceipt(rawRecoveryReceipt);
   }
-  const authorizationRoute = deriveAuthorizationRoute(
-    identity,
-    run,
-    parentReceipt,
-    recoveryReceipt,
+  const authorizedChild = recoveryReceipt
+    ? {
+        runId: recoveryReceipt.authorizedChildRunId,
+        runAttempt: recoveryReceipt.authorizedChildRunAttempt,
+      }
+    : identity;
+  const expectedParentArtifact = parentArtifactName(identity, authorizedChild);
+  const parentArtifacts = await getJson(
+    `repos/${identity.parentRepository}/actions/runs/${identity.parentRunId}/artifacts?name=${encodeURIComponent(expectedParentArtifact)}`,
   );
-
-  const parentRun = await getJson(
-    `repos/${identity.parentRepository}/actions/runs/${identity.parentRunId}/attempts/${identity.parentRunAttempt}`,
-  );
-  validateReleaseParentRun(identity, parentReceipt, authorizationRoute, parentRun);
+  validateArtifactResponse(parentArtifacts, {
+    headSha: identity.toolingSha,
+    name: expectedParentArtifact,
+    runId: identity.parentRunId,
+  });
+  validateParentAuthorizationReceipt(identity, parentReceipt, authorizedChild);
+  validateReleaseParentState(authorizationRoute, parentRun);
 
   if (identity.toolingRoute === "main") {
     const comparison = await getJson(

--- a/.github/scripts/verify-trusted-tooling-identity.node-test.cjs
+++ b/.github/scripts/verify-trusted-tooling-identity.node-test.cjs
@@ -30,6 +30,7 @@ const botActor = "github-actions[bot]";
 const humanActor = "release-maintainer";
 const digest = `sha256:${"d".repeat(64)}`;
 const inventoryDigest = "e".repeat(64);
+const originalChild = { runId: "32439999998", runAttempt: "1" };
 
 test("accepts a complete 89-package parent authorization inventory", () => {
   const packages = Array.from({ length: 89 }, (_, index) => ({
@@ -146,7 +147,9 @@ function parentReceipt(identity, overrides = {}) {
 
 function recoveryReceipt(identity, overrides = {}) {
   return {
-    version: 1,
+    version: 2,
+    authorizedChildRunId: originalChild.runId,
+    authorizedChildRunAttempt: originalChild.runAttempt,
     kind: "openclaw-clawhub-recovery-approval",
     repository: identity.repository,
     workflow: identity.workflow,
@@ -234,11 +237,14 @@ function apiFixture({
       return runFixture(identity, actor);
     }
     if (path.includes(`/actions/runs/${identity.parentRunId}/artifacts?`)) {
-      return artifactFixture(
-        parentArtifactName(identity),
-        identity.parentRunId,
-        identity.toolingSha,
-      );
+      const name = parentArtifactName(identity, {
+        runId: receipt.childRunId,
+        runAttempt: receipt.childRunAttempt,
+      });
+      if (new URL(path, "https://api.github.com/").searchParams.get("name") !== name) {
+        return { total_count: 0, artifacts: [] };
+      }
+      return artifactFixture(name, identity.parentRunId, identity.toolingSha);
     }
     if (path.includes(`/actions/runs/${identity.runId}/artifacts?`)) {
       assert.ok(recovery);
@@ -275,8 +281,8 @@ test("binds bot publication to the immutable awaited parent receipt", async () =
   assert.equal(result.authorizationRoute, "automated-awaited");
   assert.deepEqual(calls, [
     `repos/${identity.repository}/actions/runs/${identity.runId}/attempts/${identity.runAttempt}`,
-    `repos/${identity.parentRepository}/actions/runs/${identity.parentRunId}/artifacts?name=${encodeURIComponent(parentArtifactName(identity))}`,
     `repos/${identity.parentRepository}/actions/runs/${identity.parentRunId}/attempts/${identity.parentRunAttempt}`,
+    `repos/${identity.parentRepository}/actions/runs/${identity.parentRunId}/artifacts?name=${encodeURIComponent(parentArtifactName(identity))}`,
     `repos/${identity.repository}/git/ref/tags/${encodeURIComponent(identity.toolingRef)}`,
   ]);
 });
@@ -366,8 +372,6 @@ test("does not infer parent full ref from an unqualified run path", () => {
   assert.doesNotThrow(() =>
     validateReleaseParentRun(
       identity,
-      receipt,
-      receipt.authorizationRoute,
       parentRunFixture(identity, receipt, { path: identity.parentWorkflow }),
     ),
   );
@@ -380,8 +384,6 @@ test("rejects same-name branch parent paths when the receipt proves a tag", () =
     () =>
       validateReleaseParentRun(
         identity,
-        receipt,
-        receipt.authorizationRoute,
         parentRunFixture(identity, receipt, {
           path: `${identity.parentWorkflow}@refs/heads/${identity.toolingRef}`,
         }),
@@ -565,29 +567,29 @@ test("GitHub App actors cannot select recovery without a bot-suffixed login", ()
   );
 });
 
-test("bot publication rejects a live recovery artifact before parent-state evaluation", async () => {
+test("bot publication rejects recovery before artifact resolution", async () => {
   const identity = protectedIdentity();
   const receipt = parentReceipt(identity);
   const recovery = recoveryReceipt(identity, { actor: botActor });
+  const calls = [];
+  const getJson = apiFixture({ identity, receipt, recovery });
   await assert.rejects(
     verifyTrustedToolingIdentity({
       rawIdentity: JSON.stringify(identity),
       rawParentReceipt: JSON.stringify(receipt),
       rawRecoveryReceipt: JSON.stringify(recovery),
       env: callerEnv(identity),
-      getJson: apiFixture({ identity, receipt, recovery }),
+      getJson: async (path) => {
+        calls.push(path);
+        return getJson(path);
+      },
     }),
     /cannot select the recovery route/,
   );
-});
-
-test("normal human-dispatched publication keeps the parent-owned route", () => {
-  const identity = protectedIdentity();
-  const receipt = parseParentAuthorizationReceipt(JSON.stringify(parentReceipt(identity)));
-  assert.equal(
-    deriveAuthorizationRoute(identity, runFixture(identity, humanActor), receipt),
-    "automated-awaited",
-  );
+  assert.deepEqual(calls, [
+    `repos/${identity.repository}/actions/runs/${identity.runId}/attempts/${identity.runAttempt}`,
+    `repos/${identity.parentRepository}/actions/runs/${identity.parentRunId}/attempts/${identity.parentRunAttempt}`,
+  ]);
 });
 
 for (const [name, overrides, message] of [
@@ -655,39 +657,118 @@ test("detached normal publication permits only active or successful parents", as
   }
 });
 
-test("normal human-dispatched publication does not require recovery evidence", async () => {
+test("human dispatch requires the recovery receipt path and names its artifact", async () => {
   const identity = protectedIdentity();
   const receipt = parentReceipt(identity);
-  const result = await verifyTrustedToolingIdentity({
-    rawIdentity: JSON.stringify(identity),
-    rawParentReceipt: JSON.stringify(receipt),
-    env: callerEnv(identity, humanActor),
-    getJson: apiFixture({ identity, receipt, actor: humanActor }),
-  });
-  assert.equal(result.authorizationRoute, "automated-awaited");
+  await assert.rejects(
+    verifyTrustedToolingIdentity({
+      rawIdentity: JSON.stringify(identity),
+      rawParentReceipt: JSON.stringify(receipt),
+      env: callerEnv(identity, humanActor),
+      getJson: apiFixture({ identity, receipt, actor: humanActor }),
+    }),
+    new RegExp(`RECOVERY_APPROVAL_RECEIPT_PATH is required.*${recoveryArtifactName(identity)}`),
+  );
 });
 
-test("explicit recovery permits a failed parent after protected environment approval", async () => {
+test("human recovery reuses the failed parent's receipt bound to its original bot child", async () => {
   const identity = protectedIdentity();
-  const receipt = parentReceipt(identity);
+  const receipt = parentReceipt(identity, {
+    childRunId: originalChild.runId,
+    childRunAttempt: originalChild.runAttempt,
+  });
   const recovery = recoveryReceipt(identity);
+  const calls = [];
+  const getJson = apiFixture({
+    identity,
+    receipt,
+    actor: humanActor,
+    recovery,
+    parentRun: parentRunFixture(identity, receipt, {
+      status: "completed",
+      conclusion: "failure",
+    }),
+  });
   const result = await verifyTrustedToolingIdentity({
     rawIdentity: JSON.stringify(identity),
     rawParentReceipt: JSON.stringify(receipt),
     rawRecoveryReceipt: JSON.stringify(recovery),
     env: callerEnv(identity, humanActor),
-    getJson: apiFixture({
-      identity,
-      receipt,
-      actor: humanActor,
-      recovery,
-      parentRun: parentRunFixture(identity, receipt, {
-        status: "completed",
-        conclusion: "failure",
-      }),
-    }),
+    getJson: async (path) => {
+      calls.push(path);
+      return getJson(path);
+    },
   });
   assert.equal(result.authorizationRoute, "explicit-recovery");
+  assert.deepEqual(calls, [
+    `repos/${identity.repository}/actions/runs/${identity.runId}/attempts/${identity.runAttempt}`,
+    `repos/${identity.parentRepository}/actions/runs/${identity.parentRunId}/attempts/${identity.parentRunAttempt}`,
+    `repos/${identity.repository}/actions/runs/${identity.runId}/artifacts?name=${encodeURIComponent(recoveryArtifactName(identity))}`,
+    `repos/${identity.parentRepository}/actions/runs/${identity.parentRunId}/artifacts?name=${encodeURIComponent(parentArtifactName(identity, originalChild))}`,
+    `repos/${identity.repository}/git/ref/tags/${encodeURIComponent(identity.toolingRef)}`,
+  ]);
+});
+
+for (const [name, overrides, message] of [
+  [
+    "authorized child without a parent receipt",
+    { childRunId: callerRunId },
+    /missing or ambiguous/,
+  ],
+  ["child SHA changed", { childHeadSha: "f".repeat(40) }, /child head SHA mismatch/],
+  [
+    "child ref changed",
+    { childRef: "other", childFullRef: "refs/heads/other" },
+    /child ref mismatch/,
+  ],
+]) {
+  test(`recovery fails closed for ${name}`, async () => {
+    const identity = protectedIdentity();
+    const receipt = parentReceipt(identity, {
+      childRunId: originalChild.runId,
+      childRunAttempt: originalChild.runAttempt,
+      ...overrides,
+    });
+    const recovery = recoveryReceipt(identity);
+    await assert.rejects(
+      verifyTrustedToolingIdentity({
+        rawIdentity: JSON.stringify(identity),
+        rawParentReceipt: JSON.stringify(receipt),
+        rawRecoveryReceipt: JSON.stringify(recovery),
+        env: callerEnv(identity, humanActor),
+        getJson: apiFixture({ identity, receipt, actor: humanActor, recovery }),
+      }),
+      message,
+    );
+  });
+}
+
+test("rejects v1 recovery approval and non-positive authorized child attempts", () => {
+  assert.throws(
+    () =>
+      parseRecoveryApprovalReceipt(
+        JSON.stringify(recoveryReceipt(protectedIdentity(), { version: 1 })),
+      ),
+    /version must be 2/,
+  );
+  const legacy = recoveryReceipt(protectedIdentity(), { version: 1 });
+  delete legacy.authorizedChildRunId;
+  delete legacy.authorizedChildRunAttempt;
+  assert.throws(
+    () => parseRecoveryApprovalReceipt(JSON.stringify(legacy)),
+    /v2 must contain exactly/,
+  );
+  for (const field of ["authorizedChildRunId", "authorizedChildRunAttempt"]) {
+    for (const value of ["0", "-1", "1.5", 1]) {
+      assert.throws(
+        () =>
+          parseRecoveryApprovalReceipt(
+            JSON.stringify(recoveryReceipt(protectedIdentity(), { [field]: value })),
+          ),
+        new RegExp(`${field} is invalid`),
+      );
+    }
+  }
 });
 
 for (const [actor, route, recovery, conclusion] of [
@@ -699,7 +780,12 @@ for (const [actor, route, recovery, conclusion] of [
 ]) {
   test(`rejects ${conclusion} parent during approval wait for ${actor}/${route}`, async () => {
     const identity = protectedIdentity();
-    const receipt = parentReceipt(identity, { authorizationRoute: route });
+    const receipt = parentReceipt(identity, {
+      authorizationRoute: route,
+      ...(recovery
+        ? { childRunId: originalChild.runId, childRunAttempt: originalChild.runAttempt }
+        : {}),
+    });
     await assert.rejects(
       verifyTrustedToolingIdentity({
         rawIdentity: JSON.stringify(identity),

--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -733,16 +733,6 @@ jobs:
           path: ${{ runner.temp }}/plugin-inspector
           if-no-files-found: ignore
 
-      - name: Download release parent authorization receipt
-        if: inputs.trusted_tooling_identity_json != ''
-        uses: actions/download-artifact@v8
-        with:
-          name: openclaw-clawhub-parent-authorization-v2-${{ fromJson(inputs.trusted_tooling_identity_json).parentRunId }}-${{ fromJson(inputs.trusted_tooling_identity_json).parentRunAttempt }}-${{ fromJson(inputs.trusted_tooling_identity_json).runId }}-${{ fromJson(inputs.trusted_tooling_identity_json).runAttempt }}
-          path: ${{ runner.temp }}/openclaw-clawhub-parent-authorization
-          github-token: ${{ github.token }}
-          repository: ${{ fromJson(inputs.trusted_tooling_identity_json).parentRepository }}
-          run-id: ${{ fromJson(inputs.trusted_tooling_identity_json).parentRunId }}
-
       - name: Download recovery environment approval receipt
         id: recovery_approval
         if: inputs.trusted_tooling_identity_json != ''
@@ -754,6 +744,40 @@ jobs:
           github-token: ${{ github.token }}
           repository: ${{ github.repository }}
           run-id: ${{ github.run_id }}
+
+      - name: Resolve release parent authorization artifact
+        id: parent_authorization
+        if: inputs.trusted_tooling_identity_json != ''
+        env:
+          TRUSTED_TOOLING_IDENTITY_JSON: ${{ inputs.trusted_tooling_identity_json }}
+          RECOVERY_APPROVAL_RECEIPT_PATH: ${{ steps.recovery_approval.outcome == 'success' && format('{0}/openclaw-clawhub-recovery-approval/approval.json', runner.temp) || '' }}
+        run: |
+          node <<'NODE'
+          const { appendFileSync, lstatSync, readFileSync } = require("node:fs");
+          const { parentArtifactName, parseTrustedToolingIdentity, parseRecoveryApprovalReceipt } = require(`${process.env.GITHUB_WORKSPACE}/clawhub-source/.github/scripts/verify-trusted-tooling-identity.cjs`);
+          const identity = parseTrustedToolingIdentity(process.env.TRUSTED_TOOLING_IDENTITY_JSON);
+          let child = identity;
+          const path = process.env.RECOVERY_APPROVAL_RECEIPT_PATH;
+          if (path) {
+            const stat = lstatSync(path);
+            if (!stat.isFile() || stat.isSymbolicLink() || stat.size > 8 * 1024) {
+              throw new Error("Recovery approval receipt must be a regular file of at most 8 KiB");
+            }
+            const recovery = parseRecoveryApprovalReceipt(readFileSync(path, "utf8"));
+            child = { runId: recovery.authorizedChildRunId, runAttempt: recovery.authorizedChildRunAttempt };
+          }
+          appendFileSync(process.env.GITHUB_OUTPUT, `artifact_name=${parentArtifactName(identity, child)}\n`);
+          NODE
+
+      - name: Download release parent authorization receipt
+        if: inputs.trusted_tooling_identity_json != ''
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ steps.parent_authorization.outputs.artifact_name }}
+          path: ${{ runner.temp }}/openclaw-clawhub-parent-authorization
+          github-token: ${{ github.token }}
+          repository: ${{ fromJson(inputs.trusted_tooling_identity_json).parentRepository }}
+          run-id: ${{ fromJson(inputs.trusted_tooling_identity_json).parentRunId }}
 
       - name: Revalidate trusted tooling identity
         if: inputs.trusted_tooling_identity_json != ''

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixes
 
+- API/GitHub Actions: authorize human release recovery through v2 approval and the original child-bound parent receipt, fail automated attempts when their exact parent fails, and let admins preview or discard orphaned package publish attempts with a publisher-visible reason.
 - CI: warm and cache the npm packages for local Convex "use node" dependencies and raise the isolated backend's push transport timeout so local-auth browser lanes no longer race a 408-retried external-deps build into a deleted build directory.
 - CI: run the pinned Agent Skills CLI from the Bun lockfile without runtime npm access, retain subprocess failure output, and run first-party CLI coverage before third-party compatibility checks.
 - Docs: repair plugin validation remediation links to the published manifest metadata and runtime session helper sections while preserving valid CLI workflow anchors.

--- a/convex/lib/openClawPublishAuthorization.test.ts
+++ b/convex/lib/openClawPublishAuthorization.test.ts
@@ -14,6 +14,7 @@ const childSha = "c".repeat(40);
 const candidateSha = "b".repeat(40);
 const toolingSha = "a".repeat(40);
 const inventoryDigest = "d".repeat(64);
+const originalChild = { runId: "32439999998", runAttempt: "1" };
 const toolingRef = `release-publish/${toolingSha.slice(0, 12)}-32410682801`;
 
 function identity(overrides: Record<string, unknown> = {}) {
@@ -75,10 +76,12 @@ function parentReceipt(overrides: Record<string, unknown> = {}) {
   };
 }
 
-function recoveryReceipt() {
+function recoveryReceipt(overrides: Record<string, unknown> = {}) {
   const value = identity();
   return {
-    version: 1,
+    version: 2,
+    authorizedChildRunId: originalChild.runId,
+    authorizedChildRunAttempt: originalChild.runAttempt,
     kind: "openclaw-clawhub-recovery-approval",
     repository: value.repository,
     workflow: value.workflow,
@@ -90,6 +93,7 @@ function recoveryReceipt() {
     authorizationRoute: "explicit-recovery",
     parentRunId: value.parentRunId,
     parentRunAttempt: value.parentRunAttempt,
+    ...overrides,
   };
 }
 
@@ -120,6 +124,10 @@ function artifact(filename: string, value: unknown) {
   };
 }
 
+function requestUrl(input: string | URL | Request) {
+  return input instanceof Request ? input.url : input instanceof URL ? input.href : input;
+}
+
 function githubFetch(options: {
   parentStatus?: string;
   parentConclusion?: string | null;
@@ -127,12 +135,18 @@ function githubFetch(options: {
   parentReceipt?: Record<string, unknown>;
   recoveryReceipt?: Record<string, unknown>;
   omitParentArtifact?: boolean;
+  parentArtifactChild?: { runId: string; runAttempt: string };
+  omitRecoveryArtifact?: boolean;
 }) {
   const value = identity();
+  const parentName = parentAuthorizationArtifactName(
+    parseOpenClawTrustedToolingIdentity(JSON.stringify(value)),
+    options.parentArtifactChild,
+  );
   const parent = artifact("authorization.json", options.parentReceipt ?? parentReceipt());
   const recovery = artifact("approval.json", options.recoveryReceipt ?? recoveryReceipt());
   return vi.fn(async (input: string | URL | Request) => {
-    const url = input instanceof Request ? input.url : input instanceof URL ? input.href : input;
+    const url = requestUrl(input);
     if (url.includes(`/actions/runs/${value.runId}/attempts/${value.runAttempt}`)) {
       return Response.json({
         id: Number(value.runId),
@@ -161,15 +175,15 @@ function githubFetch(options: {
       });
     }
     if (url.includes(`/actions/runs/${value.parentRunId}/artifacts?`)) {
-      if (options.omitParentArtifact) return Response.json({ total_count: 0, artifacts: [] });
+      if (options.omitParentArtifact || new URL(url).searchParams.get("name") !== parentName) {
+        return Response.json({ total_count: 0, artifacts: [] });
+      }
       return Response.json({
         total_count: 1,
         artifacts: [
           {
             id: 101,
-            name: parentAuthorizationArtifactName(
-              parseOpenClawTrustedToolingIdentity(JSON.stringify(value)),
-            ),
+            name: parentName,
             expired: false,
             digest: parent.digest,
             archive_download_url: "https://api.github.com/artifacts/101/zip",
@@ -179,6 +193,7 @@ function githubFetch(options: {
       });
     }
     if (url.includes(`/actions/runs/${value.runId}/artifacts?`)) {
+      if (options.omitRecoveryArtifact) return Response.json({ total_count: 0, artifacts: [] });
       return Response.json({
         total_count: 1,
         artifacts: [
@@ -202,6 +217,37 @@ function githubFetch(options: {
       });
     }
     throw new Error(`Unexpected GitHub request: ${url}`);
+  });
+}
+
+function recoveryFetch(options: Parameters<typeof githubFetch>[0] = {}) {
+  return githubFetch({
+    parentStatus: "completed",
+    parentConclusion: "failure",
+    childActor: { login: "release-maintainer", type: "User" },
+    parentArtifactChild: originalChild,
+    parentReceipt: parentReceipt({
+      childRunId: originalChild.runId,
+      childRunAttempt: originalChild.runAttempt,
+    }),
+    ...options,
+  });
+}
+
+function verify(
+  fetchImpl: typeof fetch,
+  requiredParentState: "submission" | "terminal" = "submission",
+  digest = inventoryDigest,
+) {
+  process.env.GITHUB_TOKEN = "test-token";
+  return verifyOpenClawPublishAuthorization({
+    rawIdentity: JSON.stringify(identity()),
+    packageName: "@openclaw/demo-plugin",
+    version: "1.0.0",
+    inventoryDigest: digest,
+    oidc: oidc(),
+    requiredParentState,
+    fetchImpl,
   });
 }
 
@@ -309,8 +355,13 @@ describe("OpenClaw package publish authorization", () => {
     );
   });
 
-  it("rejects GitHub App and bot-suffixed recovery actors", async () => {
+  it("terminally rejects a failed automated parent without fetching recovery evidence", async () => {
     process.env.GITHUB_TOKEN = "test-token";
+    const fetchImpl = githubFetch({
+      parentStatus: "completed",
+      parentConclusion: "failure",
+      omitRecoveryArtifact: true,
+    });
     await expect(
       verifyOpenClawPublishAuthorization({
         rawIdentity: JSON.stringify(identity()),
@@ -318,29 +369,140 @@ describe("OpenClaw package publish authorization", () => {
         version: "1.0.0",
         inventoryDigest,
         oidc: oidc(),
-        fetchImpl: githubFetch({
-          parentStatus: "completed",
-          parentConclusion: "failure",
-          childActor: { login: "release-service", type: "App" },
-          recoveryReceipt: recoveryReceipt(),
-        }),
+        requiredParentState: "terminal",
+        fetchImpl,
       }),
-    ).rejects.toThrow("cannot use release recovery");
+    ).rejects.toThrow(
+      "OpenClaw release parent terminal state completed/failure is not authorized by automated-awaited",
+    );
+    expect(
+      fetchImpl.mock.calls.some(([url]) => requestUrl(url).includes("recovery-approval")),
+    ).toBe(false);
+  });
+
+  it.each([
+    { login: "github-actions[bot]", type: "Bot" },
+    { login: "release-service", type: "App" },
+    { login: "release-app[bot]", type: "User" },
+  ])("keeps automated actor $login on the parent route after failure", async (childActor) => {
+    const fetchImpl = githubFetch({
+      parentStatus: "completed",
+      parentConclusion: "failure",
+      childActor,
+    });
+    await expect(verify(fetchImpl)).rejects.toThrow(
+      "release parent state completed/failure is not authorized by automated-awaited",
+    );
+    expect(
+      fetchImpl.mock.calls.some(([url]) => requestUrl(url).includes("recovery-approval")),
+    ).toBe(false);
+  });
+
+  it.each(["submission", "terminal"] as const)(
+    "authorizes human recovery through the original bot child receipt in %s mode",
+    async (mode) => {
+      const fetchImpl = recoveryFetch();
+      const result = await verify(fetchImpl, mode);
+      expect(result).toMatchObject({ authorizationRoute: "explicit-recovery", artifactId: "101" });
+      expect(result.artifactDigest).toBe(
+        artifact(
+          "authorization.json",
+          parentReceipt({
+            childRunId: originalChild.runId,
+            childRunAttempt: originalChild.runAttempt,
+          }),
+        ).digest,
+      );
+      expect(result.transactionKey).toContain(`:${identity().runId}:${identity().runAttempt}:`);
+      const requests = fetchImpl.mock.calls.map(([url]) => requestUrl(url));
+      expect(requests.filter((url) => url.includes("/artifacts?"))).toEqual([
+        expect.stringContaining(
+          `openclaw-clawhub-recovery-approval-${identity().runId}-${identity().runAttempt}`,
+        ),
+        expect.stringContaining(
+          parentAuthorizationArtifactName(
+            parseOpenClawTrustedToolingIdentity(JSON.stringify(identity())),
+            originalChild,
+          ),
+        ),
+      ]);
+    },
+  );
+
+  it("requires a human child's recovery artifact even while its parent is active", async () => {
     await expect(
-      verifyOpenClawPublishAuthorization({
-        rawIdentity: JSON.stringify(identity()),
-        packageName: "@openclaw/demo-plugin",
-        version: "1.0.0",
-        inventoryDigest,
-        oidc: oidc(),
-        fetchImpl: githubFetch({
-          parentStatus: "completed",
-          parentConclusion: "failure",
-          childActor: { login: "release-app[bot]", type: "User" },
-          recoveryReceipt: recoveryReceipt(),
+      verify(
+        recoveryFetch({
+          parentStatus: "in_progress",
+          parentConclusion: null,
+          omitRecoveryArtifact: true,
         }),
-      }),
-    ).rejects.toThrow("cannot use release recovery");
+      ),
+    ).rejects.toThrow(
+      "authorization artifact openclaw-clawhub-recovery-approval-32440000001-2 is missing or ambiguous",
+    );
+  });
+
+  it("requires a parent artifact for the recovery receipt's authorized child", async () => {
+    await expect(verify(recoveryFetch({ parentArtifactChild: identity() }))).rejects.toThrow(
+      `authorization artifact openclaw-clawhub-parent-authorization-v2-${identity().parentRunId}-${identity().parentRunAttempt}-${originalChild.runId}-${originalChild.runAttempt} is missing or ambiguous`,
+    );
+  });
+
+  it.each([
+    [{ childHeadSha: "f".repeat(40) }, "child head SHA mismatch"],
+    [{ childRef: "other", childFullRef: "refs/heads/other" }, "child ref mismatch"],
+    [{ candidateSha: "f".repeat(40) }, "candidate SHA mismatch"],
+    [{ toolingSha: "f".repeat(40) }, "receipt tooling SHA mismatch"],
+  ])("preserves recovery parent bindings: %s", async (overrides, message) => {
+    await expect(
+      verify(
+        recoveryFetch({
+          parentReceipt: parentReceipt({
+            childRunId: originalChild.runId,
+            childRunAttempt: originalChild.runAttempt,
+            ...overrides,
+          }),
+        }),
+      ),
+    ).rejects.toThrow(message);
+  });
+
+  it.each([
+    [{ version: 1 }, "version must be 2"],
+    [{ authorizedChildRunId: "0" }, "authorizedChildRunId is invalid"],
+    [{ authorizedChildRunAttempt: "1.5" }, "authorizedChildRunAttempt is invalid"],
+    [{ parentRunId: "999" }, "parent run id mismatch"],
+    [{ parentRunAttempt: "4" }, "parent run attempt mismatch"],
+    [{ actor: "other" }, "actor mismatch"],
+    [{ environment: "other" }, "environment mismatch"],
+    [{ approvalJob: "other" }, "approval job mismatch"],
+    [{ workflow: ".github/workflows/other.yml" }, "workflow mismatch"],
+    [{ repository: "other/repo" }, "repository mismatch"],
+    [{ kind: "other" }, "kind mismatch"],
+    [{ runId: "999" }, "run id mismatch"],
+    [{ runAttempt: "4" }, "run attempt mismatch"],
+    [{ authorizationRoute: "automated-awaited" }, "route mismatch"],
+    [{ extra: true }, "must contain exactly"],
+    [{ actor: "a".repeat(8192) }, "missing or too large"],
+  ])("rejects invalid recovery approval: %s", async (overrides, message) => {
+    await expect(
+      verify(recoveryFetch({ recoveryReceipt: recoveryReceipt(overrides) })),
+    ).rejects.toThrow(message);
+  });
+
+  it("terminally rejects cancelled parents on the recovery route", async () => {
+    await expect(
+      verify(recoveryFetch({ parentConclusion: "cancelled" }), "terminal"),
+    ).rejects.toThrow(
+      "OpenClaw release parent terminal state completed/cancelled is not authorized by explicit-recovery",
+    );
+  });
+
+  it("rejects changed inventory on the recovery route", async () => {
+    await expect(verify(recoveryFetch(), "terminal", "f".repeat(64))).rejects.toThrow(
+      "one exact package transaction",
+    );
   });
 
   it("rejects package transaction replay against another inventory", async () => {

--- a/convex/lib/openClawPublishAuthorization.ts
+++ b/convex/lib/openClawPublishAuthorization.ts
@@ -70,6 +70,8 @@ const RECOVERY_RECEIPT_KEYS = [
   "actor",
   "approvalJob",
   "authorizationRoute",
+  "authorizedChildRunAttempt",
+  "authorizedChildRunId",
   "environment",
   "kind",
   "parentRunAttempt",
@@ -136,7 +138,7 @@ type ParentAuthorizationReceipt = {
 };
 
 type RecoveryApprovalReceipt = {
-  version: 1;
+  version: 2;
   kind: string;
   repository: string;
   workflow: string;
@@ -148,6 +150,8 @@ type RecoveryApprovalReceipt = {
   authorizationRoute: string;
   parentRunId: string;
   parentRunAttempt: string;
+  authorizedChildRunId: string;
+  authorizedChildRunAttempt: string;
 };
 
 type GitHubRun = {
@@ -225,8 +229,8 @@ function requireMatchingRef(ref: string, fullRef: string, name: string) {
   }
 }
 
-function parseJson(raw: string, name: string) {
-  if (!raw.trim() || new TextEncoder().encode(raw).byteLength > MAX_JSON_BYTES) {
+function parseJson(raw: string, name: string, maxBytes = MAX_JSON_BYTES) {
+  if (!raw.trim() || new TextEncoder().encode(raw).byteLength > maxBytes) {
     fail(`${name} is missing or too large`);
   }
   try {
@@ -387,13 +391,23 @@ function parseParentReceipt(raw: string): ParentAuthorizationReceipt {
 
 function parseRecoveryReceipt(raw: string): RecoveryApprovalReceipt {
   const value = requireRecord(
-    parseJson(raw, "recovery environment approval receipt"),
+    parseJson(raw, "recovery environment approval receipt", 8 * 1024),
     "recovery environment approval receipt",
   );
-  requireExactKeys(value, RECOVERY_RECEIPT_KEYS, "recovery environment approval receipt v1");
-  if (value.version !== 1) fail("recovery environment approval receipt version must be 1");
+  if (value.version !== 2) fail("recovery environment approval receipt version must be 2");
+  requireExactKeys(value, RECOVERY_RECEIPT_KEYS, "recovery environment approval receipt v2");
   return {
-    version: 1,
+    version: 2,
+    authorizedChildRunId: requireString(
+      value.authorizedChildRunId,
+      "recovery receipt authorizedChildRunId",
+      POSITIVE_INTEGER_PATTERN,
+    ),
+    authorizedChildRunAttempt: requireString(
+      value.authorizedChildRunAttempt,
+      "recovery receipt authorizedChildRunAttempt",
+      POSITIVE_INTEGER_PATTERN,
+    ),
     kind: requireString(value.kind, "recovery receipt kind"),
     repository: requireString(value.repository, "recovery receipt repository", REPOSITORY_PATTERN),
     workflow: requireString(value.workflow, "recovery receipt workflow", WORKFLOW_PATTERN),
@@ -423,8 +437,11 @@ function parseRecoveryReceipt(raw: string): RecoveryApprovalReceipt {
   };
 }
 
-export function parentAuthorizationArtifactName(identity: OpenClawTrustedToolingIdentity) {
-  return `${PARENT_RECEIPT_KIND}-v2-${identity.parentRunId}-${identity.parentRunAttempt}-${identity.runId}-${identity.runAttempt}`;
+export function parentAuthorizationArtifactName(
+  identity: OpenClawTrustedToolingIdentity,
+  child: Pick<OpenClawTrustedToolingIdentity, "runId" | "runAttempt"> = identity,
+) {
+  return `${PARENT_RECEIPT_KIND}-v2-${identity.parentRunId}-${identity.parentRunAttempt}-${child.runId}-${child.runAttempt}`;
 }
 
 function recoveryArtifactName(identity: OpenClawTrustedToolingIdentity) {
@@ -485,6 +502,7 @@ function validateReceipt(
   identity: OpenClawTrustedToolingIdentity,
   receipt: ParentAuthorizationReceipt,
   transaction: PackageTransaction,
+  child: Pick<OpenClawTrustedToolingIdentity, "runId" | "runAttempt">,
 ) {
   const checks: Array<[string, string, string]> = [
     ["repository", receipt.repository, identity.parentRepository],
@@ -496,8 +514,8 @@ function validateReceipt(
     ["tooling head SHA", receipt.headSha, identity.toolingSha],
     ["child repository", receipt.childRepository, identity.repository],
     ["child workflow", receipt.childWorkflow, identity.workflow],
-    ["child run id", receipt.childRunId, identity.runId],
-    ["child run attempt", receipt.childRunAttempt, identity.runAttempt],
+    ["child run id", receipt.childRunId, child.runId],
+    ["child run attempt", receipt.childRunAttempt, child.runAttempt],
     ["child ref", receipt.childRef, identity.ref],
     ["child full ref", receipt.childFullRef, identity.fullRef],
     ["child head SHA", receipt.childHeadSha, identity.sha],
@@ -556,7 +574,6 @@ function validateRecoveryReceipt(
   receipt: RecoveryApprovalReceipt,
   childRun: GitHubRun,
 ) {
-  if (isBotActor(childRun)) fail("bot and GitHub App actors cannot use release recovery");
   const actor = stringOrNumber(childRun.actor?.login);
   const checks: Array<[string, string, string]> = [
     ["kind", receipt.kind, RECOVERY_RECEIPT_KIND],
@@ -724,17 +741,6 @@ export async function verifyOpenClawPublishAuthorization(
     "trusted child run",
   );
 
-  const parentArtifact = await fetchArtifactReceipt({
-    repository: identity.parentRepository,
-    runId: identity.parentRunId,
-    headSha: identity.toolingSha,
-    name: parentAuthorizationArtifactName(identity),
-    filename: "authorization.json",
-    fetchImpl,
-  });
-  const parentReceipt = parseParentReceipt(parentArtifact.rawReceipt);
-  validateReceipt(identity, parentReceipt, transaction);
-
   const parentRun = await fetchJson<GitHubRun>(
     `repos/${identity.parentRepository}/actions/runs/${identity.parentRunId}/attempts/${identity.parentRunAttempt}`,
     fetchImpl,
@@ -752,11 +758,9 @@ export async function verifyOpenClawPublishAuthorization(
     "trusted parent run",
   );
 
-  let authorizationRoute = parentReceipt.authorizationRoute;
-  if (
-    stringOrNumber(parentRun.status) === "completed" &&
-    stringOrNumber(parentRun.conclusion) === "failure"
-  ) {
+  const automated = isBotActor(childRun);
+  let authorizedChild = { runId: identity.runId, runAttempt: identity.runAttempt };
+  if (!automated) {
     const recoveryArtifact = await fetchArtifactReceipt({
       repository: identity.repository,
       runId: identity.runId,
@@ -765,9 +769,24 @@ export async function verifyOpenClawPublishAuthorization(
       filename: "approval.json",
       fetchImpl,
     });
-    validateRecoveryReceipt(identity, parseRecoveryReceipt(recoveryArtifact.rawReceipt), childRun);
-    authorizationRoute = "explicit-recovery";
+    const recovery = parseRecoveryReceipt(recoveryArtifact.rawReceipt);
+    validateRecoveryReceipt(identity, recovery, childRun);
+    authorizedChild = {
+      runId: recovery.authorizedChildRunId,
+      runAttempt: recovery.authorizedChildRunAttempt,
+    };
   }
+  const parentArtifact = await fetchArtifactReceipt({
+    repository: identity.parentRepository,
+    runId: identity.parentRunId,
+    headSha: identity.toolingSha,
+    name: parentAuthorizationArtifactName(identity, authorizedChild),
+    filename: "authorization.json",
+    fetchImpl,
+  });
+  const parentReceipt = parseParentReceipt(parentArtifact.rawReceipt);
+  validateReceipt(identity, parentReceipt, transaction, authorizedChild);
+  const authorizationRoute = automated ? parentReceipt.authorizationRoute : "explicit-recovery";
   validateParentState(authorizationRoute, parentRun, options.requiredParentState ?? "submission");
   await validateToolingRef(identity, fetchImpl);
 

--- a/convex/maintenance.publishAttempts.test.ts
+++ b/convex/maintenance.publishAttempts.test.ts
@@ -1,0 +1,290 @@
+/* @vitest-environment node */
+
+import { getFunctionName } from "convex/server";
+import { describe, expect, it, vi } from "vitest";
+import {
+  discardStalePackagePublishAttempts,
+  discardStalePackagePublishAttemptsInternal,
+  listStalePackagePublishAttemptsInternal,
+} from "./maintenance";
+
+const auth = vi.hoisted(() => ({ requireUserFromAction: vi.fn() }));
+vi.mock("./lib/access", async (original) => ({
+  ...(await original<typeof import("./lib/access")>()),
+  requireUserFromAction: auth.requireUserFromAction,
+}));
+
+type Handler = { _handler: (ctx: unknown, args: Record<string, unknown>) => Promise<unknown> };
+const list = (listStalePackagePublishAttemptsInternal as unknown as Handler)._handler;
+const discard = (discardStalePackagePublishAttemptsInternal as unknown as Handler)._handler;
+const discardAsAdmin = (discardStalePackagePublishAttempts as unknown as Handler)._handler;
+const version = "2026.9.1";
+const slugPrefix = "@openclaw/";
+
+function attempt(id: string, overrides: Record<string, unknown> = {}) {
+  return {
+    _id: `publishAttempts:${id}`,
+    kind: "package",
+    status: "pending_checks",
+    packageId: `packages:${id}`,
+    packageReleaseId: `packageReleases:${id}`,
+    slug: `@openclaw/${id}`,
+    version,
+    createdAt: 123,
+    createdNewParent: true,
+    ...overrides,
+  };
+}
+
+function queryCtx(rows: Record<string, unknown>[]) {
+  const limits: number[] = [];
+  const ctx = {
+    db: {
+      query: vi.fn((table: string) => {
+        expect(table).toBe("publishAttempts");
+        return {
+          withIndex: (
+            name: string,
+            build: (q: { eq: (key: string, value: unknown) => unknown }) => unknown,
+          ) => {
+            expect(name).toBe("by_status_and_created");
+            let requestedStatus: unknown;
+            const q = {
+              eq: (key: string, value: unknown) => {
+                expect(key).toBe("status");
+                requestedStatus = value;
+                return q;
+              },
+            };
+            build(q);
+            return {
+              take: async (limit: number) => {
+                limits.push(limit);
+                return rows.filter((row) => row.status === requestedStatus).slice(0, limit);
+              },
+            };
+          },
+        };
+      }),
+      get: vi.fn(async (id: string) => {
+        if (id.startsWith("publishAttempts:")) return rows.find((row) => row._id === id) ?? null;
+        if (id === "packageReleases:gone") return null;
+        return { _id: id, publicationStatus: "pending" };
+      }),
+    },
+  };
+  return { ctx, limits };
+}
+
+function actionCtx(rows = [attempt("one"), attempt("gone", { status: "ready_to_finalize" })]) {
+  const { ctx } = queryCtx(rows);
+  return {
+    runQuery: vi.fn(
+      async (ref: Parameters<typeof getFunctionName>[0], args: Record<string, unknown>) => {
+        expect(getFunctionName(ref)).toBe("maintenance:listStalePackagePublishAttemptsInternal");
+        return list(ctx, args);
+      },
+    ),
+    runMutation: vi.fn(
+      async (_ref: Parameters<typeof getFunctionName>[0], args: Record<string, unknown>) => ({
+        deleted: args.releaseId !== "packageReleases:gone",
+        parentDeleted: true,
+        retiredAttemptIds: [args.attemptId],
+      }),
+    ),
+  };
+}
+
+describe("stale package publish attempt operations", () => {
+  it("lists only matching package versions, prefixes and active statuses, including missing releases", async () => {
+    const rows = [
+      attempt("checks", { checkClaimLastError: "scanner error" }),
+      attempt("gone", { status: "ready_to_finalize", finalizationLastError: "parent failed" }),
+      attempt("finalizing", { status: "finalizing" }),
+      attempt("skill", { kind: "skill" }),
+      attempt("old", { version: "2026.8.1" }),
+      attempt("other", { slug: "@other/plugin" }),
+      ...["finalized", "failed", "blocked", "expired"].map((status) => attempt(status, { status })),
+    ];
+    const { ctx } = queryCtx(rows);
+    await expect(list(ctx, { version, slugPrefix })).resolves.toEqual([
+      {
+        attemptId: "publishAttempts:checks",
+        slug: "@openclaw/checks",
+        version,
+        status: "pending_checks",
+        packageId: "packages:checks",
+        releaseId: "packageReleases:checks",
+        createdNewParent: true,
+        createdAt: 123,
+        lastError: "scanner error",
+        releasePublicationStatus: "pending",
+      },
+      {
+        attemptId: "publishAttempts:gone",
+        slug: "@openclaw/gone",
+        version,
+        status: "ready_to_finalize",
+        packageId: "packages:gone",
+        releaseId: "packageReleases:gone",
+        createdNewParent: true,
+        createdAt: 123,
+        lastError: "parent failed",
+        releasePublicationStatus: null,
+      },
+      {
+        attemptId: "publishAttempts:finalizing",
+        slug: "@openclaw/finalizing",
+        version,
+        status: "finalizing",
+        packageId: "packages:finalizing",
+        releaseId: "packageReleases:finalizing",
+        createdNewParent: true,
+        createdAt: 123,
+        lastError: null,
+        releasePublicationStatus: "pending",
+      },
+    ]);
+    expect(ctx.db.get).toHaveBeenCalledTimes(3);
+  });
+
+  it.each([
+    [undefined, 200],
+    [999, 500],
+  ] as const)(
+    "bounds large attempt reads with limit %s across all statuses",
+    async (limit, expected) => {
+      const rows = Array.from({ length: 700 }, (_, i) =>
+        attempt(String(i), {
+          kind: "skill",
+          status: i < 50 ? "pending_checks" : "ready_to_finalize",
+        }),
+      );
+      const { ctx, limits } = queryCtx(rows);
+      await expect(list(ctx, { version, limit })).resolves.toEqual([]);
+      expect(limits).toEqual([expected, expected - 50]);
+      expect(ctx.db.get).not.toHaveBeenCalled();
+    },
+  );
+
+  it("point-reads explicit IDs beyond the scan window and applies the same filter without duplicates", async () => {
+    const rows = [
+      attempt("one"),
+      attempt("other", { version: "2026.9.2" }),
+      attempt("done", { status: "finalized" }),
+      attempt("foreign", { slug: "@other/plugin" }),
+    ];
+    const { ctx } = queryCtx(rows);
+    await expect(
+      list(ctx, {
+        version,
+        slugPrefix,
+        attemptIds: [
+          "publishAttempts:one",
+          "publishAttempts:one",
+          "publishAttempts:other",
+          "publishAttempts:done",
+          "publishAttempts:foreign",
+          "publishAttempts:missing",
+        ],
+      }),
+    ).resolves.toMatchObject([{ attemptId: "publishAttempts:one" }]);
+    expect(ctx.db.query).not.toHaveBeenCalled();
+    expect(ctx.db.get.mock.calls.filter(([id]) => id === "publishAttempts:one")).toHaveLength(1);
+    await expect(
+      list(ctx, {
+        version,
+        attemptIds: Array.from({ length: 201 }, (_, i) => `publishAttempts:${i}`),
+      }),
+    ).rejects.toThrow("At most 200 attemptIds are allowed");
+  });
+
+  it("defaults to a dry run and performs no mutations", async () => {
+    const ctx = actionCtx();
+    const result = await discard(ctx, { version, slugPrefix, reason: "Incident cleanup" });
+    expect(result).toMatchObject({
+      dryRun: true,
+      candidates: [{ attemptId: "publishAttempts:one" }, { attemptId: "publishAttempts:gone" }],
+      discarded: [],
+    });
+    expect(ctx.runMutation).not.toHaveBeenCalled();
+  });
+
+  it("explicit apply delegates each candidate to the owner with the attempt ID and trimmed publisher-visible reason", async () => {
+    const ctx = actionCtx();
+    await expect(
+      discard(ctx, { version, slugPrefix, reason: "  Incident cleanup  ", dryRun: false }),
+    ).resolves.toMatchObject({
+      dryRun: false,
+      discarded: [
+        { attemptId: "publishAttempts:one", releaseDeleted: true, parentDeleted: true },
+        { attemptId: "publishAttempts:gone", releaseDeleted: false, parentDeleted: true },
+      ],
+    });
+    expect(ctx.runMutation.mock.calls.map(([ref, args]) => [getFunctionName(ref), args])).toEqual(
+      ["one", "gone"].map((id) => [
+        "packages:discardPendingPackagePublicationInternal",
+        {
+          packageId: `packages:${id}`,
+          releaseId: `packageReleases:${id}`,
+          attemptId: `publishAttempts:${id}`,
+          createdNewParent: true,
+          reason: "Incident cleanup",
+        },
+      ]),
+    );
+  });
+
+  it("restricts an apply to explicitly selected matching IDs", async () => {
+    const ctx = actionCtx();
+    await discard(ctx, {
+      version,
+      slugPrefix,
+      attemptIds: ["publishAttempts:gone"],
+      reason: "Cleanup",
+      dryRun: false,
+    });
+    expect(ctx.runMutation.mock.calls.map(([, args]) => args.attemptId)).toEqual([
+      "publishAttempts:gone",
+    ]);
+  });
+
+  it.each([
+    ["  ", "Reason is required"],
+    ["x".repeat(501), "Reason too long (max 500 chars)"],
+  ])("rejects invalid reasons before any reads or writes: %s", async (reason, message) => {
+    const ctx = actionCtx();
+    await expect(discard(ctx, { version, reason, dryRun: false })).rejects.toThrow(message);
+    expect(ctx.runQuery).not.toHaveBeenCalled();
+    expect(ctx.runMutation).not.toHaveBeenCalled();
+  });
+
+  it("accepts a trimmed 500-character reason", async () => {
+    const ctx = actionCtx([]);
+    await expect(discard(ctx, { version, reason: ` ${"x".repeat(500)} ` })).resolves.toEqual({
+      dryRun: true,
+      candidates: [],
+      discarded: [],
+    });
+  });
+
+  it("requires admin authorization before delegating the public action", async () => {
+    const args = { version, reason: "Cleanup" };
+    const ctx = { runAction: vi.fn(async () => ({ dryRun: true, candidates: [], discarded: [] })) };
+    auth.requireUserFromAction.mockRejectedValueOnce(new Error("Unauthorized"));
+    await expect(discardAsAdmin(ctx, args)).rejects.toThrow("Unauthorized");
+    for (const role of ["user", "moderator"]) {
+      auth.requireUserFromAction.mockResolvedValueOnce({ user: { role } });
+      await expect(discardAsAdmin(ctx, args)).rejects.toThrow();
+    }
+    expect(ctx.runAction).not.toHaveBeenCalled();
+    auth.requireUserFromAction.mockResolvedValueOnce({ user: { role: "admin" } });
+    await expect(discardAsAdmin(ctx, args)).resolves.toMatchObject({ dryRun: true });
+    const [ref, delegated] = ctx.runAction.mock.calls[0] as unknown as [
+      Parameters<typeof getFunctionName>[0],
+      unknown,
+    ];
+    expect(getFunctionName(ref)).toBe("maintenance:discardStalePackagePublishAttemptsInternal");
+    expect(delegated).toEqual(args);
+  });
+});

--- a/convex/maintenance.ts
+++ b/convex/maintenance.ts
@@ -32,11 +32,148 @@ import { getFrontmatterValue, hashSkillFiles } from "./lib/skills";
 import { computeIsSuspicious } from "./lib/skillSafety";
 import { getFirstSearchToken, getMirrorFirstSearchToken } from "./lib/skillSearchDigest";
 import { generateSkillSummary } from "./lib/skillSummary";
+import { ACTIVE_PUBLISH_ATTEMPT_STATUSES } from "./publishAttempts";
 
 const DEFAULT_BATCH_SIZE = 50;
 const MAX_BATCH_SIZE = 200;
 const DEFAULT_MAX_BATCHES = 20;
 const MAX_MAX_BATCHES = 200;
+
+type StalePackagePublishAttempt = {
+  attemptId: Id<"publishAttempts">;
+  slug: string;
+  version: string;
+  status: Doc<"publishAttempts">["status"];
+  packageId: Id<"packages">;
+  releaseId: Id<"packageReleases">;
+  createdNewParent: boolean;
+  createdAt: number;
+  lastError: string | null;
+  releasePublicationStatus: Doc<"packageReleases">["publicationStatus"] | null;
+};
+
+export const listStalePackagePublishAttemptsInternal = internalQuery({
+  args: {
+    version: v.string(),
+    slugPrefix: v.optional(v.string()),
+    limit: v.optional(v.number()),
+    attemptIds: v.optional(v.array(v.id("publishAttempts"))),
+  },
+  handler: async (ctx, args): Promise<StalePackagePublishAttempt[]> => {
+    // Large attempt rows exhausted 16 MiB at ~600 reads. Share a 200-row default
+    // budget across statuses; point reads let operators target attempts beyond it.
+    const limit = clampInt(args.limit ?? 200, 1, 500);
+    const attempts: Doc<"publishAttempts">[] = [];
+    if (args.attemptIds) {
+      const ids = [...new Set(args.attemptIds)];
+      if (ids.length > limit) throw new ConvexError(`At most ${limit} attemptIds are allowed`);
+      for (const id of ids) {
+        const attempt = await ctx.db.get(id);
+        if (attempt) attempts.push(attempt);
+      }
+    } else {
+      for (const status of ACTIVE_PUBLISH_ATTEMPT_STATUSES) {
+        if (attempts.length === limit) break;
+        attempts.push(
+          ...(await ctx.db
+            .query("publishAttempts")
+            .withIndex("by_status_and_created", (q) => q.eq("status", status))
+            .take(limit - attempts.length)),
+        );
+      }
+    }
+    const candidates: StalePackagePublishAttempt[] = [];
+    for (const attempt of attempts) {
+      if (
+        attempt.kind !== "package" ||
+        attempt.version !== args.version ||
+        !attempt.packageId ||
+        !attempt.packageReleaseId ||
+        !ACTIVE_PUBLISH_ATTEMPT_STATUSES.some((status) => status === attempt.status) ||
+        (args.slugPrefix !== undefined && !attempt.slug.startsWith(args.slugPrefix))
+      )
+        continue;
+      const release = await ctx.db.get(attempt.packageReleaseId);
+      candidates.push({
+        attemptId: attempt._id,
+        slug: attempt.slug,
+        version: attempt.version,
+        status: attempt.status,
+        packageId: attempt.packageId,
+        releaseId: attempt.packageReleaseId,
+        createdNewParent: attempt.createdNewParent ?? false,
+        createdAt: attempt.createdAt,
+        lastError: attempt.finalizationLastError ?? attempt.checkClaimLastError ?? null,
+        releasePublicationStatus: release?.publicationStatus ?? null,
+      });
+    }
+    return candidates;
+  },
+});
+
+const discardStalePackagePublishAttemptsArgs = {
+  version: v.string(),
+  slugPrefix: v.optional(v.string()),
+  attemptIds: v.optional(v.array(v.id("publishAttempts"))),
+  reason: v.string(),
+  dryRun: v.optional(v.boolean()),
+};
+type DiscardStalePackagePublishAttemptsResult = {
+  dryRun: boolean;
+  candidates: StalePackagePublishAttempt[];
+  discarded: Array<{
+    attemptId: Id<"publishAttempts">;
+    releaseDeleted: boolean;
+    parentDeleted: boolean;
+  }>;
+};
+
+export const discardStalePackagePublishAttemptsInternal = internalAction({
+  args: discardStalePackagePublishAttemptsArgs,
+  handler: async (ctx, args): Promise<DiscardStalePackagePublishAttemptsResult> => {
+    const reason = args.reason.trim();
+    if (!reason) throw new ConvexError("Reason is required");
+    if (reason.length > 500) throw new ConvexError("Reason too long (max 500 chars)");
+    const dryRun = args.dryRun !== false;
+    const candidates: StalePackagePublishAttempt[] = await ctx.runQuery(
+      internal.maintenance.listStalePackagePublishAttemptsInternal,
+      { version: args.version, slugPrefix: args.slugPrefix, attemptIds: args.attemptIds },
+    );
+    const discarded: DiscardStalePackagePublishAttemptsResult["discarded"] = [];
+    if (!dryRun) {
+      for (const candidate of candidates) {
+        const result = await ctx.runMutation(
+          internal.packages.discardPendingPackagePublicationInternal,
+          {
+            packageId: candidate.packageId,
+            releaseId: candidate.releaseId,
+            createdNewParent: candidate.createdNewParent,
+            reason,
+            attemptId: candidate.attemptId,
+          },
+        );
+        if (result.retiredAttemptIds.includes(candidate.attemptId)) {
+          discarded.push({
+            attemptId: candidate.attemptId,
+            releaseDeleted: result.deleted,
+            parentDeleted: result.parentDeleted ?? false,
+          });
+        }
+      }
+    }
+    return { dryRun, candidates, discarded };
+  },
+});
+
+export const discardStalePackagePublishAttempts = action({
+  args: discardStalePackagePublishAttemptsArgs,
+  handler: async (ctx, args): Promise<DiscardStalePackagePublishAttemptsResult> => {
+    const { user } = await requireUserFromAction(ctx);
+    assertRole(user, ["admin"]);
+    return ctx.runAction(internal.maintenance.discardStalePackagePublishAttemptsInternal, args);
+  },
+});
+
 const DEFAULT_EMPTY_SKILL_MAX_README_BYTES = 8000;
 const DEFAULT_EMPTY_SKILL_NOMINATION_THRESHOLD = 3;
 const PLATFORM_SKILL_LICENSE = "MIT-0" as const;

--- a/convex/packages.discardPendingPublication.test.ts
+++ b/convex/packages.discardPendingPublication.test.ts
@@ -1,0 +1,261 @@
+/* @vitest-environment node */
+
+import { describe, expect, it, vi } from "vitest";
+import { discardPendingPackagePublicationInternal } from "./packages";
+import { getPackagePublishAttemptStatusInternal } from "./publishAttempts";
+
+type Handler = {
+  _handler: (ctx: unknown, args: Record<string, unknown>) => Promise<Record<string, unknown>>;
+};
+const discard = (discardPendingPackagePublicationInternal as unknown as Handler)._handler;
+const getStatus = (getPackagePublishAttemptStatusInternal as unknown as Handler)._handler;
+const packageId = "packages:demo";
+const releaseId = "packageReleases:pending";
+const attemptId = "publishAttempts:pending";
+
+function attempt(overrides: Record<string, unknown> = {}) {
+  return {
+    _id: attemptId,
+    kind: "package",
+    status: "ready_to_finalize",
+    packageId,
+    packageReleaseId: releaseId,
+    slug: "@openclaw/demo",
+    version: "2026.9.1",
+    userId: "users:publisher",
+    createdNewParent: true,
+    checkClaimId: "checks",
+    checkClaimedAt: 1,
+    checkClaimExpiresAt: 2,
+    checkClaimLastError: "old check error",
+    checkFailureCount: 2,
+    finalizationClaimId: "finalize",
+    finalizationClaimedAt: 3,
+    finalizationClaimExpiresAt: 4,
+    finalizationLastError: "old finalization error",
+    checks: { trufflehog: { status: "clean" }, clawscan: { status: "clean" } },
+    ...overrides,
+  };
+}
+
+function makeCtx(
+  options: {
+    missingRelease?: boolean;
+    attempts?: Record<string, unknown>[];
+    publicationStatus?: string;
+  } = {},
+) {
+  const docs = new Map<string, Record<string, unknown>>([
+    [packageId, { _id: packageId, name: "@openclaw/demo", normalizedName: "demo" }],
+    ...(options.missingRelease
+      ? []
+      : [
+          [
+            releaseId,
+            {
+              _id: releaseId,
+              packageId,
+              version: "2026.9.1",
+              publicationStatus: options.publicationStatus ?? "pending",
+              files: [{ storageId: "_storage:file" }],
+              clawpackStorageId: "_storage:clawpack",
+            },
+          ] as [string, Record<string, unknown>],
+        ]),
+    ...(options.attempts ?? [attempt()]).map((row): [string, Record<string, unknown>] => [
+      String(row._id),
+      row,
+    ]),
+  ]);
+  const queries: Array<{ table: string; index: string; fields: Record<string, unknown> }> = [];
+  const ctx = {
+    db: {
+      get: vi.fn(async (id: string) => docs.get(id) ?? null),
+      patch: vi.fn(async (id: string, patch: Record<string, unknown>) =>
+        Object.assign(docs.get(id) ?? {}, patch),
+      ),
+      delete: vi.fn(async (id: string) => {
+        docs.delete(id);
+      }),
+      normalizeId: vi.fn(),
+      insert: vi.fn(),
+      replace: vi.fn(),
+      query: vi.fn((table: string) => ({
+        withIndex: (
+          index: string,
+          build: (q: { eq: (key: string, value: unknown) => unknown }) => unknown,
+        ) => {
+          const fields: Record<string, unknown> = {};
+          const q = {
+            eq: (key: string, value: unknown) => {
+              fields[key] = value;
+              return q;
+            },
+          };
+          build(q);
+          queries.push({ table, index, fields });
+          return {
+            take: async (limit: number) =>
+              [...docs.values()]
+                .filter(
+                  (row) =>
+                    String(row._id).startsWith(`${table}:`) &&
+                    Object.entries(fields).every(([key, value]) => row[key] === value),
+                )
+                .slice(0, limit),
+          };
+        },
+      })),
+    },
+    storage: { delete: vi.fn() },
+  };
+  return { ctx, docs, queries };
+}
+
+describe("discardPendingPackagePublicationInternal", () => {
+  it.each([
+    [false, "pending_checks"],
+    [false, "ready_to_finalize"],
+    [false, "finalizing"],
+    [true, "pending_checks"],
+    [true, "ready_to_finalize"],
+    [true, "finalizing"],
+  ] as const)(
+    "retires the owner and exposes the reason (missing release: %s, status: %s)",
+    async (missingRelease, status) => {
+      const { ctx, docs } = makeCtx({ missingRelease, attempts: [attempt({ status })] });
+      const reason = "Discarded failed-parent release; publish a fresh approved recovery";
+      await expect(
+        discard(ctx, { packageId, releaseId, attemptId, reason, createdNewParent: true }),
+      ).resolves.toEqual({
+        deleted: !missingRelease,
+        parentDeleted: true,
+        retiredAttemptIds: [attemptId],
+      });
+      expect(docs.has(releaseId)).toBe(false);
+      expect(docs.has(packageId)).toBe(false);
+      expect(ctx.db.patch).toHaveBeenCalledExactlyOnceWith(attemptId, {
+        status: "failed",
+        failedAt: expect.any(Number),
+        updatedAt: expect.any(Number),
+        checkClaimId: undefined,
+        checkClaimedAt: undefined,
+        checkClaimExpiresAt: undefined,
+        checkClaimLastError: status === "pending_checks" ? reason : undefined,
+        checkFailureCount: undefined,
+        finalizationClaimId: undefined,
+        finalizationClaimedAt: undefined,
+        finalizationClaimExpiresAt: undefined,
+        finalizationLastError: status === "pending_checks" ? undefined : reason,
+      });
+      const statusCtx = {
+        db: { ...ctx.db, normalizeId: vi.fn((_table: string, id: string) => id) },
+      };
+      await expect(getStatus(statusCtx, { attemptId })).resolves.toMatchObject({
+        status: "failed",
+        error: reason,
+      });
+      expect(ctx.storage.delete.mock.calls).toEqual(
+        missingRelease ? [] : [["_storage:file"], ["_storage:clawpack"]],
+      );
+    },
+  );
+
+  it.each([false, true])(
+    "finds owners by stored package name and preserves other releases, versions and terminal attempts (missing: %s)",
+    async (missingRelease) => {
+      const untouched = [
+        attempt({
+          _id: "publishAttempts:other-release",
+          packageReleaseId: "packageReleases:other",
+        }),
+        attempt({
+          _id: "publishAttempts:other-version",
+          version: "2026.9.2",
+          packageReleaseId: "packageReleases:new",
+        }),
+        attempt({ _id: "publishAttempts:finalized", status: "finalized" }),
+      ];
+      const snapshots = structuredClone(untouched);
+      const second = attempt({ _id: "publishAttempts:second", status: "pending_checks" });
+      const { ctx, docs, queries } = makeCtx({
+        missingRelease,
+        attempts: [attempt(), second, ...untouched],
+      });
+      await expect(discard(ctx, { packageId, releaseId })).resolves.toMatchObject({
+        deleted: !missingRelease,
+        retiredAttemptIds: [second._id, attemptId],
+      });
+      expect(docs.get(attemptId)).toMatchObject({
+        status: "failed",
+        finalizationLastError: "Pending package release discarded",
+      });
+      expect(docs.get(second._id)).toMatchObject({
+        status: "failed",
+        checkClaimLastError: "Pending package release discarded",
+      });
+      for (const row of snapshots) expect(docs.get(row._id)).toEqual(row);
+      expect(queries).toEqual(
+        ["pending_checks", "ready_to_finalize", "finalizing"].map((status) => ({
+          table: "publishAttempts",
+          index: "by_kind_status_slug_version_created",
+          fields: {
+            kind: "package",
+            status,
+            slug: "@openclaw/demo",
+            ...(missingRelease ? {} : { version: "2026.9.1" }),
+          },
+        })),
+      );
+    },
+  );
+
+  it("retires an explicit orphan even when both release and parent are gone", async () => {
+    const { ctx, docs } = makeCtx({ missingRelease: true });
+    docs.delete(packageId);
+    await expect(
+      discard(ctx, { packageId, releaseId, attemptId, createdNewParent: true }),
+    ).resolves.toEqual({
+      deleted: false,
+      parentDeleted: false,
+      retiredAttemptIds: [attemptId],
+    });
+    expect(docs.get(attemptId)?.status).toBe("failed");
+  });
+
+  it.each(["finalized", "failed", "blocked", "expired"])(
+    "leaves a %s attempt and its release alone after candidate discovery",
+    async (status) => {
+      const { ctx } = makeCtx({ attempts: [attempt({ status })] });
+      await expect(discard(ctx, { packageId, releaseId, attemptId })).resolves.toEqual({
+        deleted: false,
+        retiredAttemptIds: [],
+      });
+      expect(ctx.db.delete).not.toHaveBeenCalled();
+      expect(ctx.db.patch).not.toHaveBeenCalled();
+    },
+  );
+
+  it("never deletes a published release or changes its attempt", async () => {
+    const { ctx } = makeCtx({ publicationStatus: "published" });
+    await expect(discard(ctx, { packageId, releaseId, attemptId })).resolves.toEqual({
+      deleted: false,
+      retiredAttemptIds: [],
+    });
+    expect(ctx.db.delete).not.toHaveBeenCalled();
+    expect(ctx.db.patch).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { kind: "skill" },
+    { packageReleaseId: "packageReleases:other" },
+    { packageId: "packages:other" },
+  ])("rejects an attempt that does not own the release: %s", async (overrides) => {
+    const { ctx } = makeCtx({ attempts: [attempt(overrides)] });
+    await expect(discard(ctx, { packageId, releaseId, attemptId })).rejects.toThrow(
+      "Publish attempt does not own the pending package release",
+    );
+    expect(ctx.db.delete).not.toHaveBeenCalled();
+    expect(ctx.db.patch).not.toHaveBeenCalled();
+  });
+});

--- a/convex/packages.ts
+++ b/convex/packages.ts
@@ -134,6 +134,7 @@ import { matchesAllTokens, matchesExploratoryTokenPrefixes, tokenize } from "./l
 import { buildPackageInventoryDigest, hashSkillFiles } from "./lib/skills";
 import { buildDeterministicPackageZip } from "./lib/skillZip";
 import { PACKAGE_TRENDING_LEADERBOARD_KIND } from "./packageLeaderboards";
+import { ACTIVE_PUBLISH_ATTEMPT_STATUSES, failedPublishAttemptPatch } from "./publishAttempts";
 import schema from "./schema";
 
 const MAX_PUBLIC_LIST_PAGE_SIZE = 200;
@@ -11119,33 +11120,77 @@ export const discardPendingPackagePublicationInternal = internalMutation({
     packageId: v.id("packages"),
     releaseId: v.id("packageReleases"),
     createdNewParent: v.optional(v.boolean()),
+    reason: v.optional(v.string()),
+    attemptId: v.optional(v.id("publishAttempts")),
   },
-  handler: async (ctx, args) => {
+  handler: async (
+    ctx,
+    args,
+  ): Promise<{
+    deleted: boolean;
+    parentDeleted?: boolean;
+    retiredAttemptIds: Id<"publishAttempts">[];
+  }> => {
     const release = await ctx.db.get(args.releaseId);
     if (
-      !release ||
-      release.packageId !== args.packageId ||
-      release.publicationStatus !== "pending"
+      release &&
+      (release.packageId !== args.packageId || release.publicationStatus !== "pending")
     ) {
-      return { deleted: false };
+      return { deleted: false, retiredAttemptIds: [] };
+    }
+
+    const pkg = await ctx.db.get(args.packageId);
+    const attempts: Doc<"publishAttempts">[] = [];
+    if (args.attemptId) {
+      const attempt = await ctx.db.get(args.attemptId);
+      if (
+        !attempt ||
+        attempt.kind !== "package" ||
+        attempt.packageId !== args.packageId ||
+        attempt.packageReleaseId !== args.releaseId
+      ) {
+        throw new ConvexError("Publish attempt does not own the pending package release");
+      }
+      if (!ACTIVE_PUBLISH_ATTEMPT_STATUSES.some((status) => status === attempt.status)) {
+        return { deleted: false, retiredAttemptIds: [] };
+      }
+      attempts.push(attempt);
+    } else if (pkg) {
+      for (const status of ACTIVE_PUBLISH_ATTEMPT_STATUSES) {
+        // Bound large attempt reads; operators can call this mutation with attemptId for more.
+        const matches = await ctx.db
+          .query("publishAttempts")
+          .withIndex("by_kind_status_slug_version_created", (q) => {
+            const byName = q.eq("kind", "package").eq("status", status).eq("slug", pkg.name);
+            return release ? byName.eq("version", release.version) : byName;
+          })
+          .take(200);
+        attempts.push(...matches.filter((attempt) => attempt.packageReleaseId === args.releaseId));
+      }
     }
 
     const storageIds = new Set<Id<"_storage">>();
-    for (const file of release.files ?? []) {
+    for (const file of release?.files ?? []) {
       if (typeof file.storageId === "string") {
         storageIds.add(file.storageId as Id<"_storage">);
       }
     }
-    if (typeof release.clawpackStorageId === "string") {
+    if (typeof release?.clawpackStorageId === "string") {
       storageIds.add(release.clawpackStorageId as Id<"_storage">);
     }
 
-    await ctx.db.delete(release._id);
+    if (release) await ctx.db.delete(release._id);
     await Promise.allSettled([...storageIds].map((storageId) => ctx.storage.delete(storageId)));
+
+    // This reason is publisher-visible as `error` in the publish attempt status API.
+    const error = args.reason ?? "Pending package release discarded";
+    const now = Date.now();
+    for (const attempt of attempts) {
+      await ctx.db.patch(attempt._id, failedPublishAttemptPatch(attempt.status, error, now));
+    }
 
     let parentDeleted = false;
     if (args.createdNewParent) {
-      const pkg = await ctx.db.get(args.packageId);
       if (pkg && !pkg.latestReleaseId) {
         const remainingReleases = await ctx.db
           .query("packageReleases")
@@ -11158,7 +11203,11 @@ export const discardPendingPackagePublicationInternal = internalMutation({
       }
     }
 
-    return { deleted: true, parentDeleted };
+    return {
+      deleted: Boolean(release),
+      parentDeleted,
+      retiredAttemptIds: attempts.map((attempt) => attempt._id),
+    };
   },
 });
 

--- a/convex/publishAttempts.test.ts
+++ b/convex/publishAttempts.test.ts
@@ -1507,50 +1507,62 @@ describe("publishAttempts", () => {
     expect(transientCtx.db.patch.mock.calls[0]?.[1]).not.toHaveProperty("failedAt");
   });
 
-  it("terminalizes a staged release when its exact OpenClaw parent is cancelled", async () => {
-    const ctx = {
-      db: {
-        delete: vi.fn(),
-        get: vi.fn(async (id: string) =>
-          id === "publishAttempts:cancelled"
-            ? {
-                _id: id,
-                kind: "package",
-                status: "finalizing",
-                packageReleaseId: "packageReleases:pending",
-                packageFollowup: {},
-                finalizationClaimId: "finalize:claim",
-              }
-            : {
-                _id: "packageReleases:pending",
-                publicationStatus: "pending",
-              },
-        ),
-        insert: vi.fn(),
-        normalizeId: vi.fn(),
-        patch: vi.fn(),
-        query: vi.fn(),
-        replace: vi.fn(),
-        system: {},
-      },
-    };
-    const error =
-      "OpenClaw release parent terminal state completed/cancelled is not authorized by automated-awaited";
+  it.each(["cancelled", "failure"])(
+    "terminalizes a staged release when its exact OpenClaw parent concludes %s",
+    async (conclusion) => {
+      const ctx = {
+        db: {
+          delete: vi.fn(),
+          get: vi.fn(async (id: string) =>
+            id === "publishAttempts:terminal-parent"
+              ? {
+                  _id: id,
+                  kind: "package",
+                  status: "finalizing",
+                  packageReleaseId: "packageReleases:pending",
+                  packageFollowup: {},
+                  finalizationClaimId: "finalize:claim",
+                }
+              : {
+                  _id: "packageReleases:pending",
+                  publicationStatus: "pending",
+                },
+          ),
+          insert: vi.fn(),
+          normalizeId: vi.fn(),
+          patch: vi.fn(),
+          query: vi.fn(),
+          replace: vi.fn(),
+          system: {},
+        },
+      };
+      const error = `OpenClaw release parent terminal state completed/${conclusion} is not authorized by automated-awaited`;
 
-    await expect(
-      releasePackageFinalizationHandler(ctx, {
-        attemptId: "publishAttempts:cancelled",
-        claimId: "finalize:claim",
-        error,
-      }),
-    ).resolves.toEqual({ attemptId: "publishAttempts:cancelled", status: "failed" });
+      await expect(
+        releasePackageFinalizationHandler(ctx, {
+          attemptId: "publishAttempts:terminal-parent",
+          claimId: "finalize:claim",
+          error,
+        }),
+      ).resolves.toEqual({ attemptId: "publishAttempts:terminal-parent", status: "failed" });
 
-    expect(ctx.db.patch).toHaveBeenCalledWith(
-      "publishAttempts:cancelled",
-      expect.objectContaining({ status: "failed", finalizationLastError: error }),
-    );
-    expect(ctx.db.patch).toHaveBeenCalledOnce();
-  });
+      expect(ctx.db.patch).toHaveBeenCalledWith("publishAttempts:terminal-parent", {
+        status: "failed",
+        checkClaimId: undefined,
+        checkClaimedAt: undefined,
+        checkClaimExpiresAt: undefined,
+        checkClaimLastError: undefined,
+        checkFailureCount: undefined,
+        finalizationClaimId: undefined,
+        finalizationClaimedAt: undefined,
+        finalizationClaimExpiresAt: undefined,
+        finalizationLastError: error,
+        failedAt: expect.any(Number),
+        updatedAt: expect.any(Number),
+      });
+      expect(ctx.db.patch).toHaveBeenCalledOnce();
+    },
+  );
 
   it.each([
     "Staged OpenClaw publish authorization token is missing",

--- a/convex/publishAttempts.ts
+++ b/convex/publishAttempts.ts
@@ -21,6 +21,7 @@ const PUBLISH_ATTEMPT_STATUSES = [
   "failed",
   "expired",
 ] as const;
+export const ACTIVE_PUBLISH_ATTEMPT_STATUSES = PUBLISH_ATTEMPT_STATUSES.slice(0, 3);
 
 const publishResultValidator = v.object({
   skillId: v.id("skills"),
@@ -135,6 +136,27 @@ function isTerminalFinalizationConflict(error: string | undefined) {
   );
 }
 
+export function failedPublishAttemptPatch(
+  status: Doc<"publishAttempts">["status"],
+  error: string | undefined,
+  now: number,
+) {
+  return {
+    status: "failed" as const,
+    checkClaimId: undefined,
+    checkClaimedAt: undefined,
+    checkClaimExpiresAt: undefined,
+    checkClaimLastError: status === "pending_checks" ? error : undefined,
+    checkFailureCount: undefined,
+    finalizationClaimId: undefined,
+    finalizationClaimedAt: undefined,
+    finalizationClaimExpiresAt: undefined,
+    finalizationLastError: status === "pending_checks" ? undefined : error,
+    failedAt: now,
+    updatedAt: now,
+  };
+}
+
 function releaseFinalizationClaimPatch(error: string | undefined, now: number) {
   if (!isTerminalFinalizationConflict(error)) {
     return {
@@ -146,20 +168,7 @@ function releaseFinalizationClaimPatch(error: string | undefined, now: number) {
       updatedAt: now,
     };
   }
-  return {
-    status: "failed" as const,
-    checkClaimId: undefined,
-    checkClaimedAt: undefined,
-    checkClaimExpiresAt: undefined,
-    checkClaimLastError: undefined,
-    checkFailureCount: undefined,
-    finalizationClaimId: undefined,
-    finalizationClaimedAt: undefined,
-    finalizationClaimExpiresAt: undefined,
-    finalizationLastError: error,
-    failedAt: now,
-    updatedAt: now,
-  };
+  return failedPublishAttemptPatch("finalizing", error, now);
 }
 
 async function unavailableStagedTargetError(
@@ -184,20 +193,7 @@ async function terminalizeUnavailableStagedTarget(
 ) {
   const error = await unavailableStagedTargetError(ctx, attempt);
   if (!error) return false;
-  const pendingChecks = attempt.status === "pending_checks";
-  await ctx.db.patch(attempt._id, {
-    status: "failed",
-    checkClaimId: undefined,
-    checkClaimedAt: undefined,
-    checkClaimExpiresAt: undefined,
-    checkClaimLastError: pendingChecks ? error : undefined,
-    finalizationClaimId: undefined,
-    finalizationClaimedAt: undefined,
-    finalizationClaimExpiresAt: undefined,
-    finalizationLastError: pendingChecks ? undefined : error,
-    failedAt: now,
-    updatedAt: now,
-  });
+  await ctx.db.patch(attempt._id, failedPublishAttemptPatch(attempt.status, error, now));
   return true;
 }
 

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -233,6 +233,29 @@ clawhub package trusted-publisher delete @owner/package-name
 Deleting trusted publisher config is the rollback path. It disables future
 trusted publish token minting until a package manager sets config again.
 
+### OpenClaw release recovery
+
+OpenClaw automated releases stay non-public until their exact release-parent
+attempt succeeds. If that parent fails or is cancelled, the publish attempt
+fails permanently. A human recovery dispatch requires protected environment
+approval and a version 2 recovery receipt identifying the original authorized
+child. Recovery must use the same workflow ref and SHA, candidate, tooling, and
+package inventory; cancelled parents cannot recover.
+
+Operators can preview orphaned package attempts, supplying an exact `version`,
+optional `slugPrefix` or `attemptIds`, and a `reason`:
+
+```sh
+bunx convex run --prod maintenance:discardStalePackagePublishAttemptsInternal \
+  '{"version":"2026.9.1","slugPrefix":"@openclaw/","reason":"Release parent failed after staging"}'
+```
+
+It defaults to a dry run; add `"dryRun":false` to discard each pending release
+and retire its attempt. Signed-in admins can run the same operation as the
+`maintenance:discardStalePackagePublishAttempts` action. The reason appears as
+`error` at `/api/v1/publish/attempts/<id>`, so use publisher-facing wording.
+Published releases and terminal attempts are never discarded by this operation.
+
 ## FAQ
 
 ### Package scope must match selected owner

--- a/scripts/security/package-publish-workflow.test.ts
+++ b/scripts/security/package-publish-workflow.test.ts
@@ -102,14 +102,19 @@ describe("package publish reusable workflow", () => {
     const recoveryReceiptIndex = job.steps.findIndex(
       (step) => step.name === "Download recovery environment approval receipt",
     );
+    const resolveIndex = job.steps.findIndex(
+      (step) => step.name === "Resolve release parent authorization artifact",
+    );
     const publishIndex = job.steps.findIndex((step) => step.name === "Run package publish");
     const publishStep = job.steps[publishIndex];
     const verifyStep = job.steps[verifyIndex];
     const parentReceiptStep = job.steps[parentReceiptIndex];
     const recoveryReceiptStep = job.steps[recoveryReceiptIndex];
     expect(parentReceiptIndex).toBeGreaterThan(-1);
-    expect(recoveryReceiptIndex).toBe(parentReceiptIndex + 1);
-    expect(verifyIndex).toBe(recoveryReceiptIndex + 1);
+    expect(recoveryReceiptIndex).toBeGreaterThan(-1);
+    expect(resolveIndex).toBe(recoveryReceiptIndex + 1);
+    expect(parentReceiptIndex).toBe(resolveIndex + 1);
+    expect(verifyIndex).toBe(parentReceiptIndex + 1);
     expect(verifyIndex + 1).toBe(publishIndex);
     expect(parentReceiptStep).toMatchObject({
       if: "inputs.trusted_tooling_identity_json != ''",
@@ -120,15 +125,11 @@ describe("package publish reusable workflow", () => {
         "run-id": "${{ fromJson(inputs.trusted_tooling_identity_json).parentRunId }}",
       },
     });
-    expect(String(parentReceiptStep?.with?.name)).toContain(
-      "openclaw-clawhub-parent-authorization-v2-",
+    expect(parentReceiptStep?.with?.name).toBe(
+      "${{ steps.parent_authorization.outputs.artifact_name }}",
     );
-    expect(String(parentReceiptStep?.with?.name)).toContain(
-      "${{ fromJson(inputs.trusted_tooling_identity_json).runId }}",
-    );
-    expect(String(parentReceiptStep?.with?.name)).toContain(
-      "${{ fromJson(inputs.trusted_tooling_identity_json).runAttempt }}",
-    );
+    expect(job.steps[resolveIndex]?.run).toContain("parentArtifactName(identity, child)");
+    expect(job.steps[resolveIndex]?.run).toContain("parseRecoveryApprovalReceipt");
     expect(recoveryReceiptStep).toMatchObject({
       id: "recovery_approval",
       if: "inputs.trusted_tooling_identity_json != ''",

--- a/specs/package-publish-tooling-identity.md
+++ b/specs/package-publish-tooling-identity.md
@@ -56,21 +56,52 @@ full-ref authority; run metadata must not be used to infer it.
 
 ## Recovery Approval Receipt
 
-Failed-parent recovery is a separate, canonical route. The child must be a
-direct human dispatch and must cross the `clawhub-plugin-release` environment
-through the `approve_plugins_clawhub_release` job. That job uploads:
+The live child actor selects the route. Actors typed as `Bot` or `App`, and
+logins ending in `[bot]`, use the automated parent route and never recovery.
+A human dispatch always uses `explicit-recovery`; the identity cannot select
+or bypass that policy, even while the parent is active or successful.
+
+A human child must cross the `clawhub-plugin-release` environment through the
+`approve_plugins_clawhub_release` job. That job uploads:
 
 `openclaw-clawhub-recovery-approval-<childRunId>-<childRunAttempt>`
 
-The archive contains only `approval.json`, binding the exact child and parent
-attempts, actor, environment, approval job, and `explicit-recovery` route.
-Actors typed as `Bot` or `App`, and logins ending in `[bot]`, cannot recover.
-The identity cannot request recovery.
+The archive contains only `approval.json`, bounded at 8 KiB. Its version 2
+object contains exactly:
+
+- `version`: `2`; `kind`: `openclaw-clawhub-recovery-approval`
+- `repository`, `workflow`, `runId`, `runAttempt`: the recovery child identity
+- `actor`: the live child actor login
+- `environment`: `clawhub-plugin-release`
+- `approvalJob`: `approve_plugins_clawhub_release`
+- `authorizationRoute`: `explicit-recovery`
+- `parentRunId`, `parentRunAttempt`: the identity's exact parent attempt
+- `authorizedChildRunId`, `authorizedChildRunAttempt`: positive-integer strings
+  naming the original child attempt authorized by that parent
+
+Version 1 is rejected. It never supported end-to-end recovery and has no
+shipped release-tag compatibility contract.
+
+A completed parent cannot upload another artifact. Recovery therefore resolves
+the existing parent receipt using the approval's authorized child:
+
+`openclaw-clawhub-parent-authorization-v2-<parentRunId>-<parentRunAttempt>-<authorizedChildRunId>-<authorizedChildRunAttempt>`
+
+Only the receipt's child run ID and attempt may differ from the recovery
+identity. The parent attempt, child repository and workflow, child ref/full
+ref/SHA, candidate repository/SHA, tooling ref/full ref/SHA, and exact package
+transaction must all still match. A human approval cannot authorize different
+workflow code, payload, tooling, package, version, or inventory. The parent
+receipt retains its automated route; the verified human approval establishes
+`explicit-recovery` for this child.
 
 ## State Policy
 
-ClawHub derives parent state policy from the evidenced route. Submission and
-public visibility are separate boundaries:
+ClawHub derives parent state policy from the live actor and verified receipts.
+Automated children use their own child-bound parent receipt and never fetch a
+recovery artifact. Human children require their own recovery artifact before
+resolving the original child-bound parent receipt. Submission and public
+visibility are separate boundaries:
 
 - submission:
   - `automated-awaited`: parent must be active
@@ -92,8 +123,8 @@ Workflow and CLI checks are diagnostics. They do not authorize a registry
 mutation.
 
 For each upload or publish credential request, ClawHub verifies GitHub OIDC,
-the exact v2 identity, the live child and parent attempts, immutable receipts,
-the package transaction, and the current tooling ref. It then mints a
+the exact v2 identity, the live child and parent attempts, actor-derived route,
+immutable receipts, the package transaction, and the current tooling ref. It then mints a
 short-lived credential bound to:
 
 - upload or publish scope
@@ -104,8 +135,12 @@ short-lived credential bound to:
 - receipt artifact id and digest
 - derived authorization route
 
-Each scope can be minted once for an exact authorization transaction. Replay
-and cross-package, cross-version, or changed-inventory minting fail closed.
+Each scope can be minted once for an exact authorization transaction. The
+transaction key includes the recovery child's own run ID and attempt, so a new
+approved recovery child gets a fresh transaction while reuse of the same
+child/scope is rejected. The returned artifact ID and digest identify the
+original parent receipt. Replay and cross-package, cross-version, or
+changed-inventory minting fail closed.
 The server records a first-class transaction key on each scoped credential.
 Large-artifact upload tickets bind to that key, so the upload-scoped credential
 that creates the ticket and the distinct publish-scoped credential that
@@ -140,6 +175,42 @@ authorization.
 
 The package source recorded by the registry comes from
 `candidateRepository`/`candidateSha`, not the tooling workflow SHA.
+
+## Terminal outcomes
+
+An automated-route attempt whose exact parent attempt completed without success
+is terminal: the attempt becomes `failed`, the release remains non-public, and
+finalization never retries it. In particular, a failed bot parent reports
+`OpenClaw release parent terminal state completed/failure is not authorized by automated-awaited`,
+not a missing recovery artifact. Cancellation is terminal on both routes.
+
+## Operator discard
+
+`maintenance:listStalePackagePublishAttemptsInternal` lists non-terminal package
+attempts for an exact version and optional slug prefix. Attempt documents are
+large: a roughly 600-row incident scan exhausted the 16 MiB read budget. The
+query shares a default 200-row budget (maximum 500) across the three active
+statuses, then applies the package/version/prefix filters. It is a bounded
+window, not an exhaustive inventory; explicit attempt IDs use point reads
+through the same filters. Missing releases are returned with a null publication
+status.
+
+`maintenance:discardStalePackagePublishAttemptsInternal` and the admin-only
+`discardStalePackagePublishAttempts` action default to a dry run. Applying
+requires `dryRun: false` and a trimmed, non-empty reason of at most 500
+characters. The result identifies candidates and actual retired attempts,
+including whether each release or newly created empty package was deleted.
+
+The package owner mutation rechecks attempt ownership and non-terminal state
+before deleting a pending release and its storage. It retires the attempt in
+the same mutation, even if the release is already gone, clearing both claim
+families and storing the reason as the publisher-visible attempt status error.
+Without an explicit attempt ID it finds active owners by the package's stored
+name and release version; a missing release allows lookup by name and release
+ID. If both parent and release are gone, an explicit attempt ID is required.
+Terminal attempts, published releases, and publish tokens are outside this
+operation. The worker's missing-target and terminal-finalization paths share
+the same failure patch.
 
 ## Manual Route And Cutover
 

--- a/src/__tests__/package-publish-workflow.test.ts
+++ b/src/__tests__/package-publish-workflow.test.ts
@@ -223,6 +223,9 @@ describe("package publish workflow", () => {
     const recoveryReceiptIndex = steps.findIndex(
       (step) => step.name === "Download recovery environment approval receipt",
     );
+    const resolveIndex = steps.findIndex(
+      (step) => step.name === "Resolve release parent authorization artifact",
+    );
     const publishIndex = steps.findIndex((step) => step.name === "Run package publish");
     const verifyStep = steps[verifyIndex];
     const publishStep = steps[publishIndex];
@@ -237,8 +240,10 @@ describe("package publish workflow", () => {
       default: "",
     });
     expect(parentReceiptIndex).toBeGreaterThan(-1);
-    expect(recoveryReceiptIndex).toBe(parentReceiptIndex + 1);
-    expect(verifyIndex).toBe(recoveryReceiptIndex + 1);
+    expect(recoveryReceiptIndex).toBeGreaterThan(-1);
+    expect(resolveIndex).toBe(recoveryReceiptIndex + 1);
+    expect(parentReceiptIndex).toBe(resolveIndex + 1);
+    expect(verifyIndex).toBe(parentReceiptIndex + 1);
     expect(verifyIndex).toBeGreaterThan(-1);
     expect(verifyIndex + 1).toBe(publishIndex);
     expect(parentReceiptStep).toMatchObject({
@@ -250,13 +255,17 @@ describe("package publish workflow", () => {
         "run-id": "${{ fromJson(inputs.trusted_tooling_identity_json).parentRunId }}",
       },
     });
-    expect(parentReceiptStep?.with?.name).toContain("openclaw-clawhub-parent-authorization-v2-");
-    expect(parentReceiptStep?.with?.name).toContain(
-      "${{ fromJson(inputs.trusted_tooling_identity_json).runId }}",
+    expect(parentReceiptStep?.with?.name).toBe(
+      "${{ steps.parent_authorization.outputs.artifact_name }}",
     );
-    expect(parentReceiptStep?.with?.name).toContain(
-      "${{ fromJson(inputs.trusted_tooling_identity_json).runAttempt }}",
-    );
+    expect(steps[resolveIndex]).toMatchObject({
+      id: "parent_authorization",
+      if: "inputs.trusted_tooling_identity_json != ''",
+    });
+    expect(steps[resolveIndex]?.run).toContain("parseRecoveryApprovalReceipt");
+    expect(steps[resolveIndex]?.run).toContain("recovery.authorizedChildRunId");
+    expect(steps[resolveIndex]?.run).toContain("recovery.authorizedChildRunAttempt");
+    expect(steps[resolveIndex]?.run).toContain("stat.size > 8 * 1024");
     expect(recoveryReceiptStep).toMatchObject({
       id: "recovery_approval",
       if: "inputs.trusted_tooling_identity_json != ''",


### PR DESCRIPTION
## Summary

Follow-ups to openclaw/openclaw#137598 (which makes `approve_plugins_clawhub_release` upload the recovery approval receipt).

**Recovery contract completion.** `verifyOpenClawPublishAuthorization` required a parent receipt bound to the exact child run *and*, once the parent attempt was `completed/failure`, the child's recovery receipt. A completed parent cannot upload a new artifact, so a human recovery child could never obtain a child-bound parent receipt and `explicit-recovery` was unreachable end to end. Worse, a bot child whose parent failed after staging was forced down the recovery branch and failed with the non-terminal `authorization artifact ... is missing or ambiguous`, so the finalizer retried it forever (the 2026.9.1 incident: 61 attempts from children 33783671044 and 33795427004 under failed parents).

The route is now derived from the live child actor:

- `Bot`/`App`/`[bot]` actors use the automated route with their own child-bound parent receipt and never fetch recovery evidence. A parent attempt that completed without success is terminal: `OpenClaw release parent terminal state completed/failure is not authorized by automated-awaited`, which `isTerminalFinalizationConflict` already classifies, so the attempt becomes `failed` and the release stays non-public.
- Human dispatch always requires a **version 2** recovery receipt from its own run (`openclaw-clawhub-recovery-approval-<childRunId>-<childRunAttempt>`) that names the original `authorizedChildRunId`/`authorizedChildRunAttempt`. ClawHub resolves the parent receipt bound to that child and still requires the recovery child to match the parent attempt, workflow ref + SHA, candidate, tooling, and exact package transaction; only the child run id/attempt may differ. Version 1 receipts are rejected (never worked, not in any shipped tag).
- The workflow-side diagnostic verifier (`.github/scripts/verify-trusted-tooling-identity.cjs`) and `package-publish.yml` mirror this; the workflow resolves the parent artifact name from the approval file before downloading it.

**Operator cleanup for orphaned attempts.** `discardPendingPackagePublicationInternal` deleted the pending release and storage but left the `publishAttempts` row in `ready_to_finalize` until the retry worker happened to terminalize it. It now retires the owning attempt in the same mutation (also when the release is already gone) with a publisher-visible reason, and the three copies of the terminal failure patch collapse into `failedPublishAttemptPatch` in `convex/publishAttempts.ts`. New `maintenance:listStalePackagePublishAttemptsInternal` and `maintenance:discardStalePackagePublishAttemptsInternal` (plus the admin-gated `discardStalePackagePublishAttempts` action) give operators a dry-run-by-default discard for a version / slug prefix / explicit attempt ids.

Spec: `specs/package-publish-tooling-identity.md` (recovery receipt v2, actor-derived route, terminal outcomes, operator discard). Docs: `docs/publishing.md` runbook.

**Production state (verified read-only 2026-09-04):** every 2026.9.1 package attempt is already terminal (89 finalized, 63 failed `Pending package release not found` after the manual discards), so no data change ships with this PR.

**Cross-repo ordering:** ClawHub deploys first. OpenClaw must then emit the v2 recovery receipt with the authorized child (follow-up in `scripts/clawhub-parent-authorization.mjs` / `plugin-clawhub-release.yml`); until then human recovery stays unusable exactly as today, and bot children are unaffected.

## Test commands run

```
bun run test -- convex/lib/openClawPublishAuthorization.test.ts convex/publishAttempts.test.ts convex/maintenance.publishAttempts.test.ts convex/packages.discardPendingPublication.test.ts src/__tests__/package-publish-workflow.test.ts scripts/security/package-publish-workflow.test.ts   # 7 files, 129 passed
node --test .github/scripts/verify-trusted-tooling-identity.node-test.cjs   # 58 passed
bun run ci:static
bun run ci:types-build
bunx tsc -p packages/schema/tsconfig.json --noEmit && bunx tsc -p packages/clawhub/tsconfig.json --noEmit
```

Regression evidence: the new `terminally rejects a failed automated parent without fetching recovery evidence` test fails on the pre-change verifier with `authorization artifact openclaw-clawhub-recovery-approval-32440000001-2 is missing or ambiguous` and passes after.

`bun run ci:unit` locally shows 18 suites failing on the identical `Storage.prototype.length` jsdom setup error on clean `main` under Node 26 (environment); the CI `unit` job is the proof for this branch. Autoreview (Codex, P1): scoped-clean.
