### PR TITLE
fix(security): make AIG compatible with GPT-5.6

### DIFF
--- a/.github/workflows/prepublication-publish-checks.yml
+++ b/.github/workflows/prepublication-publish-checks.yml
@@ -119,7 +119,7 @@ jobs:
         env:
           CODEX_API_KEY: ${{ secrets.CODEX_API_KEY || secrets.OPENAI_API_KEY }}
           DEFAULT_BASE_URL: https://api.openai.com/v1
-          DEFAULT_MODEL: gpt-5.6
+          DEFAULT_MODEL: gpt-4.1-2025-04-14
           LLM_API_KEY: ${{ secrets.OPENAI_API_KEY || secrets.CODEX_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           SECURITY_SCAN_WORKER_TOKEN: ${{ secrets.SECURITY_SCAN_WORKER_TOKEN }}

--- a/.github/workflows/prepublication-publish-checks.yml
+++ b/.github/workflows/prepublication-publish-checks.yml
@@ -112,14 +112,18 @@ jobs:
         run: |
           set -euo pipefail
           python -m pip install --require-hashes -r scripts/security/aig-worker-requirements.txt
+          # Backport Tencent/AI-Infra-Guard@f18ae642d62be142192d6bd4c21c4ea7e098bbc8 until its next PyPI release.
+          AIG_SITE_PACKAGES="$(python -c 'import site; print(site.getsitepackages()[0])')"
+          patch --batch --fuzz=0 --strip=1 --directory="$AIG_SITE_PACKAGES" < scripts/security/aig-skill-scan-0.2.1-gpt5.patch
           python -c 'from importlib.metadata import version; assert version("aig-skill-scan") == "0.2.1"'
+          python -c 'import inspect; from skill_scan.utils.llm import LLM; assert "temperature=" not in inspect.getsource(LLM.chat_stream)'
           aig-skill-scan --help >/dev/null
 
       - name: Run pre-publication publish worker
         env:
           CODEX_API_KEY: ${{ secrets.CODEX_API_KEY || secrets.OPENAI_API_KEY }}
           DEFAULT_BASE_URL: https://api.openai.com/v1
-          DEFAULT_MODEL: gpt-4.1-2025-04-14
+          DEFAULT_MODEL: gpt-5.6
           LLM_API_KEY: ${{ secrets.OPENAI_API_KEY || secrets.CODEX_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           SECURITY_SCAN_WORKER_TOKEN: ${{ secrets.SECURITY_SCAN_WORKER_TOKEN }}

--- a/.github/workflows/security-scan-codex.yml
+++ b/.github/workflows/security-scan-codex.yml
@@ -121,7 +121,7 @@ jobs:
         env:
           CODEX_API_KEY: ${{ secrets.CODEX_API_KEY || secrets.OPENAI_API_KEY }}
           DEFAULT_BASE_URL: https://api.openai.com/v1
-          DEFAULT_MODEL: gpt-5.6
+          DEFAULT_MODEL: gpt-4.1-2025-04-14
           LLM_API_KEY: ${{ secrets.OPENAI_API_KEY || secrets.CODEX_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           SECURITY_SCAN_WORKER_TOKEN: ${{ secrets.SECURITY_SCAN_WORKER_TOKEN }}

--- a/.github/workflows/security-scan-codex.yml
+++ b/.github/workflows/security-scan-codex.yml
@@ -99,7 +99,11 @@ jobs:
         run: |
           set -euo pipefail
           python -m pip install --require-hashes -r scripts/security/aig-worker-requirements.txt
+          # Backport Tencent/AI-Infra-Guard@f18ae642d62be142192d6bd4c21c4ea7e098bbc8 until its next PyPI release.
+          AIG_SITE_PACKAGES="$(python -c 'import site; print(site.getsitepackages()[0])')"
+          patch --batch --fuzz=0 --strip=1 --directory="$AIG_SITE_PACKAGES" < scripts/security/aig-skill-scan-0.2.1-gpt5.patch
           python -c 'from importlib.metadata import version; assert version("aig-skill-scan") == "0.2.1"'
+          python -c 'import inspect; from skill_scan.utils.llm import LLM; assert "temperature=" not in inspect.getsource(LLM.chat_stream)'
           aig-skill-scan --help >/dev/null
 
       - name: Install SkillSpector
@@ -121,7 +125,7 @@ jobs:
         env:
           CODEX_API_KEY: ${{ secrets.CODEX_API_KEY || secrets.OPENAI_API_KEY }}
           DEFAULT_BASE_URL: https://api.openai.com/v1
-          DEFAULT_MODEL: gpt-4.1-2025-04-14
+          DEFAULT_MODEL: gpt-5.6
           LLM_API_KEY: ${{ secrets.OPENAI_API_KEY || secrets.CODEX_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           SECURITY_SCAN_WORKER_TOKEN: ${{ secrets.SECURITY_SCAN_WORKER_TOKEN }}

--- a/scripts/security/aig-skill-scan-0.2.1-gpt5.patch
+++ b/scripts/security/aig-skill-scan-0.2.1-gpt5.patch
@@ -1,0 +1,19 @@
+diff --git a/skill_scan/utils/llm.py b/skill_scan/utils/llm.py
+--- a/skill_scan/utils/llm.py
++++ b/skill_scan/utils/llm.py
+@@ -44,7 +44,6 @@ class LLM:
+             timeout=60,
+             default_headers=default_headers if default_headers else None,
+         )
+-        self.temperature = 0.7
+         self.context_window = context_window
+ 
+     def chat(self, message: list[dict], p=False, ret_usage=False) -> str | tuple[str, dict]:
+@@ -75,7 +74,6 @@ class LLM:
+         response = self.client.chat.completions.create(
+             model=self.model,
+             messages=message,
+-            temperature=self.temperature,
+             stream=True,
+             stream_options={"include_usage": True},
+         )

--- a/scripts/security/prepublication-worker-workflow.test.ts
+++ b/scripts/security/prepublication-worker-workflow.test.ts
@@ -180,7 +180,7 @@ describe("pre-publication publish worker workflow", () => {
     expect(runStep?.env).toEqual({
       CODEX_API_KEY: "${{ secrets.CODEX_API_KEY || secrets.OPENAI_API_KEY }}",
       DEFAULT_BASE_URL: "https://api.openai.com/v1",
-      DEFAULT_MODEL: "gpt-5.6",
+      DEFAULT_MODEL: "gpt-4.1-2025-04-14",
       LLM_API_KEY: "${{ secrets.OPENAI_API_KEY || secrets.CODEX_API_KEY }}",
       OPENAI_API_KEY: "${{ secrets.OPENAI_API_KEY }}",
       SECURITY_SCAN_WORKER_TOKEN: "${{ secrets.SECURITY_SCAN_WORKER_TOKEN }}",

--- a/scripts/security/prepublication-worker-workflow.test.ts
+++ b/scripts/security/prepublication-worker-workflow.test.ts
@@ -171,6 +171,9 @@ describe("pre-publication publish worker workflow", () => {
     );
     expect(aigInstall).not.toContain("pip install 'aig-skill-scan==0.2.1'");
     expect(aigInstall).toContain('version("aig-skill-scan") == "0.2.1"');
+    expect(aigInstall).toContain("aig-skill-scan-0.2.1-gpt5.patch");
+    expect(aigInstall).toContain("f18ae642d62be142192d6bd4c21c4ea7e098bbc8");
+    expect(aigInstall).toContain('assert "temperature=" not in inspect.getsource(LLM.chat_stream)');
     expect(aigInstall).toContain("aig-skill-scan --help");
     expect(steps.find((step) => step.name === "Install Codex CLI")?.run).toContain(
       "npm install -g @openai/codex@0.142.3",
@@ -180,7 +183,7 @@ describe("pre-publication publish worker workflow", () => {
     expect(runStep?.env).toEqual({
       CODEX_API_KEY: "${{ secrets.CODEX_API_KEY || secrets.OPENAI_API_KEY }}",
       DEFAULT_BASE_URL: "https://api.openai.com/v1",
-      DEFAULT_MODEL: "gpt-4.1-2025-04-14",
+      DEFAULT_MODEL: "gpt-5.6",
       LLM_API_KEY: "${{ secrets.OPENAI_API_KEY || secrets.CODEX_API_KEY }}",
       OPENAI_API_KEY: "${{ secrets.OPENAI_API_KEY }}",
       SECURITY_SCAN_WORKER_TOKEN: "${{ secrets.SECURITY_SCAN_WORKER_TOKEN }}",

--- a/scripts/security/security-scan-worker-workflow.test.ts
+++ b/scripts/security/security-scan-worker-workflow.test.ts
@@ -161,7 +161,7 @@ describe("security-scan-codex workflow", () => {
     expect(steps.find((step) => step.name === "Run Codex security worker")?.env).toEqual({
       CODEX_API_KEY: "${{ secrets.CODEX_API_KEY || secrets.OPENAI_API_KEY }}",
       DEFAULT_BASE_URL: "https://api.openai.com/v1",
-      DEFAULT_MODEL: "gpt-5.6",
+      DEFAULT_MODEL: "gpt-4.1-2025-04-14",
       LLM_API_KEY: "${{ secrets.OPENAI_API_KEY || secrets.CODEX_API_KEY }}",
       OPENAI_API_KEY: "${{ secrets.OPENAI_API_KEY }}",
       SECURITY_SCAN_WORKER_TOKEN: "${{ secrets.SECURITY_SCAN_WORKER_TOKEN }}",

--- a/scripts/security/security-scan-worker-workflow.test.ts
+++ b/scripts/security/security-scan-worker-workflow.test.ts
@@ -155,13 +155,16 @@ describe("security-scan-codex workflow", () => {
     );
     expect(aigInstall).not.toContain("pip install 'aig-skill-scan==0.2.1'");
     expect(aigInstall).toContain('version("aig-skill-scan") == "0.2.1"');
+    expect(aigInstall).toContain("aig-skill-scan-0.2.1-gpt5.patch");
+    expect(aigInstall).toContain("f18ae642d62be142192d6bd4c21c4ea7e098bbc8");
+    expect(aigInstall).toContain('assert "temperature=" not in inspect.getsource(LLM.chat_stream)');
     expect(aigInstall).toContain("aig-skill-scan --help");
     expect(skillspectorInstall).toContain("git+https://github.com/NVIDIA/skillspector.git@8f37cfa");
     expect(skillspectorInstall).not.toContain("git+https://github.com/NVIDIA/skillspector.git'");
     expect(steps.find((step) => step.name === "Run Codex security worker")?.env).toEqual({
       CODEX_API_KEY: "${{ secrets.CODEX_API_KEY || secrets.OPENAI_API_KEY }}",
       DEFAULT_BASE_URL: "https://api.openai.com/v1",
-      DEFAULT_MODEL: "gpt-4.1-2025-04-14",
+      DEFAULT_MODEL: "gpt-5.6",
       LLM_API_KEY: "${{ secrets.OPENAI_API_KEY || secrets.CODEX_API_KEY }}",
       OPENAI_API_KEY: "${{ secrets.OPENAI_API_KEY }}",
       SECURITY_SCAN_WORKER_TOKEN: "${{ secrets.SECURITY_SCAN_WORKER_TOKEN }}",


### PR DESCRIPTION
## Summary

- run both production ClawScan workers with `gpt-5.6`
- backport Tencent's exact upstream fix that removes A.I.G 0.2.1's incompatible hardcoded `temperature: 0.7`
- keep the published A.I.G package and its transitive dependencies hash-locked
- fail installation unless the patched method is active

Upstream fix: https://github.com/Tencent/AI-Infra-Guard/commit/f18ae642d62be142192d6bd4c21c4ea7e098bbc8

## Production context

- GPT-5.6 canary that exposed the incompatibility: https://github.com/openclaw/clawhub/actions/runs/33946786066
- temporary rollback: https://github.com/openclaw/clawhub/pull/3609

## Validation

- focused workflow tests (red before implementation, green after)
- applied the backport to a clean A.I.G 0.2.1 virtualenv and verified `LLM.chat_stream` no longer passes `temperature`
- `bun run ci:static`
- `bun run ci:unit` (484 files passed, 1 skipped; 6,450 tests passed, 3 skipped)
- `$autoreview` clean

After merge, publish a fresh personal-account canary skill and verify A.I.G, ClawScan, and publication all complete on the exact merge SHA.
