### PR TITLE
feat: operate reviewed plugin category backfills

### DIFF
--- a/.github/workflows/plugin-category-refresh.yml
+++ b/.github/workflows/plugin-category-refresh.yml
@@ -1,0 +1,93 @@
+name: Plugin Category Refresh
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "Fixed operator action (accept rehearses without applying categories)"
+        type: choice
+        required: true
+        default: status
+        options: [status, preview, report, accept, apply, rollback]
+      expected_sha:
+        description: "Exact main commit already deployed to production"
+        type: string
+        required: true
+      run_id:
+        description: "Stable category refresh run ID; reuse it when resuming"
+        type: string
+        required: true
+      cursor:
+        description: "Previous resumeCursor; blank starts at the beginning"
+        type: string
+        default: ""
+      max_pages:
+        description: "Bounded pages per dispatch (1–20)"
+        type: string
+        default: "10"
+      workers:
+        description: "Concurrent preview actions (1–4)"
+        type: string
+        default: "3"
+      reviewed_ids:
+        description: "JSON array of at most 100 journal IDs; report computes their review hash"
+        type: string
+        default: "[]"
+      review_hash:
+        description: "Exact report SHA-256 required by accept, apply, and rollback"
+        type: string
+        default: ""
+
+concurrency:
+  group: plugin-category-refresh-production
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  operate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: read
+    environment:
+      name: Production
+    steps:
+      - name: Require exact main revision
+        env:
+          CATEGORY_EXPECTED_SHA: ${{ inputs.expected_sha }}
+        run: |
+          set -euo pipefail
+          if [[ "$GITHUB_REF" != refs/heads/main || ! "$CATEGORY_EXPECTED_SHA" =~ ^[a-f0-9]{40}$ || "$GITHUB_SHA" != "$CATEGORY_EXPECTED_SHA" ]]; then
+            echo '::error::Category refresh requires the exact deployed main SHA.'
+            exit 1
+          fi
+
+      - uses: actions/checkout@v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - uses: ./.github/actions/setup-bun
+
+      - name: Run bounded category operation
+        env:
+          CONVEX_DEPLOY_KEY: ${{ secrets.CONVEX_DEPLOY_KEY }}
+          CATEGORY_MODE: ${{ inputs.mode }}
+          CATEGORY_EXPECTED_SHA: ${{ inputs.expected_sha }}
+          CATEGORY_RUN_ID: ${{ inputs.run_id }}
+          CATEGORY_CURSOR: ${{ inputs.cursor }}
+          CATEGORY_MAX_PAGES: ${{ inputs.max_pages }}
+          CATEGORY_WORKERS: ${{ inputs.workers }}
+          CATEGORY_REVIEWED_IDS: ${{ inputs.reviewed_ids }}
+          CATEGORY_REVIEW_HASH: ${{ inputs.review_hash }}
+        run: bun scripts/plugin-category-operator.ts
+
+      - name: Preserve bounded operator evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: plugin-category-refresh-${{ github.run_id }}-${{ github.run_attempt }}
+          path: artifacts/plugin-category-operator/result.json
+          if-no-files-found: warn
+          retention-days: 30

--- a/docs/plugin-category-refresh.md
+++ b/docs/plugin-category-refresh.md
@@ -1,0 +1,103 @@
+---
+title: "Refreshing plugin categories"
+summary: "Operate the reviewed production plugin category refresh and rollback workflow"
+read_when:
+  - You are operating an approved production plugin category backfill
+llms: false
+---
+
+# Refreshing plugin categories
+
+The **Plugin Category Refresh** GitHub workflow operates on production
+`wry-manatee-359` using the existing Production environment credential. It never
+deploys code. First deploy the matching frontend and backend from main through
+the normal release workflow. Every operation verifies the exact deployed commit
+and public category vocabulary before proceeding.
+
+Keep production deployments frozen for the whole refresh window. The SHA check
+is a preflight, not a global deployment lock. Apply starts an asynchronous
+migration: wait until status reports completion before allowing any deployment,
+and recheck status if an operation loses its response. The backend separately
+rechecks each row's classifier, pinned bundled assignment, latest release, and
+source hash. The operator should verify the deployed SHA around each wave.
+
+## Preview and review
+
+Use a stable run ID for a complete traversal. A preview writes journal rows and
+may call `gpt-5.6-luna`; it does not change the categories people browse. The
+production `OPENAI_API_KEY` must exist and `OPENAI_PLUGIN_CATEGORY_MODEL` must be
+unset or `gpt-5.6-luna`. Status reports these checks as booleans, without secrets.
+
+```bash
+gh workflow run plugin-category-refresh.yml --repo openclaw/clawhub --ref main \
+  -f mode=status -f expected_sha="$DEPLOYED_SHA" -f run_id="$CATEGORY_RUN"
+
+gh workflow run plugin-category-refresh.yml --repo openclaw/clawhub --ref main \
+  -f mode=preview -f expected_sha="$DEPLOYED_SHA" -f run_id="$CATEGORY_RUN" \
+  -f max_pages=20 -f workers=3 -f cursor="$PREVIEW_CURSOR"
+```
+
+Each preview handles at most twenty pages of ten package rows, with at most four
+simultaneous actions. Pages can contain no plugins. Download the workflow's
+`plugin-category-refresh-*` artifact and use its `resumeCursor` for the next
+dispatch. On failure, that cursor stops before the first incomplete page, even
+if later pages completed. Reuse the same run ID: existing journal rows are
+skipped, never replaced. A request that lost its response might still finish on
+the server; wait for it to settle before retrying. Run one final traversal from
+the beginning with the same run ID to reconcile changes during enumeration.
+Each page preserves bounded package IDs and diagnostic reasons for skipped or
+failed entries, including entries that never produced a journal row.
+
+Run `mode=report` with `cursor`/`max_pages` to export up to 2,000 journal rows per
+dispatch. Report cursors and preview cursors belong to different tables; do not
+interchange them. Inspect proposed categories, source, evidence, previous
+categories, version, and status. Fallback rows cannot be accepted; retry failed
+classifications under a new run ID. Existing author declarations, including
+valid legacy arrays, remain authoritative.
+
+Choose at most 100 rows for a wave, starting with a small pilot. Use `report`
+with the JSON `reviewed_ids` array to get the exact selected rows and their
+`reviewHash`. The hash binds the release, source hash, classification, and
+category assignment. It intentionally excludes mutable journal status so it
+remains valid as that assignment moves from preview to accepted to applied.
+
+```bash
+gh workflow run plugin-category-refresh.yml --repo openclaw/clawhub --ref main \
+  -f mode=report -f expected_sha="$DEPLOYED_SHA" -f run_id="$CATEGORY_RUN" \
+  -f reviewed_ids="$REVIEWED_IDS_JSON"
+
+gh workflow run plugin-category-refresh.yml --repo openclaw/clawhub --ref main \
+  -f mode=accept -f expected_sha="$DEPLOYED_SHA" -f run_id="$CATEGORY_RUN" \
+  -f reviewed_ids="$REVIEWED_IDS_JSON" -f review_hash="$REVIEW_HASH"
+```
+
+Accept marks reviewed rows accepted and rehearses the first ten through a
+transaction that rolls back. Category state stays unchanged. A failed rehearsal
+leaves accepted rows available for inspection. Fresh generated previews must use
+classifier `plugin-single-category-v3`; bundled previews must match the pinned
+OpenClaw source commit and manifest hashes in the checked-out inventory.
+
+## Apply, monitor, and undo
+
+Dispatch `mode=apply` with the same reviewed IDs and hash after a successful
+rehearsal. Apply repeats the first-ten rehearsal and verifies how many rows it
+processed, so a previous failed or lost rehearsal response cannot bypass this
+gate. The workflow requires every selected row to be accepted and refuses
+to start while another migration worker runs or any unreviewed accepted row
+exists. The shared migration worker applies batches of ten. Its accepted-row
+index covers all runs, so use this workflow as the sole operator during a wave.
+
+Poll `mode=status`, then export `mode=report`. The component's processed count
+includes attempts; count actual `applied` and `stale` journal rows separately.
+The backend checks the latest release and evidence again when applying; changed
+rows become stale instead of overwriting newer work. Wait for the worker to
+finish and verify browse/detail output before starting another wave.
+
+If a wave stops partway through, report and select only its remaining accepted
+rows, obtain their new review hash, and dispatch apply again. The workflow
+restarts the accepted index only when no worker is active. For rollback, report
+and select applied rows, then dispatch `mode=rollback` with those IDs and hash.
+Rollback refuses when a newer publication or category edit changed the applied
+state. After a partial rollback failure, report and select only the remaining
+applied rows before retrying. Keep the journal and downloaded artifacts until
+verification is complete; artifacts expire after thirty days.

