### PR TITLE
fix(test): keep the Vitest localStorage shim working on Node 26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixes
 
+- Tests: keep the Vitest localStorage shim working on Node 26, whose native `Storage` global has a non-configurable `length`, so `bun run ci:unit` passes on Node 24 and 26.
 - API/GitHub Actions: authorize human release recovery through v2 approval and the original child-bound parent receipt, fail automated attempts when their exact parent fails, and let admins preview or discard orphaned package publish attempts with a publisher-visible reason.
 - CI: warm and cache the npm packages for local Convex "use node" dependencies and raise the isolated backend's push transport timeout so local-auth browser lanes no longer race a 408-retried external-deps build into a deleted build directory.
 - CI: run the pinned Agent Skills CLI from the Bun lockfile without runtime npm access, retain subprocess failure output, and run first-party CLI coverage before third-party compatibility checks.

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -16,7 +16,7 @@ function installLocalStorageShim() {
   if (typeof window === "undefined" || typeof Storage === "undefined") return;
   if (typeof window.localStorage?.clear === "function") return;
 
-  Object.defineProperties(Storage.prototype, {
+  const shim: PropertyDescriptorMap = {
     length: {
       configurable: true,
       get() {
@@ -53,9 +53,21 @@ function installLocalStorageShim() {
         getStorageData(this as Storage).set(String(key), String(value));
       },
     },
-  });
+  };
 
-  const localStorage = Object.create(Storage.prototype) as Storage;
+  // Node 26 ships a native `Storage` global whose `localStorage` is undefined without
+  // `--localstorage-file`, so non-jsdom environments (edge-runtime) reach this shim with
+  // Node's prototype, where `length` is non-configurable and redefining it throws.
+  // Patch what the prototype allows and put the rest directly on the shim instance.
+  const prototypeShim: PropertyDescriptorMap = {};
+  const instanceShim: PropertyDescriptorMap = {};
+  for (const [name, descriptor] of Object.entries(shim)) {
+    const existing = Object.getOwnPropertyDescriptor(Storage.prototype, name);
+    (existing && !existing.configurable ? instanceShim : prototypeShim)[name] = descriptor;
+  }
+  Object.defineProperties(Storage.prototype, prototypeShim);
+
+  const localStorage = Object.create(Storage.prototype, instanceShim) as Storage;
   storageData.set(localStorage, new Map());
   Object.defineProperty(window, "localStorage", {
     configurable: true,


### PR DESCRIPTION
## Summary

`bun run ci:unit` failed 18 test files under Node 26.8.1 with `TypeError: Cannot redefine property: length` from `installLocalStorageShim` in `vitest.setup.ts`. The same files pass on Node 24 and CI is green there.

The failing files all run under `@vitest-environment edge-runtime`, not jsdom. In that environment Vitest aliases `window` to the Node global and the edge VM defines neither `Storage` nor `localStorage`. On Node 24 nothing leaks through, so the shim's `typeof Storage === "undefined"` guard bailed out. Node 26 ships a native `Storage` global plus a `localStorage` getter that returns `undefined` unless `--localstorage-file` is set, so the shim proceeded and tried to redefine Node's `Storage.prototype.length`, the one member Node defines as non-configurable.

The shim now checks each member with `Object.getOwnPropertyDescriptor` first. Members that are missing or configurable still go on `Storage.prototype`; any existing non-configurable member is defined directly on the shim instance instead, so `localStorage.length` keeps working rather than falling through to Node's native getter. Plain jsdom is unchanged on both Node versions.

## Test plan

- `SITE_URL= VITE_SITE_URL= VITE_CONVEX_URL=https://example.invalid bunx vitest run convex/lib/skillHourlyStats.test.ts` on Node 26.8.1 and Node 24.20.0: 10 passed each
- Throwaway edge-runtime probe on Node 26 exercising `setItem`/`getItem`/`key`/`removeItem`/`clear` and the instance `length` getter: passed
- `bun run ci:unit` on Node 26.8.1: 481 files passed, 1 skipped
- `bun run ci:static`: passed
