### PR TITLE
docs: fix the package publish anchor that breaks on the published site

### DIFF
--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -213,7 +213,7 @@ publishes and skill publishing retain their existing category behavior.
 
 Topics remain separate: use `--topics` or the workflow's `topics` input to set
 them, omit the input to preserve existing topics, or use `--topics ""` /
-`clear_topics: true` to clear them. See the [package CLI reference](./cli.md#package-publish-source)
+`clear_topics: true` to clear them. See the [package CLI reference](./cli.md#package-publish-%3Csource%3E)
 and [topic rules](#skill-catalog-metadata).
 
 ### Trusted Publishing for Packages


### PR DESCRIPTION
## What

`docs/publishing.md:216` links to `./cli.md#package-publish-source`. That anchor does not exist on the published site, so the link 404s on docs.openclaw.ai while resolving fine on GitHub.

The heading it targets is `### \`package publish <source>\`` in `docs/cli.md`. OpenClaw's publishing parser (`scripts/lib/docs-markdown.mjs` in openclaw/openclaw) percent-encodes punctuation rather than stripping it, so the real anchor id is `package-publish-%3Csource%3E`.

This is a third instance of the class fixed in #3618, which corrected the two other cross-page anchors in this same file. Line 336 of this file already uses the encoded form, so line 216 was the lone outlier.

## Why it matters beyond the 404

openclaw/openclaw's docs CI mirrors this repo (`OPENCLAW_DOCS_SYNC_CLAWHUB_REPO`) and has an anchor audit (`pnpm docs:check-links:anchors`) that is not yet gated in CI. Work is underway to gate it. While the mirror is present, that audit enforces ClawHub fragments too, so this link is currently the only thing keeping that audit non-green.

## Validation

Ran openclaw's anchor audit against a checkout of this branch:

Before:
```
checked_internal_links=12585
broken_links=1
mirrored_clawhub_docs=yes
clawhub/publishing.md:216 :: /clawhub/cli#package-publish-source :: fragment not found
```

After:
```
checked_internal_links=12585
broken_links=0
omitted_compatibility_aliases=1
mirrored_clawhub_docs=yes
```

I also swept every `docs/*.md` in this repo for the same defect class using the same parser; this was the only remaining broken in-repo fragment.