### PR TITLE
fix(packages): delete unpublished blobs when package publish fails

### DIFF
--- a/convex/httpApiV1.handlers.test.ts
+++ b/convex/httpApiV1.handlers.test.ts
@@ -16899,6 +16899,147 @@ describe("httpApiV1 handlers", () => {
     );
   });
 
+  it("delete unpublished package blobs when loose-file publish action throws after stores", async () => {
+    vi.mocked(getOptionalApiTokenUserId).mockResolvedValue("users:1" as never);
+    vi.mocked(requirePackagePublishAuth).mockResolvedValue({
+      kind: "user",
+      userId: "users:1",
+      user: { _id: "users:1", handle: "p" },
+    } as never);
+    const runMutation = vi.fn().mockResolvedValue(okRate());
+    const runAction = vi.fn().mockRejectedValue(new Error("GitHub account is too new to publish"));
+    const storedIds: string[] = [];
+    const storageStore = vi.fn(async () => {
+      const id = `storage:loose-${storedIds.length + 1}`;
+      storedIds.push(id);
+      return id;
+    });
+    const storageDelete = vi.fn(async () => {});
+    const form = packagePublishForm(
+      packagePublishMetadata({
+        ownerHandle: "openclaw",
+        bundle: { hostTargets: ["desktop"] },
+      }),
+    );
+    form.append("files", new File(["{}"], "openclaw.plugin.json", { type: "application/json" }));
+    form.append("files", new File(["readme"], "README.md", { type: "text/markdown" }));
+
+    const response = await __handlers.publishPackageV1Handler(
+      makeCtx({
+        runAction,
+        runMutation,
+        storage: { store: storageStore, delete: storageDelete },
+      }),
+      new Request("https://example.com/api/v1/packages", {
+        method: "POST",
+        headers: { Authorization: "Bearer clh_test" },
+        body: form,
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.text()).toBe("GitHub account is too new to publish");
+    expect(runAction).toHaveBeenCalledOnce();
+    expect(storedIds).toEqual(["storage:loose-1", "storage:loose-2"]);
+    expect(storageDelete).toHaveBeenCalledTimes(storedIds.length);
+    for (const id of storedIds) {
+      expect(storageDelete).toHaveBeenCalledWith(id);
+    }
+  });
+
+  it("delete unpublished package blobs when ClawPack extracted-file store throws after tarball store", async () => {
+    vi.mocked(getOptionalApiTokenUserId).mockResolvedValue("users:1" as never);
+    vi.mocked(requirePackagePublishAuth).mockResolvedValue({
+      kind: "user",
+      userId: "users:1",
+      user: { _id: "users:1", handle: "p" },
+    } as never);
+    const runMutation = vi.fn().mockResolvedValue(okRate());
+    const runAction = vi.fn();
+    const storageStore = vi.fn(async () => {
+      if (storageStore.mock.calls.length > 1) {
+        throw new Error("extracted store failed");
+      }
+      return "storage:tarball";
+    });
+    const storageDelete = vi.fn(async () => {});
+    const pack = npmPackFixture({
+      "package/package.json": JSON.stringify({ name: "demo-plugin", version: "1.0.0" }),
+      "package/openclaw.plugin.json": JSON.stringify({ id: "demo.plugin" }),
+      "package/dist/index.js": "export const demo = true;\n",
+    });
+    const form = packagePublishForm(packagePublishMetadata({ family: "code-plugin" }));
+    form.append(
+      "clawpack",
+      new File([bytesToArrayBuffer(pack)], "demo-plugin-1.0.0.tgz", {
+        type: "application/octet-stream",
+      }),
+    );
+
+    const response = await __handlers.publishPackageV1Handler(
+      makeCtx({
+        runAction,
+        runMutation,
+        storage: { store: storageStore, delete: storageDelete },
+      }),
+      new Request("https://example.com/api/v1/packages", {
+        method: "POST",
+        headers: { Authorization: "Bearer clh_test" },
+        body: form,
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.text()).toBe("extracted store failed");
+    expect(runAction).not.toHaveBeenCalled();
+    expect(storageStore).toHaveBeenCalled();
+    expect(storageDelete).toHaveBeenCalledWith("storage:tarball");
+  });
+
+  it("delete unpublished package blobs when a later loose-file store throws", async () => {
+    vi.mocked(getOptionalApiTokenUserId).mockResolvedValue("users:1" as never);
+    vi.mocked(requirePackagePublishAuth).mockResolvedValue({
+      kind: "user",
+      userId: "users:1",
+      user: { _id: "users:1", handle: "p" },
+    } as never);
+    const runMutation = vi.fn().mockResolvedValue(okRate());
+    const runAction = vi.fn();
+    const storageStore = vi.fn(async () => {
+      if (storageStore.mock.calls.length > 1) {
+        throw new Error("second file store failed");
+      }
+      return "storage:first";
+    });
+    const storageDelete = vi.fn(async () => {});
+    const form = packagePublishForm(
+      packagePublishMetadata({
+        ownerHandle: "openclaw",
+        bundle: { hostTargets: ["desktop"] },
+      }),
+    );
+    form.append("files", new File(["{}"], "openclaw.plugin.json", { type: "application/json" }));
+    form.append("files", new File(["readme"], "README.md", { type: "text/markdown" }));
+
+    const response = await __handlers.publishPackageV1Handler(
+      makeCtx({
+        runAction,
+        runMutation,
+        storage: { store: storageStore, delete: storageDelete },
+      }),
+      new Request("https://example.com/api/v1/packages", {
+        method: "POST",
+        headers: { Authorization: "Bearer clh_test" },
+        body: form,
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.text()).toBe("second file store failed");
+    expect(runAction).not.toHaveBeenCalled();
+    expect(storageDelete).toHaveBeenCalledWith("storage:first");
+  });
+
   it("returns package publish attempt status to the exact API token actor", async () => {
     vi.mocked(requirePackagePublishAuth).mockResolvedValue({
       kind: "user",

--- a/convex/httpApiV1/packagesV1.ts
+++ b/convex/httpApiV1/packagesV1.ts
@@ -1375,9 +1375,7 @@ async function deleteUnpublishedPackagePublishBlobs(
   if (stored.artifact?.storageId) {
     storageIds.push(stored.artifact.storageId);
   }
-  await Promise.allSettled(
-    storageIds.map((storageId) => remove(storageId as Id<"_storage">)),
-  );
+  await Promise.allSettled(storageIds.map((storageId) => remove(storageId as Id<"_storage">)));
 }
 
 async function storeClawPackFiles(

--- a/convex/httpApiV1/packagesV1.ts
+++ b/convex/httpApiV1/packagesV1.ts
@@ -1357,6 +1357,23 @@ async function storeClawPackFile(
 const CLAWPACK_STORE_BATCH_BYTES = 8 * 1024 * 1024;
 const CLAWPACK_STORE_BATCH_FILES = 16;
 
+async function deleteUnpublishedPackagePublishBlobs(
+  ctx: ActionCtx,
+  stored: {
+    files?: Array<{ storageId: Id<"_storage"> }>;
+    artifact?: { storageId?: Id<"_storage"> } | null;
+  },
+) {
+  const storageIds: Array<Id<"_storage">> = [];
+  for (const file of stored.files ?? []) {
+    storageIds.push(file.storageId);
+  }
+  if (stored.artifact?.storageId) {
+    storageIds.push(stored.artifact.storageId);
+  }
+  await Promise.allSettled(storageIds.map((storageId) => ctx.storage.delete(storageId)));
+}
+
 async function storeClawPackFiles(
   ctx: ActionCtx,
   entries: Array<{ path: string; bytes: Uint8Array }>,
@@ -1365,20 +1382,34 @@ async function storeClawPackFiles(
   let batch: Array<{ path: string; bytes: Uint8Array }> = [];
   let batchBytes = 0;
   const flush = async () => {
-    files.push(...(await Promise.all(batch.map((entry) => storeClawPackFile(ctx, entry)))));
+    const results = await Promise.allSettled(batch.map((entry) => storeClawPackFile(ctx, entry)));
+    for (const result of results) {
+      if (result.status === "fulfilled") {
+        files.push(result.value);
+      }
+    }
+    const rejected = results.find((result) => result.status === "rejected");
+    if (rejected?.status === "rejected") {
+      throw rejected.reason;
+    }
     batch = [];
     batchBytes = 0;
   };
-  for (const entry of entries) {
-    const overflows =
-      batch.length >= CLAWPACK_STORE_BATCH_FILES ||
-      batchBytes + entry.bytes.byteLength > CLAWPACK_STORE_BATCH_BYTES;
-    if (batch.length > 0 && overflows) await flush();
-    batch.push(entry);
-    batchBytes += entry.bytes.byteLength;
+  try {
+    for (const entry of entries) {
+      const overflows =
+        batch.length >= CLAWPACK_STORE_BATCH_FILES ||
+        batchBytes + entry.bytes.byteLength > CLAWPACK_STORE_BATCH_BYTES;
+      if (batch.length > 0 && overflows) await flush();
+      batch.push(entry);
+      batchBytes += entry.bytes.byteLength;
+    }
+    if (batch.length > 0) await flush();
+    return files;
+  } catch (error) {
+    await deleteUnpublishedPackagePublishBlobs(ctx, { files });
+    throw error;
   }
-  if (batch.length > 0) await flush();
-  return files;
 }
 
 async function storeUploadedPackageFile(
@@ -1489,8 +1520,14 @@ async function buildPackagePublishRequestFromClawPack(
     npmUnpackedSize: parsed.unpackedSize,
     npmFileCount: parsed.fileCount,
   };
-  const files = await storeClawPackFiles(ctx, parsed.entries);
-  return { ...metadata, files, artifact };
+  try {
+    const files = await storeClawPackFiles(ctx, parsed.entries);
+    return { ...metadata, files, artifact };
+  } catch (error) {
+    // Extracted-file store failed after the tarball was already written.
+    await deleteUnpublishedPackagePublishBlobs(ctx, { artifact });
+    throw error;
+  }
 }
 
 function assertClawPackPublicationIdentity(
@@ -1630,11 +1667,26 @@ async function parseMultipartPackagePublish(
   }
 
   const packageFileParts = fileParts.filter((entry) => !isMacJunkPath(entry.name));
-  const files = await Promise.all(
-    packageFileParts.map((entry) => storeUploadedPackageFile(ctx, entry)),
-  );
-  if (files.length === 0) throw new Error("files required");
-  return { ...metadata, files };
+  const files: StoredPackagePublishFile[] = [];
+  try {
+    const results = await Promise.allSettled(
+      packageFileParts.map((entry) => storeUploadedPackageFile(ctx, entry)),
+    );
+    for (const result of results) {
+      if (result.status === "fulfilled") {
+        files.push(result.value);
+      }
+    }
+    const rejected = results.find((result) => result.status === "rejected");
+    if (rejected?.status === "rejected") {
+      throw rejected.reason;
+    }
+    if (files.length === 0) throw new Error("files required");
+    return { ...metadata, files };
+  } catch (error) {
+    await deleteUnpublishedPackagePublishBlobs(ctx, { files });
+    throw error;
+  }
 }
 
 async function listPackages(
@@ -2521,12 +2573,13 @@ export async function publishPackageV1Handler(ctx: ActionCtx, request: Request) 
   const auth = await requirePackagePublishAuthOrResponse(ctx, request, rate.headers);
   if (!auth.ok) return auth.response;
 
+  let payload: ServerPackagePublishRequest | undefined;
   try {
     const contentType = request.headers.get("content-type") ?? "";
     if (!contentType.includes("multipart/form-data")) {
       return text("Package publish requires multipart/form-data", 415, rate.headers);
     }
-    const payload = await parseMultipartPackagePublish(ctx, auth.auth, request);
+    payload = await parseMultipartPackagePublish(ctx, auth.auth, request);
     const result =
       auth.auth.kind === "user"
         ? await runActionRef(ctx, internalRefs.packages.publishPackageForUserInternal, {
@@ -2539,6 +2592,10 @@ export async function publishPackageV1Handler(ctx: ActionCtx, request: Request) 
           });
     return json(result, 200, rate.headers);
   } catch (error) {
+    // Parse succeeded, so these blobs have no release owner yet.
+    if (payload) {
+      await deleteUnpublishedPackagePublishBlobs(ctx, payload);
+    }
     return packagePublishErrorToResponse(error, rate.headers);
   }
 }

--- a/convex/httpApiV1/packagesV1.ts
+++ b/convex/httpApiV1/packagesV1.ts
@@ -1360,18 +1360,24 @@ const CLAWPACK_STORE_BATCH_FILES = 16;
 async function deleteUnpublishedPackagePublishBlobs(
   ctx: ActionCtx,
   stored: {
-    files?: Array<{ storageId: Id<"_storage"> }>;
-    artifact?: { storageId?: Id<"_storage"> } | null;
+    files?: Array<{ storageId: string }>;
+    artifact?: { storageId?: string } | null;
   },
 ) {
-  const storageIds: Array<Id<"_storage">> = [];
+  const remove = ctx.storage.delete?.bind(ctx.storage);
+  if (!remove) {
+    return;
+  }
+  const storageIds: string[] = [];
   for (const file of stored.files ?? []) {
     storageIds.push(file.storageId);
   }
   if (stored.artifact?.storageId) {
     storageIds.push(stored.artifact.storageId);
   }
-  await Promise.allSettled(storageIds.map((storageId) => ctx.storage.delete(storageId)));
+  await Promise.allSettled(
+    storageIds.map((storageId) => remove(storageId as Id<"_storage">)),
+  );
 }
 
 async function storeClawPackFiles(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users publishing a package through authenticated `POST /api/v1/packages` with `multipart/form-data` would leave Convex storage blobs behind when publish failed. The request stored the ClawPack tarball and extracted files, or the loose uploaded files, then validated name, version, account age, and owner. A 400 from that validation, or a later extracted-file store failure, never deleted those ids. The blobs were not attached to a package release, so they stayed billed and unreferenced.

## Why This Change Was Made

Multipart package publish now follows the same cleanup contract as skill-scan upload. File and artifact storage ids are tracked. If parse fails after any store, or if publish throws after parse succeeds, those ids are deleted with `Promise.allSettled` and `storage.delete`. A successful publish keeps the blobs. The existing HTTP 400 mapping is unchanged; cleanup runs first, then the same error response is returned.

## User Impact

Failed CLI or API package publishes no longer leave orphaned upload blobs in Convex storage. Successful publishes are unchanged.

## Evidence

Live `bun` on Windows, worktree `C:/Users/sebta/.grok/tmp/pr-gate-batch/clawhub-f007`. The script calls production `publishPackageV1Handler` with an in-memory storage stand-in. The old loop stores two loose files and never deletes them. The patched handler stores the same two ids and deletes both before returning 400. A ClawPack path that stores the tarball then fails on the first extracted-file store deletes the tarball id.

```console
$ bun /tmp/clawhub-f007-proof.mjs
before_error=GitHub account is too new to publish
before_stored=storage:before-1,storage:before-2 before_deleted=-
after_status=400 after_error=GitHub account is too new to publish
after_stored=storage:after-1,storage:after-2 after_deleted=storage:after-1,storage:after-2
store_count=2 delete_count=2
clawpack_status=400 clawpack_error=extracted store failed
clawpack_stored=storage:tarball clawpack_deleted=storage:tarball
```

The unpatched path leaves `storage:before-1,storage:before-2` with `before_deleted=-`. The patched path prints `after_deleted=storage:after-1,storage:after-2` and `clawpack_deleted=storage:tarball`.

## Real behavior proof

- **Behavior or issue addressed:** Failed multipart package publish now deletes Convex blobs that were stored before the request returned 400.
- **Real environment tested:** Windows, bun 1.4.1, worktree `C:/Users/sebta/.grok/tmp/pr-gate-batch/clawhub-f007` on `fix/package-publish-blob-cleanup`. Proof imported production `publishPackageV1Handler` from `convex/httpApiV1/packagesV1.ts`.
- **Exact steps or command run after this patch:** Ran `bun /tmp/clawhub-f007-proof.mjs`. The script posted a multipart package publish with two loose files, first through the old store-then-throw loop, then through production `publishPackageV1Handler`. It also posted a ClawPack where the tarball store succeeded and the next store failed.
- **Evidence after fix:** terminal output copied above. After the patch, `after_stored=storage:after-1,storage:after-2` and `after_deleted=storage:after-1,storage:after-2`. The ClawPack path stored `storage:tarball` and deleted `storage:tarball`. Before the patch, `before_stored=storage:before-1,storage:before-2` and `before_deleted=-`.
- **Observed result after fix:** An invalid multipart package publish now removes the blobs it stored. The old loop left those blobs unreferenced. A ClawPack whose extracted-file store fails now removes the tarball blob.
- **What was not tested:** A live clawhub.ai POST with a real API token. Successful publish retention of stored blobs on the hosted backend (local handler path keeps them when publish returns 200).

## Notes

Same cleanup contract as skill multipart in [#3549](https://github.com/openclaw/clawhub/pull/3549) and skill scan uploads in [#2479](https://github.com/openclaw/clawhub/pull/2479). Multipart package store-without-cleanup landed in [#2414](https://github.com/openclaw/clawhub/pull/2414) (2026-06-02, 95 days). The handler catch without delete dates to [#1093](https://github.com/openclaw/clawhub/pull/1093) (2026-03-20, 169 days).

Allow edits from maintainers is enabled.

## Tracker

Ref #3673

That issue stays open if this PR is closed without landing on main.
