### PR TITLE
fix(packages): reclaim unadopted legacy ZIPs

### DIFF
--- a/convex/packages.public.test.ts
+++ b/convex/packages.public.test.ts
@@ -12434,6 +12434,185 @@ describe("packages public queries", () => {
     expect(runMutation).not.toHaveBeenCalled();
   });
 
+  it("does not leave a legacy zip blob when staged publish rejects a duplicate version", async () => {
+    const previousFlag = process.env.CLAWHUB_STAGED_PREPUBLICATION_PUBLISHES;
+    process.env.CLAWHUB_STAGED_PREPUBLICATION_PUBLISHES = "1";
+    const storedIds: string[] = [];
+    const deletedIds: string[] = [];
+    const runMutation = vi.fn(async () => {
+      throw new Error("duplicate publish should not create an attempt");
+    });
+    const trustedPublisher = {
+      _id: "packageTrustedPublishers:1",
+      packageId: "packages:demo",
+      provider: "github-actions",
+      repository: "example/example",
+      repositoryId: "1",
+      repositoryOwner: "example",
+      repositoryOwnerId: "2",
+      workflowFilename: "plugin-clawhub-release.yml",
+      environment: "clawhub-release",
+    };
+    const ctx = {
+      runQuery: vi
+        .fn()
+        .mockResolvedValueOnce({
+          _id: "packagePublishTokens:1",
+          packageId: "packages:demo",
+          provider: "github-actions",
+          repository: "example/example",
+          repositoryId: "1",
+          repositoryOwner: "example",
+          repositoryOwnerId: "2",
+          workflowFilename: "plugin-clawhub-release.yml",
+          environment: "clawhub-release",
+          version: "1.0.0",
+          sha: "abc123",
+          ref: "refs/heads/main",
+          runId: "100",
+          runAttempt: "1",
+          expiresAt: Date.now() + 60_000,
+        })
+        .mockResolvedValueOnce(trustedPublisher)
+        .mockResolvedValueOnce(makePackageDoc({ family: "bundle-plugin" }))
+        .mockResolvedValueOnce(trustedPublisher)
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce({
+          attemptId: "publishAttempts:secret-blocked",
+          status: "blocked",
+        }),
+      runMutation,
+      runAction: makePublishRunActionMock(),
+      scheduler: {
+        runAfter: vi.fn(),
+      },
+      storage: {
+        ...makePackageManifestStorage(),
+        store: vi.fn(async () => {
+          storedIds.push("storage:legacy-zip");
+          return "storage:legacy-zip";
+        }),
+        delete: vi.fn(async (storageId: string) => {
+          deletedIds.push(storageId);
+        }),
+      },
+    };
+
+    try {
+      await expect(
+        publishPackageForTrustedPublisherInternalHandler(ctx as never, {
+          publishTokenId: "packagePublishTokens:1",
+          payload: {
+            name: "demo-plugin",
+            family: "bundle-plugin",
+            version: "1.0.0",
+            changelog: "duplicate",
+            bundle: { hostTargets: ["desktop"] },
+            files: [packageManifestFile],
+          },
+        }),
+      ).rejects.toThrow(
+        "Version 1.0.0 already exists. Increment the version number and try again.",
+      );
+    } finally {
+      if (previousFlag === undefined) {
+        delete process.env.CLAWHUB_STAGED_PREPUBLICATION_PUBLISHES;
+      } else {
+        process.env.CLAWHUB_STAGED_PREPUBLICATION_PUBLISHES = previousFlag;
+      }
+    }
+
+    expect(runMutation).not.toHaveBeenCalled();
+    expect(storedIds.filter((storageId) => !deletedIds.includes(storageId))).toEqual([]);
+  });
+
+  it("deletes a newly stored legacy zip when release insert fails", async () => {
+    const storedIds: string[] = [];
+    const deletedIds: string[] = [];
+    const runMutation = vi.fn(async (_ref: unknown, args: unknown) => {
+      if (
+        typeof args === "object" &&
+        args !== null &&
+        "name" in args &&
+        "version" in args &&
+        "files" in args
+      ) {
+        throw new Error(
+          "Version 1.0.0 already exists. Increment the version number and try again.",
+        );
+      }
+      return null;
+    });
+    const trustedPublisher = {
+      _id: "packageTrustedPublishers:1",
+      packageId: "packages:demo",
+      provider: "github-actions",
+      repository: "example/example",
+      repositoryId: "1",
+      repositoryOwner: "example",
+      repositoryOwnerId: "2",
+      workflowFilename: "plugin-clawhub-release.yml",
+      environment: "clawhub-release",
+    };
+    const ctx = {
+      runQuery: vi
+        .fn()
+        .mockResolvedValueOnce({
+          _id: "packagePublishTokens:1",
+          packageId: "packages:demo",
+          provider: "github-actions",
+          repository: "example/example",
+          repositoryId: "1",
+          repositoryOwner: "example",
+          repositoryOwnerId: "2",
+          workflowFilename: "plugin-clawhub-release.yml",
+          environment: "clawhub-release",
+          version: "1.0.0",
+          sha: "abc123",
+          ref: "refs/heads/main",
+          runId: "100",
+          runAttempt: "1",
+          expiresAt: Date.now() + 60_000,
+        })
+        .mockResolvedValueOnce(trustedPublisher)
+        .mockResolvedValueOnce(makePackageDoc({ family: "bundle-plugin" }))
+        .mockResolvedValueOnce(trustedPublisher)
+        .mockResolvedValueOnce(null),
+      runMutation,
+      runAction: makePublishRunActionMock(),
+      scheduler: {
+        runAfter: vi.fn(),
+      },
+      storage: {
+        ...makePackageManifestStorage(),
+        store: vi.fn(async () => {
+          storedIds.push("storage:legacy-zip");
+          return "storage:legacy-zip";
+        }),
+        delete: vi.fn(async (storageId: string) => {
+          deletedIds.push(storageId);
+        }),
+      },
+    };
+
+    await expect(
+      publishPackageForTrustedPublisherInternalHandler(ctx as never, {
+        publishTokenId: "packagePublishTokens:1",
+        payload: {
+          name: "demo-plugin",
+          family: "bundle-plugin",
+          version: "1.0.0",
+          changelog: "duplicate",
+          bundle: { hostTargets: ["desktop"] },
+          files: [packageManifestFile],
+        },
+      }),
+    ).rejects.toThrow("Version 1.0.0 already exists. Increment the version number and try again.");
+
+    expect(storedIds).toEqual(["storage:legacy-zip"]);
+    expect(deletedIds).toEqual(["storage:legacy-zip"]);
+  });
+
   it("accepts trusted publish tokens when no environment is pinned", async () => {
     const runMutation = vi.fn(async (_ref: unknown, args: unknown) => {
       if (

--- a/convex/packages.ts
+++ b/convex/packages.ts
@@ -8964,21 +8964,6 @@ async function publishPackageImpl(
           files: await withSkillMarkdownTextsForManifestSummary(ctx, files),
         });
 
-  const legacyZipStorageId =
-    payload.artifact?.kind === "npm-pack"
-      ? undefined
-      : await ctx.storage.store(
-          new Blob(
-            [
-              legacyZipBytes.buffer.slice(
-                legacyZipBytes.byteOffset,
-                legacyZipBytes.byteOffset + legacyZipBytes.byteLength,
-              ) as ArrayBuffer,
-            ],
-            { type: "application/zip" },
-          ),
-        );
-
   const packageInsertArgs = {
     actorUserId,
     ownerUserId,
@@ -9004,8 +8989,7 @@ async function publishPackageImpl(
     integritySha256,
     sha256hash: legacyZipSha256,
     artifactKind: payload.artifact?.kind ?? "legacy-zip",
-    clawpackStorageId:
-      (payload.artifact?.storageId as Id<"_storage"> | undefined) ?? legacyZipStorageId,
+    clawpackStorageId: payload.artifact?.storageId as Id<"_storage"> | undefined,
     clawpackSha256: payload.artifact?.sha256 ?? legacyZipSha256,
     clawpackSize: payload.artifact?.size ?? legacyZipBytes.byteLength,
     clawpackFormat: payload.artifact?.format,
@@ -9025,6 +9009,38 @@ async function publishPackageImpl(
     source: effectiveSource,
     trustedPublishTokenId: auth.kind === "github-actions" ? auth.publishToken._id : undefined,
     trustedPublishInventoryDigest: auth.kind === "github-actions" ? inventoryDigest : undefined,
+  };
+  // Store the zip only when a release row will own it; delete if insert fails first.
+  const storeLegacyZipIfNeeded = async () => {
+    if (payload.artifact?.kind === "npm-pack" || packageInsertArgs.clawpackStorageId) {
+      return undefined;
+    }
+    const legacyZipStorageId = await ctx.storage.store(
+      new Blob(
+        [
+          legacyZipBytes.buffer.slice(
+            legacyZipBytes.byteOffset,
+            legacyZipBytes.byteOffset + legacyZipBytes.byteLength,
+          ) as ArrayBuffer,
+        ],
+        { type: "application/zip" },
+      ),
+    );
+    packageInsertArgs.clawpackStorageId = legacyZipStorageId;
+    return legacyZipStorageId;
+  };
+  const insertReleaseOwningLegacyZip = async <TResult>(
+    insert: () => Promise<TResult>,
+  ): Promise<TResult> => {
+    const legacyZipStorageId = await storeLegacyZipIfNeeded();
+    try {
+      return await insert();
+    } catch (error) {
+      if (legacyZipStorageId) {
+        await ctx.storage.delete(legacyZipStorageId).catch(() => undefined);
+      }
+      throw error;
+    }
   };
   const publishedArtifactSha256 = family === "claw" ? packageInsertArgs.clawpackSha256 : undefined;
   const attemptArtifactFingerprint = publishedArtifactSha256 ?? integritySha256;
@@ -9164,16 +9180,18 @@ async function publishPackageImpl(
       version,
       inventoryDigest,
     });
-    const pendingResult = await runMutationRef<{
-      ok: true;
-      packageId: Id<"packages">;
-      releaseId: Id<"packageReleases">;
-      publicationStatus?: "pending" | "published";
-      createdNewParent?: boolean;
-    }>(ctx, internalRefs.packages.insertReleaseInternal, {
-      ...packageInsertArgs,
-      publicationStatus: "pending",
-    });
+    const pendingResult = await insertReleaseOwningLegacyZip(() =>
+      runMutationRef<{
+        ok: true;
+        packageId: Id<"packages">;
+        releaseId: Id<"packageReleases">;
+        publicationStatus?: "pending" | "published";
+        createdNewParent?: boolean;
+      }>(ctx, internalRefs.packages.insertReleaseInternal, {
+        ...packageInsertArgs,
+        publicationStatus: "pending",
+      }),
+    );
 
     const staged = await runMutationRef<{
       attemptId: Id<"publishAttempts">;
@@ -9283,11 +9301,13 @@ async function publishPackageImpl(
     version,
     inventoryDigest,
   });
-  const publishResult = await runMutationRef<{
-    ok: true;
-    packageId: Id<"packages">;
-    releaseId: Id<"packageReleases">;
-  }>(ctx, internalRefs.packages.insertReleaseInternal, packageInsertArgs);
+  const publishResult = await insertReleaseOwningLegacyZip(() =>
+    runMutationRef<{
+      ok: true;
+      packageId: Id<"packages">;
+      releaseId: Id<"packageReleases">;
+    }>(ctx, internalRefs.packages.insertReleaseInternal, packageInsertArgs),
+  );
   if (inspectorResult?.warnings.length) {
     const insertFindingsResult = await runMutationRef<{
       ok: true;


### PR DESCRIPTION
Rejected package publications could leave generated ZIPs that no release owned. Trusted idempotent retries could also return an existing release successfully while leaking a newly generated ZIP. This change delays allocation until insertion and reclaims only generated ZIPs that the release does not adopt. Committed archives and caller-supplied artifacts remain available after later failures.

Closes #3677.

The insertion result identifies reuse internally; publication and legacy finalization remove that marker before returning their public result. Concurrent pending insertions reject safely, while valid staged retries retain the existing attempt path. The existing plugin plan documents the ownership boundary.

### Before/after proof

Used anonymous local Convex 1.44.0 at `http://127.0.0.1:3460` / `:3461`: real stored files, publisher/token/package/release rows, publication actions, insertion mutations, and HTTP downloads. No mocked storage or action context.

| Case | Before | After |
| --- | --- | --- |
| Rejected direct insertion | One orphan ZIP | Zero new blobs |
| Rejected staged duplicate | One orphan ZIP | Zero new blobs; allocation avoided |
| Trusted retry reuses existing release | Original patch leaks another 923-byte ZIP | Zero new blobs; same release/archive; original ZIP remains HTTP 200/923 bytes |
| Successful direct/staged publication | Archive retained | Archive retained and downloadable |
| Downstream error after commit | Adopted archive retained | Adopted archive retained and downloadable |
| Caller-supplied tarball on success/duplicate | Tarball retained | Same storage ID/hash; storage set unchanged |
| Concurrent pending insertion finds existing row | Focused baseline returns reused row | Actual mutation rejects; storage/release/attempt state unchanged |
| Pending release has no check attempt | Existing cleanup/retry path | Real orphan is removed; fresh upload of the same package/version creates a new pending release and attempt |

The core baseline is main `a230dae1b7`; the retry baseline is the original patch integrated with main `0ef3e59e53`. The downstream-error case deliberately injects a local-only error into the scan-enqueue mutation after the actual release commit. This is fault-injection evidence, not a production incident. All temporary fixture/injection changes were removed before validation.

### Validation

- Four new regressions fail before repair; all 379 focused package tests pass after.
- `bun run ci:static`, `bun run ci:unit` (6,951 passed, 3 skipped), `bun run ci:packages`, and `bun run ci:types-build` pass.
- Explicit schema, CLI, and Convex `tsc --noEmit` checks pass; the clean function set pushes to the disposable runtime with typechecking enabled.
- Independent source review found no actionable issues. Full-branch autoreview raised one orphan-recovery concern; it was rejected after the native recovery case above and confirmation that the relevant cleanup branch is byte-identical to main. No accepted/actionable findings remain.

Contributor history is preserved with a normal merge from main. Current-head hosted checks must pass before landing.