--- a/scripts/plugin-category-operator.test.ts
+++ b/scripts/plugin-category-operator.test.ts
@@ -1,0 +1,448 @@
+/* @vitest-environment node */
+import { describe, expect, it, vi } from "vitest";
+import inventory from "../convex/lib/bundledPluginCategoryAssignments.json";
+import {
+  assertReviewed,
+  operate,
+  parseOptions,
+  previewPages,
+  reviewHash,
+  reviewRow,
+} from "./plugin-category-operator";
+
+const sha = "a".repeat(40);
+const id = "a".repeat(32);
+const secondId = "b".repeat(32);
+const env = {
+  GITHUB_REF: "refs/heads/main",
+  GITHUB_SHA: sha,
+  CATEGORY_EXPECTED_SHA: sha,
+  CONVEX_DEPLOY_KEY: "prod:wry-manatee-359|test-only",
+  CATEGORY_MODE: "preview",
+  CATEGORY_RUN_ID: "claw-774-test",
+};
+const row = () => ({
+  _id: id,
+  runId: env.CATEGORY_RUN_ID,
+  packageId: "package",
+  releaseId: "release",
+  packageName: "test-plugin",
+  version: "1.0.0",
+  status: "preview",
+  beforeHash: "a".repeat(64),
+  beforeCategories: ["tools"],
+  categories: ["developer-tools"],
+  classification: {
+    source: "generated",
+    classifierVersion: "plugin-single-category-v3",
+    inputHash: "b".repeat(64),
+    evidence: "Reviews code.",
+  },
+});
+function options(mode = "preview", rows = [row()]) {
+  return parseOptions({
+    ...env,
+    CATEGORY_MODE: mode,
+    ...(["accept", "apply", "rollback"].includes(mode)
+      ? {
+          CATEGORY_REVIEWED_IDS: JSON.stringify(rows.map((r) => r._id)),
+          CATEGORY_REVIEW_HASH: reviewHash(rows),
+        }
+      : {}),
+  });
+}
+type Client = Parameters<typeof operate>[0];
+function client(overrides: Partial<Client> = {}): Client {
+  return {
+    run: vi.fn(async () => ({ appBuildSha: sha })) as Client["run"],
+    query: vi.fn(async () => []) as Client["query"],
+    envNames: vi.fn(async () => ["OPENAI_API_KEY"]),
+    model: vi.fn(async () => "gpt-5.6-luna"),
+    taxonomyMatches: vi.fn(async () => true),
+    ...overrides,
+  };
+}
+
+describe("production category operator guards", () => {
+  it.each([
+    { GITHUB_REF: "refs/heads/codex/task" },
+    { GITHUB_SHA: "b".repeat(40) },
+    { CATEGORY_EXPECTED_SHA: "$(echo unsafe)" },
+    { CONVEX_DEPLOY_KEY: "prod:academic-chihuahua-392|test-only" },
+    { CONVEX_DEPLOY_KEY: "" },
+    { CATEGORY_RUN_ID: "bad; command" },
+    { CATEGORY_MAX_PAGES: "21" },
+    { CATEGORY_WORKERS: "5" },
+    { CATEGORY_WORKERS: "1.5" },
+    { CATEGORY_MODE: "eval" },
+    { CATEGORY_REVIEWED_IDS: "not-json" },
+    { CATEGORY_CURSOR: "bad\n" },
+  ])("rejects wrong target and malformed request %j", (override) => {
+    expect(() => parseOptions({ ...env, ...override })).toThrow();
+  });
+  it("rejects missing, duplicate, oversized, and injection-shaped review IDs", () => {
+    for (const ids of [
+      [],
+      [id, id],
+      ["');ctx.db.delete('x')"],
+      Array.from({ length: 101 }, (_, n) => `a${String(n).padStart(31, "0")}`),
+    ]) {
+      expect(() =>
+        parseOptions({
+          ...env,
+          CATEGORY_MODE: "apply",
+          CATEGORY_REVIEWED_IDS: JSON.stringify(ids),
+          CATEGORY_REVIEW_HASH: "a".repeat(64),
+        }),
+      ).toThrow();
+    }
+  });
+  it("stops before any write when deployment SHA or model differs", async () => {
+    const wrong = client({ run: vi.fn(async () => ({ appBuildSha: "old" })) as Client["run"] });
+    await expect(operate(wrong, options(), vi.fn())).rejects.toThrow("deployed SHA");
+    expect(wrong.run).toHaveBeenCalledTimes(1);
+    const otherModel = client({
+      envNames: async () => ["OPENAI_API_KEY", "OPENAI_PLUGIN_CATEGORY_MODEL"],
+      model: async () => "other-model",
+    });
+    await expect(operate(otherModel, options(), vi.fn())).rejects.toThrow("gpt-5.6-luna");
+    expect(otherModel.run).toHaveBeenCalledTimes(1);
+    const oldTaxonomy = client({ taxonomyMatches: async () => false });
+    await expect(operate(oldTaxonomy, options(), vi.fn())).rejects.toThrow("category contract");
+    expect(oldTaxonomy.run).toHaveBeenCalledTimes(1);
+  });
+  it("requires exact inspected evidence and current classifier while preserving old manifest arrays", () => {
+    const original = row();
+    const request = options("accept", [original]);
+    assertReviewed([original], request);
+    expect(() => assertReviewed([{ ...original, categories: ["other"] }], request)).toThrow(
+      "Review hash changed",
+    );
+    expect(() => assertReviewed([{ ...original, runId: "another-run" }], request)).toThrow(
+      "belong",
+    );
+    const old = {
+      ...original,
+      classification: {
+        ...original.classification,
+        classifierVersion: "plugin-single-category-v2",
+      },
+    };
+    expect(() => assertReviewed([old], options("accept", [old]))).toThrow("v3");
+    const fallback = {
+      ...original,
+      classification: { ...original.classification, source: "fallback" },
+    };
+    expect(() => assertReviewed([fallback], options("accept", [fallback]))).toThrow("Fallback");
+    const manifest = {
+      ...original,
+      categories: ["tools", "runtime"],
+      classification: { ...original.classification, source: "manifest" },
+    };
+    expect(() => assertReviewed([manifest], options("accept", [manifest]))).not.toThrow();
+  });
+  it("checks the exact bundled source pin, input hash, and assignment", () => {
+    const entry = inventory.assignments[0];
+    const bundled = {
+      ...row(),
+      packageName: entry.packageName,
+      categories: entry.categories,
+      classification: {
+        source: "bundled",
+        classifierVersion: `bundled-product-categories:${inventory.sourceCommit}`,
+        inputHash: entry.manifestSha256,
+        evidence: "Reviewed manifest",
+      },
+    };
+    assertReviewed([bundled], options("accept", [bundled]));
+    const changed = {
+      ...bundled,
+      classification: { ...bundled.classification, inputHash: "e".repeat(64) },
+    };
+    expect(() => assertReviewed([changed], options("accept", [changed]))).toThrow(
+      "pinned inventory",
+    );
+  });
+  it("hashes ordered assignments independently of status and drops unrelated document bodies", () => {
+    const original = {
+      ...row(),
+      rawSource: "DO NOT EXPORT",
+      newReleaseSummary: { secrets: "DO NOT EXPORT" },
+    };
+    expect(reviewHash([original])).toBe(reviewHash([{ ...original, status: "accepted" }]));
+    expect(JSON.stringify(reviewRow(original))).not.toContain("DO NOT EXPORT");
+    expect(() =>
+      assertReviewed([{ ...original, status: "accepted" }], options("accept", [original])),
+    ).toThrow("status");
+  });
+});
+
+describe("bounded preview checkpoints", () => {
+  it("preserves bounded skip diagnostics even when no journal row was created", async () => {
+    const run = vi.fn(async (name: string) =>
+      name.endsWith("getPage")
+        ? { cursor: "end", isDone: true, ids: [id, secondId] }
+        : {
+            cursor: "end",
+            isDone: true,
+            previewed: 0,
+            skipped: 1,
+            failed: 1,
+            diagnostics: [
+              {
+                packageId: id,
+                reason: "No bounded plugin manifest evidence.",
+                rawSource: "DO NOT EXPORT",
+              },
+              {
+                packageId: secondId,
+                reason: "Malformed artifact. ".repeat(100),
+                rawSource: "DO NOT EXPORT",
+              },
+            ],
+          },
+    ) as Client["run"];
+    const checkpoint = vi.fn();
+    const result = await previewPages(client({ run }), options(), checkpoint);
+    expect(result.pages[0].result?.diagnostics).toEqual([
+      { packageId: id, reason: "No bounded plugin manifest evidence." },
+      { packageId: secondId, reason: "Malformed artifact. ".repeat(100).slice(0, 500) },
+    ]);
+    expect(JSON.stringify(checkpoint.mock.calls)).not.toContain("DO NOT EXPORT");
+    expect(result).toMatchObject({ skipped: 1, failed: 1, isDone: true });
+  });
+  it("retains the last contiguous cursor when a later page succeeds before an earlier failure", async () => {
+    let release: () => void = () => {};
+    const delayed = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const run = vi.fn(async (name: string, args: Record<string, unknown>) => {
+      if (name.endsWith("getPage")) {
+        const index = args.cursor ? Number(String(args.cursor).slice(1)) : 0;
+        return { cursor: `c${index + 1}`, isDone: index === 2, ids: [id] };
+      }
+      if (!args.cursor) {
+        await delayed;
+        throw new Error("transport failure");
+      }
+      release();
+      return { cursor: "c2", isDone: false, previewed: 1, skipped: 0, failed: 0 };
+    }) as Client["run"];
+    const saved: Record<string, unknown>[] = [];
+    const result = await previewPages(
+      client({ run }),
+      { ...options(), maxPages: 2, workers: 2 },
+      async (value) => {
+        saved.push(value);
+      },
+    );
+    expect(result.resumeCursor).toBeNull();
+    expect(result.completedPages).toBe(1);
+    expect(result.failedPages).toEqual([0]);
+    expect(saved.at(-1)).toEqual(result);
+    expect(run).toHaveBeenCalledWith("pluginCategoryRefresh:preview", {
+      runId: env.CATEGORY_RUN_ID,
+      batchSize: 10,
+      cursor: "c1",
+    });
+  });
+  it("bounds calls, continues empty package pages, and reports the next resumable cursor", async () => {
+    const run = vi.fn(async (name: string, args: Record<string, unknown>) => {
+      const index = args.cursor ? Number(String(args.cursor).slice(1)) : 0;
+      return name.endsWith("getPage")
+        ? { cursor: `c${index + 1}`, isDone: false, ids: [] }
+        : { cursor: `c${index + 1}`, isDone: false, previewed: 0, skipped: 0, failed: 0 };
+    }) as Client["run"];
+    const result = await previewPages(
+      client({ run }),
+      { ...options(), maxPages: 2 },
+      async () => {},
+    );
+    expect(result.resumeCursor).toBe("c2");
+    expect(result.isDone).toBe(false);
+    expect(run).toHaveBeenCalledTimes(4);
+  });
+  it("leaves a replayable hole if corpus changes alter a pre-enumerated boundary", async () => {
+    const run = vi.fn(async (name: string) =>
+      name.endsWith("getPage")
+        ? { cursor: "planned", isDone: true, ids: [] }
+        : { cursor: "moved", isDone: true, previewed: 1, skipped: 0, failed: 0 },
+    ) as Client["run"];
+    const result = await previewPages(client({ run }), options(), async () => {});
+    expect(result.resumeCursor).toBeNull();
+    expect(result.failedPages).toEqual([0]);
+  });
+});
+
+describe("reviewed write waves", () => {
+  it("reports applied and stale separately instead of counting every processed row as applied", async () => {
+    const rows = [
+      { ...row(), status: "applied" },
+      { ...row(), _id: secondId, status: "stale", reason: "Latest release changed." },
+    ];
+    const c = client({ query: vi.fn(async () => rows) as Client["query"] });
+    const request = parseOptions({
+      ...env,
+      CATEGORY_MODE: "report",
+      CATEGORY_REVIEWED_IDS: JSON.stringify([id, secondId]),
+    });
+    const report = await operate(c, request, async () => {});
+    expect(report).toMatchObject({ rowCount: 2, statuses: { applied: 1, stale: 1 } });
+    expect("rows" in report && report.rows[1]).toMatchObject({
+      status: "stale",
+      reason: "Latest release changed.",
+    });
+  });
+  function writeClient(
+    rows: ReturnType<typeof row>[],
+    accepted: Array<{ id: string; runId: string }> = [],
+  ) {
+    let started = false;
+    return client({
+      query: vi.fn(async (source: string) =>
+        source.includes("by_status") ? accepted : rows,
+      ) as Client["query"],
+      run: vi.fn(async (name: string, args: Record<string, unknown>) => {
+        if (name === "appMeta:getDeploymentInfo") return { appBuildSha: sha };
+        if (name === "lib:getStatus")
+          return started ? [{ state: "success", processed: rows.length, isDone: true }] : [];
+        if (name === "pluginCategoryRefresh:accept") return { accepted: rows.length };
+        if (name === "pluginCategoryRefresh:rollback") return { rolledBack: true };
+        if (name === "migrations:run" && !args.dryRun) started = true;
+        return {
+          DryRun: "No changes were committed.",
+          Name: "migrations:applyAcceptedPluginCategoryRefreshes",
+          Status: "DRY RUN: Migration was started and finished in one batch.",
+          processed: rows.length,
+        };
+      }) as Client["run"],
+    });
+  }
+  it("accepts only reviewed rows and rehearses through the rollback-aware runner", async () => {
+    const c = writeClient([row()]);
+    const result = await operate(c, options("accept"), async () => {});
+    expect(result).toMatchObject({ accepted: 1, dryRun: { transactionRolledBack: true } });
+    expect(c.run).toHaveBeenCalledWith("migrations:run", {
+      fn: "migrations:applyAcceptedPluginCategoryRefreshes",
+      batchSize: 10,
+      reset: true,
+      dryRun: true,
+    });
+  });
+  it("blocks global migration when a foreign or unreviewed accepted row exists", async () => {
+    const acceptedRow = { ...row(), status: "accepted" };
+    for (const waiting of [
+      { id: secondId, runId: env.CATEGORY_RUN_ID },
+      { id, runId: "foreign-run" },
+    ]) {
+      const c = writeClient([acceptedRow], [waiting]);
+      await expect(operate(c, options("apply", [acceptedRow]), async () => {})).rejects.toThrow(
+        "Foreign accepted",
+      );
+      expect(c.run).not.toHaveBeenCalledWith("migrations:run", expect.anything());
+    }
+  });
+  it("starts only the exact accepted wave", async () => {
+    const acceptedRow = { ...row(), status: "accepted" };
+    const c = writeClient([acceptedRow], [{ id, runId: env.CATEGORY_RUN_ID }]);
+    await expect(
+      operate(c, options("apply", [acceptedRow]), async () => {}),
+    ).resolves.toMatchObject({ started: true });
+  });
+  it.each([0, 2])(
+    "refuses apply when rehearsal processes %i instead of the reviewed row",
+    async (processed) => {
+      const acceptedRow = { ...row(), status: "accepted" };
+      const c = writeClient([acceptedRow], [{ id, runId: env.CATEGORY_RUN_ID }]);
+      const original = c.run;
+      c.run = vi.fn(async (name: string, args: Record<string, unknown>, component?: boolean) => {
+        const result = await original(name, args, component);
+        return name === "migrations:run" && args.dryRun
+          ? { ...(result as object), processed }
+          : result;
+      }) as Client["run"];
+      await expect(operate(c, options("apply", [acceptedRow]), async () => {})).rejects.toThrow(
+        "did not exercise",
+      );
+      expect(c.run).not.toHaveBeenCalledWith("migrations:run", {
+        fn: "migrations:applyAcceptedPluginCategoryRefreshes",
+        batchSize: 10,
+        reset: true,
+      });
+    },
+  );
+  it("fails and checkpoints a no-op rollback instead of reporting success", async () => {
+    const applied = { ...row(), status: "applied" };
+    const c = writeClient([applied]);
+    const original = c.run;
+    c.run = (async (name: string, args: Record<string, unknown>, component?: boolean) =>
+      name === "pluginCategoryRefresh:rollback"
+        ? { rolledBack: false }
+        : original(name, args, component)) as Client["run"];
+    const checkpoint = vi.fn();
+    await expect(operate(c, options("rollback", [applied]), checkpoint)).rejects.toThrow(
+      "did not restore",
+    );
+    expect(checkpoint).toHaveBeenCalledWith({ results: [{ id, rolledBack: false }] });
+  });
+  it("fails and checkpoints an apply when the component reports an immediate batch failure", async () => {
+    const acceptedRow = { ...row(), status: "accepted" };
+    const c = writeClient([acceptedRow], [{ id, runId: env.CATEGORY_RUN_ID }]);
+    const original = c.run;
+    let applied = false;
+    c.run = (async (name: string, args: Record<string, unknown>, component?: boolean) => {
+      if (name === "migrations:run") applied = true;
+      if (name === "lib:getStatus" && applied)
+        return [{ state: "failed", processed: 0, isDone: false, error: "batch failed" }];
+      return original(name, args, component);
+    }) as Client["run"];
+    const checkpoint = vi.fn();
+    await expect(operate(c, options("apply", [acceptedRow]), checkpoint)).rejects.toThrow(
+      "failed to start",
+    );
+    expect(checkpoint).toHaveBeenCalledWith({
+      reviewedIds: [id],
+      migration: [
+        { state: "failed", processed: 0, isDone: false, cursor: undefined, hasError: true },
+      ],
+    });
+  });
+  it("does not reset an active worker or treat a failed rehearsal as successful", async () => {
+    const active = writeClient([row()]);
+    const original = active.run;
+    active.run = (async (name: string, args: Record<string, unknown>, component?: boolean) =>
+      name === "lib:getStatus"
+        ? [{ state: "inProgress", processed: 0, isDone: false }]
+        : original(name, args, component)) as Client["run"];
+    await expect(operate(active, options("accept"), async () => {})).rejects.toThrow(
+      "active migration",
+    );
+    const failed = writeClient([row()]);
+    const originalFailed = failed.run;
+    failed.run = (async (name: string, args: Record<string, unknown>, component?: boolean) =>
+      name === "migrations:run"
+        ? {
+            DryRun: "No changes were committed.",
+            Name: "migrations:applyAcceptedPluginCategoryRefreshes",
+            Status: "DRY RUN: Migration failed: source failure",
+            processed: 0,
+          }
+        : originalFailed(name, args, component)) as Client["run"];
+    await expect(operate(failed, options("accept"), async () => {})).rejects.toThrow(
+      "dry run failed",
+    );
+  });
+  it("keeps rollback available for applied older classifications and uses backend hash guard", async () => {
+    const applied = {
+      ...row(),
+      status: "applied",
+      classification: { ...row().classification, classifierVersion: "older" },
+    };
+    const c = writeClient([applied]);
+    await operate(c, options("rollback", [applied]), async () => {});
+    expect(c.run).toHaveBeenCalledWith("pluginCategoryRefresh:rollback", {
+      id,
+      confirm: "rollback-plugin-category-refresh",
+    });
+  });
+});

