### PR TITLE
test(ui-proof): poll for process-group teardown in the reaper test

### DIFF
--- a/scripts/ui-proof-backend.test.mjs
+++ b/scripts/ui-proof-backend.test.mjs
@@ -473,5 +473,10 @@ it("reaps a real process tree whose leader exits while a grandchild holds pipes 
       signal.addEventListener("abort", () => reject(signal.reason), { once: true }),
     );
   await expect(proof.run()).rejects.toThrow("Convex backend exited (7)");
-  expect(() => process.kill(-backend.pid, 0)).toThrow();
+  // Cleanup resolves on stdio closure, but the SIGKILLed grandchild stays a zombie (still a
+  // group member) until init reaps it, so the group can outlive run() by a few milliseconds.
+  await vi.waitFor(() => expect(() => process.kill(-backend.pid, 0)).toThrow(/ESRCH/), {
+    timeout: 2000,
+    interval: 10,
+  });
 });


### PR DESCRIPTION
## Summary

The CI `unit` job flaked on #3598 (run 33900242516) in `scripts/ui-proof-backend.test.mjs`: "reaps a real process tree whose leader exits while a grandchild holds pipes" failed on its final assertion that the process group is gone right after `run()` rejects.

The reaper's contract is stdio closure bounded by the grace window; it deliberately never polls for the group to vanish because the group ID may be reused. After SIGKILL the kernel closes the grandchild's inherited pipes (so `close` fires and `run()` rejects), but the grandchild remains a zombie, still counted by `kill(-pgid, 0)`, until init reaps it. That window is outside the implementation's contract, so the test now polls with a bounded 2 s deadline and requires ESRCH specifically (the old assertion accepted any throw, including EPERM on a live group).

Test-only change; no changelog entry.

## Testing

- `SITE_URL= VITE_SITE_URL= VITE_CONVEX_URL=https://example.invalid bunx vitest run scripts/ui-proof-backend.test.mjs` x20: 20/20 passed (28 tests each)
- `bun run ci:static`: green
