### PR TITLE
feat: inventory curated company plugin sources

### DIFF
--- a/convex/lib/githubImport.ts
+++ b/convex/lib/githubImport.ts
@@ -229,7 +229,7 @@ export function stripGitHubZipRoot(entries: ZipEntryMap): ZipEntryMap {
   if (!firstRoot) return entries;
   const prefix = `${firstRoot}/`;
   if (!paths.every((path) => path.startsWith(prefix))) return entries;
-  const out: ZipEntryMap = {};
+  const out: ZipEntryMap = Object.create(null);
   for (const [path, data] of Object.entries(entries)) {
     const stripped = path.slice(prefix.length);
     if (!stripped) continue;

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "lint:oxlint": "oxlint --type-aware --tsconfig ./tsconfig.oxlint.json ./src ./convex ./packages/clawhub/src ./packages/clawhub-admin/src ./packages/schema/src",
     "llms:check": "bun scripts/generate-llms-txt.ts --check",
     "llms:generate": "bun scripts/generate-llms-txt.ts",
+    "plugins:inventory": "bun scripts/company-plugins/cli.ts",
     "preinstall": "bunx --bun only-allow@1.2.2 bun",
     "preview": "bun --bun vite preview",
     "proof:publish": "node scripts/ui-proof-publish.mjs",

--- a/scripts/company-plugins/capabilities.ts
+++ b/scripts/company-plugins/capabilities.ts
@@ -1,0 +1,109 @@
+type Json = Record<string, unknown>;
+const roots: Record<string, string[]> = {
+  skills: ["skills"],
+  mcpServers: [".mcp.json", "mcp.json"],
+  settings: ["settings.json"],
+  lspServers: [".lsp.json"],
+  commands: ["commands"],
+  agents: ["agents", ".cursor/agents"],
+  hooks: ["hooks/hooks.json"],
+  rules: ["rules", ".cursor/rules"],
+  outputStyles: ["output-styles"],
+  apps: [".app.json"],
+};
+function isRecord(value: unknown): value is Json {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+function isHttpUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return ["https:", "http:"].includes(url.protocol) && Boolean(url.hostname);
+  } catch {
+    return false;
+  }
+}
+function validConfig(cap: string, value: unknown): boolean {
+  if (!isRecord(value) || !Object.keys(value).length) return false;
+  if (cap === "settings") return true;
+  if (cap === "hooks") return isRecord(value.hooks) && Object.keys(value.hooks).length > 0;
+  const servers = value[cap] ?? value.servers ?? value;
+  if (!isRecord(servers) || !Object.keys(servers).length) return false;
+  return Object.values(servers).every(
+    (server) =>
+      isRecord(server) &&
+      ((typeof server.command === "string" && Boolean(server.command.trim())) ||
+        (cap === "mcpServers" && typeof server.url === "string" && isHttpUrl(server.url))),
+  );
+}
+export function inspectCapabilities(files: Record<string, string>, manifest: Json, format: string) {
+  // Match OpenClaw 2026.9.3's bundle-manifest/bundle-mcp loaders, not Cursor's
+  // broader schema: no root SKILL.md fallback or inline MCP array objects;
+  // Cursor/Claude MCP defaults are merged with explicitly declared paths.
+  const runnable: string[] = [];
+  const omitted: string[] = [];
+  const errors: string[] = [];
+  const has = (root: string) =>
+    Object.keys(files).some((p) => p === root || p.startsWith(`${root}/`));
+  for (const [cap, defaults] of Object.entries(roots)) {
+    const raw = manifest[cap];
+    const declared = typeof raw === "string" ? [raw] : Array.isArray(raw) ? raw : [];
+    // The shipped loader uses mcp.json for Agent Plugins and .mcp.json for
+    // Cursor/Claude/Codex. Other filenames must be explicitly declared.
+    const implicit =
+      cap === "mcpServers" ? [format === "agent" ? "mcp.json" : ".mcp.json"] : defaults;
+    const paths = new Set(implicit.filter(has));
+    for (const path of declared) {
+      if (
+        typeof path !== "string" ||
+        path.startsWith("/") ||
+        path.includes("\\") ||
+        path.split("/").includes("..")
+      ) {
+        errors.push(`Unsafe ${cap} path`);
+        continue;
+      }
+      const normalized = path.replace(/^\.\//, "").replace(/\/$/, "");
+      if (!normalized || !has(normalized)) {
+        errors.push(`Missing ${cap} path: ${path}`);
+        continue;
+      }
+      paths.add(normalized);
+    }
+    const inline = isRecord(raw) && Object.keys(raw).length > 0;
+    if (!inline && !paths.size) continue;
+    // This is the approved v1 import contract, not a promise that an arbitrary
+    // source has passed the separate OpenClaw installation acceptance seam.
+    const supported =
+      ["skills", "mcpServers", "settings"].includes(cap) ||
+      (["commands", "lspServers"].includes(cap) && format === "claude") ||
+      (cap === "hooks" && (format === "codex" || format === "openclaw"));
+    if (!supported) {
+      omitted.push(cap);
+      continue;
+    }
+    let valid = false;
+    if (cap === "skills" || cap === "commands") {
+      valid = [...paths].some((root) =>
+        Object.entries(files).some(
+          ([path, text]) =>
+            (path === root || path.startsWith(`${root}/`)) &&
+            (cap === "skills" ? /(?:^|\/)SKILL\.md$/.test(path) : path.endsWith(".md")) &&
+            Boolean(text.trim()),
+        ),
+      );
+    } else {
+      const configs: unknown[] = inline ? [raw] : [];
+      for (const path of paths) {
+        try {
+          configs.push(JSON.parse(files[path]));
+        } catch {
+          errors.push(`Invalid ${cap} JSON: ${path}`);
+        }
+      }
+      valid = configs.length > 0 && configs.every((config) => validConfig(cap, config));
+    }
+    if (valid) runnable.push(cap);
+    else errors.push(`Invalid or empty ${cap} capability`);
+  }
+  return { runnable: runnable.sort(), omitted: omitted.sort(), errors };
+}

--- a/scripts/company-plugins/cli.ts
+++ b/scripts/company-plugins/cli.ts
@@ -1,0 +1,53 @@
+#!/usr/bin/env bun
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { parseArgs } from "node:util";
+import { curatedManifestSchema } from "./contract";
+import { inventoryPlugins } from "./inventory";
+import { fetchSnapshot } from "./sources";
+
+const { values } = parseArgs({
+  options: {
+    manifest: { type: "string" },
+    output: { type: "string" },
+    catalog: { type: "string" },
+    help: { type: "boolean" },
+  },
+  strict: true,
+});
+if (values.help) {
+  console.log(
+    "bun run plugins:inventory --manifest <curated.json> --catalog <catalog.json> --output <report.json>\nRead-only inventory. Never publishes packages or contacts authors.",
+  );
+} else {
+  if (!values.manifest || !values.output || !values.catalog)
+    throw new Error("--manifest, --catalog and --output are required (use --help)");
+  const manifest = curatedManifestSchema.parse(JSON.parse(await readFile(values.manifest, "utf8")));
+  const catalog = JSON.parse(await readFile(values.catalog, "utf8"));
+  if (!Array.isArray(catalog) || !catalog.every((item) => item && typeof item.name === "string"))
+    throw new Error("Catalog must be an array of current ClawHub packages with names");
+  const targets = new Map<string, string>();
+  for (const source of [...manifest.registries, ...manifest.sources]) {
+    if (targets.has(source.repo) && targets.get(source.repo) !== source.ref)
+      throw new Error(
+        `Conflicting refs for ${source.repo}; curate one snapshot per repository per run`,
+      );
+    targets.set(source.repo, source.ref);
+  }
+  const snapshots = [];
+  for (const [repo, ref] of targets) {
+    console.error(`Inventorying ${repo}@${ref}`);
+    snapshots.push(await fetchSnapshot(repo, ref));
+  }
+  const report = await inventoryPlugins({ manifest, snapshots, catalog });
+  await mkdir(dirname(resolve(values.output)), { recursive: true });
+  await writeFile(values.output, JSON.stringify(report, null, 2) + "\n");
+  console.log(
+    JSON.stringify({
+      report: resolve(values.output),
+      candidates: report.candidates.length,
+      selected: report.candidates.filter((c) => c.status === "selected").length,
+      permissionNeeded: report.permissionNeeded.length,
+    }),
+  );
+}

--- a/scripts/company-plugins/contract.ts
+++ b/scripts/company-plugins/contract.ts
@@ -1,0 +1,87 @@
+import { z } from "zod";
+import { PLUGIN_CATEGORY_SLUGS } from "../../packages/schema/src/catalogMetadata";
+
+const slug = z.string().regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/);
+const repo = z
+  .string()
+  .regex(/^[\w.-]+\/[\w.-]+$/)
+  .transform((value) => value.toLowerCase());
+const path = z
+  .string()
+  .refine(
+    (value) =>
+      !value.startsWith("/") &&
+      !/[\\\0]/.test(value) &&
+      (!value || !value.split("/").some((part) => !part || part === ".." || part === ".")),
+    "Use a repository-relative canonical path",
+  );
+const registry = z.enum(["cursor", "claude", "openai"]);
+const identity = z.object({ integration: slug, job: slug });
+const source = identity
+  .extend({
+    repo,
+    path,
+    ref: z.string().min(1),
+    publisher: slug,
+    authorship: z.enum(["company", "registry"]),
+    format: z.enum(["cursor", "claude", "codex", "agent", "openclaw"]),
+    registry: registry.optional(),
+    repositoryId: z.number().int().positive(),
+    ownerId: z.number().int().positive(),
+    ownershipEvidence: z.url(),
+    categories: z.array(z.enum(PLUGIN_CATEGORY_SLUGS)).max(3),
+    preferred: z.boolean().optional(),
+    decisionReason: z.string().min(1).optional(),
+  })
+  .strict()
+  .superRefine((value, ctx) => {
+    if (
+      value.authorship === "registry" &&
+      (!value.registry ||
+        value.publisher !==
+          ({ cursor: "cursor", claude: "anthropic", openai: "openai" } as const)[value.registry])
+    ) {
+      ctx.addIssue({
+        code: "custom",
+        message: "Registry copies must use their registry publisher",
+      });
+    }
+    if (value.preferred && !value.decisionReason)
+      ctx.addIssue({ code: "custom", message: "A curator preference requires a reason" });
+  });
+export const curatedManifestSchema = z
+  .object({
+    version: z.literal(1),
+    registries: z.array(z.object({ registry, repo, ref: z.string().min(1) }).strict()),
+    sources: z.array(source),
+    openclaw: z.array(
+      identity
+        .extend({
+          package: z.string().min(1).optional(),
+          bundledId: slug.optional(),
+          evidence: z.url(),
+        })
+        .strict()
+        .refine(
+          (v) => Boolean(v.package || v.bundledId),
+          "An OpenClaw identity requires a package or bundled id",
+        ),
+    ),
+  })
+  .strict();
+export type CuratedManifest = z.infer<typeof curatedManifestSchema>;
+export type CuratedSource = CuratedManifest["sources"][number];
+export type Registry = z.infer<typeof registry>;
+export type Snapshot = {
+  repo: string;
+  repositoryId: number;
+  ownerId: number;
+  commit: string;
+  updatedAt: string;
+  files: Record<string, string>;
+  fileHashes?: Record<string, string>;
+  fileSizes?: Record<string, number>;
+};
+export function sourceKey(repo: string, path: string) {
+  return `${repo.toLowerCase()}#${path}`;
+}

--- a/scripts/company-plugins/inventory.test.ts
+++ b/scripts/company-plugins/inventory.test.ts
@@ -1,0 +1,364 @@
+// @vitest-environment node
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { inspectCapabilities } from "./capabilities";
+import { inventoryPlugins, type InventoryInput } from "./inventory";
+
+const mit = readFileSync(new URL("../../LICENSE", import.meta.url), "utf8");
+const commit = "a".repeat(40);
+const company = {
+  repo: "example/notes",
+  repositoryId: 12,
+  ownerId: 10,
+  commit,
+  updatedAt: "2026-09-01T00:00:00Z",
+  files: {
+    LICENSE: mit,
+    ".claude-plugin/plugin.json": JSON.stringify({
+      name: "notes",
+      version: "1.0.0",
+      mcpServers: "./.mcp.json",
+    }),
+    ".mcp.json": '{"mcpServers":{"notes":{"type":"http","url":"https://example.com/mcp"}}}',
+  },
+};
+const wrapper = {
+  ...company,
+  repo: "cursor/plugins",
+  repositoryId: 22,
+  ownerId: 20,
+  files: {
+    ".cursor-plugin/marketplace.json": JSON.stringify({
+      plugins: [{ name: "notes", source: "notes" }],
+    }),
+    "notes/LICENSE": mit,
+    "notes/.cursor-plugin/plugin.json": JSON.stringify({
+      name: "notes",
+      author: { name: "Example" },
+      mcpServers: "./.mcp.json",
+      category: "productivity",
+    }),
+    "notes/.mcp.json": company.files[".mcp.json"],
+  },
+};
+const input = (): InventoryInput => ({
+  snapshots: [structuredClone(wrapper), structuredClone(company)],
+  manifest: {
+    version: 1,
+    registries: [{ registry: "cursor", repo: "cursor/plugins", ref: "main" }],
+    sources: [
+      {
+        integration: "example",
+        job: "notes",
+        repo: "cursor/plugins",
+        path: "notes",
+        ref: "main",
+        publisher: "cursor",
+        authorship: "registry",
+        format: "cursor",
+        registry: "cursor",
+        repositoryId: 22,
+        ownerId: 20,
+        ownershipEvidence: "https://github.com/cursor/plugins",
+        categories: ["tools"],
+      },
+      {
+        integration: "example",
+        job: "notes",
+        repo: "example/notes",
+        path: "",
+        ref: "main",
+        publisher: "example",
+        authorship: "company",
+        format: "claude",
+        repositoryId: 12,
+        ownerId: 10,
+        ownershipEvidence: "https://example.com/developers/plugins",
+        categories: ["tools"],
+      },
+    ],
+    openclaw: [],
+  },
+  catalog: [],
+});
+
+describe("curated plugin inventory", () => {
+  it("withholds a bundle containing only plural skills.md files", async () => {
+    const data = input();
+    data.snapshots[1].files = {
+      LICENSE: mit,
+      ".claude-plugin/plugin.json": JSON.stringify({ name: "notes" }),
+      "skills/notes/skills.md": "# Notes\nRead notes.",
+    };
+    const candidate = (await inventoryPlugins(data)).candidates[1];
+    expect(candidate.status).toBe("blocked");
+    expect(candidate.capabilities.runnable).not.toContain("skills");
+  });
+  it("rejects a later conflicting SPDX declaration in an otherwise MIT subtree", async () => {
+    const data = input();
+    data.snapshots[1].files["notice.txt"] =
+      "SPDX-License-Identifier: MIT\nSPDX-License-Identifier: GPL-3.0-only\n";
+    expect((await inventoryPlugins(data)).candidates[1].status).toBe("blocked");
+  });
+  it("does not request licensing permission for an existing OpenClaw equivalent", async () => {
+    const data = input();
+    data.snapshots[1].files.LICENSE = "All rights reserved";
+    data.manifest.openclaw = [
+      {
+        integration: "example",
+        job: "notes",
+        bundledId: "notes",
+        evidence: "https://github.com/openclaw/openclaw",
+      },
+    ];
+    expect((await inventoryPlugins(data)).permissionNeeded).toHaveLength(0);
+  });
+  it("reports an unsafe registry entry without hiding the valid candidates", async () => {
+    const data = input();
+    data.snapshots[0].files[".cursor-plugin/marketplace.json"] = JSON.stringify({
+      plugins: [
+        { name: "unsafe", source: "../escape" },
+        { name: "notes", source: "notes" },
+      ],
+    });
+    const report = await inventoryPlugins(data);
+    expect(report.candidates.find((c) => c.name === "unsafe")).toMatchObject({
+      status: "blocked",
+      reasons: ["Unsafe registry source path"],
+    });
+    expect(report.candidates.filter((c) => c.status === "selected")).toHaveLength(1);
+  });
+  it("reports the verified company source as canonical without trusting the wrapper's author label", async () => {
+    const report = await inventoryPlugins(input());
+    expect(
+      report.candidates.map((c) => ({ repo: c.repo, status: c.status, publisher: c.publisher })),
+    ).toEqual([
+      { repo: "cursor/plugins", status: "superseded", publisher: "cursor" },
+      { repo: "example/notes", status: "selected", publisher: "example" },
+    ]);
+    expect(report.candidates[1]).toMatchObject({
+      commit,
+      categories: ["tools"],
+      license: { status: "eligible" },
+      capabilities: { runnable: ["mcpServers"], omitted: [] },
+    });
+  });
+  it("suppresses imports when a bundled OpenClaw equivalent exists and reports the catalog gap", async () => {
+    const data = input();
+    data.manifest.openclaw = [
+      {
+        integration: "example",
+        job: "notes",
+        bundledId: "notes",
+        package: "@openclaw/notes",
+        evidence: "https://github.com/openclaw/openclaw",
+      },
+    ];
+    const report = await inventoryPlugins(data);
+    expect(report.candidates.every((c) => c.status === "existing-openclaw")).toBe(true);
+    expect(report.parityGaps).toHaveLength(1);
+  });
+  it("keeps a distinct primary job while suppressing same-job wrappers", async () => {
+    const data = input();
+    data.manifest.sources[0].job = "meeting-notes";
+    expect(
+      (await inventoryPlugins(data)).candidates.filter((c) => c.status === "selected"),
+    ).toHaveLength(2);
+  });
+  it("blocks repository transfer even when author metadata and license are unchanged", async () => {
+    const data = input();
+    data.snapshots[1] = { ...company, ownerId: 999 };
+    const report = await inventoryPlugins(data);
+    expect(report.candidates[1]).toMatchObject({
+      status: "blocked",
+      reasons: ["Verified repository/owner identity changed"],
+    });
+  });
+  it("does not grant a bundle-wide license from licenses in individual skill folders", async () => {
+    const data = input();
+    data.snapshots[1] = {
+      ...company,
+      files: {
+        ".claude-plugin/plugin.json": company.files[".claude-plugin/plugin.json"],
+        "skills/notes/LICENSE": mit,
+      },
+    };
+    expect((await inventoryPlugins(data)).candidates[1].license?.status).toBe("blocked");
+  });
+  it("accepts an explicit plugin-local MIT grant under a differently licensed registry", async () => {
+    const data = input();
+    data.snapshots[0] = {
+      ...wrapper,
+      files: { ...wrapper.files, LICENSE: "Apache License, Version 2.0" },
+    };
+    expect((await inventoryPlugins(data)).candidates[0].license?.status).toBe("eligible");
+  });
+  it.each([
+    ["missing", undefined],
+    ["partial", "MIT License\nCopyright 2026 Example\nPermission is hereby granted"],
+    ["custom", mit + "\nUse is restricted to personal projects."],
+  ])("withholds %s license evidence", async (_name, license) => {
+    const data = input();
+    const files: Record<string, string> = { ...company.files };
+    if (license) files.LICENSE = license;
+    else delete files.LICENSE;
+    data.snapshots[1] = { ...company, files };
+    expect((await inventoryPlugins(data)).candidates[1].status).toBe("blocked");
+  });
+  it("rejects a contradictory nested license and preserves ancestor notices", async () => {
+    const data = input();
+    data.snapshots[1] = {
+      ...company,
+      files: {
+        ...company.files,
+        "skills/private/LICENSE": "All rights reserved",
+        "skills/private/SKILL.md": "Private instructions",
+        NOTICE: "Example attribution",
+      },
+    };
+    const candidate = (await inventoryPlugins(data)).candidates[1];
+    expect(candidate.status).toBe("blocked");
+    expect(candidate.license?.notices).toContain("NOTICE");
+  });
+  it("keeps package-owned categories authoritative", async () => {
+    const data = input();
+    data.snapshots[1] = {
+      ...company,
+      files: {
+        ...company.files,
+        "openclaw.plugin.json": JSON.stringify({
+          id: "notes",
+          categories: ["memory"],
+          skills: ["skills"],
+        }),
+      },
+    };
+    expect((await inventoryPlugins(data)).candidates[1].categories).toEqual(["memory"]);
+  });
+  it("deduplicates the same exact source discovered in two registries", async () => {
+    const data = input();
+    data.manifest.registries.push({ registry: "claude", repo: "anthropics/plugins", ref: "main" });
+    data.snapshots.push({
+      ...company,
+      repo: "anthropics/plugins",
+      files: {
+        ".claude-plugin/marketplace.json": JSON.stringify({
+          plugins: [{ name: "notes", source: { source: "github", repo: "example/notes" } }],
+        }),
+      },
+    });
+    const selected = (await inventoryPlugins(data)).candidates.filter(
+      (c) => c.status === "selected",
+    );
+    expect(selected).toHaveLength(1);
+    expect(selected[0].repo).toBe("example/notes");
+  });
+  it("prefers runnable capability coverage over registry branding", async () => {
+    const data = input();
+    data.manifest.sources[1] = {
+      ...data.manifest.sources[1],
+      authorship: "registry",
+      registry: "openai",
+      publisher: "openai",
+    };
+    data.snapshots[1] = {
+      ...company,
+      files: { ...company.files, "skills/notes/SKILL.md": "# Notes" },
+    };
+    expect((await inventoryPlugins(data)).candidates[1].status).toBe("selected");
+  });
+  it("changes the source hash when an inherited license or notice changes", async () => {
+    const data = input();
+    data.snapshots[0] = { ...wrapper, files: { ...wrapper.files, NOTICE: "First notice" } };
+    const before = (await inventoryPlugins(data)).candidates[0].contentHash;
+    data.snapshots[0].files.NOTICE = "Second notice";
+    expect((await inventoryPlugins(data)).candidates[0].contentHash).not.toBe(before);
+  });
+  it("isolates malformed uncurated plugin JSON without losing valid candidates", async () => {
+    const data = input();
+    data.snapshots[0].files = {
+      ...wrapper.files,
+      ".cursor-plugin/marketplace.json": JSON.stringify({
+        plugins: [
+          { name: "notes", source: "notes" },
+          { name: "broken", source: "broken" },
+        ],
+      }),
+      "broken/.cursor-plugin/plugin.json": "{",
+    };
+    const report = await inventoryPlugins(data);
+    expect(report.candidates.find((c) => c.name === "broken")?.status).toBe("blocked");
+    expect(report.candidates.find((c) => c.repo === "example/notes")?.status).toBe("selected");
+  });
+  it.each(["{}", "{"])("withholds a missing or malformed plugin identity: %s", async (manifest) => {
+    const data = input();
+    data.snapshots[1] = {
+      ...company,
+      files: { ...company.files, ".claude-plugin/plugin.json": manifest },
+    };
+    expect((await inventoryPlugins(data)).candidates[1].status).toBe("blocked");
+  });
+  it.each([
+    "{",
+    "{}",
+    '{"mcpServers":{"notes":{}}}',
+    '{"mcpServers":{"notes":{"url":"https://"}}}',
+    '{"mcpServers":{"notes":{"url":"http://[invalid"}}}',
+  ])("does not rank malformed or empty MCP definitions as runnable: %s", async (mcp) => {
+    const data = input();
+    data.snapshots[1] = { ...company, files: { ...company.files, ".mcp.json": mcp } };
+    const candidate = (await inventoryPlugins(data)).candidates[1];
+    expect(candidate.status).toBe("blocked");
+    expect(candidate.capabilities.runnable).not.toContain("mcpServers");
+  });
+  it("points at the actual bundled target when the published package is missing", async () => {
+    const data = input();
+    data.manifest.openclaw = [
+      {
+        integration: "example",
+        job: "notes",
+        package: "@openclaw/notes",
+        bundledId: "notes",
+        evidence: "https://github.com/openclaw/openclaw",
+      },
+    ];
+    expect((await inventoryPlugins(data)).candidates[0].canonical).toBe("notes");
+  });
+  it("rejects conflicting OpenClaw canonical identities", async () => {
+    const data = input();
+    data.manifest.openclaw = [
+      {
+        integration: "example",
+        job: "notes",
+        bundledId: "notes",
+        evidence: "https://github.com/openclaw/openclaw",
+      },
+      {
+        integration: "example",
+        job: "notes",
+        bundledId: "different",
+        evidence: "https://github.com/openclaw/openclaw",
+      },
+    ];
+    await expect(inventoryPlugins(data)).rejects.toThrow("Duplicate OpenClaw identity");
+  });
+});
+
+it.each(["claude", "cursor", "codex"])(
+  "loads only the runtime's implicit MCP path for %s",
+  (format) => {
+    const mcp = company.files[".mcp.json"];
+    expect(inspectCapabilities({ "mcp.json": mcp }, {}, format).runnable).not.toContain(
+      "mcpServers",
+    );
+    expect(inspectCapabilities({ ".mcp.json": mcp }, {}, format).runnable).toContain("mcpServers");
+    expect(
+      inspectCapabilities({ "mcp.json": mcp }, { mcpServers: "mcp.json" }, format).runnable,
+    ).toContain("mcpServers");
+  },
+);
+it("loads Agent Plugins' implicit mcp.json", () => {
+  expect(
+    inspectCapabilities({ "mcp.json": company.files[".mcp.json"] }, {}, "agent").runnable,
+  ).toContain("mcpServers");
+});

--- a/scripts/company-plugins/inventory.ts
+++ b/scripts/company-plugins/inventory.ts
@@ -1,0 +1,360 @@
+import { createHash } from "node:crypto";
+import { buildGitHubFolderContentHash } from "../../packages/clawhub/src/skills";
+import { resolvePluginCategories } from "../../packages/schema/src/catalogMetadata";
+import { inspectCapabilities } from "./capabilities";
+import {
+  curatedManifestSchema,
+  sourceKey,
+  type CuratedManifest,
+  type CuratedSource,
+  type Registry,
+  type Snapshot,
+} from "./contract";
+import { inspectLicense } from "./license";
+export type InventoryInput = {
+  manifest: CuratedManifest;
+  snapshots: Snapshot[];
+  catalog: { name: string; publisher?: string }[];
+};
+type Format = "cursor" | "claude" | "codex" | "agent" | "openclaw";
+type Discovery = {
+  name: string;
+  repo: string;
+  path: string;
+  registry?: Registry;
+  registryCommit?: string;
+  description?: string;
+  category?: string;
+  upstream?: unknown;
+  discoveryError?: string;
+};
+type Candidate = Discovery & {
+  commit?: string;
+  sourceUrl?: string;
+  integration?: string;
+  job?: string;
+  publisher?: string;
+  authorship?: string;
+  format?: Format;
+  declaredAuthor?: unknown;
+  declaredLicense?: unknown;
+  upstreamVersion?: string;
+  icon?: string;
+  categories: string[];
+  capabilities: { runnable: string[]; omitted: string[] };
+  license?: ReturnType<typeof inspectLicense>;
+  contentHash?: string;
+  status:
+    | "uncurated"
+    | "blocked"
+    | "selected"
+    | "superseded"
+    | "existing-openclaw"
+    | "needs-decision";
+  reasons: string[];
+  canonical?: string;
+  ownershipEvidence?: string;
+};
+function record(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+function json(text: string | undefined) {
+  if (!text) return {};
+  return record(JSON.parse(text));
+}
+const markers = [
+  { format: "openclaw", path: "openclaw.plugin.json" },
+  { format: "codex", path: ".codex-plugin/plugin.json" },
+  { format: "claude", path: ".claude-plugin/plugin.json" },
+  { format: "cursor", path: ".cursor-plugin/plugin.json" },
+  { format: "agent", path: "plugin.json" },
+] as const;
+const mappedCategories: Record<string, string[]> = {
+  productivity: ["tools"],
+  integrations: ["tools"],
+  "developer tools": ["runtime"],
+  development: ["runtime"],
+  security: ["security"],
+  design: ["media"],
+  monitoring: ["gateway"],
+  utilities: ["tools"],
+};
+function describe(
+  discovered: Discovery,
+  snapshot: Snapshot | undefined,
+  source: CuratedSource | undefined,
+): Candidate {
+  const result: Candidate = {
+    ...discovered,
+    categories: [],
+    capabilities: { runnable: [], omitted: [] },
+    status: source ? "blocked" : "uncurated",
+    reasons: [],
+  };
+  if (source)
+    Object.assign(result, {
+      integration: source.integration,
+      job: source.job,
+      publisher: source.publisher,
+      authorship: source.authorship,
+      ownershipEvidence: source.ownershipEvidence,
+    });
+  if (!snapshot) {
+    result.reasons.push(
+      "External source snapshot required; registry metadata is not source evidence",
+    );
+    return result;
+  }
+  result.commit = snapshot.commit;
+  result.sourceUrl = `https://github.com/${snapshot.repo}/tree/${snapshot.commit}${discovered.path ? `/${discovered.path.split("/").map(encodeURIComponent).join("/")}` : ""}`;
+  const prefix = discovered.path ? `${discovered.path}/` : "";
+  const files = Object.fromEntries(
+    Object.entries(snapshot.files)
+      .filter(([p]) => p.startsWith(prefix))
+      .map(([p, v]) => [p.slice(prefix.length), v]),
+  );
+  const marker = markers.find((m) => files[m.path] && (!source || m.format === source.format));
+  if (!marker) {
+    result.reasons.push("Supported plugin manifest not found");
+    return result;
+  }
+  const manifest = json(files[marker.path]);
+  const native = json(files["openclaw.plugin.json"]);
+  const identifier = marker.format === "openclaw" ? manifest.id : manifest.name;
+  if (typeof identifier !== "string" || !identifier.trim())
+    throw new Error(`Invalid ${marker.format} manifest: plugin identity is required`);
+  if (
+    marker.format === "agent" &&
+    manifest.$schema !== "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json"
+  )
+    throw new Error("Unsupported Agent Plugins manifest schema");
+  result.format = marker.format;
+  result.declaredAuthor = manifest.author;
+  result.declaredLicense = manifest.license;
+  result.description =
+    typeof manifest.description === "string" ? manifest.description : discovered.description;
+  result.upstreamVersion = typeof manifest.version === "string" ? manifest.version : undefined;
+  const ui = record(manifest.interface);
+  result.icon =
+    typeof manifest.logo === "string"
+      ? manifest.logo
+      : typeof ui.logo === "string"
+        ? ui.logo
+        : undefined;
+  const capabilities = inspectCapabilities(files, manifest, marker.format);
+  result.capabilities = { runnable: capabilities.runnable, omitted: capabilities.omitted };
+  result.reasons.push(...capabilities.errors);
+  result.license = inspectLicense(snapshot.files, discovered.path);
+  const category = String(
+    manifest.category ?? ui.category ?? discovered.category ?? "",
+  ).toLowerCase();
+  result.categories = resolvePluginCategories({
+    declared: Array.isArray(native.categories) ? (native.categories as string[]) : undefined,
+    inferred: source?.categories.length ? source.categories : mappedCategories[category],
+  });
+  const closurePaths = new Set([
+    ...Object.keys(files).map((p) => prefix + p),
+    ...result.license.files.map((file) => file.path),
+    ...result.license.notices,
+  ]);
+  result.contentHash = buildGitHubFolderContentHash(
+    [...closurePaths].map((path) => ({
+      path,
+      size: snapshot.fileSizes?.[path] ?? Buffer.byteLength(snapshot.files[path]),
+      sha256:
+        snapshot.fileHashes?.[path] ??
+        createHash("sha256").update(snapshot.files[path]).digest("hex"),
+    })),
+  );
+  if (source) {
+    if (snapshot.repositoryId !== source.repositoryId || snapshot.ownerId !== source.ownerId)
+      result.reasons.push("Verified repository/owner identity changed");
+    if (!/^[a-f0-9]{40}$/.test(snapshot.commit)) result.reasons.push("Exact commit is required");
+    if (manifest.license && manifest.license !== "MIT")
+      result.reasons.push("Manifest license contradicts MIT-only policy");
+    result.reasons.push(...result.license.reasons);
+    if (!result.capabilities.runnable.length)
+      result.reasons.push("No runnable OpenClaw capability");
+    if (!result.reasons.length) result.status = "selected";
+  } else result.reasons.push("Not in the curated source manifest");
+  return result;
+}
+function discover(snapshot: Snapshot, registry: Registry): Discovery[] {
+  const marketplace =
+    registry === "cursor"
+      ? ".cursor-plugin/marketplace.json"
+      : registry === "claude"
+        ? ".claude-plugin/marketplace.json"
+        : ".agents/plugins/marketplace.json";
+  const plugins = json(snapshot.files[marketplace]).plugins;
+  if (!Array.isArray(plugins))
+    throw new Error(`Missing marketplace: ${snapshot.repo}/${marketplace}`);
+  return plugins.map((raw) => {
+    const p = record(raw);
+    const s = record(p.source);
+    let repo = snapshot.repo;
+    let path = typeof p.source === "string" ? p.source : typeof s.path === "string" ? s.path : "";
+    if (typeof s.url === "string" || typeof s.repo === "string") {
+      const url = String(s.url ?? `https://github.com/${s.repo}`);
+      const match = /^https:\/\/github.com\/([\w.-]+\/[\w.-]+?)(?:\.git)?\/?$/.exec(url);
+      repo = match?.[1]?.toLowerCase() ?? url;
+    }
+    path = path.replace(/^\.\//, "").replace(/\/$/, "");
+    const unsafePath =
+      path.startsWith("/") ||
+      /[\\\0]/.test(path) ||
+      Boolean(path && path.split("/").some((part) => !part || part === ".." || part === "."));
+    return {
+      name: String(p.name ?? ""),
+      repo,
+      path,
+      registry,
+      registryCommit: snapshot.commit,
+      description: typeof p.description === "string" ? p.description : undefined,
+      category: typeof p.category === "string" ? p.category : undefined,
+      upstream: p.source,
+      ...(unsafePath ? { discoveryError: "Unsafe registry source path" } : {}),
+    };
+  });
+}
+export async function inventoryPlugins(input: InventoryInput) {
+  const manifest = curatedManifestSchema.parse(input.manifest);
+  const byRepo = new Map(input.snapshots.map((s) => [s.repo.toLowerCase(), s]));
+  const sources = new Map<string, CuratedSource>();
+  for (const s of manifest.sources) {
+    const key = sourceKey(s.repo, s.path);
+    if (sources.has(key)) throw new Error(`Duplicate curated source: ${key}`);
+    sources.set(key, s);
+  }
+  const openclawIdentities = new Set<string>();
+  for (const entry of manifest.openclaw) {
+    const key = `${entry.integration}/${entry.job}`;
+    if (openclawIdentities.has(key)) throw new Error(`Duplicate OpenClaw identity: ${key}`);
+    openclawIdentities.add(key);
+  }
+  const discoveries: Discovery[] = [];
+  for (const reg of manifest.registries) {
+    const snapshot = byRepo.get(reg.repo);
+    if (!snapshot) throw new Error(`Missing registry snapshot: ${reg.repo}`);
+    discoveries.push(...discover(snapshot, reg.registry));
+  }
+  for (const source of manifest.sources)
+    if (!discoveries.some((d) => sourceKey(d.repo, d.path) === sourceKey(source.repo, source.path)))
+      discoveries.push({
+        name: source.integration,
+        repo: source.repo,
+        path: source.path,
+        registry: source.registry,
+      });
+  const candidates = discoveries.map((d): Candidate => {
+    const source = sources.get(sourceKey(d.repo, d.path));
+    try {
+      if (d.discoveryError) throw new Error(d.discoveryError);
+      return describe(d, byRepo.get(d.repo), source);
+    } catch (error) {
+      return {
+        ...d,
+        integration: source?.integration,
+        job: source?.job,
+        publisher: source?.publisher,
+        status: "blocked",
+        categories: [],
+        capabilities: { runnable: [], omitted: [] },
+        reasons: [error instanceof Error ? error.message : "Invalid source metadata"],
+      };
+    }
+  });
+  const groups = new Map<string, Candidate[]>();
+  for (const c of candidates) {
+    if (!c.integration || !c.job) continue;
+    const identity = `${c.integration}/${c.job}`;
+    groups.set(identity, [...(groups.get(identity) ?? []), c]);
+  }
+  const parityGaps: CuratedManifest["openclaw"] = [];
+  for (const [identity, group] of groups) {
+    const existing = manifest.openclaw.find(
+      (o) =>
+        `${o.integration}/${o.job}` === identity &&
+        (o.bundledId || input.catalog.some((p) => p.name === o.package)),
+    );
+    if (existing) {
+      if (existing.bundledId && !input.catalog.some((p) => p.name === existing.package))
+        parityGaps.push(existing);
+      for (const c of group) {
+        c.status = "existing-openclaw";
+        c.canonical = input.catalog.some((p) => p.name === existing.package)
+          ? existing.package
+          : existing.bundledId;
+        c.reasons.push("Equivalent OpenClaw integration has precedence");
+      }
+      continue;
+    }
+    const eligible = group.filter((c) => c.status === "selected");
+    const unique = [...new Map(eligible.map((c) => [sourceKey(c.repo, c.path), c])).values()];
+    unique.sort((a, b) => {
+      const tier = (c: Candidate) => (c.authorship === "company" ? 0 : 1);
+      return (
+        tier(a) - tier(b) ||
+        b.capabilities.runnable.length - a.capabilities.runnable.length ||
+        Date.parse(byRepo.get(b.repo)!.updatedAt) - Date.parse(byRepo.get(a.repo)!.updatedAt)
+      );
+    });
+    let winner = unique[0];
+    if (!winner) continue;
+    const tied = unique.filter(
+      (c) =>
+        c.authorship === winner.authorship &&
+        c.capabilities.runnable.length === winner.capabilities.runnable.length &&
+        byRepo.get(c.repo)!.updatedAt === byRepo.get(winner.repo)!.updatedAt,
+    );
+    if (tied.length > 1) {
+      const preferred = tied.filter((c) => sources.get(sourceKey(c.repo, c.path))?.preferred);
+      if (preferred.length !== 1) {
+        for (const c of eligible) {
+          const inTie = tied.some(
+            (option) => sourceKey(option.repo, option.path) === sourceKey(c.repo, c.path),
+          );
+          c.status = inTie ? "needs-decision" : "superseded";
+          c.reasons.push(
+            inTie
+              ? "Equivalent candidates require an explicit curator decision"
+              : "Lower-ranked than the unresolved canonical candidates",
+          );
+        }
+        continue;
+      }
+      winner = preferred[0];
+    }
+    for (const c of eligible) {
+      if (c === winner) {
+        c.reasons.push(
+          "Canonical source selected by provenance, runnable coverage and maintenance",
+        );
+        continue;
+      }
+      c.status = "superseded";
+      c.canonical = sourceKey(winner.repo, winner.path);
+      c.reasons.push(
+        sourceKey(c.repo, c.path) === sourceKey(winner.repo, winner.path)
+          ? "Exact source duplicate"
+          : "Same integration and primary job",
+      );
+    }
+  }
+  candidates.sort(
+    (a, b) =>
+      sourceKey(a.repo, a.path).localeCompare(sourceKey(b.repo, b.path)) ||
+      String(a.registry).localeCompare(String(b.registry)),
+  );
+  return {
+    version: 1,
+    snapshots: input.snapshots.map(({ files: _, fileHashes: __, fileSizes: ___, ...s }) => s),
+    candidates,
+    parityGaps,
+    permissionNeeded: candidates
+      .filter((c) => c.license?.status === "blocked" && ["uncurated", "blocked"].includes(c.status))
+      .map((c) => ({ repo: c.repo, path: c.path, reasons: c.license!.reasons })),
+  };
+}

--- a/scripts/company-plugins/license.ts
+++ b/scripts/company-plugins/license.ts
@@ -1,0 +1,85 @@
+import { createHash } from "node:crypto";
+import { posix } from "node:path";
+
+// Accept the complete standard grant, conditions and disclaimer. A label or
+// partial grant is not evidence of permission for the bytes being imported.
+const MIT_BODY = `Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.`;
+const normalize = (text: string) => text.replace(/\s+/g, " ").trim();
+const isLicense = (path: string) =>
+  /^(?:licen[cs]e|copying)(?:[._-].*)?$/i.test(posix.basename(path));
+const inTree = (file: string, root: string) => !root || file.startsWith(`${root}/`);
+function isMit(text: string) {
+  const start = text.indexOf("Permission is hereby granted");
+  if (start < 0 || normalize(text.slice(start)) !== normalize(MIT_BODY)) return false;
+  const prefix = text
+    .slice(0, start)
+    .trim()
+    .split(/\r?\n/)
+    .filter((line) => line.trim());
+  return (
+    prefix.some((line) => /^copyright\b/i.test(line)) &&
+    prefix.every((line) =>
+      /^(?:MIT License|The MIT License(?: \(MIT\))?|Copyright\b.*)$/i.test(line.trim()),
+    )
+  );
+}
+export function inspectLicense(files: Record<string, string>, root: string) {
+  const closure = Object.keys(files).filter((path) => inTree(path, root));
+  const relevant = Object.entries(files).filter(
+    ([path]) =>
+      isLicense(path) &&
+      (inTree(path, root) ||
+        inTree(`${root}/_`, posix.dirname(path) === "." ? "" : posix.dirname(path))),
+  );
+  const directory = (path: string) => (posix.dirname(path) === "." ? "" : posix.dirname(path));
+  const applicable = (file: string) => {
+    const ancestors = relevant.filter(([path]) => inTree(file, directory(path)));
+    const depth = Math.max(-1, ...ancestors.map(([path]) => directory(path).length));
+    return ancestors.filter(([path]) => directory(path).length === depth);
+  };
+  const used = new Set(closure.flatMap((file) => applicable(file).map(([path]) => path)));
+  const evidence = relevant.filter(([path]) => used.has(path));
+  const reasons: string[] = [];
+  for (const [path, text] of evidence)
+    if (!isMit(text)) reasons.push(`Non-standard or non-MIT license: ${path}`);
+  for (const file of closure) {
+    if (isLicense(file)) continue;
+    const grants = applicable(file);
+    const licensed = grants.length > 0 && grants.every(([, text]) => isMit(text));
+    if (!licensed) reasons.push(`No applicable MIT license: ${file}`);
+    const declarations = [...files[file].matchAll(/SPDX-License-Identifier:[ \t]*([^\r\n*]+)/gi)];
+    if (declarations.some((match) => match[1].trim() !== "MIT"))
+      reasons.push(`Conflicting SPDX license: ${file}`);
+  }
+  if (!closure.length) reasons.push("Source subtree is empty");
+  const notices = Object.keys(files).filter(
+    (path) =>
+      /^(?:notice|copyright)(?:[._-].*)?$/i.test(posix.basename(path)) &&
+      (inTree(path, root) ||
+        inTree(`${root}/_`, posix.dirname(path) === "." ? "" : posix.dirname(path))),
+  );
+  return {
+    status: reasons.length ? ("blocked" as const) : ("eligible" as const),
+    reasons,
+    files: evidence.map(([path, text]) => ({
+      path,
+      sha256: createHash("sha256").update(text).digest("hex"),
+      text,
+    })),
+    notices,
+  };
+}

--- a/scripts/company-plugins/sources.test.ts
+++ b/scripts/company-plugins/sources.test.ts
@@ -1,0 +1,28 @@
+// @vitest-environment node
+import { zipSync } from "fflate";
+import { expect, it } from "vitest";
+import { fetchSnapshot } from "./sources";
+it("preserves prototype-named upstream files in the inspected content and hashes", async () => {
+  const sha = "a".repeat(40);
+  const archive = zipSync({
+    "repo-sha/__proto__": new TextEncoder().encode("SPDX-License-Identifier: GPL-3.0-only"),
+  });
+  const fetcher = (async (input: string | URL | Request) => {
+    const url = String(input);
+    if (url.includes("codeload.github.com")) return new Response(archive);
+    if (url.includes("/commits/"))
+      return Response.json({ sha, commit: { committer: { date: "2026-09-01T00:00:00Z" } } });
+    return Response.json({
+      id: 1,
+      owner: { id: 2 },
+      full_name: "company/plugins",
+      private: false,
+      disabled: false,
+    });
+  }) as typeof fetch;
+  const snapshot = await fetchSnapshot("company/plugins", "main", fetcher);
+  expect(Object.hasOwn(snapshot.files, "__proto__")).toBe(true);
+  expect(snapshot.files.__proto__).toContain("GPL-3.0-only");
+  expect(snapshot.fileHashes?.__proto__).toMatch(/^[a-f0-9]{64}$/);
+  expect(snapshot.fileSizes?.__proto__).toBe(37);
+});

--- a/scripts/company-plugins/sources.ts
+++ b/scripts/company-plugins/sources.ts
@@ -1,0 +1,135 @@
+import { createHash } from "node:crypto";
+import { fromBuffer, type ZipFile } from "yauzl";
+import {
+  fetchGitHubZipBytes,
+  resolveGitHubCommit,
+  stripGitHubZipRoot,
+} from "../../convex/lib/githubImport";
+import type { Snapshot } from "./contract";
+
+const MAX_FILES = 7500;
+const MAX_FILE_BYTES = 10 * 1024 * 1024;
+const MAX_TOTAL_BYTES = 80 * 1024 * 1024;
+async function unpack(bytes: Uint8Array) {
+  const zip = await new Promise<ZipFile>((resolve, reject) =>
+    fromBuffer(Buffer.from(bytes), { lazyEntries: true }, (error, value) =>
+      error ? reject(error) : resolve(value!),
+    ),
+  );
+  const entries: Record<string, Uint8Array> = Object.create(null);
+  let count = 0;
+  let total = 0;
+  return await new Promise<Record<string, Uint8Array>>((resolve, reject) => {
+    const fail = (error: Error) => {
+      zip.close();
+      reject(error);
+    };
+    zip.on("error", fail);
+    zip.on("end", () => resolve(stripGitHubZipRoot(entries)));
+    zip.on("entry", (entry) => {
+      const path = entry.fileName;
+      const mode = (entry.externalFileAttributes >>> 16) & 0o170000;
+      if (
+        ++count > MAX_FILES * 2 ||
+        entry.uncompressedSize > MAX_FILE_BYTES ||
+        (total += entry.uncompressedSize) > MAX_TOTAL_BYTES
+      )
+        return fail(new Error("Upstream archive exceeds import limits"));
+      if (
+        (mode && mode !== 0o100000 && mode !== 0o040000) ||
+        path.startsWith("/") ||
+        path.includes("\\") ||
+        path.split("/").some((part: string) => part === "..") ||
+        Object.hasOwn(entries, path)
+      )
+        return fail(new Error("Unsafe upstream archive entry"));
+      if (path.endsWith("/")) {
+        zip.readEntry();
+        return;
+      }
+      zip.openReadStream(entry, (error, stream) => {
+        if (error || !stream) return fail(error ?? new Error("Archive entry unavailable"));
+        const chunks: Buffer[] = [];
+        let size = 0;
+        stream.on("data", (chunk) => {
+          size += chunk.length;
+          if (size > MAX_FILE_BYTES) {
+            stream.destroy(new Error("Archive file too large"));
+            return;
+          }
+          chunks.push(chunk);
+        });
+        stream.on("error", fail);
+        stream.on("end", () => {
+          entries[path] = Buffer.concat(chunks);
+          zip.readEntry();
+        });
+      });
+    });
+    zip.readEntry();
+  });
+}
+export async function fetchSnapshot(
+  repo: string,
+  ref: string,
+  fetcher: typeof fetch = fetch,
+): Promise<Snapshot> {
+  if (!/^[\w.-]+\/[\w.-]+$/.test(repo))
+    throw new Error("Only explicit GitHub owner/repository sources are supported");
+  const boundedFetch: typeof fetch = (input, init) =>
+    fetcher(input, { ...init, redirect: "error", signal: AbortSignal.timeout(60_000) });
+  const headers: Record<string, string> = {
+    Accept: "application/vnd.github+json",
+    "User-Agent": "clawhub/company-plugins",
+  };
+  if (process.env.GITHUB_TOKEN) headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
+  const response = await boundedFetch(`https://api.github.com/repos/${repo}`, { headers });
+  if (!response.ok)
+    throw new Error(`Repository metadata returned HTTP ${response.status}: ${repo}`);
+  const metadata = (await response.json()) as {
+    id: number;
+    owner: { id: number };
+    private: boolean;
+    archived: boolean;
+    disabled: boolean;
+    full_name: string;
+  };
+  if (
+    metadata.private ||
+    metadata.disabled ||
+    metadata.full_name.toLowerCase() !== repo.toLowerCase()
+  )
+    throw new Error(`Source is private, disabled or renamed: ${repo}`);
+  const [owner, name] = repo.split("/");
+  const source = await resolveGitHubCommit(
+    { owner, repo: name, ref, path: "", originalUrl: `https://github.com/${repo}` },
+    boundedFetch,
+  );
+  const commitResponse = await boundedFetch(
+    `https://api.github.com/repos/${repo}/commits/${source.commit}`,
+    { headers },
+  );
+  if (!commitResponse.ok) throw new Error(`Commit metadata unavailable: ${repo}`);
+  const commit = (await commitResponse.json()) as { commit: { committer: { date: string } } };
+  const entries = await unpack(
+    await fetchGitHubZipBytes(source, boundedFetch, { maxZipBytes: 50 * 1024 * 1024 }),
+  );
+  const files: Record<string, string> = Object.create(null);
+  const fileHashes: Record<string, string> = Object.create(null);
+  const fileSizes: Record<string, number> = Object.create(null);
+  for (const [path, bytes] of Object.entries(entries)) {
+    files[path] = Buffer.from(bytes).toString("utf8");
+    fileSizes[path] = bytes.byteLength;
+    fileHashes[path] = createHash("sha256").update(bytes).digest("hex");
+  }
+  return {
+    repo: repo.toLowerCase(),
+    repositoryId: metadata.id,
+    ownerId: metadata.owner.id,
+    commit: source.commit,
+    updatedAt: commit.commit.committer.date,
+    files,
+    fileHashes,
+    fileSizes,
+  };
+}


### PR DESCRIPTION
Adds a read-only inventory command for curated company plugin imports. It resolves Cursor, Claude and OpenAI registries plus explicitly verified company repositories to exact commits, reports canonical winners by integration/job, and withholds sources with incomplete MIT licensing or unsupported capabilities.

The live inventory contains 426 candidates. With the proposed four-source allowlist it selects Arize and Cursor’s Intercom copy; Granola and OpenAI’s Notion bundle remain withheld. The report includes duplicate decisions, source hashes, ownership evidence, category mappings and an informational licensing-permission list. It performs no publication or outreach.

Validation: `bun run ci:static`, `bun run ci:unit` (6,525 tests passed), `bun run ci:types-build`, `bun run ci:packages`, and focused archive/inventory tests passed. Before/after regressions cover canonical precedence, licensing conflicts, malformed MCP configurations and complete archive hashing. Autoreview has no accepted findings; runtime-dependent suggestions were checked against installed OpenClaw 2026.9.3.