--- a/scripts/plugin-category-operator.ts
+++ b/scripts/plugin-category-operator.ts
@@ -1,0 +1,603 @@
+import { execFile } from "node:child_process";
+import { createHash } from "node:crypto";
+import { appendFile, mkdir, rename, writeFile } from "node:fs/promises";
+import { promisify } from "node:util";
+import { PLUGIN_CATEGORY_DEFINITIONS } from "clawhub-schema";
+import inventory from "../convex/lib/bundledPluginCategoryAssignments.json";
+
+const TARGET = "wry-manatee-359";
+const CLASSIFIER = "plugin-single-category-v3";
+const SOURCE = "3bf34b0570d3e55ad16f7c4cb25249797a59042b";
+const MIGRATION = "migrations:applyAcceptedPluginCategoryRefreshes";
+const MODES = ["preview", "report", "accept", "apply", "status", "rollback"] as const;
+type Mode = (typeof MODES)[number];
+type Json = Record<string, unknown>;
+type Row = {
+  _id: string;
+  runId: string;
+  packageId: string;
+  releaseId: string;
+  packageName: string;
+  version: string;
+  status: string;
+  reason?: string;
+  beforeHash: string;
+  beforeCategories?: string[];
+  categories: string[];
+  classification: {
+    source: string;
+    classifierVersion: string;
+    inputHash: string;
+    evidence: string;
+  };
+};
+type Page = { cursor: string; isDone: boolean; ids: string[] };
+type Preview = Omit<Page, "ids"> & {
+  previewed: number;
+  skipped: number;
+  failed: number;
+  diagnostics?: Array<{ packageId: string; reason: string }>;
+};
+type Options = {
+  mode: Mode;
+  sha: string;
+  runId: string;
+  cursor: string | null;
+  maxPages: number;
+  workers: number;
+  ids: string[];
+  reviewHash: string;
+};
+type Client = {
+  run: <T>(name: string, args: Json, component?: boolean) => Promise<T>;
+  query: <T>(source: string) => Promise<T>;
+  envNames: () => Promise<string[]>;
+  model: () => Promise<string>;
+  taxonomyMatches: () => Promise<boolean>;
+};
+
+class OperatorError extends Error {}
+
+function requireValue(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new OperatorError(message);
+}
+
+export function parseOptions(env: NodeJS.ProcessEnv): Options {
+  requireValue(env.GITHUB_REF === "refs/heads/main", "Production operator requires main.");
+  const sha = env.CATEGORY_EXPECTED_SHA ?? "";
+  requireValue(
+    /^[a-f0-9]{40}$/.test(sha) && sha === env.GITHUB_SHA,
+    "Exact checkout SHA required.",
+  );
+  requireValue(
+    env.CONVEX_DEPLOY_KEY?.startsWith(`prod:${TARGET}|`),
+    "Production credential must target wry-manatee-359.",
+  );
+  requireValue(inventory.sourceCommit === SOURCE, "Reviewed bundled source pin changed.");
+  const mode = env.CATEGORY_MODE as Mode;
+  requireValue(MODES.includes(mode), "Unsupported operator mode.");
+  const runId = env.CATEGORY_RUN_ID ?? "";
+  requireValue(/^[a-zA-Z0-9][a-zA-Z0-9._-]{0,79}$/.test(runId), "Invalid run ID.");
+  const cursor = env.CATEGORY_CURSOR || null;
+  requireValue(
+    cursor === null || (cursor.length <= 8192 && !/[\r\n]/.test(cursor)),
+    "Invalid cursor.",
+  );
+  const maxPages = Number(env.CATEGORY_MAX_PAGES ?? "10");
+  const workers = Number(env.CATEGORY_WORKERS ?? "3");
+  requireValue(Number.isInteger(maxPages) && maxPages >= 1 && maxPages <= 20, "Use 1–20 pages.");
+  requireValue(Number.isInteger(workers) && workers >= 1 && workers <= 4, "Use 1–4 workers.");
+  let ids: unknown;
+  try {
+    ids = JSON.parse(env.CATEGORY_REVIEWED_IDS || "[]");
+  } catch {
+    throw new OperatorError("Reviewed IDs must be a JSON array.");
+  }
+  requireValue(
+    Array.isArray(ids) &&
+      ids.length <= 100 &&
+      ids.every((id) => typeof id === "string" && /^[a-z0-9]{20,64}$/.test(id)),
+    "Use at most 100 valid journal IDs.",
+  );
+  requireValue(new Set(ids).size === ids.length, "Duplicate reviewed IDs.");
+  const reviewHash = env.CATEGORY_REVIEW_HASH || "";
+  if (["accept", "apply", "rollback"].includes(mode)) {
+    requireValue(
+      ids.length > 0 && /^[a-f0-9]{64}$/.test(reviewHash),
+      "Reviewed IDs and SHA-256 review hash required.",
+    );
+    requireValue(cursor === null, "Write modes do not accept a cursor.");
+  } else {
+    requireValue(!reviewHash, "Review hash is only accepted by write modes.");
+    requireValue(
+      mode === "report" || ids.length === 0,
+      "Reviewed IDs are only supported by report and write modes.",
+    );
+  }
+  return { mode, sha, runId, cursor, maxPages, workers, ids, reviewHash };
+}
+
+// Only selected category evidence enters artifacts; never archive release bodies,
+// source files, CLI stderr, environment output, or arbitrary database documents.
+export function reviewRow(row: Row) {
+  return {
+    id: row._id,
+    runId: row.runId,
+    packageId: row.packageId,
+    releaseId: row.releaseId,
+    packageName: row.packageName,
+    version: row.version,
+    beforeHash: row.beforeHash,
+    beforeCategories: row.beforeCategories ?? [],
+    categories: row.categories,
+    classification: {
+      source: row.classification.source,
+      classifierVersion: row.classification.classifierVersion,
+      inputHash: row.classification.inputHash,
+      evidence: row.classification.evidence.slice(0, 500),
+    },
+  };
+}
+
+export function reviewHash(rows: Row[]) {
+  return createHash("sha256")
+    .update(JSON.stringify(rows.map(reviewRow).sort((a, b) => a.id.localeCompare(b.id))))
+    .digest("hex");
+}
+
+function reportRows(rows: Row[]) {
+  const statuses: Record<string, number> = {};
+  const sources: Record<string, number> = {};
+  for (const row of rows) {
+    statuses[row.status] = (statuses[row.status] ?? 0) + 1;
+    sources[row.classification.source] = (sources[row.classification.source] ?? 0) + 1;
+  }
+  return {
+    rows: rows.map((row) => ({
+      ...reviewRow(row),
+      status: row.status,
+      reason: row.reason?.slice(0, 500),
+    })),
+    rowCount: rows.length,
+    statuses,
+    sources,
+    reviewHash: reviewHash(rows),
+  };
+}
+
+export function assertReviewed(rows: Row[], options: Options) {
+  requireValue(
+    rows.length === options.ids.length && rows.every(Boolean),
+    "A reviewed row is missing.",
+  );
+  requireValue(
+    rows.every((row) => options.ids.includes(row._id) && row.runId === options.runId),
+    "Reviewed rows must belong to this run.",
+  );
+  requireValue(
+    reviewHash(rows) === options.reviewHash,
+    "Review hash changed; report and review again.",
+  );
+  const status = { accept: "preview", apply: "accepted", rollback: "applied" }[
+    options.mode as "accept" | "apply" | "rollback"
+  ];
+  requireValue(
+    rows.every((row) => row.status === status),
+    "Journal status does not match this operation.",
+  );
+  // Rollback remains possible for an applied older classifier. The backend's
+  // afterHash guard prevents overwriting subsequent publication/editor changes.
+  if (options.mode === "rollback") return;
+  for (const row of rows) {
+    const c = row.classification;
+    requireValue(
+      /^[a-f0-9]{64}$/.test(row.beforeHash) && /^[a-f0-9]{64}$/.test(c.inputHash),
+      "Missing source/evidence hash.",
+    );
+    requireValue(
+      c.source === "manifest" || c.source === "generated" || c.source === "bundled",
+      "Fallback classifications cannot be applied.",
+    );
+    if (c.source === "bundled") {
+      const assignment = inventory.assignments.find(
+        (entry) => entry.packageName === row.packageName,
+      );
+      requireValue(
+        c.classifierVersion === `bundled-product-categories:${SOURCE}` &&
+          assignment?.manifestSha256 === c.inputHash &&
+          JSON.stringify(assignment.categories) === JSON.stringify(row.categories),
+        "Bundled preview no longer matches the pinned inventory.",
+      );
+    } else {
+      requireValue(c.classifierVersion === CLASSIFIER, "Generate a fresh v3 preview.");
+    }
+    requireValue(
+      row.categories.length >= 1 && row.categories.length <= (c.source === "manifest" ? 3 : 1),
+      "Invalid category count.",
+    );
+  }
+}
+
+export async function previewPages(
+  client: Client,
+  options: Options,
+  checkpoint: (value: Json) => Promise<void>,
+) {
+  const pages: Array<{ input: string | null; page: Page }> = [];
+  let cursor = options.cursor;
+  for (let i = 0; i < options.maxPages; i++) {
+    const page = await client.run<Page>("pluginCategoryRefresh:getPage", {
+      batchSize: 10,
+      ...(cursor ? { cursor } : {}),
+    });
+    requireValue(
+      page.isDone || (page.cursor && page.cursor !== cursor),
+      "Page cursor did not advance.",
+    );
+    pages.push({ input: cursor, page });
+    cursor = page.cursor;
+    if (page.isDone) break;
+  }
+  const completed: Array<Preview | undefined> = [];
+  const failures: number[] = [];
+  let next = 0;
+  const state = () => {
+    let contiguous = 0;
+    while (completed[contiguous]) contiguous++;
+    const last = completed[contiguous - 1];
+    return {
+      runId: options.runId,
+      inputCursor: options.cursor,
+      resumeCursor: last?.cursor ?? options.cursor,
+      isDone: last?.isDone ?? false,
+      completedPages: completed.filter(Boolean).length,
+      plannedPages: pages.length,
+      failedPages: [...failures],
+      previewed: completed.reduce((sum, item) => sum + (item?.previewed ?? 0), 0),
+      skipped: completed.reduce((sum, item) => sum + (item?.skipped ?? 0), 0),
+      failed: completed.reduce((sum, item) => sum + (item?.failed ?? 0), 0),
+      pages: pages.map((page, index) => ({
+        index,
+        inputCursor: page.input,
+        result: completed[index] ?? null,
+      })),
+    };
+  };
+  // Serialize artifact replacement while workers finish out of order. Never
+  // advance past a hole: retries reuse runId and the server skips stored rows.
+  let saving = Promise.resolve();
+  const save = () => {
+    const value = state();
+    saving = saving.then(() => checkpoint(value));
+    return saving;
+  };
+  await save();
+  await Promise.all(
+    Array.from({ length: options.workers }, async () => {
+      while (next < pages.length && failures.length === 0) {
+        const index = next++;
+        const page = pages[index];
+        try {
+          const result = await client.run<Preview>("pluginCategoryRefresh:preview", {
+            runId: options.runId,
+            batchSize: 10,
+            ...(page.input ? { cursor: page.input } : {}),
+          });
+          // A moving corpus can change page boundaries. Resume from the last
+          // contiguous result and reconcile from the beginning after the sweep.
+          requireValue(
+            result.cursor === page.page.cursor && result.isDone === page.page.isDone,
+            "Page boundaries changed; resume from checkpoint.",
+          );
+          completed[index] = {
+            cursor: result.cursor,
+            isDone: result.isDone,
+            previewed: result.previewed,
+            skipped: result.skipped,
+            failed: result.failed,
+            diagnostics: (result.diagnostics ?? []).slice(0, 10).map(({ packageId, reason }) => ({
+              packageId: packageId.slice(0, 64),
+              reason: reason.slice(0, 500),
+            })),
+          };
+        } catch {
+          failures.push(index);
+        }
+        await save();
+      }
+    }),
+  );
+  return state();
+}
+
+async function selectedRows(client: Client, ids: string[]) {
+  return client.query<Row[]>(
+    `return await Promise.all(${JSON.stringify(ids)}.map(id => ctx.db.get(id)));`,
+  );
+}
+
+async function acceptedRows(client: Client) {
+  return client.query<Array<{ id: string; runId: string }>>(
+    'return (await ctx.db.query("pluginCategoryRefreshes").withIndex("by_status", q => q.eq("status", "accepted")).take(101)).map(row => ({id: row._id, runId: row.runId}));',
+  );
+}
+
+async function migrationStatus(client: Client) {
+  const rows = await client.run<
+    Array<{ state: string; processed: number; isDone: boolean; cursor?: string; error?: string }>
+  >("lib:getStatus", { names: [MIGRATION] }, true);
+  return rows.map(({ state, processed, isDone, cursor, error }) => ({
+    state,
+    processed,
+    isDone,
+    cursor,
+    hasError: Boolean(error),
+  }));
+}
+
+async function rehearse(client: Client, reviewedCount: number) {
+  // The runner catches the component's DRY RUN rollback and returns formatted
+  // status. Calling the defined migration directly would surface an error.
+  const result = await client.run<{
+    DryRun: string;
+    Name: string;
+    Status: string;
+    processed: number;
+  }>("migrations:run", { fn: MIGRATION, batchSize: 10, reset: true, dryRun: true });
+  requireValue(
+    result.DryRun === "No changes were committed." &&
+      result.Name === MIGRATION &&
+      result.Status.startsWith("DRY RUN: ") &&
+      !result.Status.includes("failed:") &&
+      result.processed === Math.min(reviewedCount, 10),
+    "Migration dry run failed or did not exercise the reviewed batch; accepted rows remain for inspection.",
+  );
+  return { processed: result.processed, transactionRolledBack: true };
+}
+
+export async function operate(
+  client: Client,
+  options: Options,
+  checkpoint: (value: Json) => Promise<void>,
+) {
+  // This is a preflight, not a deployment lock. The operator runbook requires
+  // deployments to stay frozen through migration completion; per-row backend
+  // guards separately reject stale evidence, classifiers, and bundled inputs.
+  const deployed = await client.run<{ appBuildSha: string }>("appMeta:getDeploymentInfo", {});
+  requireValue(
+    deployed.appBuildSha === options.sha,
+    "Production deployed SHA differs from the reviewed checkout.",
+  );
+  requireValue(
+    await client.taxonomyMatches(),
+    "Public category contract differs from this checkout.",
+  );
+  if (options.mode === "preview" || options.mode === "status") {
+    const names = await client.envNames();
+    const model = names.includes("OPENAI_PLUGIN_CATEGORY_MODEL")
+      ? (await client.model()).trim()
+      : "gpt-5.6-luna";
+    const config = {
+      hasApiKey: names.includes("OPENAI_API_KEY"),
+      usesLuna: model === "gpt-5.6-luna",
+    };
+    if (options.mode === "status")
+      return {
+        config,
+        migration: await migrationStatus(client),
+        accepted: await acceptedRows(client),
+      };
+    requireValue(
+      config.hasApiKey && config.usesLuna,
+      "Production classifier requires OPENAI_API_KEY and gpt-5.6-luna.",
+    );
+    return previewPages(client, options, checkpoint);
+  }
+  if (options.mode === "report") {
+    if (options.ids.length) {
+      const rows = await selectedRows(client, options.ids);
+      requireValue(
+        rows.every((row) => row && row.runId === options.runId),
+        "Reviewed rows must belong to this run.",
+      );
+      return reportRows(rows);
+    }
+    const rows: Row[] = [];
+    let cursor = options.cursor;
+    let isDone = false;
+    for (let page = 0; page < options.maxPages && !isDone; page++) {
+      const result = await client.run<{ page: Row[]; continueCursor: string; isDone: boolean }>(
+        "pluginCategoryRefresh:list",
+        { runId: options.runId, paginationOpts: { cursor, numItems: 100 } },
+      );
+      requireValue(
+        result.isDone || result.continueCursor !== cursor,
+        "Report cursor did not advance.",
+      );
+      rows.push(...result.page);
+      cursor = result.continueCursor;
+      isDone = result.isDone;
+    }
+    return { ...reportRows(rows), resumeCursor: cursor, isDone };
+  }
+  const rows = await selectedRows(client, options.ids);
+  assertReviewed(rows, options);
+  const status = await migrationStatus(client);
+  requireValue(
+    !status.some((row) => row.state === "inProgress"),
+    "Wait for the active migration worker before writing.",
+  );
+  const accepted = await acceptedRows(client);
+  requireValue(
+    accepted.every((row) => row.runId === options.runId && options.ids.includes(row.id)),
+    "Foreign accepted rows must be resolved before this wave.",
+  );
+  if (options.mode === "rollback") {
+    const results = [];
+    for (const id of options.ids) {
+      const result = await client.run<{ rolledBack: boolean }>("pluginCategoryRefresh:rollback", {
+        id,
+        confirm: "rollback-plugin-category-refresh",
+      });
+      results.push({ id, ...result });
+      await checkpoint({ results });
+      requireValue(
+        result.rolledBack,
+        "Rollback did not restore the selected row; inspect the checkpoint before retrying.",
+      );
+    }
+    return { results };
+  }
+  if (options.mode === "accept") {
+    const result = await client.run<{ accepted: number }>("pluginCategoryRefresh:accept", {
+      ids: options.ids,
+      confirm: "apply-plugin-category-refresh",
+    });
+    requireValue(
+      result.accepted === rows.length,
+      "Not all reviewed rows were accepted; inspect status.",
+    );
+    const dryRun = await rehearse(client, rows.length);
+    return {
+      accepted: result.accepted,
+      dryRun,
+      reviewHash: options.reviewHash,
+    };
+  }
+  requireValue(accepted.length === rows.length, "Accepted wave differs from reviewed rows.");
+  // Acceptance survives a failed/lost rehearsal response. A fresh rehearsal
+  // prevents apply from bypassing that gate and allows a safe retry.
+  const dryRun = await rehearse(client, rows.length);
+  // Accepted rows are removed from the status index after each successful batch.
+  // Reset only with no active worker; this safely resumes the remaining reviewed
+  // rows even if an earlier wave reached the old end of that index.
+  await client.run("migrations:run", { fn: MIGRATION, batchSize: 10, reset: true });
+  const migration = await migrationStatus(client);
+  // The component catches batch errors and returns a failed state instead of
+  // rejecting the RPC. Preserve that outcome and fail the workflow explicitly.
+  await checkpoint({ reviewedIds: options.ids, migration });
+  requireValue(
+    migration.length === 1 &&
+      migration.every((row) => !row.hasError && ["inProgress", "success"].includes(row.state)),
+    "Migration failed to start successfully; inspect status and remaining accepted rows.",
+  );
+  return { started: true, reviewedIds: options.ids, migration, dryRun };
+}
+
+const execute = promisify(execFile);
+function cliClient(): Client {
+  const invoke = async (args: string[]) => {
+    try {
+      const { stdout } = await execute(
+        "node",
+        ["node_modules/convex/bin/main.js", ...args, "--deployment", TARGET],
+        { timeout: 240_000, maxBuffer: 8 * 1024 * 1024 },
+      );
+      return stdout;
+    } catch {
+      // CLI diagnostics can include source or deployment configuration. Never
+      // forward stdout/stderr/error objects to Actions logs or proof artifacts.
+      throw new OperatorError(
+        "Convex operation failed; inspect the deployed function and retry the checkpoint.",
+      );
+    }
+  };
+  return {
+    run: async <T>(name: string, args: Json, component = false) =>
+      JSON.parse(
+        await invoke([
+          "run",
+          "--codegen",
+          "disable",
+          ...(component ? ["--component", "migrations"] : []),
+          name,
+          JSON.stringify(args),
+        ]),
+      ) as T,
+    query: async <T>(source: string) =>
+      JSON.parse(await invoke(["run", "--codegen", "disable", "--inline-query", source])) as T,
+    envNames: async () =>
+      (await invoke(["env", "list", "--names-only"]))
+        .split(/\r?\n/)
+        .map((name) => name.trim())
+        .filter(Boolean),
+    model: () => invoke(["env", "get", "OPENAI_PLUGIN_CATEGORY_MODEL"]),
+    taxonomyMatches: async () => {
+      const response = await fetch("https://clawhub.ai/api/v1/plugins/categories", {
+        signal: AbortSignal.timeout(15_000),
+      });
+      if (!response.ok) return false;
+      const result = (await response.json()) as {
+        categories?: Array<{ slug: string; icon: string }>;
+      };
+      const expected = PLUGIN_CATEGORY_DEFINITIONS.map(({ slug, icon }) => ({ slug, icon }));
+      return (
+        JSON.stringify(result.categories?.map(({ slug, icon }) => ({ slug, icon }))) ===
+        JSON.stringify(expected)
+      );
+    },
+  };
+}
+
+if (import.meta.main) {
+  const directory = "artifacts/plugin-category-operator";
+  const checkpoint = async (value: Json) => {
+    await mkdir(directory, { recursive: true });
+    await writeFile(`${directory}/result.json.tmp`, `${JSON.stringify(value, null, 2)}\n`, {
+      mode: 0o600,
+    });
+    await rename(`${directory}/result.json.tmp`, `${directory}/result.json`);
+  };
+  try {
+    const options = parseOptions(process.env);
+    const result = await operate(cliClient(), options, checkpoint);
+    await checkpoint({
+      target: TARGET,
+      expectedSha: options.sha,
+      runId: options.runId,
+      mode: options.mode,
+      ...result,
+    });
+    const summary = {
+      target: TARGET,
+      mode: options.mode,
+      runId: options.runId,
+      ...Object.fromEntries(
+        Object.entries(result).filter(([key]) =>
+          [
+            "resumeCursor",
+            "isDone",
+            "completedPages",
+            "plannedPages",
+            "previewed",
+            "skipped",
+            "failed",
+            "failedPages",
+            "reviewHash",
+            "accepted",
+            "started",
+            "config",
+            "migration",
+            "rowCount",
+            "statuses",
+            "sources",
+          ].includes(key),
+        ),
+      ),
+    };
+    console.log(JSON.stringify(summary, null, 2));
+    if (process.env.GITHUB_STEP_SUMMARY)
+      await appendFile(
+        process.env.GITHUB_STEP_SUMMARY,
+        `\nCategory operator result\n\n\`\`\`json\n${JSON.stringify(summary, null, 2)}\n\`\`\`\n`,
+      );
+    if ("failedPages" in result && (result.failedPages as number[]).length) process.exitCode = 1;
+  } catch (error) {
+    console.error(
+      error instanceof OperatorError
+        ? error.message
+        : "Operator failed; inspect the checkpoint and retry.",
+    );
+    process.exitCode = 1;
+  }
+}


