### PR TITLE
fix: use deploy-key authentication for category backfills

### DIFF
--- a/scripts/plugin-category-operator.native.test.ts
+++ b/scripts/plugin-category-operator.native.test.ts
@@ -1,0 +1,91 @@
+/* @vitest-environment node */
+import { execFile } from "node:child_process";
+import { createServer } from "node:http";
+import { promisify } from "node:util";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createConvexCliClient, processFailureClass } from "./plugin-category-operator";
+
+afterEach(() => vi.unstubAllEnvs());
+
+describe("native Convex CLI deployment-key selection", () => {
+  it("reproduces the named-selector login path and keeps every adapter operation on key resolution", async () => {
+    const requests: Array<{ method: string; path: string }> = [];
+    // No deployment credentials or cloud service are involved. Stop every
+    // request at this loopback provision service before a backend can be used.
+    const server = createServer((request, response) => {
+      requests.push({ method: request.method ?? "", path: request.url ?? "" });
+      request.resume();
+      response.writeHead(401, { "content-type": "application/json" });
+      response.end(JSON.stringify({ code: "FixtureDenied", message: "Fixture request stopped." }));
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("Loopback fixture unavailable");
+    vi.stubEnv("CONVEX_PROVISION_HOST", `http://127.0.0.1:${address.port}`);
+    vi.stubEnv("CONVEX_DEPLOY_KEY", "prod:operator-fixture-123|not-a-real-key");
+    vi.stubEnv("CONVEX_DEPLOYMENT", undefined);
+    vi.stubEnv("CONVEX_OVERRIDE_ACCESS_TOKEN", undefined);
+    vi.stubEnv("CONVEX_SELF_HOSTED_URL", undefined);
+    vi.stubEnv("CONVEX_SELF_HOSTED_ADMIN_KEY", undefined);
+    vi.stubEnv("CI", "1");
+    try {
+      await expect(
+        promisify(execFile)(
+          "node",
+          [
+            "node_modules/convex/bin/main.js",
+            "run",
+            "--codegen",
+            "disable",
+            "appMeta:getDeploymentInfo",
+            "{}",
+            "--deployment",
+            "operator-fixture-123",
+          ],
+          { timeout: 10_000 },
+        ),
+      ).rejects.toMatchObject({ code: 1 });
+      expect(requests[0]).toEqual({
+        method: "GET",
+        path: "/api/deployment/operator-fixture-123/team_and_project",
+      });
+
+      const client = createConvexCliClient();
+      const probes = [
+        ["appMeta:getDeploymentInfo", () => client.run("appMeta:getDeploymentInfo", {})],
+        ["lib:getStatus", () => client.run("lib:getStatus", { names: [] }, true)],
+        ["journal-query", () => client.query("return []; ")],
+        ["environment-names", () => client.envNames()],
+        ["category-model", () => client.model()],
+      ] as const;
+      for (const [operation, run] of probes) {
+        requests.length = 0;
+        await expect(run()).rejects.toThrow(`Convex ${operation} failed (exit-1)`);
+        expect(requests[0]).toEqual({ method: "POST", path: "/api/deployment/url_for_key" });
+        expect(requests.some((request) => request.path.includes("team_and_project"))).toBe(false);
+      }
+    } finally {
+      server.closeAllConnections();
+      await new Promise<void>((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve())),
+      );
+    }
+  }, 30_000);
+
+  it("classifies process failures without disclosing stderr, stdout, arguments, or arbitrary codes", () => {
+    const privateFields = {
+      stderr: "credential=DO_NOT_PRINT",
+      stdout: "raw source",
+      message: "private command args",
+    };
+    expect(processFailureClass({ ...privateFields, code: 1 })).toBe("exit-1");
+    expect(processFailureClass({ ...privateFields, code: "ENOENT" })).toBe("executable-missing");
+    expect(processFailureClass({ ...privateFields, code: "EACCES" })).toBe("executable-denied");
+    expect(
+      processFailureClass({ ...privateFields, code: "ERR_CHILD_PROCESS_STDIO_MAXBUFFER" }),
+    ).toBe("output-limit");
+    expect(processFailureClass({ ...privateFields, killed: true })).toBe("timeout");
+    expect(processFailureClass({ ...privateFields, code: "DO_NOT_PRINT" })).toBe("process-error");
+    expect(processFailureClass(null)).toBe("process-error");
+  });
+});

--- a/scripts/plugin-category-operator.ts
+++ b/scripts/plugin-category-operator.ts
@@ -485,27 +485,40 @@ export async function operate(
 }
 
 const execute = promisify(execFile);
-function cliClient(): Client {
-  const invoke = async (args: string[]) => {
+export function processFailureClass(error: unknown) {
+  const failure = error as { code?: unknown; killed?: unknown } | null;
+  if (failure?.killed === true) return "timeout";
+  if (failure?.code === "ENOENT") return "executable-missing";
+  if (failure?.code === "EACCES") return "executable-denied";
+  if (failure?.code === "ERR_CHILD_PROCESS_STDIO_MAXBUFFER") return "output-limit";
+  if (typeof failure?.code === "number" && Number.isInteger(failure.code))
+    return `exit-${failure.code}`;
+  return "process-error";
+}
+
+export function createConvexCliClient(): Client {
+  const invoke = async (operation: string, args: string[]) => {
     try {
-      const { stdout } = await execute(
-        "node",
-        ["node_modules/convex/bin/main.js", ...args, "--deployment", TARGET],
-        { timeout: 240_000, maxBuffer: 8 * 1024 * 1024 },
-      );
+      // A named --deployment bypasses deploy-key resolution in Convex CLI.
+      // parseOptions already binds the credential to prod:wry-manatee-359;
+      // let that credential select its deployment without a cloud-login path.
+      const { stdout } = await execute("node", ["node_modules/convex/bin/main.js", ...args], {
+        timeout: 240_000,
+        maxBuffer: 8 * 1024 * 1024,
+      });
       return stdout;
-    } catch {
+    } catch (error) {
       // CLI diagnostics can include source or deployment configuration. Never
       // forward stdout/stderr/error objects to Actions logs or proof artifacts.
       throw new OperatorError(
-        "Convex operation failed; inspect the deployed function and retry the checkpoint.",
+        `Convex ${operation} failed (${processFailureClass(error)}); inspect the deployed function and retry the checkpoint.`,
       );
     }
   };
   return {
     run: async <T>(name: string, args: Json, component = false) =>
       JSON.parse(
-        await invoke([
+        await invoke(name, [
           "run",
           "--codegen",
           "disable",
@@ -515,13 +528,15 @@ function cliClient(): Client {
         ]),
       ) as T,
     query: async <T>(source: string) =>
-      JSON.parse(await invoke(["run", "--codegen", "disable", "--inline-query", source])) as T,
+      JSON.parse(
+        await invoke("journal-query", ["run", "--codegen", "disable", "--inline-query", source]),
+      ) as T,
     envNames: async () =>
-      (await invoke(["env", "list", "--names-only"]))
+      (await invoke("environment-names", ["env", "list", "--names-only"]))
         .split(/\r?\n/)
         .map((name) => name.trim())
         .filter(Boolean),
-    model: () => invoke(["env", "get", "OPENAI_PLUGIN_CATEGORY_MODEL"]),
+    model: () => invoke("category-model", ["env", "get", "OPENAI_PLUGIN_CATEGORY_MODEL"]),
     taxonomyMatches: async () => {
       const response = await fetch("https://clawhub.ai/api/v1/plugins/categories", {
         signal: AbortSignal.timeout(15_000),
@@ -550,7 +565,7 @@ if (import.meta.main) {
   };
   try {
     const options = parseOptions(process.env);
-    const result = await operate(cliClient(), options, checkpoint);
+    const result = await operate(createConvexCliClient(), options, checkpoint);
     await checkpoint({
       target: TARGET,
       expectedSha: options.sha,


### PR DESCRIPTION
The production category operator failed its first status check because Convex CLI resolves a named `--deployment` before deployment-key authentication, entering the cloud-login path. Let the already-validated `prod:wry-manatee-359` credential select its deployment instead. Failures now identify the fixed operation and sanitized exit class without exposing command arguments, output, or credentials.

This corrects the wrapper from [operator PR #3651](https://github.com/openclaw/clawhub/pull/3651). The failure occurred before any category preview or application; the deployed category backend and preserved production baseline are unchanged.

## Validation

- Native installed CLI regression reproduces the old team/project request and corrected deployment-key routing for run, component status, inline query, environment names, and model lookup. Provisioning is confined to a loopback fixture with a non-secret key.
- Actual local Convex read-only checks pass for all five adapter forms; no accepted rows or writes.
- 33 focused tests and full ci:unit pass (6,578 tests; three skipped). ci:static and TypeScript pass; autoreview and secret scanning are clean.
- [Sanitized routing proof](https://raw.githubusercontent.com/openclaw/clawhub/qa-artifacts/plugin-categories/2026-09-08/agent-runtimes/clawhub/summary.json) under operatorRoutingFollowup.
