### PR TITLE
docs: fix two anchors that break on the published site

### DIFF
--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -257,7 +257,7 @@ security checks, and preserves the failed attempt and original authorization
 as audit history. Current token or publisher-access revocation still blocks
 publication. It cannot override moderation or revive an active attempt.
 Without `--wait`, the result is explicitly pending. The equivalent HTTP route is
-[`POST /api/v1/publish/attempts/{id}/recover`](http-api.md#post-apiv1publishattemptsidrecover).
+[`POST /api/v1/publish/attempts/{id}/recover`](http-api.md#post-%2Fapi%2Fv1%2Fpublish%2Fattempts%2F%7Bid%7D%2Frecover).
 
 Operators can preview orphaned package attempts, supplying an exact `version`,
 optional `slugPrefix` or `attemptIds`, and a `reason`:
@@ -299,7 +299,7 @@ Package transfers require admin access to both the current owner and the
 destination publisher, unless performed by a platform admin. Use `--to <owner>`
 to select an existing, active destination publisher. Scoped package names can
 transfer only to the publisher matching their scope. See
-[`package transfer`](./cli.md#package-transfer-name) for details.
+[`package transfer`](./cli.md#package-transfer-%3Cname%3E) for details.
 
 Skills use the separate [ownership transfer workflow](./cli.md#transfer).
 Transfers to another user normally require recipient acceptance.


### PR DESCRIPTION
## What

Updates two intra-doc anchors in `docs/publishing.md`.

## Why

Both links work on GitHub and 404 on docs.openclaw.ai. The two renderers slug headings differently: OpenClaw's publishing parser (`scripts/lib/docs-markdown.mjs` in openclaw/openclaw) **percent-encodes** punctuation where GitHub strips it.

| Heading | Anchor the published site generates | Anchor the link used |
|---|---|---|
| `POST /api/v1/publish/attempts/{id}/recover` | `post-%2Fapi%2Fv1%2Fpublish%2Fattempts%2F%7Bid%7D%2Frecover` | `post-apiv1publishattemptsidrecover` |
| `package transfer <name>` | `package-transfer-%3Cname%3E` | `package-transfer-name` |

The old forms exist in neither renderer's id set for these headings, which is why this stays invisible when previewing on GitHub.

## Validation

Ran OpenClaw's own anchor checker against this working tree via `OPENCLAW_DOCS_SYNC_CLAWHUB_REPO`:

```
pnpm docs:check-links:anchors
# before: checked_internal_links=8622  broken_links=2   (both in publishing.md)
# after:  checked_internal_links=8622  broken_links=0
```

Found while running the OpenClaw docs validators during a documentation audit. These were the only two broken fragments in the entire published tree.