### PR TITLE
fix(workers): disambiguate skill and plugin scan manifests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixes
 
+- Workers: scan plugin packages containing both skill and plugin manifests without ambiguous-target failures, preserving full-package scanning and bundled-skill paths.
 - CLI/API: recover failed staged plugin publications from their retained artifacts with `clawhub package recover`, fresh security checks, current publisher authorization, and preserved attempt history.
 - Tests: keep the Vitest localStorage shim working on Node 26, whose native `Storage` global has a non-configurable `length`, so `bun run ci:unit` passes on Node 24 and 26.
 - API/GitHub Actions: authorize human release recovery through v2 approval and the original child-bound parent receipt, fail automated attempts when their exact parent fails, and let admins preview or discard orphaned package publish attempts with a publisher-visible reason.

--- a/scripts/security/run-codex-scan-worker-clawscan.test.ts
+++ b/scripts/security/run-codex-scan-worker-clawscan.test.ts
@@ -474,6 +474,8 @@ JSON`,
     await mkdir(join(packageRoot, "skills", "alpha"), { recursive: true });
     await mkdir(join(packageRoot, "skills", "beta"), { recursive: true });
     await writeFile(join(packageRoot, "package.json"), "{}\n");
+    await writeFile(join(packageRoot, "openclaw.plugin.json"), '{"id":"demo-plugin"}\n');
+    await writeFile(join(packageRoot, "SKILL.md"), "# Bundled skill\n");
     await writeFile(join(packageRoot, "skills", "alpha", "SKILL.md"), "# alpha\n");
     await writeFile(join(packageRoot, "skills", "beta", "SKILL.md"), "# beta\n");
 
@@ -504,7 +506,8 @@ JSON`,
     const copiedFixture = join(workspace, "skillspector-fixture.json");
     await writeFakeClawScanCommand(
       fakeClawScan,
-      `out=""
+      `test "$1" = "./artifact/package/openclaw.plugin.json"
+out=""
 fixture=""
 while [[ $# -gt 0 ]]; do
   case "$1" in

--- a/scripts/security/run-codex-scan-worker.ts
+++ b/scripts/security/run-codex-scan-worker.ts
@@ -1,6 +1,6 @@
 import { spawn } from "node:child_process";
 import { mkdirSync, readFileSync } from "node:fs";
-import { appendFile, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { appendFile, lstat, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { basename, dirname, extname, join, resolve, sep } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -1500,7 +1500,7 @@ function bundledSkillRootsForJob(job: ClaimedJob) {
 
 export async function resolveBundledSkillSpectorScanInputs(workspace: string, job: ClaimedJob) {
   if (job.job.targetKind !== "packageRelease") return [];
-  const packageRoot = await resolveClawScanTarget(workspace, job);
+  const packageRoot = await resolveScanArtifactRoot(workspace, job);
   const artifactRoot = resolve(workspace, packageRoot);
   return bundledSkillRootsForJob(job)
     .map((rootPath) => {
@@ -2017,12 +2017,27 @@ export async function runClawScan(
   return mapped;
 }
 
-async function resolveClawScanTarget(workspace: string, job: ClaimedJob) {
+async function resolveScanArtifactRoot(workspace: string, job: ClaimedJob) {
   if (job.job.targetKind === "packageRelease") {
     const packageRoot = join(workspace, "artifact", "package");
     if (await fileExists(join(packageRoot, "package.json"))) return "./artifact/package";
   }
   return "./artifact";
+}
+
+export async function resolveClawScanTarget(workspace: string, job: ClaimedJob) {
+  const root = await resolveScanArtifactRoot(workspace, job);
+  const manifests = ["SKILL.md", "openclaw.plugin.json"];
+  const present = await Promise.all(
+    manifests.map(async (name) =>
+      (await lstat(join(workspace, root, name)).catch(() => null))?.isFile(),
+    ),
+  );
+  // ClawScan rejects dual-manifest directories. An explicit manifest selects the
+  // claimed kind while ClawScan still scans the entire dual-layout directory.
+  return present.every(Boolean)
+    ? `${root}/${manifests[job.job.targetKind === "packageRelease" ? 1 : 0]}`
+    : root;
 }
 
 export function scanHealthClassification(input: {

--- a/scripts/security/run-prepublication-worker.test.ts
+++ b/scripts/security/run-prepublication-worker.test.ts
@@ -787,10 +787,11 @@ describe("pre-publication worker", () => {
     expect(payload.clawscan.summary).toContain("Python bytecode");
   });
 
-  it("runs native ClawScan as the required non-shadow security gate", async () => {
+  it("runs the required skill scan with an explicit manifest for a dual-layout artifact", async () => {
     const workspace = await tempDir();
     await mkdir(join(workspace, "artifact"), { recursive: true });
     await writeFile(join(workspace, "artifact", "SKILL.md"), "# Demo\n");
+    await writeFile(join(workspace, "artifact", "openclaw.plugin.json"), '{"id":"demo"}\n');
     const fakeClawScan = join(workspace, "fake-clawscan");
     await writeFile(
       fakeClawScan,
@@ -864,7 +865,7 @@ JSON
       );
 
       const args = await readFile(join(workspace, "clawscan-args.txt"), "utf8");
-      expect(args).toContain("./artifact");
+      expect(args.split("\n")[0]).toBe("./artifact/SKILL.md");
       expect(args).toContain("--profile\nclawhub");
       expect(args).toContain("--output\n");
       expect(args).toContain("--sandbox\noff");
@@ -893,18 +894,23 @@ JSON
     }
   });
 
-  it("accepts package scans when the skill-only A.I.G scanner is skipped", async () => {
-    const workspace = await tempDir();
-    await mkdir(join(workspace, "artifact", "package"), { recursive: true });
-    await writeFile(
-      join(workspace, "artifact", "package", "package.json"),
-      '{"name":"demo-plugin"}\n',
-    );
-    const fakeClawScan = join(workspace, "fake-clawscan");
-    await writeFile(
-      fakeClawScan,
-      `#!/usr/bin/env bash
+  it.each(["./artifact", "./artifact/package"])(
+    "scans the plugin manifest in dual-layout package %s",
+    async (packageRoot) => {
+      const workspace = await tempDir();
+      await mkdir(join(workspace, packageRoot), { recursive: true });
+      await writeFile(join(workspace, packageRoot, "package.json"), '{"name":"demo-plugin"}\n');
+      await writeFile(
+        join(workspace, packageRoot, "openclaw.plugin.json"),
+        '{"id":"demo-plugin"}\n',
+      );
+      await writeFile(join(workspace, packageRoot, "SKILL.md"), "# Bundled skill\n");
+      const fakeClawScan = join(workspace, "fake-clawscan");
+      await writeFile(
+        fakeClawScan,
+        `#!/usr/bin/env bash
 set -euo pipefail
+test "$1" = "${packageRoot}/openclaw.plugin.json"
 output=""
 while [ "$#" -gt 0 ]; do
   if [ "$1" = "--output" ]; then
@@ -917,44 +923,45 @@ cat > "$output" <<'JSON'
 {"schemaVersion":"clawscan-run-v1","profile":"clawhub","scanners":{"aig":{"status":"skipped"},"clawscan-static":{"status":"completed"},"skillspector":{"status":"completed"}},"judge":{"status":"completed","result":{"verdict":"benign","confidence":"high","summary":"Native ClawScan passed."}}}
 JSON
 `,
-    );
-    await chmod(fakeClawScan, 0o755);
-    const previousCommand = process.env.PREPUBLICATION_CLAWSCAN_COMMAND;
-    process.env.PREPUBLICATION_CLAWSCAN_COMMAND = fakeClawScan;
+      );
+      await chmod(fakeClawScan, 0o755);
+      const previousCommand = process.env.PREPUBLICATION_CLAWSCAN_COMMAND;
+      process.env.PREPUBLICATION_CLAWSCAN_COMMAND = fakeClawScan;
 
-    try {
-      await expect(
-        runNativeClawScan(
-          {
-            job: {
-              _id: String(attempt.attemptId),
-              attempts: 1,
-              hasMaliciousSignal: false,
-              leaseToken: attempt.claimId,
-              source: "pre-publication",
-              targetKind: "packageRelease",
-              waitForVtUntil: 0,
+      try {
+        await expect(
+          runNativeClawScan(
+            {
+              job: {
+                _id: String(attempt.attemptId),
+                attempts: 1,
+                hasMaliciousSignal: false,
+                leaseToken: attempt.claimId,
+                source: "pre-publication",
+                targetKind: "packageRelease",
+                waitForVtUntil: 0,
+              },
+              target: {},
             },
-            target: {},
+            workspace,
+          ),
+        ).resolves.toEqual({
+          analysis: expect.objectContaining({
+            status: "clean",
+            verdict: "benign",
+          }),
+          aigAnalysis: undefined,
+          check: {
+            status: "clean",
+            summary: "Native ClawScan passed.",
           },
-          workspace,
-        ),
-      ).resolves.toEqual({
-        analysis: expect.objectContaining({
-          status: "clean",
-          verdict: "benign",
-        }),
-        aigAnalysis: undefined,
-        check: {
-          status: "clean",
-          summary: "Native ClawScan passed.",
-        },
-      });
-    } finally {
-      if (previousCommand === undefined) delete process.env.PREPUBLICATION_CLAWSCAN_COMMAND;
-      else process.env.PREPUBLICATION_CLAWSCAN_COMMAND = previousCommand;
-    }
-  });
+        });
+      } finally {
+        if (previousCommand === undefined) delete process.env.PREPUBLICATION_CLAWSCAN_COMMAND;
+        else process.env.PREPUBLICATION_CLAWSCAN_COMMAND = previousCommand;
+      }
+    },
+  );
 
   it("fails closed when a completed skill scan omits a required scanner", async () => {
     const workspace = await tempDir();

--- a/scripts/security/run-prepublication-worker.ts
+++ b/scripts/security/run-prepublication-worker.ts
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { basename, join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -17,6 +17,7 @@ import {
   assertAigFilePathsHaveNoCompiledPython,
   type ClaimedJob,
   normalizeAigAnalysis,
+  resolveClawScanTarget,
   type StoredLlmAnalysis,
   writeArtifactWorkspace,
 } from "./run-codex-scan-worker";
@@ -417,18 +418,6 @@ function clawScanCommand() {
   return process.env.PREPUBLICATION_CLAWSCAN_COMMAND?.trim() || "clawscan";
 }
 
-async function fileExists(path: string) {
-  return Boolean(await stat(path).catch(() => null));
-}
-
-async function resolveNativeClawScanTarget(workspace: string, job: ClaimedJob) {
-  if (job.job.targetKind === "packageRelease") {
-    const packageRoot = join(workspace, "artifact", "package");
-    if (await fileExists(join(packageRoot, "package.json"))) return "./artifact/package";
-  }
-  return "./artifact";
-}
-
 function asRecord(value: unknown): Record<string, unknown> | undefined {
   if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
   return value as Record<string, unknown>;
@@ -585,7 +574,7 @@ export async function runNativeClawScan(
   workspace: string,
 ): Promise<ClawScanResult> {
   const artifactPath = join(workspace, "clawscan-result.json");
-  const target = await resolveNativeClawScanTarget(workspace, job);
+  const target = await resolveClawScanTarget(workspace, job);
   if (job.job.targetKind !== "packageRelease") {
     assertAigFilePathsHaveNoCompiledPython(job.target.files?.map((file) => file.path) ?? []);
   }

--- a/specs/security-moderation.md
+++ b/specs/security-moderation.md
@@ -445,6 +445,10 @@ See also: [acceptable-usage.md](./acceptable-usage.md) for the marketplace polic
   target kind and source through the same completion/failure contract. Skill
   versions and scan requests use the isolated `artifact` root; extracted
   ClawPack releases use `artifact/package`.
+- Both workers disambiguate directories containing `SKILL.md` and
+  `openclaw.plugin.json` by selecting the manifest matching the claimed target
+  kind. ClawScan still scans the full directory. Single-manifest directory
+  scans and the separate bundled-SkillSpector directory base remain unchanged.
 - OSS ClawScan is the only security-scan implementation. Every claimed target
   kind and source runs through the same ClawScan profile and completion/failure
   contract. ClawScan failures use the existing failure/retry lifecycle; there


### PR DESCRIPTION
## What Problem This Solves

A plugin containing both `SKILL.md` and `openclaw.plugin.json` never completes ClawScan: both workers pass its directory, and ClawScan rejects the ambiguous target before producing a verdict. This was observed while recovering the staged Lobster 2026.9.2 release.

## Why This Change Was Made

Both workers now share target selection. When both regular manifests exist, the claimed target kind selects the explicit plugin or skill manifest. Ordinary single-manifest directory scans retain their behavior. Bundled SkillSpector continues to resolve its directory separately, so skill paths do not become children of a manifest filename. The duplicate prepublication resolver is removed; scanner requirements, artifact bytes, credentials, verdict mapping and retry policy are unchanged.

## Evidence

- Four regression cases failed on the previous source and passed after repair: skill dual-layout, flat plugin dual-layout, npm-pack plugin dual-layout, and postpublication plugin scanning with bundled-skill paths preserved. All 64 focused worker tests pass.
- Full unit coverage: 6,492 passed, three skipped. Static and application/Convex/schema/CLI type/build gates passed. Independent review is clean through P2.
- Exact released ClawScan 0.1.7 binary proof, with verified npm integrity and benign synthetic files: the directory exits 1 with the observed ambiguity error; explicit plugin and skill manifest inputs both exit 0. Both completed static scans include `SKILL.md`, `openclaw.plugin.json` and adjacent `index.js`, with no omitted files. This proof invokes no provider or judge and does not claim a security verdict.
- Upstream source contract: [`target.go`](https://github.com/openclaw/clawscan/blob/6432c40f23404595f4203f1762ae07d67c481067/internal/runner/target.go#L116) expands explicit dual-layout manifests back to the full directory; [`target_test.go`](https://github.com/openclaw/clawscan/blob/6432c40f23404595f4203f1762ae07d67c481067/internal/runner/target_test.go#L165) covers ambiguous directories and both selections.

Production/tooling delta: +4 net lines after removing the duplicate resolver; test delta: +10 net lines; documentation: +5. The four production lines add dependency-required disambiguation while preserving the separate scan-root contract. Production verification is complete: a new audited recovery over Lobster’s same retained release passed the actual scanners with the merged worker and reached published status. Its public artifact SHA-256 remains `ee0bea5ff4ddf2c7361bc5a8080943ec288f6e4d7e6202bdd66c5e67284ca1f8`. [All 89 public artifact checks](https://github.com/openclaw/openclaw/releases/download/v2026.9.2/openclaw-2026.9.2-publication-supplement.json) passed. No artifact republish or scanner bypass was used. Hosted CI passed on attempt 2 after the unrelated local Convex isolate initialization failure; main CI also passed.

## Inspectable released-binary evidence

The following is observed output from the exact npm 0.1.7 native binary, not the worker test executable. Only the disposable absolute directory has been replaced with `<fixture-dir>`. The tarball SHA-512 was independently checked against the published npm integrity. These are benign fixtures; no provider credentials or judge were used.

```text
clawscan ./fixture --scanner clawscan-static --output ambiguous.json
exit 1: target ./fixture contains both SKILL.md and openclaw.plugin.json; point Clawscan directly at the desired manifest
clawscan ./fixture/openclaw.plugin.json --scanner clawscan-static --output plugin.json
exit 0
clawscan ./fixture/SKILL.md --scanner clawscan-static --output skill.json
exit 0
```

<details>
<summary>Actual plugin scan artifact (absolute fixture path redacted)</summary>

```json
{
  "schemaVersion": "clawscan-run-v1",
  "configSource": null,
  "target": {
    "kind": "plugin",
    "input": "./fixture/openclaw.plugin.json",
    "resolvedPath": "<fixture-dir>",
    "id": "manifest-selection-proof"
  },
  "startedAt": "2026-09-06T01:14:05.951448Z",
  "completedAt": "2026-09-06T01:14:05.97422Z",
  "env": {},
  "sandbox": {
    "mode": "docker",
    "image": "ghcr.io/openclaw/clawscan-runtime:latest",
    "network": "on"
  },
  "scanners": {
    "clawscan-static": {
      "status": "completed",
      "startedAt": "2026-09-06T01:14:05.9515Z",
      "completedAt": "2026-09-06T01:14:05.974216Z",
      "durationMs": 22,
      "command": [
        "clawscan-static",
        "<fixture-dir>"
      ],
      "error": "",
      "outputPath": "plugin/fixture/openclaw-plugin-json/clawscan-static.json",
      "raw": {
        "schemaVersion": "clawscan-static-v1",
        "scanner": {
          "id": "clawscan-static",
          "name": "ClawScan built-in static scanner",
          "version": "clawscan-static-v1",
          "rules": [
            {
              "id": "static.prompt_injection",
              "description": "Looks for direct attempts to override prior instructions.",
              "severity": "medium"
            },
            {
              "id": "static.credential_exfiltration",
              "description": "Looks for language that asks an agent to leak or exfiltrate credentials.",
              "severity": "high"
            },
            {
              "id": "static.pipe_to_shell",
              "description": "Looks for curl or wget output piped directly into a shell.",
              "severity": "medium"
            },
            {
              "id": "static.destructive_shell",
              "description": "Looks for destructive recursive removal of the filesystem root.",
              "severity": "high"
            },
            {
              "id": "static.python_process_execution",
              "description": "Looks for Python APIs that execute shell commands or child processes.",
              "severity": "high"
            },
            {
              "id": "static.python_bytecode",
              "description": "Flags precompiled Python bytecode that can execute without reviewable source.",
              "severity": "high"
            },
            {
              "id": "static.nul_byte_in_text",
              "description": "Flags NUL bytes that can disguise executable or policy-relevant content as an opaque binary.",
              "severity": "high"
            },
            {
              "id": "static.opaque_binary",
              "description": "Surfaces opaque binary content that cannot be inspected by text rules.",
              "severity": "low"
            }
          ]
        },
        "files": {
          "scanned": [
            {
              "path": "SKILL.md",
              "bytes": 124,
              "sha256": "7d12b68f49305716eec9da97cdb1fdd76a16e61d96e0dddbc2a18896d910202e"
            },
            {
              "path": "openclaw.plugin.json",
              "bytes": 34,
              "sha256": "d979a10cf6b055c2fac4289fd86c4c6335887f7af38a1a6322f80c80efdc1e3f"
            },
            {
              "path": "index.js",
              "bytes": 56,
              "sha256": "f5f7575661e70ee7041264b6e20e2fccfc0e76f32bfaaade13763a1e3ef5ed4f"
            }
          ],
          "omitted": [],
          "totalScannedBytes": 214,
          "totalOmittedBytes": 0,
          "suppressedScanned": 0,
          "suppressedOmitted": 0
        },
        "findings": []
      }
    }
  },
  "gate": "pass",
  "gateRules": [],
  "judge": null
}
```

</details>

<details>
<summary>Actual skill scan artifact (absolute fixture path redacted)</summary>

```json
{
  "schemaVersion": "clawscan-run-v1",
  "configSource": null,
  "target": {
    "kind": "skill",
    "input": "./fixture/SKILL.md",
    "resolvedPath": "<fixture-dir>"
  },
  "startedAt": "2026-09-06T01:14:06.030266Z",
  "completedAt": "2026-09-06T01:14:06.032576Z",
  "env": {},
  "sandbox": {
    "mode": "docker",
    "image": "ghcr.io/openclaw/clawscan-runtime:latest",
    "network": "on"
  },
  "scanners": {
    "clawscan-static": {
      "status": "completed",
      "startedAt": "2026-09-06T01:14:06.030278Z",
      "completedAt": "2026-09-06T01:14:06.032573Z",
      "durationMs": 2,
      "command": [
        "clawscan-static",
        "<fixture-dir>"
      ],
      "error": "",
      "outputPath": "skill/fixture/skill-md/clawscan-static.json",
      "raw": {
        "schemaVersion": "clawscan-static-v1",
        "scanner": {
          "id": "clawscan-static",
          "name": "ClawScan built-in static scanner",
          "version": "clawscan-static-v1",
          "rules": [
            {
              "id": "static.prompt_injection",
              "description": "Looks for direct attempts to override prior instructions.",
              "severity": "medium"
            },
            {
              "id": "static.credential_exfiltration",
              "description": "Looks for language that asks an agent to leak or exfiltrate credentials.",
              "severity": "high"
            },
            {
              "id": "static.pipe_to_shell",
              "description": "Looks for curl or wget output piped directly into a shell.",
              "severity": "medium"
            },
            {
              "id": "static.destructive_shell",
              "description": "Looks for destructive recursive removal of the filesystem root.",
              "severity": "high"
            },
            {
              "id": "static.python_process_execution",
              "description": "Looks for Python APIs that execute shell commands or child processes.",
              "severity": "high"
            },
            {
              "id": "static.python_bytecode",
              "description": "Flags precompiled Python bytecode that can execute without reviewable source.",
              "severity": "high"
            },
            {
              "id": "static.nul_byte_in_text",
              "description": "Flags NUL bytes that can disguise executable or policy-relevant content as an opaque binary.",
              "severity": "high"
            },
            {
              "id": "static.opaque_binary",
              "description": "Surfaces opaque binary content that cannot be inspected by text rules.",
              "severity": "low"
            }
          ]
        },
        "files": {
          "scanned": [
            {
              "path": "SKILL.md",
              "bytes": 124,
              "sha256": "7d12b68f49305716eec9da97cdb1fdd76a16e61d96e0dddbc2a18896d910202e"
            },
            {
              "path": "openclaw.plugin.json",
              "bytes": 34,
              "sha256": "d979a10cf6b055c2fac4289fd86c4c6335887f7af38a1a6322f80c80efdc1e3f"
            },
            {
              "path": "index.js",
              "bytes": 56,
              "sha256": "f5f7575661e70ee7041264b6e20e2fccfc0e76f32bfaaade13763a1e3ef5ed4f"
            }
          ],
          "omitted": [],
          "totalScannedBytes": 214,
          "totalOmittedBytes": 0,
          "suppressedScanned": 0,
          "suppressedOmitted": 0
        },
        "findings": []
      }
    }
  },
  "gate": "pass",
  "gateRules": [],
  "judge": null
}
```

</details>

The tagged public upstream source was also inspected directly at `6432c40f23404595f4203f1762ae07d67c481067` (`v0.1.7`). Its `resolveTarget` expansion is:

```go
	if kind == targetKindPlugin ||
		(kind == targetKindSkill && sameManifestFile(resolved, skillManifestName) &&
			regularManifestExists(filepath.Join(filepath.Dir(resolved), pluginManifestName))) {
		if info, err := os.Stat(resolved); err == nil && !info.IsDir() {
			resolved = filepath.Dir(resolved)
		}
	}
```

This addresses the review’s inspectable-evidence and full-directory-contract requests, including its rank-up move. The CI moderation browser retry is on the unchanged commit after a local Convex isolate initialization error; no test assertions were weakened.