### PR DESCRIPTION
Run the reviewed latest-plugin category refresh through a dedicated manual GitHub workflow using the existing Production credential. The workflow fixes the deployment to wry-manatee-359, requires the exact deployed main SHA and 22-category contract, and offers bounded status, preview, report, accept, apply and rollback operations.

Previews retain package IDs and bounded skip/failure reasons. Selected rows are bound to an immutable review hash; apply requires a fresh rollback-only rehearsal and reports immediate migration failures. The backend rechecks latest release, classifier and bundled inventory identities and updates category indexes transactionally. Deployment remains manually frozen until workers complete; this workflow does not provide a global deployment lock.

Builds on [compatibility fixes](https://github.com/openclaw/clawhub/pull/3650). This is the operational layer of [CLAW-774 Expand plugin categories around product uses and reclassify latest releases](https://linear.app/my-openclaw/issue/CLAW-774/expand-plugin-categories-around-product-uses-and-reclassify-latest).

## Validation

- 31 focused operator tests pass, including stale selection, missing/failed rehearsal, immediate migration failure, partial rollback, and non-journal skip diagnostics.
- Real CLI rejects non-main execution; native Convex dry-run confirms the component returns rollback-only results.
- Existing real production-sample rehearsal: 93 applied of 100 plugins, 190 exact releases and all 22 filters checked; 90 historical releases unchanged; exact rollback and replay passed. This proves the backend, not an already-run production workflow.
- Final combined ci:static, ci:unit (6,576 passed; three skipped), and ci:types-build pass. Autoreview and secret scanning are clean.
- [Real UI, native backend and operator evidence](https://raw.githubusercontent.com/openclaw/clawhub/qa-artifacts/plugin-categories/2026-09-08/agent-runtimes/clawhub/summary.json).

After the normal exact-SHA Test and production deployment, capture a fresh baseline, preview and review assignments, then apply selected waves. Retain journal/artifacts for verification and rollback; remove one-off application tooling only after rollout verification. Production has not yet been changed by this local proof.
