### PR TITLE
fix(ui): keep sticky header opaque across routes

### DIFF
--- a/specs/regression-notes/2026-09-09-opaque-header.md
+++ b/specs/regression-notes/2026-09-09-opaque-header.md
@@ -1,0 +1,18 @@
+# Opaque sticky header
+
+The shared navbar uses the opaque, theme-aware `--nav-bg` surface on every route,
+both at the top of the page and while scrolling. Page headings and body content
+must not show through navigation, including when search suggestions are open.
+
+Route-specific hero treatments may remove the header border, but must not make
+its background transparent. Light and dark themes retain their own page colors.
+
+The previous detail/home overrides made the header transparent at the top and
+78% opaque after scrolling. Shared scroll and search overrides added other glass
+treatments. Removing these overrides restores the base navbar invariant and
+eliminates the scroll listener whose only purpose was switching those treatments.
+
+Verify in a real browser on the security audit page with its heading scrolled
+behind the header, on the homepage, and with search suggestions open. Check
+desktop/mobile and light/dark; the header's computed background alpha must remain
+1 without horizontal overflow.

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -145,7 +145,6 @@ export default function Header() {
   const [typeaheadActiveIndex, setTypeaheadActiveIndex] = useState(0);
   const [mobileSearchOpen, setMobileSearchOpen] = useState(false);
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
-  const [headerScrolled, setHeaderScrolled] = useState(false);
   const searchWrapRef = useRef<HTMLDivElement | null>(null);
   const mobileSearchWrapRef = useRef<HTMLDivElement | null>(null);
   const mobileSearchTriggerRef = useRef<HTMLButtonElement | null>(null);
@@ -250,26 +249,6 @@ export default function Header() {
     document.addEventListener("pointerdown", handlePointerDown);
     return () => document.removeEventListener("pointerdown", handlePointerDown);
   }, [typeaheadOpen, mobileSearchOpen]);
-
-  useEffect(() => {
-    const threshold = 8;
-    let frame = 0;
-    const update = () => {
-      frame = 0;
-      setHeaderScrolled(window.scrollY > threshold);
-    };
-    const onScroll = () => {
-      if (frame) return;
-      frame = window.requestAnimationFrame(update);
-    };
-
-    update();
-    window.addEventListener("scroll", onScroll, { passive: true });
-    return () => {
-      window.removeEventListener("scroll", onScroll);
-      if (frame) window.cancelAnimationFrame(frame);
-    };
-  }, [location.pathname]);
 
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
@@ -403,7 +382,7 @@ export default function Header() {
   };
 
   return (
-    <header className={`navbar navbar-calm${headerScrolled ? " navbar-calm-scrolled" : ""}`}>
+    <header className="navbar navbar-calm">
       <div className="navbar-inner">
         <div className="navbar-top">
           <div className="navbar-calm-start">

--- a/src/styles.css
+++ b/src/styles.css
@@ -572,28 +572,6 @@ code {
   display: none;
 }
 
-.app-shell:has(
-    .skill-detail-page,
-    .plugin-detail-page,
-    .security-audit-page,
-    .publisher-profile-route,
-    .dashboard-route
-  )
-  .navbar.navbar-calm {
-  background: transparent;
-}
-
-.app-shell:has(
-    .skill-detail-page,
-    .plugin-detail-page,
-    .security-audit-page,
-    .publisher-profile-route,
-    .dashboard-route
-  )
-  .navbar.navbar-calm.navbar-calm-scrolled {
-  background: color-mix(in srgb, var(--nav-bg) 78%, transparent);
-}
-
 .app-shell main {
   position: relative;
   flex: 1;
@@ -654,6 +632,7 @@ code {
   position: sticky;
   top: 0;
   z-index: 10;
+  /* Sticky navigation must obscure page content in every route and scroll state. */
   background: var(--nav-bg);
   border-bottom: 1px solid var(--line);
 }
@@ -29397,37 +29376,12 @@ a[class*="rounded-full"] {
 }
 
 /* Header sync from the design experiment: search, menu, and brand mark only. */
-.navbar.navbar-calm {
-  background: var(--nav-bg);
-  transition:
-    background 0.2s ease,
-    backdrop-filter 0.2s ease,
-    -webkit-backdrop-filter 0.2s ease;
-}
-
-.navbar.navbar-calm.navbar-calm-scrolled {
-  background: color-mix(in srgb, var(--nav-bg) 84%, transparent);
-  backdrop-filter: blur(12px) saturate(1.08);
-  -webkit-backdrop-filter: blur(12px) saturate(1.08);
-}
-
 .navbar-calm .navbar-inner {
   position: relative;
 }
 
 .app-shell:has(.home-v2-main) .navbar.navbar-calm {
   border-bottom: none;
-  background: transparent;
-}
-
-.app-shell:has(.home-v2-main) .navbar.navbar-calm.navbar-calm-scrolled {
-  background: color-mix(in srgb, var(--nav-bg) 78%, transparent);
-}
-
-.navbar.navbar-calm.navbar-calm-scrolled:has(.navbar-search-typeahead) {
-  background: color-mix(in srgb, var(--nav-bg) 94%, transparent);
-  -webkit-backdrop-filter: none;
-  backdrop-filter: none;
 }
 
 .app-shell:has(.navbar-search-typeahead)::after {


### PR DESCRIPTION
## Summary

- Keep the sticky header opaque on every route, including security audits and the homepage, using the existing light/dark `--nav-bg` surface.
- Remove transparent route overrides and scroll/search glass styles, plus the scroll listener used only to toggle them.
- Record the shared header invariant in a focused regression note.

Fixes content bleeding through navigation on `/nickflach/skills/kannaka-node/security-audit`.

## Before / after proof

Eight paired screenshots from real Chromium running the local ClawHub app: the reported audit page in desktop/mobile and light/dark, plus homepage and open-search states in desktop/mobile. [View all eight before/after pairs](https://github.com/openclaw/clawhub/pull/3655#issuecomment-5612101723).

Baseline: `e769826f1f951c5fb7d4838bab1cc03a9ee31d53`. Candidate: `0a6d9b6434`.

Both captures use `http://127.0.0.1:4380`, signed out, en-US/UTC, and the existing public read-only Convex backend. Audit content snapshots match exactly across all four pairs. No mocked HTML, backend modifications, production writes, or private data.

Browser assertions cover 14 states: background alpha changes from 0/0.78 to 1; sticky position stays at 0; no horizontal overflow. All 16 published images were visually inspected. Empty/error/auth-specific content does not change this data-independent header surface; no separate fixtures were needed. Static state comparisons make a video unnecessary.

## Validation

- `bun run test:ui-contract` — 93 tests passed.
- `bun run ci:unit` — 6,585 tests passed, 3 skipped; coverage passed.
- `bun run ci:static` — passed.
- `bun run ci:types-build` — passed, including schema and CLI TypeScript checks and the production build.
- Focused Playwright baseline/candidate assertions — passed; baseline reproduces transparency, candidate is opaque in all 14 states.
- Manual diff review — no remaining scroll-class references or competing navbar background overrides.

## Worked on by

- Patrick Erichsen (@Patrick-Erichsen)
