### PR TITLE
fix(security): retain scanner error tail

### DIFF
--- a/scripts/security/run-prepublication-worker.ts
+++ b/scripts/security/run-prepublication-worker.ts
@@ -463,7 +463,8 @@ function collectClawScanScannerFailures(
     const status = readString(scannerRecord, ["status"]) ?? "unknown";
     if (status !== "completed") {
       const error = readString(scannerRecord, ["error"]);
-      failures.push(`${scanner}=${status}${error ? ` (${publicText(error, 300)})` : ""}`);
+      const errorTail = error ? publicText(error.slice(-450), 450) : undefined;
+      failures.push(`${scanner}=${status}${errorTail ? ` (${errorTail})` : ""}`);
     }
   }
   return failures;


### PR DESCRIPTION
## Summary

- retain the redacted tail of failed scanner output, where A.I.G emits the actionable exception
- keep the stored/logged diagnostic bounded to 450 characters

## Validation

- `bun run test scripts/security/run-prepublication-worker.test.ts`
- `bun run ci:static`
