### PR TITLE
fix(security): use AIG-compatible OpenAI model

### DIFF
--- a/.github/workflows/prepublication-publish-checks.yml
+++ b/.github/workflows/prepublication-publish-checks.yml
@@ -119,7 +119,7 @@ jobs:
         env:
           CODEX_API_KEY: ${{ secrets.CODEX_API_KEY || secrets.OPENAI_API_KEY }}
           DEFAULT_BASE_URL: https://api.openai.com/v1
-          DEFAULT_MODEL: gpt-5.5
+          DEFAULT_MODEL: gpt-4.1-2025-04-14
           LLM_API_KEY: ${{ secrets.OPENAI_API_KEY || secrets.CODEX_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           SECURITY_SCAN_WORKER_TOKEN: ${{ secrets.SECURITY_SCAN_WORKER_TOKEN }}

--- a/.github/workflows/security-scan-codex.yml
+++ b/.github/workflows/security-scan-codex.yml
@@ -121,7 +121,7 @@ jobs:
         env:
           CODEX_API_KEY: ${{ secrets.CODEX_API_KEY || secrets.OPENAI_API_KEY }}
           DEFAULT_BASE_URL: https://api.openai.com/v1
-          DEFAULT_MODEL: gpt-5.5
+          DEFAULT_MODEL: gpt-4.1-2025-04-14
           LLM_API_KEY: ${{ secrets.OPENAI_API_KEY || secrets.CODEX_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           SECURITY_SCAN_WORKER_TOKEN: ${{ secrets.SECURITY_SCAN_WORKER_TOKEN }}

--- a/scripts/security/prepublication-worker-workflow.test.ts
+++ b/scripts/security/prepublication-worker-workflow.test.ts
@@ -180,7 +180,7 @@ describe("pre-publication publish worker workflow", () => {
     expect(runStep?.env).toEqual({
       CODEX_API_KEY: "${{ secrets.CODEX_API_KEY || secrets.OPENAI_API_KEY }}",
       DEFAULT_BASE_URL: "https://api.openai.com/v1",
-      DEFAULT_MODEL: "gpt-5.5",
+      DEFAULT_MODEL: "gpt-4.1-2025-04-14",
       LLM_API_KEY: "${{ secrets.OPENAI_API_KEY || secrets.CODEX_API_KEY }}",
       OPENAI_API_KEY: "${{ secrets.OPENAI_API_KEY }}",
       SECURITY_SCAN_WORKER_TOKEN: "${{ secrets.SECURITY_SCAN_WORKER_TOKEN }}",

--- a/scripts/security/security-scan-worker-workflow.test.ts
+++ b/scripts/security/security-scan-worker-workflow.test.ts
@@ -161,7 +161,7 @@ describe("security-scan-codex workflow", () => {
     expect(steps.find((step) => step.name === "Run Codex security worker")?.env).toEqual({
       CODEX_API_KEY: "${{ secrets.CODEX_API_KEY || secrets.OPENAI_API_KEY }}",
       DEFAULT_BASE_URL: "https://api.openai.com/v1",
-      DEFAULT_MODEL: "gpt-5.5",
+      DEFAULT_MODEL: "gpt-4.1-2025-04-14",
       LLM_API_KEY: "${{ secrets.OPENAI_API_KEY || secrets.CODEX_API_KEY }}",
       OPENAI_API_KEY: "${{ secrets.OPENAI_API_KEY }}",
       SECURITY_SCAN_WORKER_TOKEN: "${{ secrets.SECURITY_SCAN_WORKER_TOKEN }}",


### PR DESCRIPTION
## Summary

- pin A.I.G's OpenAI model to `gpt-4.1-2025-04-14` in both pre-publication and post-publication workers
- keep workflow contract tests aligned with the production configuration

## Why

A.I.G 0.2.1 uses Chat Completions streaming and sends `temperature: 0.7`. The previous `gpt-5.5` configuration reached OpenAI successfully but failed with HTTP 400 because that model only accepts the default temperature. GPT-4.1 supports A.I.G's API shape, and the dated snapshot keeps scanner behavior stable.

## Validation

- `bun vitest run scripts/security/prepublication-worker-workflow.test.ts scripts/security/security-scan-worker-workflow.test.ts`
- `bun run ci:static`
- `.agents/skills/autoreview/scripts/autoreview --mode local` (clean)
- production failure reproduced in [run 33931020643](https://github.com/openclaw/clawhub/actions/runs/33931020643)

## Rollout proof

After merge, publish a new version of `aig-production-canary` from Patrick's production account and verify that ClawScan, SkillSpector, and A.I.G all complete and the saved audit renders on ClawHub.
