### PR TITLE
fix: preserve literal multipart metadata when publishing with Bun

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixes
 
+- CLI: preserve literal multipart text when publishing with Bun, including semicolons in JSON metadata and values beginning with `@` or `<`, without changing uploaded file bytes.
 - Workers: scan plugin packages containing both skill and plugin manifests without ambiguous-target failures, preserving full-package scanning and bundled-skill paths.
 - CLI/API: recover failed staged plugin publications from their retained artifacts with `clawhub package recover`, fresh security checks, current publisher authorization, and preserved attempt history.
 - Tests: keep the Vitest localStorage shim working on Node 26, whose native `Storage` global has a non-configurable `length`, so `bun run ci:unit` passes on Node 24 and 26.

--- a/packages/clawhub/src/http.bun.test.ts
+++ b/packages/clawhub/src/http.bun.test.ts
@@ -1,5 +1,7 @@
 /* @vitest-environment node */
 
+import { once } from "node:events";
+import { Worker } from "node:worker_threads";
 import { describe, expect, it, vi } from "vitest";
 import { createHttpClient } from "./http.js";
 
@@ -55,6 +57,49 @@ function createBunClient(options?: {
 }
 
 describe("bun http client", () => {
+  it("preserves literal multipart fields and file bytes through real curl", async ({ signal }) => {
+    // curl blocks this thread; the loopback receiver must run independently.
+    const receiver = new Worker(
+      `const { createServer } = require('node:http');
+       const { parentPort } = require('node:worker_threads');
+       const server = createServer(async (req, res) => {
+         const chunks = [];
+         for await (const chunk of req) chunks.push(chunk);
+         const form = await new Request('http://localhost/', {
+           method: 'POST', headers: req.headers, body: Buffer.concat(chunks)
+         }).formData();
+         const file = form.get('file');
+         res.setHeader('content-type', 'application/json');
+         res.end(JSON.stringify({ payload: form.get('payload'), file: await file.text() }));
+       });
+       server.listen(0, '127.0.0.1', () => parentPort.postMessage(server.address().port));`,
+      { eval: true },
+    );
+    try {
+      const [port] = await once(receiver, "message", { signal });
+      const client = createHttpClient({ runtime: "bun", configureDispatcher: false });
+      for (const payload of [
+        JSON.stringify({ manualOverrideReason: "Retry publication; retain original artifacts" }),
+        "@literal-not-a-file",
+        "<literal-not-a-file",
+      ]) {
+        const form = new FormData();
+        form.append("payload", payload);
+        form.append("file", new Blob(["unchanged file bytes"]), "fixture.txt");
+        await expect(
+          client.apiRequestForm(`http://127.0.0.1:${port}`, {
+            method: "POST",
+            path: "/upload",
+            form,
+            retryCount: 0,
+          }),
+        ).resolves.toEqual({ payload, file: "unchanged file bytes" });
+      }
+    } finally {
+      await receiver.terminate();
+    }
+  });
+
   it("uses curl for apiRequest GET and POST", async () => {
     const { client, spawnImpl } = createBunClient({
       spawnImpl: () => ({ status: 0, stdout: '{"ok":true}\n200', stderr: "" }),

--- a/packages/clawhub/src/http.ts
+++ b/packages/clawhub/src/http.ts
@@ -811,7 +811,7 @@ async function fetchJsonFormViaCurl(
         await deps.writeFileImpl(filePath, bytes);
         formArgs.push("-F", `${key}=@${filePath};filename=${filename}`);
       } else {
-        formArgs.push("-F", `${key}=${value}`);
+        formArgs.push("--form-string", `${key}=${value}`);
       }
     }
 

--- a/specs/package-publish-tooling-identity.md
+++ b/specs/package-publish-tooling-identity.md
@@ -219,6 +219,11 @@ requires v2, including the pre-cutover reusable-workflow revision. The only
 non-v2 OpenClaw route is a directly authenticated ClawHub user supplying an
 explicit manual override.
 
+The CLI must transmit multipart metadata as literal text, including JSON
+containing semicolons and strings beginning with `@` or `<`. Curl's form syntax
+applies only to actual file parts; scalar fields must not become file reads or
+lose text. The upload transport must preserve both metadata and artifact bytes.
+
 OpenClaw must add the v2 identity, post-dispatch parent receipt, package
 inventory list, and child inputs before this server gate is deployed. The v2 child must
 accept the staged response instead of waiting inline for publication, so the


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users publishing with Bun would submit truncated JSON metadata when a text field contained a semicolon. Literal values beginning with `@` or `<` could also be interpreted as curl file-input syntax instead of text.

## Why This Change Was Made

Send scalar multipart fields with curl's `--form-string`. Actual file parts keep their existing upload path. The transport contract and changelog now record literal metadata preservation.

## User Impact

Publish reasons and other multipart metadata retain their full text, while uploaded artifact bytes remain unchanged. Server authorization and publication checks are unaffected.

## Evidence

A real curl request to an independent loopback HTTP receiver reproduced the defect before the fix: `{"manualOverrideReason":"Retry publication; retain original artifacts"}` arrived truncated at the semicolon, while the file contents were intact. After the fix, the same regression preserves the full JSON, leading `@`/`<` strings, and uploaded file contents.

- Focused Node/Bun HTTP suites: 28 tests passed; pre-fix regression failed for the intended truncation.
- `bun run ci:static`: passed.
- `bun run ci:unit`: 6,492 passed, 3 skipped; coverage passed.
- `bun run ci:packages`: CLI source/artifact and admin verification passed.
- Explicit schema and CLI TypeScript `--noEmit`: passed.
- Structured code review: no actionable findings.

No production deployment or CLI npm release is included.
