### PR TITLE
fix(security): enable GPT-5.6 for AIG workers

### DIFF
--- a/.github/workflows/prepublication-publish-checks.yml
+++ b/.github/workflows/prepublication-publish-checks.yml
@@ -123,7 +123,7 @@ jobs:
         env:
           CODEX_API_KEY: ${{ secrets.CODEX_API_KEY || secrets.OPENAI_API_KEY }}
           DEFAULT_BASE_URL: https://api.openai.com/v1
-          DEFAULT_MODEL: gpt-4.1-2025-04-14
+          DEFAULT_MODEL: gpt-5.6
           LLM_API_KEY: ${{ secrets.OPENAI_API_KEY || secrets.CODEX_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           SECURITY_SCAN_WORKER_TOKEN: ${{ secrets.SECURITY_SCAN_WORKER_TOKEN }}

--- a/.github/workflows/security-scan-codex.yml
+++ b/.github/workflows/security-scan-codex.yml
@@ -125,7 +125,7 @@ jobs:
         env:
           CODEX_API_KEY: ${{ secrets.CODEX_API_KEY || secrets.OPENAI_API_KEY }}
           DEFAULT_BASE_URL: https://api.openai.com/v1
-          DEFAULT_MODEL: gpt-4.1-2025-04-14
+          DEFAULT_MODEL: gpt-5.6
           LLM_API_KEY: ${{ secrets.OPENAI_API_KEY || secrets.CODEX_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           SECURITY_SCAN_WORKER_TOKEN: ${{ secrets.SECURITY_SCAN_WORKER_TOKEN }}

--- a/scripts/security/prepublication-worker-workflow.test.ts
+++ b/scripts/security/prepublication-worker-workflow.test.ts
@@ -183,7 +183,7 @@ describe("pre-publication publish worker workflow", () => {
     expect(runStep?.env).toEqual({
       CODEX_API_KEY: "${{ secrets.CODEX_API_KEY || secrets.OPENAI_API_KEY }}",
       DEFAULT_BASE_URL: "https://api.openai.com/v1",
-      DEFAULT_MODEL: "gpt-4.1-2025-04-14",
+      DEFAULT_MODEL: "gpt-5.6",
       LLM_API_KEY: "${{ secrets.OPENAI_API_KEY || secrets.CODEX_API_KEY }}",
       OPENAI_API_KEY: "${{ secrets.OPENAI_API_KEY }}",
       SECURITY_SCAN_WORKER_TOKEN: "${{ secrets.SECURITY_SCAN_WORKER_TOKEN }}",

--- a/scripts/security/security-scan-worker-workflow.test.ts
+++ b/scripts/security/security-scan-worker-workflow.test.ts
@@ -164,7 +164,7 @@ describe("security-scan-codex workflow", () => {
     expect(steps.find((step) => step.name === "Run Codex security worker")?.env).toEqual({
       CODEX_API_KEY: "${{ secrets.CODEX_API_KEY || secrets.OPENAI_API_KEY }}",
       DEFAULT_BASE_URL: "https://api.openai.com/v1",
-      DEFAULT_MODEL: "gpt-4.1-2025-04-14",
+      DEFAULT_MODEL: "gpt-5.6",
       LLM_API_KEY: "${{ secrets.OPENAI_API_KEY || secrets.CODEX_API_KEY }}",
       OPENAI_API_KEY: "${{ secrets.OPENAI_API_KEY }}",
       SECURITY_SCAN_WORKER_TOKEN: "${{ secrets.SECURITY_SCAN_WORKER_TOKEN }}",


### PR DESCRIPTION
## Summary

- switch both production ClawScan workers from GPT-4.1 to `gpt-5.6`
- update the workflow contract tests

This is deliberately based on current `main`, where the A.I.G 0.2.1 compatibility backport from #3610 is already present. It corrects the stacked-merge outcome that preserved the rollback model line.

## Validation

- `bun vitest run scripts/security/prepublication-worker-workflow.test.ts scripts/security/security-scan-worker-workflow.test.ts`
- `$autoreview` clean
- production canary 1.0.10 will run after merge and must show `DEFAULT_MODEL: gpt-5.6`
