### PR TITLE
fix: exclude withheld plugins from normal catalog discovery

### DIFF
--- a/convex/catalogTopics.test.ts
+++ b/convex/catalogTopics.test.ts
@@ -76,6 +76,7 @@ function makePluginCategoryDigest(overrides: Record<string, unknown> = {}) {
     isOfficial: false,
     ownerUserId: "users:owner",
     pluginCategory: "runtime",
+    latestVersion: "1.0.0",
     scanStatus: "clean",
     createdAt: 1,
     updatedAt: 2,

--- a/convex/lib/globalStats.ts
+++ b/convex/lib/globalStats.ts
@@ -11,7 +11,7 @@ type SkillVisibilityFields = Pick<
   Partial<Pick<Doc<"skills">, "moderationVerdict">>;
 type PackageVisibilityFields = Pick<
   Doc<"packageSearchDigest">,
-  "softDeletedAt" | "family" | "channel" | "scanStatus"
+  "softDeletedAt" | "family" | "channel" | "scanStatus" | "latestVersion"
 >;
 
 type GlobalStatsReadCtx = Pick<MutationCtx | QueryCtx, "db">;
@@ -40,7 +40,7 @@ export function getPublicSkillVisibilityDelta(
 export function isPublicPluginDoc<T extends PackageVisibilityFields>(
   pkg: T | null | undefined,
 ): pkg is T {
-  if (!pkg || pkg.softDeletedAt) return false;
+  if (!pkg || pkg.softDeletedAt || !pkg.latestVersion) return false;
   if (pkg.family !== "code-plugin" && pkg.family !== "bundle-plugin") return false;
   if (pkg.channel === "private") return false;
   if (isPackageBlockedFromPublic(pkg.scanStatus)) return false;

--- a/convex/lib/packageSearchDigest.test.ts
+++ b/convex/lib/packageSearchDigest.test.ts
@@ -102,6 +102,7 @@ describe("packageSearchDigest", () => {
       channel: "community",
       scanStatus: "clean",
       softDeletedAt: undefined,
+      latestVersion: "1.0.0",
     };
 
     const ctx = {
@@ -165,6 +166,7 @@ describe("packageSearchDigest", () => {
       channel: "community",
       scanStatus: "clean",
       softDeletedAt: undefined,
+      latestVersion: "1.0.0",
     };
 
     const ctx = {

--- a/convex/packages.catalogVisibility.runtime.test.ts
+++ b/convex/packages.catalogVisibility.runtime.test.ts
@@ -1,0 +1,219 @@
+/// <reference types="vite/client" />
+/* @vitest-environment edge-runtime */
+
+import { register as registerRateLimiter } from "@convex-dev/rate-limiter/test";
+import { convexTest } from "convex-test";
+import { describe, expect, it } from "vitest";
+import { api } from "./_generated/api";
+import { extractPackageDigestFields, upsertPackageSearchDigest } from "./lib/packageSearchDigest";
+import { hashToken } from "./lib/tokens";
+import { PACKAGE_TRENDING_LEADERBOARD_KIND } from "./packageLeaderboards";
+import schema from "./schema";
+
+const modules = import.meta.glob("./**/*.ts");
+const bearer = "local-catalog-visibility-fixture";
+
+async function fixture(role: "user" | "admin" = "admin") {
+  const t = convexTest(schema, modules);
+  registerRateLimiter(t);
+  const fixtureOwnerUserId = await t.run(async (ctx) => {
+    const ownerUserId = await ctx.db.insert("users", { handle: "maintainer", role });
+    await ctx.db.insert("apiTokens", {
+      userId: ownerUserId,
+      label: "local fixture",
+      prefix: "local",
+      tokenHash: await hashToken(bearer),
+      createdAt: Date.now(),
+    });
+    const storageId = await ctx.storage.store(new Blob(["fixture plugin"]));
+    const variants = [
+      { name: "whatsapp", channel: "private", published: false },
+      { name: "whatsapp-reserved", published: false },
+      { name: "whatsapp-pending", published: false, pending: true },
+      { name: "whatsapp-empty-version", emptyVersion: true },
+      { name: "whatsapp-private", channel: "private" },
+      { name: "whatsapp-hidden", softDeletedAt: 1 },
+      { name: "whatsapp-blocked", scanStatus: "malicious" },
+      { name: "@openclaw/whatsapp" },
+      { name: "whatsapp-bundle", family: "bundle-plugin" },
+    ] as const;
+    const leaderboardItems = [];
+    for (const variant of variants) {
+      const options = variant as {
+        name: string;
+        channel?: "private";
+        published?: boolean;
+        pending?: boolean;
+        emptyVersion?: boolean;
+        softDeletedAt?: number;
+        scanStatus?: "malicious";
+        family?: "bundle-plugin";
+      };
+      const published = options.published !== false;
+      const version = options.emptyVersion ? "" : "1.0.0";
+      const packageId = await ctx.db.insert("packages", {
+        name: options.name,
+        normalizedName: options.name,
+        displayName: options.name,
+        ownerUserId,
+        family: options.family ?? "code-plugin",
+        channel: options.channel ?? "official",
+        isOfficial: !options.channel,
+        scanStatus: options.scanStatus ?? "clean",
+        softDeletedAt: options.softDeletedAt,
+        categories: ["channels"],
+        topics: ["WhatsApp"],
+        tags: {},
+        stats: { downloads: 1, installs: 1, stars: 0, versions: published ? 1 : 0 },
+        createdAt: 1,
+        updatedAt: 1,
+      });
+      if (published || options.pending) {
+        const releaseId = await ctx.db.insert("packageReleases", {
+          packageId,
+          version,
+          publicationStatus: published ? "published" : "pending",
+          changelog: "Initial release",
+          distTags: ["latest"],
+          files: [{ path: "index.js", size: 14, storageId, sha256: "a".repeat(64) }],
+          integritySha256: "b".repeat(64),
+          createdAt: 1,
+          createdBy: ownerUserId,
+          verification: {
+            tier: "source-linked",
+            scope: "artifact-only",
+            scanStatus: options.scanStatus ?? "clean",
+          },
+        });
+        if (published) {
+          await ctx.db.patch(packageId, {
+            latestReleaseId: releaseId,
+            latestVersionSummary: { version, createdAt: 1, changelog: "Initial release" },
+            tags: { latest: releaseId },
+          });
+        }
+      }
+      leaderboardItems.push({ packageId, score: 1, installs: 1, downloads: 1 });
+      const pkg = await ctx.db.get(packageId);
+      if (!pkg) throw new Error("Missing fixture");
+      await upsertPackageSearchDigest(ctx, extractPackageDigestFields(pkg));
+      await ctx.db.insert("packageBadges", {
+        packageId,
+        kind: "highlighted",
+        byUserId: ownerUserId,
+        at: 1,
+      });
+    }
+    await ctx.db.insert("packageLeaderboards", {
+      kind: PACKAGE_TRENDING_LEADERBOARD_KIND,
+      generatedAt: 1,
+      rangeStartDay: 0,
+      rangeEndDay: 1,
+      items: leaderboardItems,
+    });
+    return ownerUserId;
+  });
+  return { t, ownerUserId: fixtureOwnerUserId };
+}
+
+const expectedNames = ["@openclaw/whatsapp", "whatsapp-bundle"];
+const routes = [
+  "/api/v1/plugins/search?q=whatsapp",
+  "/api/v1/packages/search?q=whatsapp",
+  "/api/v1/plugins/search?q=whatsapp&highlightedOnly=true",
+  "/api/v1/plugins/search?q=whatsapp&category=channels",
+  "/api/v1/plugins/search?q=whatsapp&topic=whatsapp&createdAfter=0",
+  "/api/v1/plugins",
+  "/api/v1/packages",
+  "/api/v1/plugins?highlightedOnly=true",
+  "/api/v1/plugins?category=channels&officialFirst=true",
+  "/api/v1/plugins?topic=whatsapp",
+  "/api/v1/plugins?sort=downloads",
+  "/api/v1/plugins?sort=installs",
+  "/api/v1/plugins?sort=recommended",
+  "/api/v1/plugins?sort=trending",
+  "/api/v1/code-plugins",
+  "/api/v1/code-plugins?sort=downloads",
+  "/api/v1/bundle-plugins",
+  "/api/v1/plugins?channel=private",
+  "/api/v1/plugins/search?q=whatsapp&channel=private",
+];
+
+describe("normal plugin catalog visibility", () => {
+  it.each(["anonymous", "user", "admin"] as const)(
+    "only discovers published public plugins as %s",
+    async (viewer) => {
+      const { t, ownerUserId } = await fixture(viewer === "user" ? "user" : "admin");
+      const headers: Record<string, string> =
+        viewer === "anonymous" ? {} : { Authorization: `Bearer ${bearer}` };
+      for (const route of routes) {
+        const response = await t.fetch(route, { headers });
+        expect(response.status, route).toBe(200);
+        const body = await response.json();
+        const names = body.results
+          ? body.results.map((entry: { package: { name: string } }) => entry.package.name)
+          : body.items.map((entry: { name: string }) => entry.name);
+        const expected = route.includes("channel=private")
+          ? []
+          : route.includes("/code-plugins")
+            ? ["@openclaw/whatsapp"]
+            : route.includes("/bundle-plugins")
+              ? ["whatsapp-bundle"]
+              : expectedNames;
+        expect(names.sort(), route).toEqual(expected);
+      }
+      const browser = viewer === "anonymous" ? t : t.withIdentity({ subject: ownerUserId });
+      expect(
+        (await browser.query(api.packages.searchPublic, { query: "whatsapp" }))
+          .map((entry) => entry.package.name)
+          .sort(),
+      ).toEqual(expectedNames);
+      expect(
+        (
+          await browser.query(api.packages.listPublicPage, {
+            paginationOpts: { cursor: null, numItems: 20 },
+          })
+        ).page
+          .map((entry) => entry.name)
+          .sort(),
+      ).toEqual(expectedNames);
+    },
+  );
+
+  it.each([false, true])(
+    "paginates past placeholders without losing public plugins (authenticated=%s)",
+    async (authenticated) => {
+      const { t } = await fixture();
+      const headers: Record<string, string> = authenticated
+        ? { Authorization: `Bearer ${bearer}` }
+        : {};
+      for (const sort of ["updated", "downloads", "installs", "recommended", "trending"]) {
+        const names: string[] = [];
+        let cursor: string | undefined;
+        for (let page = 0; page < 12; page += 1) {
+          const query = new URLSearchParams({ limit: "1", sort, ...(cursor ? { cursor } : {}) });
+          const response = await t.fetch(`/api/v1/plugins?${query}`, { headers });
+          expect(response.status).toBe(200);
+          const body = await response.json();
+          expect(body.items.length).toBeLessThanOrEqual(1);
+          names.push(...body.items.map((entry: { name: string }) => entry.name));
+          cursor = body.nextCursor;
+          if (!cursor) break;
+        }
+        expect(cursor, sort).toBeFalsy();
+        expect(names.sort(), sort).toEqual(expectedNames);
+      }
+    },
+  );
+
+  it("keeps blocked releases visible to the staff-only moderation queue", async () => {
+    const { t } = await fixture();
+    const route = "/api/v1/packages/moderation/queue?status=blocked";
+    expect((await t.fetch(route)).status).toBe(401);
+    const response = await t.fetch(route, { headers: { Authorization: `Bearer ${bearer}` } });
+    expect(response.status).toBe(200);
+    expect((await response.json()).items.map((entry: { name: string }) => entry.name)).toEqual([
+      "whatsapp-blocked",
+    ]);
+  });
+});

--- a/convex/packages.catalogVisibility.runtime.test.ts
+++ b/convex/packages.catalogVisibility.runtime.test.ts
@@ -4,7 +4,7 @@
 import { register as registerRateLimiter } from "@convex-dev/rate-limiter/test";
 import { convexTest } from "convex-test";
 import { describe, expect, it } from "vitest";
-import { api } from "./_generated/api";
+import { api, internal } from "./_generated/api";
 import { extractPackageDigestFields, upsertPackageSearchDigest } from "./lib/packageSearchDigest";
 import { hashToken } from "./lib/tokens";
 import { PACKAGE_TRENDING_LEADERBOARD_KIND } from "./packageLeaderboards";
@@ -17,6 +17,12 @@ async function fixture(role: "user" | "admin" = "admin") {
   const t = convexTest(schema, modules);
   registerRateLimiter(t);
   const fixtureOwnerUserId = await t.run(async (ctx) => {
+    await ctx.db.insert("globalStats", {
+      key: "default",
+      activeSkillsCount: 0,
+      activePluginsCount: 0,
+      updatedAt: 1,
+    });
     const ownerUserId = await ctx.db.insert("users", { handle: "maintainer", role });
     await ctx.db.insert("apiTokens", {
       userId: ownerUserId,
@@ -62,7 +68,7 @@ async function fixture(role: "user" | "admin" = "admin") {
         scanStatus: options.scanStatus ?? "clean",
         softDeletedAt: options.softDeletedAt,
         categories: ["channels"],
-        topics: ["WhatsApp"],
+        topics: expectedNames.includes(options.name) ? ["WhatsApp"] : ["WhatsApp", "Withheld Only"],
         tags: {},
         stats: { downloads: 1, installs: 1, stars: 0, versions: published ? 1 : 0 },
         createdAt: 1,
@@ -137,11 +143,14 @@ const routes = [
   "/api/v1/bundle-plugins",
   "/api/v1/plugins?channel=private",
   "/api/v1/plugins/search?q=whatsapp&channel=private",
+  "/api/v1/plugins?channel=private&category=channels",
+  "/api/v1/plugins?channel=private&highlightedOnly=true",
+  "/api/v1/plugins?channel=private&sort=downloads",
 ];
 
 describe("normal plugin catalog visibility", () => {
   it.each(["anonymous", "user", "admin"] as const)(
-    "only discovers published public plugins as %s",
+    "requires explicit authorized opt-in to discover published private plugins as %s",
     async (viewer) => {
       const { t, ownerUserId } = await fixture(viewer === "user" ? "user" : "admin");
       const headers: Record<string, string> =
@@ -150,11 +159,14 @@ describe("normal plugin catalog visibility", () => {
         const response = await t.fetch(route, { headers });
         expect(response.status, route).toBe(200);
         const body = await response.json();
+        if (route === "/api/v1/plugins") expect(body.totalCount).toBe(2);
         const names = body.results
           ? body.results.map((entry: { package: { name: string } }) => entry.package.name)
           : body.items.map((entry: { name: string }) => entry.name);
         const expected = route.includes("channel=private")
-          ? []
+          ? viewer === "anonymous"
+            ? []
+            : ["whatsapp-private"]
           : route.includes("/code-plugins")
             ? ["@openclaw/whatsapp"]
             : route.includes("/bundle-plugins")
@@ -163,6 +175,13 @@ describe("normal plugin catalog visibility", () => {
         expect(names.sort(), route).toEqual(expected);
       }
       const browser = viewer === "anonymous" ? t : t.withIdentity({ subject: ownerUserId });
+      expect(await browser.query(api.packages.countPublicPlugins, {})).toBe(2);
+      expect(
+        await browser.query(api.catalogTopics.listTopByCategory, {
+          kind: "plugin",
+          category: "channels",
+        }),
+      ).toEqual(["whatsapp"]);
       expect(
         (await browser.query(api.packages.searchPublic, { query: "whatsapp" }))
           .map((entry) => entry.package.name)
@@ -179,6 +198,40 @@ describe("normal plugin catalog visibility", () => {
       ).toEqual(expectedNames);
     },
   );
+
+  it("does not expose private plugins to an unrelated authenticated user", async () => {
+    const { t } = await fixture();
+    const outsiderBearer = `${bearer}-outsider`;
+    await t.run(async (ctx) => {
+      const userId = await ctx.db.insert("users", { handle: "outsider", role: "user" });
+      await ctx.db.insert("apiTokens", {
+        userId,
+        label: "outsider fixture",
+        prefix: "local",
+        tokenHash: await hashToken(outsiderBearer),
+        createdAt: Date.now(),
+      });
+    });
+    for (const route of routes.filter((path) => path.includes("channel=private"))) {
+      const response = await t.fetch(route, {
+        headers: { Authorization: `Bearer ${outsiderBearer}` },
+      });
+      expect(response.status, route).toBe(200);
+      const body = await response.json();
+      expect(body.results ?? body.items, route).toEqual([]);
+    }
+  });
+
+  it("reconciles existing counts without counting unpublished placeholders", async () => {
+    const { t } = await fixture();
+    await t.run(async (ctx) => {
+      const stats = await ctx.db.query("globalStats").unique();
+      if (!stats) throw new Error("Missing fixture stats");
+      await ctx.db.patch(stats._id, { activePluginsCount: 5 });
+    });
+    await t.action(internal.statsMaintenance.updateGlobalStatsAction, {});
+    expect(await t.query(api.packages.countPublicPlugins, {})).toBe(2);
+  });
 
   it.each([false, true])(
     "paginates past placeholders without losing public plugins (authenticated=%s)",

--- a/convex/packages.public.test.ts
+++ b/convex/packages.public.test.ts
@@ -4819,7 +4819,7 @@ describe("packages public queries", () => {
     expect(result.page.map((entry) => entry.name)).toEqual(["public-plugin"]);
   });
 
-  it("returns no private catalog entries even when owners filter for them", async () => {
+  it("allows owners to explicitly browse published private packages", async () => {
     const { ctx, indexNames } = makeDigestCtx({
       pages: [
         {
@@ -4845,7 +4845,7 @@ describe("packages public queries", () => {
       viewerUserId: "users:owner",
     });
 
-    expect(result.page.map((entry) => entry.name)).toEqual([]);
+    expect(result.page.map((entry) => entry.name)).toEqual(["secret-plugin"]);
     expect(indexNames).toEqual(["by_active_channel_updated"]);
   });
 
@@ -5024,7 +5024,7 @@ describe("packages public queries", () => {
     expect(result.map((entry) => entry.package.name)).toEqual(["youtube"]);
   });
 
-  it("excludes private packages from catalog search even for owners", async () => {
+  it("allows owners to explicitly search published private packages", async () => {
     const { ctx } = makeDigestCtx({
       pages: [
         {
@@ -5051,7 +5051,7 @@ describe("packages public queries", () => {
       viewerUserId: "users:owner",
     });
 
-    expect(result.map((entry) => entry.package.name)).toEqual([]);
+    expect(result.map((entry) => entry.package.name)).toEqual(["secret-tools"]);
   });
 
   it("uses bounded topic and fallback digest takes for search", async () => {
@@ -5360,7 +5360,7 @@ describe("packages public queries", () => {
     expect(result.map((entry) => entry.package.name)).toEqual(["agentmail", "email"]);
   });
 
-  it("excludes private packages from catalog search even for org collaborators", async () => {
+  it("allows org collaborators to explicitly search published private packages", async () => {
     const { ctx } = makeDigestCtx({
       pages: [
         {
@@ -5392,7 +5392,7 @@ describe("packages public queries", () => {
       viewerUserId: "users:member",
     });
 
-    expect(result.map((entry) => entry.package.name)).toEqual([]);
+    expect(result.map((entry) => entry.package.name)).toEqual(["secret-tools"]);
   });
 
   it("uses the active updated index for public listings", async () => {

--- a/convex/packages.public.test.ts
+++ b/convex/packages.public.test.ts
@@ -4587,7 +4587,7 @@ describe("packages public queries", () => {
     expect(result.page.map((entry) => entry.name)).toEqual(["public-plugin"]);
   });
 
-  it("allows owners to list their private packages", async () => {
+  it("excludes private packages from catalog pages even for owners", async () => {
     const { ctx } = makeDigestCtx({
       pages: [
         {
@@ -4609,7 +4609,7 @@ describe("packages public queries", () => {
       viewerUserId: "users:owner",
     });
 
-    expect(result.page.map((entry) => entry.name)).toEqual(["secret-plugin", "public-plugin"]);
+    expect(result.page.map((entry) => entry.name)).toEqual(["public-plugin"]);
   });
 
   it("keeps highlighted package pages in newest-featured order", async () => {
@@ -4707,7 +4707,7 @@ describe("packages public queries", () => {
     expect(result.page.map((entry) => entry.name)).toEqual(["public-plugin"]);
   });
 
-  it("lets legacy no-link personal package owners list private package digests", async () => {
+  it("excludes private catalog digests even for legacy personal owners", async () => {
     const { ctx } = makeDigestCtx({
       publisherDocs: {
         "publishers:legacy-personal": {
@@ -4739,10 +4739,7 @@ describe("packages public queries", () => {
       viewerUserId: "users:viewer",
     });
 
-    expect(result.page.map((entry) => entry.name)).toEqual([
-      "legacy-personal-secret",
-      "public-plugin",
-    ]);
+    expect(result.page.map((entry) => entry.name)).toEqual(["public-plugin"]);
   });
 
   it("does not let inactive no-link personal publishers expose private package digests", async () => {
@@ -4781,7 +4778,7 @@ describe("packages public queries", () => {
     expect(result.page.map((entry) => entry.name)).toEqual(["public-plugin"]);
   });
 
-  it("does not reuse legacy no-link personal access across package owners", async () => {
+  it("excludes all private catalog digests across legacy personal owners", async () => {
     const { ctx } = makeDigestCtx({
       publisherDocs: {
         "publishers:legacy-personal": {
@@ -4819,10 +4816,10 @@ describe("packages public queries", () => {
       viewerUserId: "users:viewer",
     });
 
-    expect(result.page.map((entry) => entry.name)).toEqual(["own-legacy-secret", "public-plugin"]);
+    expect(result.page.map((entry) => entry.name)).toEqual(["public-plugin"]);
   });
 
-  it("allows owners to filter to only their private packages", async () => {
+  it("returns no private catalog entries even when owners filter for them", async () => {
     const { ctx, indexNames } = makeDigestCtx({
       pages: [
         {
@@ -4848,11 +4845,11 @@ describe("packages public queries", () => {
       viewerUserId: "users:owner",
     });
 
-    expect(result.page.map((entry) => entry.name)).toEqual(["secret-plugin"]);
+    expect(result.page.map((entry) => entry.name)).toEqual([]);
     expect(indexNames).toEqual(["by_active_channel_updated"]);
   });
 
-  it("allows org collaborators to list their private packages", async () => {
+  it("excludes private packages from catalog pages even for org collaborators", async () => {
     const { ctx } = makeDigestCtx({
       pages: [
         {
@@ -4878,7 +4875,7 @@ describe("packages public queries", () => {
       viewerUserId: "users:member",
     });
 
-    expect(result.page.map((entry) => entry.name)).toEqual(["secret-plugin", "public-plugin"]);
+    expect(result.page.map((entry) => entry.name)).toEqual(["public-plugin"]);
   });
 
   it("applies isOfficial filtering even with family and channel set", async () => {
@@ -5027,7 +5024,7 @@ describe("packages public queries", () => {
     expect(result.map((entry) => entry.package.name)).toEqual(["youtube"]);
   });
 
-  it("allows owners to search their private packages", async () => {
+  it("excludes private packages from catalog search even for owners", async () => {
     const { ctx } = makeDigestCtx({
       pages: [
         {
@@ -5054,7 +5051,7 @@ describe("packages public queries", () => {
       viewerUserId: "users:owner",
     });
 
-    expect(result.map((entry) => entry.package.name)).toEqual(["secret-tools"]);
+    expect(result.map((entry) => entry.package.name)).toEqual([]);
   });
 
   it("uses bounded topic and fallback digest takes for search", async () => {
@@ -5363,7 +5360,7 @@ describe("packages public queries", () => {
     expect(result.map((entry) => entry.package.name)).toEqual(["agentmail", "email"]);
   });
 
-  it("allows org collaborators to search their private packages", async () => {
+  it("excludes private packages from catalog search even for org collaborators", async () => {
     const { ctx } = makeDigestCtx({
       pages: [
         {
@@ -5395,7 +5392,7 @@ describe("packages public queries", () => {
       viewerUserId: "users:member",
     });
 
-    expect(result.map((entry) => entry.package.name)).toEqual(["secret-tools"]);
+    expect(result.map((entry) => entry.package.name)).toEqual([]);
   });
 
   it("uses the active updated index for public listings", async () => {

--- a/convex/packages.ts
+++ b/convex/packages.ts
@@ -1458,6 +1458,7 @@ function packageArtifactSummary(
 function digestMatchesFilters(
   digest: PackageDigestLike,
   args: {
+    channel?: PackageChannel;
     category?: string;
     topic?: string;
     createdAfter?: number;
@@ -1465,7 +1466,8 @@ function digestMatchesFilters(
   },
 ) {
   // Catalog discovery must not inherit an owner's permission to inspect hidden reservations.
-  if (digest.softDeletedAt || digest.channel === "private" || !digest.latestVersion) return false;
+  if (digest.softDeletedAt || !digest.latestVersion) return false;
+  if (digest.channel === "private" && args.channel !== "private") return false;
   if (isPackageBlockedFromPublic(digest.scanStatus)) return false;
   if (!isClawFamilyPubliclyVisible(digest.family)) return false;
   if (digest.scanStatus && args.excludedScanStatuses?.includes(digest.scanStatus)) return false;
@@ -1516,9 +1518,8 @@ function packageMatchesListFilters(
     excludedScanStatuses?: PackageListScanStatus[];
   },
 ) {
-  if (pkg.softDeletedAt || pkg.channel === "private" || !pkg.latestVersionSummary?.version) {
-    return false;
-  }
+  if (pkg.softDeletedAt || !pkg.latestVersionSummary?.version) return false;
+  if (pkg.channel === "private" && args.channel !== "private") return false;
   if (isPackageBlockedFromPublic(pkg.scanStatus)) return false;
   if (!isClawFamilyPubliclyVisible(pkg.family)) return false;
   if (pkg.scanStatus && args.excludedScanStatuses?.includes(pkg.scanStatus)) return false;

--- a/convex/packages.ts
+++ b/convex/packages.ts
@@ -1464,6 +1464,9 @@ function digestMatchesFilters(
     excludedScanStatuses?: PackageListScanStatus[];
   },
 ) {
+  // Catalog discovery must not inherit an owner's permission to inspect hidden reservations.
+  if (digest.softDeletedAt || digest.channel === "private" || !digest.latestVersion) return false;
+  if (isPackageBlockedFromPublic(digest.scanStatus)) return false;
   if (!isClawFamilyPubliclyVisible(digest.family)) return false;
   if (digest.scanStatus && args.excludedScanStatuses?.includes(digest.scanStatus)) return false;
   if (args.category) {
@@ -1513,6 +1516,10 @@ function packageMatchesListFilters(
     excludedScanStatuses?: PackageListScanStatus[];
   },
 ) {
+  if (pkg.softDeletedAt || pkg.channel === "private" || !pkg.latestVersionSummary?.version) {
+    return false;
+  }
+  if (isPackageBlockedFromPublic(pkg.scanStatus)) return false;
   if (!isClawFamilyPubliclyVisible(pkg.family)) return false;
   if (pkg.scanStatus && args.excludedScanStatuses?.includes(pkg.scanStatus)) return false;
   if (args.family && pkg.family !== args.family) return false;

--- a/convex/statsMaintenance.test.ts
+++ b/convex/statsMaintenance.test.ts
@@ -308,36 +308,42 @@ describe("public package digest count maintenance", () => {
     const paginate = vi.fn().mockResolvedValue({
       page: [
         {
+          latestVersion: "1.0.0",
           family: "code-plugin",
           channel: "community",
           scanStatus: "clean",
           softDeletedAt: undefined,
         },
         {
+          latestVersion: "1.0.0",
           family: "bundle-plugin",
           channel: "official",
           scanStatus: "not-run",
           softDeletedAt: undefined,
         },
         {
+          latestVersion: "1.0.0",
           family: "skill",
           channel: "community",
           scanStatus: "clean",
           softDeletedAt: undefined,
         },
         {
+          latestVersion: "1.0.0",
           family: "code-plugin",
           channel: "private",
           scanStatus: "clean",
           softDeletedAt: undefined,
         },
         {
+          latestVersion: "1.0.0",
           family: "bundle-plugin",
           channel: "community",
           scanStatus: "malicious",
           softDeletedAt: undefined,
         },
         {
+          latestVersion: "1.0.0",
           family: "code-plugin",
           channel: "community",
           scanStatus: "clean",

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -588,8 +588,9 @@ Notes:
 - Skill entries stay backed by the skill registry and can still be published only through `POST /api/v1/skills`.
 - `POST /api/v1/packages` is still only for code-plugin and bundle-plugin releases.
 - Anonymous callers only see public package channels.
-- Authenticated callers can see private packages for publishers they belong to in list/search results.
-- `channel=private` only returns packages the authenticated caller can read.
+- List/search defaults to public, published plugin packages, including for authenticated callers.
+- Explicit `channel=private` returns published private packages the authenticated caller can read.
+- Reservations, unpublished, deleted, and blocked plugin packages are excluded from list/search.
 
 ### `GET /api/v1/packages/search`
 
@@ -611,8 +612,9 @@ Notes:
 - Invalid values for `family`, `channel`, `isOfficial`, `featured`, or
   `highlightedOnly` return `400`. Unknown query parameters are ignored.
 - Anonymous callers only see public package channels.
-- Authenticated callers can search private packages for publishers they belong to.
-- `channel=private` only returns packages the authenticated caller can read.
+- Search defaults to public, published plugin packages, including for authenticated callers.
+- Explicit `channel=private` returns published private packages the authenticated caller can read.
+- Reservations, unpublished, deleted, and blocked plugin packages are excluded from search.
 
 ### `GET /api/v1/plugins`
 

--- a/specs/plans/plugins.md
+++ b/specs/plans/plugins.md
@@ -781,6 +781,13 @@ API shape rule:
   never accompany the published `@openclaw/whatsapp` in normal discovery.
   Owner management/detail access and explicitly staff-only moderation APIs
   retain their separate authorization rules and may inspect withheld records.
+- Explicit `channel=private` list/search requests may return published private
+  packages the authenticated caller is authorized to read; reservations,
+  unpublished, deleted, and blocked packages remain excluded.
+- Public plugin counts and topic suggestions use the same public publication
+  criteria. After deploying this eligibility change, the existing
+  `statsMaintenance:updateGlobalStatsAction` recount repairs historical totals;
+  the daily global-stats cron also performs this reconciliation.
 - family-specific endpoints are allowed for install and publish semantics
 - code-plugin download/install endpoints must not be overloaded for bundle
   plugins

--- a/specs/plans/plugins.md
+++ b/specs/plans/plugins.md
@@ -770,6 +770,17 @@ code-plugin packages only.
 API shape rule:
 
 - shared `/packages` endpoints are for discovery and shared metadata
+- Normal plugin/package search and browse return only public, non-deleted,
+  non-blocked packages with a published latest version. The package's
+  `latestVersionSummary.version` and its search digest's `latestVersion` are
+  the publication markers used on these read paths; reservations and pending
+  first publications have neither. These filters apply before result limits
+  and pagination, including featured, category, topic, and sorted discovery.
+- Authentication, package ownership, and publisher membership must not widen
+  normal catalog visibility. A private reservation such as `whatsapp` must
+  never accompany the published `@openclaw/whatsapp` in normal discovery.
+  Owner management/detail access and explicitly staff-only moderation APIs
+  retain their separate authorization rules and may inspect withheld records.
 - family-specific endpoints are allowed for install and publish semantics
 - code-plugin download/install endpoints must not be overloaded for bundle
   plugins


### PR DESCRIPTION
Authenticated plugin discovery reused owner-read authorization, so a maintainer searching for `whatsapp` received the private, reserved `whatsapp` record alongside `@openclaw/whatsapp`. A read-only production request reproduced this: the reservation has `channel: private`, `latestVersion: null`, and zero versions.

Require public, non-deleted, non-blocked records with a published latest version in the owning package query filters, before limits and pagination. This covers plugin/package search and browse, code/bundle helpers, featured/category/topic filters, and sorted/trending pages. Authentication no longer widens default discovery. Explicit `channel=private` requests still return published private packages the caller is authorized to read. Reservations and withheld placeholders remain excluded. Owner inspection and staff-only moderation keep their separate authorization.

Public counts and topic suggestions now also require a published latest version. The existing `statsMaintenance:updateGlobalStatsAction` recount repairs historical totals after deployment; the daily cron also reconciles them. No production records are changed or deleted by this PR.

### Before / after proof

Deployed baseline `651a7641a2` and the fix to the same disposable local Convex database at `http://127.0.0.1:3298`. Fixtures include the private `whatsapp` reservation, public reservations/pending releases, private/hidden/blocked published records, an empty-version placeholder, `@openclaw/whatsapp`, and a published bundle.

| Request | Baseline | Fixed |
| --- | --- | --- |
| Anonymous `/api/v1/plugins/search?q=whatsapp` | Public reservation, pending, and empty-version placeholders included | Only the two published public plugins |
| Maintainer `/api/v1/plugins/search?q=whatsapp` | Also includes private `whatsapp`, private published plugin, and blocked plugin | Only the two published public plugins |
| Package search and plugin/code/bundle browse | Same visibility leak | Only eligible public plugins |
| Authorized explicit `channel=private` search/browse | Reservation and published private plugin | Only the published private plugin; anonymous/unrelated callers get no results |
| Public plugin count | 5, including unpublished placeholders | 2 after existing recount; new digest updates maintain the same rule |
| Staff `/api/v1/packages/moderation/queue?status=blocked` | Blocked fixture returned; anonymous gets 401 | Unchanged |

HTTP proof was captured before and after against real deployed functions. Regression tests additionally assert withheld-only topics never appear in suggestions.

Real browser proof is now complete. Disposable Playwright Chromium captured the running app at `http://127.0.0.1:3197/plugins` and the retained owner management surface at `/dashboard`, using the same local fixtures with the owner signed in as `@local-admin`. Browser baseline is the merged audit prerequisite `39ff7db30c2e` (the original visibility behavior); candidate is exact PR head `ec021d9db1`. No code changes were needed for this proof. [Full capture report and screenshots](https://github.com/openclaw/clawhub/tree/qa-artifacts/clawhub-ui-proof/pr-3646/ec021d9db1).

| Signed-in catalog before: five entries | Signed-in catalog after: two published public plugins |
| --- | --- |
| ![Before catalog](https://raw.githubusercontent.com/openclaw/clawhub/qa-artifacts/clawhub-ui-proof/pr-3646/ec021d9db1/baseline/owner-catalog.png) | ![After catalog](https://raw.githubusercontent.com/openclaw/clawhub/qa-artifacts/clawhub-ui-proof/pr-3646/ec021d9db1/candidate/owner-catalog.png) |

[Anonymous before](https://raw.githubusercontent.com/openclaw/clawhub/qa-artifacts/clawhub-ui-proof/pr-3646/ec021d9db1/baseline/anonymous-catalog.png) → [anonymous after](https://raw.githubusercontent.com/openclaw/clawhub/qa-artifacts/clawhub-ui-proof/pr-3646/ec021d9db1/candidate/anonymous-catalog.png).

The owner dashboard retains the private reservation and published private package, independently of normal discovery:

![Retained owner management access](https://raw.githubusercontent.com/openclaw/clawhub/qa-artifacts/clawhub-ui-proof/pr-3646/ec021d9db1/candidate/owner-dashboard.png)

The changed default visibility is intentional and maintainer-approved; explicit authorized `channel=private` remains supported. Existing totals are reconciled by the documented post-deployment recount or daily job; this PR does not perform a production deployment. The local recount and its regression test both verified 5 → 2.

### Validation

- 407 focused tests passed, including actual HTTP/auth/query coverage for anonymous callers, owners, admins, unrelated users, pagination, counts/topics, recount, and staff moderation. The new review regressions failed before the fixes.
- `bun run ci:static`: passed after prerequisite #3635 merged; no audit exceptions added.
- `bun run ci:unit`: 6,500 passed, 3 skipped.
- `bun run ci:types-build`: passed, including package TypeScript checks and production build.
- `bun run ci:e2e-http`: passed.
- `bunx tsc -p convex/tsconfig.json --noEmit`: passed.
- Local Convex deployment with TypeScript enabled, HTTP smoke, and existing stats recount: passed.
- Structured autoreview: clean, no accepted/actionable findings on the initial patch or follow-up fixes (Codex).
