### PR TITLE
fix(security): run AIG with GPT-5.6

### DIFF
--- a/.github/workflows/prepublication-publish-checks.yml
+++ b/.github/workflows/prepublication-publish-checks.yml
@@ -119,7 +119,7 @@ jobs:
         env:
           CODEX_API_KEY: ${{ secrets.CODEX_API_KEY || secrets.OPENAI_API_KEY }}
           DEFAULT_BASE_URL: https://api.openai.com/v1
-          DEFAULT_MODEL: gpt-4.1-2025-04-14
+          DEFAULT_MODEL: gpt-5.6
           LLM_API_KEY: ${{ secrets.OPENAI_API_KEY || secrets.CODEX_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           SECURITY_SCAN_WORKER_TOKEN: ${{ secrets.SECURITY_SCAN_WORKER_TOKEN }}

--- a/.github/workflows/security-scan-codex.yml
+++ b/.github/workflows/security-scan-codex.yml
@@ -121,7 +121,7 @@ jobs:
         env:
           CODEX_API_KEY: ${{ secrets.CODEX_API_KEY || secrets.OPENAI_API_KEY }}
           DEFAULT_BASE_URL: https://api.openai.com/v1
-          DEFAULT_MODEL: gpt-4.1-2025-04-14
+          DEFAULT_MODEL: gpt-5.6
           LLM_API_KEY: ${{ secrets.OPENAI_API_KEY || secrets.CODEX_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           SECURITY_SCAN_WORKER_TOKEN: ${{ secrets.SECURITY_SCAN_WORKER_TOKEN }}

--- a/scripts/security/prepublication-worker-workflow.test.ts
+++ b/scripts/security/prepublication-worker-workflow.test.ts
@@ -180,7 +180,7 @@ describe("pre-publication publish worker workflow", () => {
     expect(runStep?.env).toEqual({
       CODEX_API_KEY: "${{ secrets.CODEX_API_KEY || secrets.OPENAI_API_KEY }}",
       DEFAULT_BASE_URL: "https://api.openai.com/v1",
-      DEFAULT_MODEL: "gpt-4.1-2025-04-14",
+      DEFAULT_MODEL: "gpt-5.6",
       LLM_API_KEY: "${{ secrets.OPENAI_API_KEY || secrets.CODEX_API_KEY }}",
       OPENAI_API_KEY: "${{ secrets.OPENAI_API_KEY }}",
       SECURITY_SCAN_WORKER_TOKEN: "${{ secrets.SECURITY_SCAN_WORKER_TOKEN }}",

--- a/scripts/security/security-scan-worker-workflow.test.ts
+++ b/scripts/security/security-scan-worker-workflow.test.ts
@@ -161,7 +161,7 @@ describe("security-scan-codex workflow", () => {
     expect(steps.find((step) => step.name === "Run Codex security worker")?.env).toEqual({
       CODEX_API_KEY: "${{ secrets.CODEX_API_KEY || secrets.OPENAI_API_KEY }}",
       DEFAULT_BASE_URL: "https://api.openai.com/v1",
-      DEFAULT_MODEL: "gpt-4.1-2025-04-14",
+      DEFAULT_MODEL: "gpt-5.6",
       LLM_API_KEY: "${{ secrets.OPENAI_API_KEY || secrets.CODEX_API_KEY }}",
       OPENAI_API_KEY: "${{ secrets.OPENAI_API_KEY }}",
       SECURITY_SCAN_WORKER_TOKEN: "${{ secrets.SECURITY_SCAN_WORKER_TOKEN }}",


### PR DESCRIPTION
## Summary

- use the `gpt-5.6` alias for A.I.G in both prepublication and postpublication ClawScan workers
- keep workflow contract tests aligned with the production model selection

## Before / after proof

- Before: the new contract expectations failed because both workflows still supplied `gpt-4.1-2025-04-14`.
- After: both focused workflow tests pass with `gpt-5.6`; the full 6,450-test unit gate and static gate pass.
- Production canary: publish a new `patrick-erichsen-2/aig-production-canary` version after merge and verify its persisted A.I.G 0.2.1 result.

## Validation

- `bunx vitest run scripts/security/security-scan-worker-workflow.test.ts scripts/security/prepublication-worker-workflow.test.ts`
- `bun run ci:static`
- `bun run ci:unit`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
