### PR TITLE
fix(security): restore prepublication SkillSpector

### DIFF
--- a/.github/workflows/prepublication-publish-checks.yml
+++ b/.github/workflows/prepublication-publish-checks.yml
@@ -98,6 +98,16 @@ jobs:
           npm install -g @openclaw/clawscan@0.1.7
           clawscan --version
 
+      - name: Install SkillSpector
+        run: |
+          set -euo pipefail
+          python -m venv "$RUNNER_TEMP/skillspector-venv"
+          source "$RUNNER_TEMP/skillspector-venv/bin/activate"
+          python -m pip install --upgrade pip
+          python -m pip install 'git+https://github.com/NVIDIA/skillspector.git@8f37cfa'
+          echo "$RUNNER_TEMP/skillspector-venv/bin" >> "$GITHUB_PATH"
+          skillspector --help >/dev/null
+
       - name: Install A.I.G scanner
         run: |
           set -euo pipefail

--- a/scripts/security/prepublication-worker-workflow.test.ts
+++ b/scripts/security/prepublication-worker-workflow.test.ts
@@ -156,6 +156,9 @@ describe("pre-publication publish worker workflow", () => {
     expect(steps.find((step) => step.name === "Install ClawScan CLI")?.run).toContain(
       "npm install -g @openclaw/clawscan@0.1.7",
     );
+    const skillspectorInstall = steps.find((step) => step.name === "Install SkillSpector")?.run;
+    expect(skillspectorInstall).toContain("git+https://github.com/NVIDIA/skillspector.git@8f37cfa");
+    expect(skillspectorInstall).toContain("skillspector --help");
     expect(steps).toContainEqual(
       expect.objectContaining({
         uses: "actions/setup-python@v7",
@@ -173,7 +176,6 @@ describe("pre-publication publish worker workflow", () => {
       "npm install -g @openai/codex@0.142.3",
     );
     expect(steps.find((step) => step.name === "Authenticate Codex CLI")).toBeUndefined();
-    expect(steps.find((step) => step.name === "Install SkillSpector")).toBeUndefined();
     expect(JSON.stringify(job)).not.toContain("CODEX_SECURITY_SCAN_SHADOW_CLAWSCAN");
     expect(runStep?.env).toEqual({
       CODEX_API_KEY: "${{ secrets.CODEX_API_KEY || secrets.OPENAI_API_KEY }}",

--- a/scripts/security/run-prepublication-worker.test.ts
+++ b/scripts/security/run-prepublication-worker.test.ts
@@ -1011,6 +1011,62 @@ JSON
     }
   });
 
+  it("preserves a redacted scanner error when a required scanner fails", async () => {
+    const workspace = await tempDir();
+    await mkdir(join(workspace, "artifact"), { recursive: true });
+    await writeFile(join(workspace, "artifact", "SKILL.md"), "# Demo\n");
+    const fakeClawScan = join(workspace, "fake-clawscan");
+    await writeFile(
+      fakeClawScan,
+      `#!/usr/bin/env bash
+set -euo pipefail
+output=""
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "--output" ]; then
+    output="$2"
+    break
+  fi
+  shift
+done
+cat > "$output" <<'JSON'
+{"schemaVersion":"clawscan-run-v1","profile":"clawhub","scanners":{"aig":{"status":"failed","error":"provider rejected request with api_key=secret-value"},"clawscan-static":{"status":"completed"},"skillspector":{"status":"completed"}},"judge":{"status":"failed"}}
+JSON
+`,
+    );
+    await chmod(fakeClawScan, 0o755);
+    const previousCommand = process.env.PREPUBLICATION_CLAWSCAN_COMMAND;
+    process.env.PREPUBLICATION_CLAWSCAN_COMMAND = fakeClawScan;
+
+    try {
+      await expect(
+        runNativeClawScan(
+          {
+            job: {
+              _id: String(attempt.attemptId),
+              attempts: 1,
+              hasMaliciousSignal: false,
+              leaseToken: attempt.claimId,
+              source: "pre-publication",
+              targetKind: "skillVersion",
+              waitForVtUntil: 0,
+            },
+            target: {},
+          },
+          workspace,
+        ),
+      ).resolves.toEqual({
+        check: {
+          status: "failed",
+          summary:
+            "ClawScan scanner did not complete: aig=failed (provider rejected request with api_key=[redacted-secret])",
+        },
+      });
+    } finally {
+      if (previousCommand === undefined) delete process.env.PREPUBLICATION_CLAWSCAN_COMMAND;
+      else process.env.PREPUBLICATION_CLAWSCAN_COMMAND = previousCommand;
+    }
+  });
+
   it("fails closed when completed A.I.G output has no SARIF run", async () => {
     const workspace = await tempDir();
     await mkdir(join(workspace, "artifact"), { recursive: true });

--- a/scripts/security/run-prepublication-worker.ts
+++ b/scripts/security/run-prepublication-worker.ts
@@ -461,7 +461,10 @@ function collectClawScanScannerFailures(
     if (value === undefined) continue;
     const scannerRecord = asRecord(value);
     const status = readString(scannerRecord, ["status"]) ?? "unknown";
-    if (status !== "completed") failures.push(`${scanner}=${status}`);
+    if (status !== "completed") {
+      const error = readString(scannerRecord, ["error"]);
+      failures.push(`${scanner}=${status}${error ? ` (${publicText(error, 300)})` : ""}`);
+    }
   }
   return failures;
 }


### PR DESCRIPTION
## Summary

- restore the pinned NVIDIA SkillSpector dependency in the host-mode pre-publication worker
- preserve redacted per-scanner errors so failed A.I.G runs are diagnosable
- keep the existing external scan worker pin unchanged

## Production finding

After #3522 deployed, the production canary and other staged skills failed closed with `skillspector=failed, aig=failed`. The worker had switched from the ClawScan Docker runtime to host mode but did not install SkillSpector in the pre-publication workflow.

## Validation

- `bun run test scripts/security/run-prepublication-worker.test.ts scripts/security/prepublication-worker-workflow.test.ts scripts/security/security-scan-worker-workflow.test.ts`
- `bun run ci:static`
