### PR TITLE
chore(security): log prepublication scanner summaries

### DIFF
--- a/scripts/security/run-prepublication-worker.ts
+++ b/scripts/security/run-prepublication-worker.ts
@@ -795,6 +795,7 @@ export async function processPrePublicationAttempt(
     logger.info(
       {
         attemptId: attempt.attemptId,
+        clawscanSummary: clawscan.summary,
         clawscanStatus: clawscan.status,
         durationMs: Date.now() - startedAt,
         event: "prepublication_attempt_completed",


### PR DESCRIPTION
## Summary

- include the already-redacted ClawScan summary in pre-publication worker completion logs
- make production canary failures diagnosable without exposing credentials or raw artifacts

## Validation

- `bun run test scripts/security/run-prepublication-worker.test.ts`
- `bun run format:check -- scripts/security/run-prepublication-worker.ts`
- `bun run lint -- scripts/security/run-prepublication-worker.ts`
