### PR TITLE
fix(ui): remove VirusTotal from security displays

### DIFF
--- a/docs/security-audits.md
+++ b/docs/security-audits.md
@@ -112,8 +112,7 @@ The audit page combines:
 
 1. SkillSpector
 2. A.I.G
-3. VirusTotal
-4. Risk analysis
+3. Risk analysis
 
 ## A.I.G
 
@@ -127,43 +126,12 @@ A.I.G 0.2.1 cannot inspect packaged Python bytecode. Until Tencent ships its
 rejects skills containing `.pyc`, `.pyo`, or `.pyd` files before A.I.G runs.
 ClawScan also detects packaged Python bytecode independently.
 
-## VirusTotal
-
-ClawHub uses VirusTotal as malware telemetry in the audit stack. VirusTotal is a
-trusted industry standard for file reputation and malware scanning, and our
-partnership lets ClawHub add broader security intelligence to skill and plugin
-review.
-
-VirusTotal is especially useful for known malicious artifacts, engine hits, and
-reputation signals that complement ClawHub's agent-aware review. When vendor
-engine counts are available, the audit summarizes them in plain language, such
-as:
-
-```text
-62/62 vendors flagged this skill as clean.
-```
-
-or:
-
-```text
-2/64 vendors flagged this skill as malicious, 1/64 flagged it as suspicious, and 61/64 flagged it as clean.
-```
-
-When ClawHub has no vendor-count telemetry to summarize, the audit says:
-
-```text
-No VirusTotal findings
-```
-
-VirusTotal remains telemetry. It does not replace ClawHub's own artifact-aware
-risk analysis.
-
 ## Risk analysis
 
 Risk analysis is powered internally by ClawScan, ClawHub's own security audit
 system. It reviews each release as an agent-facing artifact: instructions,
 metadata, declared permissions, files, capability signals, static scan signals,
-SkillSpector findings, A.I.G findings for skills, VirusTotal telemetry, and
+SkillSpector findings, A.I.G findings for skills, and
 publisher-provided context.
 Static scan signals are internal context for this review; they are not a
 standalone public audit section or install-blocking verdict.

--- a/specs/security-moderation.md
+++ b/specs/security-moderation.md
@@ -410,7 +410,7 @@ See also: [acceptable-usage.md](./acceptable-usage.md) for the marketplace polic
 - Static findings are internal evidence for Codex-backed ClawScan only. They do
   not hide, block, set public security status, affect installability, or trigger
   user autobans.
-- Public artifact pages present SkillSpector findings, VirusTotal malware telemetry,
+- Public artifact pages present SkillSpector findings, A.I.G findings for skills,
   and ClawScan-powered risk review as one consolidated Security audit page.
   This is a product-facing model only; scanner storage, moderation decisions,
   and worker behavior remain separate internally.
@@ -439,8 +439,10 @@ See also: [acceptable-usage.md](./acceptable-usage.md) for the marketplace polic
   result. This is not a prepublication-worker contract.
 - Current skill and plugin scans are queued through `securityScanJobs` and
   completed by the external Codex worker.
-- VirusTotal telemetry remains a separate Security audit signal and is not an
-  input to the production ClawScan profile or judge.
+- VirusTotal is not displayed in the UI: audit pages, the audit directory, version
+  scan badges, and pending-scan notices omit its results, links, and placeholders.
+  Stored telemetry and machine-readable audit exports remain available; it is
+  not an input to the production ClawScan profile or judge.
 - The worker's explicit artifact-only OSS ClawScan route accepts every claimed
   target kind and source through the same completion/failure contract. Skill
   versions and scan requests use the isolated `artifact` root; extracted

--- a/src/__tests__/package-detail-route.test.tsx
+++ b/src/__tests__/package-detail-route.test.tsx
@@ -1618,7 +1618,7 @@ describe("plugin detail route", () => {
     );
     expect(
       screen.getByRole("button", {
-        name: "Security checks across malware telemetry and agentic risk",
+        name: "Security checks for vulnerabilities and agentic risk",
       }),
     ).toBeTruthy();
     expect(screen.queryByText("Looks safe.")).toBeNull();

--- a/src/__tests__/plugin-security-audit-route.test.tsx
+++ b/src/__tests__/plugin-security-audit-route.test.tsx
@@ -113,7 +113,7 @@ describe("plugin security audit route", () => {
     expect(screen.queryByRole("button", { name: "Download security audit" })).toBeNull();
   });
 
-  it("links VirusTotal to the canonical npm-pack artifact hash", () => {
+  it("omits VirusTotal links even when the canonical npm-pack artifact hash exists", () => {
     const loaderData = makeLoaderData();
     loaderData.version.version = {
       ...loaderData.version.version,
@@ -126,8 +126,6 @@ describe("plugin security audit route", () => {
 
     render(<PluginSecurityAuditPage name="demo-plugin" loaderData={loaderData as never} />);
 
-    expect(screen.getByRole("link", { name: "View on VirusTotal" }).getAttribute("href")).toBe(
-      "https://www.virustotal.com/gui/file/tgz-sha",
-    );
+    expect(screen.queryByRole("link", { name: /VirusTotal/i })).toBeNull();
   });
 });

--- a/src/__tests__/skill-detail-page.test.tsx
+++ b/src/__tests__/skill-detail-page.test.tsx
@@ -1493,7 +1493,7 @@ describe("SkillDetailPage", () => {
     ).toBeTruthy();
     expect(
       screen.getByRole("button", {
-        name: "Security checks across malware telemetry and agentic risk",
+        name: "Security checks for vulnerabilities and agentic risk",
       }),
     ).toBeTruthy();
     expect(screen.queryByText("No risk analysis has been recorded yet.")).toBeNull();

--- a/src/components/DetailSecuritySummary.test.tsx
+++ b/src/components/DetailSecuritySummary.test.tsx
@@ -29,9 +29,7 @@ describe("DetailSecuritySummary", () => {
     ).toBeNull();
     expect(screen.queryByText("Install from publishers you trust.")).toBeNull();
     expect(screen.queryByRole("link", { name: /VirusTotal/i })).toBeNull();
-    expect(
-      screen.queryByText("Security checks across malware telemetry and agentic risk"),
-    ).toBeNull();
+    expect(screen.queryByText("Security checks for vulnerabilities and agentic risk")).toBeNull();
     expect(document.querySelector(".security-audit-meter")?.getAttribute("data-level")).toBe("3");
     expect(document.querySelectorAll(".security-audit-meter span")).toHaveLength(3);
   });

--- a/src/components/SecurityAuditPage.tsx
+++ b/src/components/SecurityAuditPage.tsx
@@ -1,14 +1,5 @@
 import { getSecurityAuditOverviewCopy } from "clawhub-schema";
-import {
-  ArrowLeft,
-  Check,
-  Clock,
-  Download,
-  ExternalLink,
-  Info,
-  RefreshCw,
-  TriangleAlert,
-} from "lucide-react";
+import { ArrowLeft, Check, Clock, Download, Info, RefreshCw, TriangleAlert } from "lucide-react";
 import { useEffect, useState } from "react";
 import type { Id } from "../../convex/_generated/dataModel";
 import { getRuntimeEnv } from "../lib/runtimeEnv";
@@ -439,103 +430,6 @@ function SecurityAuditHero({ props }: { props: SecurityAuditPageProps }) {
   );
 }
 
-function getVirusTotalEngineStats(analysis?: VtAnalysis | null) {
-  return analysis?.engineStats ?? analysis?.metadata?.stats ?? null;
-}
-
-function joinReadableClauses(clauses: string[]) {
-  if (clauses.length <= 1) return clauses[0] ?? "";
-  if (clauses.length === 2) return `${clauses[0]}, and ${clauses[1]}`;
-  return `${clauses.slice(0, -1).join(", ")}, and ${clauses.at(-1)}`;
-}
-
-function hasNonEngineVirusTotalSource(analysis?: VtAnalysis | null) {
-  if (!analysis) return false;
-  const source = analysis.source?.trim().toLowerCase();
-  const scanner = analysis.scanner?.trim().toLowerCase();
-  return Boolean(
-    (source && !source.startsWith("engines")) || (scanner && !scanner.startsWith("engines")),
-  );
-}
-
-function getArtifactKindLabel(entity: EntityRef) {
-  return entity.kind === "plugin" ? "plugin" : "skill";
-}
-
-function getVirusTotalNoFindingsCopy(_entity: EntityRef) {
-  return "No VirusTotal findings";
-}
-
-function getVirusTotalPendingCopy(entity: EntityRef) {
-  return `VirusTotal findings are pending for this ${getArtifactKindLabel(entity)} version.`;
-}
-
-function getVirusTotalEngineOverview(analysis: VtAnalysis | null | undefined, entity: EntityRef) {
-  const stats = getVirusTotalEngineStats(analysis);
-  if (stats) {
-    const malicious = stats.malicious ?? 0;
-    const suspicious = stats.suspicious ?? 0;
-    const clean = (stats.harmless ?? 0) + (stats.undetected ?? 0);
-    const total = malicious + suspicious + clean;
-    if (total <= 0) return getVirusTotalNoFindingsCopy(entity);
-
-    const artifactKind = getArtifactKindLabel(entity);
-    const hasFullEngineStats =
-      stats.malicious !== undefined &&
-      stats.suspicious !== undefined &&
-      stats.harmless !== undefined &&
-      stats.undetected !== undefined;
-    const firstCountLabel = (count: number) =>
-      hasFullEngineStats
-        ? `${count}/${total} vendors`
-        : `${count} ${count === 1 ? "vendor" : "vendors"}`;
-    const followupCountLabel = (count: number) =>
-      hasFullEngineStats ? `${count}/${total}` : `${count} ${count === 1 ? "vendor" : "vendors"}`;
-
-    if (malicious === 0 && suspicious === 0) {
-      return `${firstCountLabel(clean)} flagged this ${artifactKind} as clean.`;
-    }
-
-    const clauses: string[] = [];
-    if (malicious > 0) {
-      clauses.push(`${firstCountLabel(malicious)} flagged this ${artifactKind} as malicious`);
-    }
-    if (suspicious > 0) {
-      clauses.push(
-        clauses.length === 0
-          ? `${firstCountLabel(suspicious)} flagged this ${artifactKind} as suspicious`
-          : `${followupCountLabel(suspicious)} flagged it as suspicious`,
-      );
-    }
-    if (clean > 0) {
-      clauses.push(`${followupCountLabel(clean)} flagged it as clean`);
-    }
-    return `${joinReadableClauses(clauses)}.`;
-  }
-
-  if (hasNonEngineVirusTotalSource(analysis)) {
-    return getVirusTotalNoFindingsCopy(entity);
-  }
-
-  const status = analysis?.status?.trim().toLowerCase();
-  if (
-    status === "clean" ||
-    status === "benign" ||
-    analysis?.verdict === "undetected-only-fallback"
-  ) {
-    return getVirusTotalNoFindingsCopy(entity);
-  }
-  if (status && !["loading", "not_found", "pending"].includes(status)) {
-    return `VirusTotal engine telemetry is currently ${status} for this artifact.`;
-  }
-
-  return null;
-}
-
-function getVirusTotalOverviewCopy(analysis: VtAnalysis | null | undefined, entity: EntityRef) {
-  return getVirusTotalEngineOverview(analysis, entity) ?? getVirusTotalPendingCopy(entity);
-}
-
 function SecurityAuditOverview(props: SecurityAuditPageProps) {
   const overviewCopy = getSecurityAuditOverviewCopy({ llmAnalysis: props.llmAnalysis });
   return (
@@ -764,28 +658,6 @@ function AigFindingCard({ finding }: { finding: AigAnalysis["findings"][number] 
         ) : null}
       </dl>
     </article>
-  );
-}
-
-function VirusTotalSection(props: SecurityAuditPageProps) {
-  const vtUrl = props.sha256hash ? `https://www.virustotal.com/gui/file/${props.sha256hash}` : null;
-  return (
-    <div className="security-report-panel-body">
-      <div className="security-report-overview-body">
-        <p>{getVirusTotalOverviewCopy(props.vtAnalysis, props.entity)}</p>
-      </div>
-      {vtUrl ? (
-        <a
-          href={vtUrl}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="security-audit-external-link"
-        >
-          View on VirusTotal
-          <ExternalLink className="h-3 w-3" aria-hidden="true" />
-        </a>
-      ) : null}
-    </div>
   );
 }
 
@@ -1066,7 +938,6 @@ function SecurityAuditScannerSection({
       </div>
       {kind === "static" ? <StaticScanSection {...props} /> : null}
       {kind === "aig" ? <AigSection {...props} /> : null}
-      {kind === "virustotal" ? <VirusTotalSection {...props} /> : null}
       {kind === "skillspector" ? <SkillSpectorSection {...props} /> : null}
     </section>
   );

--- a/src/components/SkillDetailPageView.tsx
+++ b/src/components/SkillDetailPageView.tsx
@@ -378,9 +378,8 @@ export function SkillDetailPageView({
             <div className="pending-banner-content">
               <strong>Security scan in progress</strong>
               <p>
-                Your skill is being scanned by VirusTotal. It will be visible to others once the
-                scan completes. This usually takes up to 5 minutes — grab a coffee or exfoliate your
-                shell while you wait.
+                Your skill is undergoing security checks. It will be visible to others once the
+                checks complete.
               </p>
             </div>
           </div>

--- a/src/components/SkillSecurityScanResults.test.tsx
+++ b/src/components/SkillSecurityScanResults.test.tsx
@@ -232,7 +232,6 @@ describe("SecurityScanResults static guidance", () => {
   it("hides advisory static findings from the public scan panel", () => {
     render(
       <SecurityScanResults
-        vtAnalysis={{ status: "clean", checkedAt: Date.now() }}
         llmAnalysis={{ status: "clean", checkedAt: Date.now() }}
         staticFindings={[
           {
@@ -254,7 +253,6 @@ describe("SecurityScanResults static guidance", () => {
   it("keeps mixed advisory static findings hidden when scanners are clean", () => {
     render(
       <SecurityScanResults
-        vtAnalysis={{ status: "clean", checkedAt: Date.now() }}
         llmAnalysis={{ status: "clean", checkedAt: Date.now() }}
         staticFindings={[
           {
@@ -451,9 +449,7 @@ describe("SecurityScanResults static guidance", () => {
     expect(screen.getAllByText("Review").length).toBeGreaterThan(0);
     expect(screen.queryByText("Risk")).toBeNull();
     expect(screen.queryByText("ClawScan risk")).toBeNull();
-    expect(
-      screen.getByText("Security checks across malware telemetry and agentic risk"),
-    ).toBeTruthy();
+    expect(screen.getByText("Security checks for vulnerabilities and agentic risk")).toBeTruthy();
     expect(container.querySelector(".security-scan-hero-subtext")?.textContent).not.toContain(
       "Warn",
     );
@@ -486,7 +482,7 @@ describe("SecurityScanResults static guidance", () => {
       Array.from(container.querySelectorAll(".security-report-main > section h2")).map((node) =>
         node.textContent?.trim(),
       ),
-    ).toEqual(["Overview", "SkillSpector", "VirusTotal"]);
+    ).toEqual(["Overview", "SkillSpector"]);
   });
 
   it("renders SkillSpector findings as the agentic-risk finding source", async () => {
@@ -552,7 +548,7 @@ describe("SecurityScanResults static guidance", () => {
       Array.from(container.querySelectorAll(".security-report-main > section h2")).map((node) =>
         node.textContent?.trim(),
       ),
-    ).toEqual(["Overview", "SkillSpector", "VirusTotal"]);
+    ).toEqual(["Overview", "SkillSpector"]);
   });
 
   it("renders A.I.G coverage and concise findings with Tencent attribution", async () => {
@@ -603,7 +599,7 @@ describe("SecurityScanResults static guidance", () => {
       Array.from(container.querySelectorAll(".security-report-main > section h2")).map((node) =>
         node.textContent?.trim(),
       ),
-    ).toEqual(["Overview", "A.I.G", "SkillSpector", "VirusTotal"]);
+    ).toEqual(["Overview", "A.I.G", "SkillSpector"]);
   });
 
   it("renders legacy message-only A.I.G findings once", () => {
@@ -762,8 +758,8 @@ describe("SecurityScanResults static guidance", () => {
     expect(outcomeRow?.textContent).not.toContain("Pending");
     expect(outcomeRow?.textContent).not.toContain("Malicious");
     expect(
-      screen.getByText("VirusTotal findings are pending for this skill version."),
-    ).toBeTruthy();
+      screen.queryByText("VirusTotal findings are pending for this skill version."),
+    ).toBeNull();
     expect(screen.queryByText("No SkillSpector findings.")).toBeNull();
     expect(screen.getByText("Vulnerability Patterns")).toBeTruthy();
     expect(screen.getByText("Prompt Injection")).toBeTruthy();
@@ -941,7 +937,7 @@ describe("SecurityScanResults static guidance", () => {
     expect(screen.queryByText(/to give this audit context on these findings/i)).toBeNull();
   });
 
-  it("keeps plugin audit metadata focused while preserving hash links", () => {
+  it("keeps plugin audit metadata focused without VirusTotal hash links", () => {
     render(
       <SecurityAuditPage
         entity={{
@@ -964,9 +960,7 @@ describe("SecurityScanResults static guidance", () => {
     expect(screen.getByText("Version")).toBeTruthy();
     expect(screen.queryByText("Hash")).toBeNull();
     expect(screen.queryByText("seeded-plugin-hash")).toBeNull();
-    expect(screen.getByRole("link", { name: /View on VirusTotal/i }).getAttribute("href")).toBe(
-      "https://www.virustotal.com/gui/file/seeded-plugin-hash",
-    );
+    expect(screen.queryByRole("link", { name: /VirusTotal/i })).toBeNull();
   });
 
   it("does not show SkillSpector as pending for plugins without bundled skills", () => {
@@ -1011,213 +1005,52 @@ describe("SecurityScanResults static guidance", () => {
     expect(screen.getByText("Jan 2, 2024 · 3:04 AM UTC")).toBeTruthy();
   });
 
-  it("shows VirusTotal reports in the shared scanner report shell", () => {
-    const { container } = render(
-      <SecurityAuditPage
-        entity={{
-          kind: "skill",
-          title: "Hash Guard",
-          name: "hash-guard",
-          version: "1.2.3",
-          detailPath: "/local/hash-guard",
-        }}
-        sha256hash="abc123"
-        vtAnalysis={{
-          status: "clean",
-          verdict: "benign",
-          source: "engines",
-          engineStats: { malicious: 0, suspicious: 0, harmless: 4, undetected: 58 },
-          checkedAt: Date.now(),
-        }}
-      />,
-    );
+  it.each(["skill", "plugin"] as const)(
+    "omits VirusTotal from %s audits even when stored telemetry is present",
+    (kind) => {
+      const { container } = render(
+        <SecurityAuditPage
+          entity={{
+            kind,
+            title: "Hash Guard",
+            name: "hash-guard",
+            version: "1.2.3",
+            detailPath: "/local/hash-guard",
+          }}
+          sha256hash="abc123"
+          vtAnalysis={{
+            status: "malicious",
+            source: "engines",
+            engineStats: { malicious: 2, suspicious: 1, harmless: 3, undetected: 58 },
+            checkedAt: Date.UTC(2025, 0, 1),
+          }}
+          llmAnalysis={{
+            status: "clean",
+            summary: "No ClawScan issues.",
+            checkedAt: Date.UTC(2024, 0, 2, 3, 4),
+          }}
+        />,
+      );
+      expect(container.textContent).not.toMatch(/VirusTotal|vendors flagged/i);
+      expect(container.querySelector('a[href*="virustotal.com"]')).toBeNull();
+      expect(screen.getByRole("heading", { name: "Overview" })).toBeTruthy();
+      expect(screen.getByText("Pass")).toBeTruthy();
+      expect(screen.getByText("Jan 2, 2024 · 3:04 AM UTC")).toBeTruthy();
+    },
+  );
 
-    expect(screen.getByRole("heading", { name: "Hash Guard" })).toBeTruthy();
-    expect(
-      screen.getByText("Security checks across malware telemetry and agentic risk"),
-    ).toBeTruthy();
-    expect(screen.getByRole("heading", { name: "Overview" })).toBeTruthy();
-    expect(screen.getByText("62/62 vendors flagged this skill as clean.")).toBeTruthy();
-    expect(screen.queryByLabelText("VirusTotal findings")).toBeNull();
-    expect(screen.getByRole("heading", { name: "Security Audit Metadata" })).toBeTruthy();
-    expect(screen.getByRole("link", { name: /View on VirusTotal/i }).getAttribute("href")).toBe(
-      "https://www.virustotal.com/gui/file/abc123",
-    );
-    expect(screen.queryByRole("heading", { name: /Findings/i })).toBeNull();
-    expect(screen.queryByText("ASI03: Identity and Privilege Abuse")).toBeNull();
-    expect(screen.queryByText("Scanner verdict")).toBeNull();
-    expect(screen.queryByText("Artifact")).toBeNull();
-    expect(
-      Array.from(container.querySelectorAll(".security-report-main > section h2")).map((node) =>
-        node.textContent?.trim(),
-      ),
-    ).toEqual(["Overview", "SkillSpector", "VirusTotal"]);
-  });
-
-  it("summarizes completed engine-only VirusTotal scans", () => {
-    render(
-      <SecurityAuditPage
-        entity={{
-          kind: "skill",
-          title: "Hash Guard",
-          name: "hash-guard",
-          version: "1.2.3",
-          detailPath: "/local/hash-guard",
-        }}
-        sha256hash="abc123"
-        vtAnalysis={{
-          status: "clean",
-          source: "engines",
-          engineStats: { malicious: 0, suspicious: 0, harmless: 2, undetected: 60 },
-          checkedAt: Date.now(),
-        }}
-      />,
-    );
-
-    expect(screen.getByRole("heading", { name: "Overview" })).toBeTruthy();
-    expect(screen.getByText("62/62 vendors flagged this skill as clean.")).toBeTruthy();
-    expect(screen.queryByLabelText("VirusTotal findings")).toBeNull();
-    expect(screen.queryByText(/No VirusTotal analysis has been recorded/i)).toBeNull();
-  });
-
-  it("summarizes non-zero VirusTotal detection counts in normal prose", () => {
-    const { rerender } = render(
-      <SecurityAuditPage
-        entity={{
-          kind: "skill",
-          title: "Hash Guard",
-          name: "hash-guard",
-          version: "1.2.3",
-          detailPath: "/local/hash-guard",
-        }}
-        sha256hash="abc123"
-        vtAnalysis={{
-          status: "malicious",
-          source: "engines",
-          engineStats: { malicious: 2, suspicious: 1, harmless: 3, undetected: 58 },
-          checkedAt: Date.now(),
-        }}
-      />,
-    );
-
-    expect(
-      screen.getByText(
-        "2/64 vendors flagged this skill as malicious, 1/64 flagged it as suspicious, and 61/64 flagged it as clean.",
-      ),
-    ).toBeTruthy();
-    expect(screen.queryByLabelText("VirusTotal findings")).toBeNull();
-    expect(screen.queryByText("Harmless")).toBeNull();
-    expect(screen.queryByText("Undetected")).toBeNull();
-
-    rerender(
-      <SecurityAuditPage
-        entity={{
-          kind: "plugin",
-          title: "Plugin Guard",
-          name: "plugin-guard",
-          version: "1.2.3",
-          detailPath: "/plugins/plugin-guard",
-        }}
-        sha256hash="abc123"
-        vtAnalysis={{
-          status: "suspicious",
-          source: "engines",
-          engineStats: { malicious: 0, suspicious: 1, harmless: 3, undetected: 60 },
-          checkedAt: Date.now(),
-        }}
-      />,
-    );
-
-    expect(
-      screen.getByText(
-        "1/64 vendors flagged this plugin as suspicious, and 63/64 flagged it as clean.",
-      ),
-    ).toBeTruthy();
-  });
-
-  it("avoids denominator prose for partial VirusTotal engine stats", () => {
-    render(
-      <SecurityAuditPage
-        entity={{
-          kind: "skill",
-          title: "Hash Guard",
-          name: "hash-guard",
-          version: "1.2.3",
-          detailPath: "/local/hash-guard",
-        }}
-        sha256hash="abc123"
-        vtAnalysis={{
-          status: "suspicious",
-          source: "engines",
-          engineStats: { suspicious: 1 },
-          checkedAt: Date.now(),
-        }}
-      />,
-    );
-
-    expect(screen.getByText("1 vendor flagged this skill as suspicious.")).toBeTruthy();
-    expect(screen.queryByText("1/1 vendors flagged this skill as suspicious.")).toBeNull();
-  });
-
-  it("renders VirusTotal undetected-only fallback as pass", () => {
-    render(
-      <SecurityAuditPage
-        entity={{
-          kind: "plugin",
-          title: "Opik",
-          name: "@opik/opik-openclaw",
-          version: "0.2.14",
-          detailPath: "/plugins/@opik/opik-openclaw",
-        }}
-        sha256hash="abc123"
-        vtAnalysis={{
-          status: "clean",
-          verdict: "undetected-only-fallback",
-          analysis:
-            "VirusTotal reported no malicious or suspicious engine hits. ClawHub promoted this source-linked package after clean LLM and clean static scans.",
-          source: "engines-undetected-fallback",
-          checkedAt: Date.now(),
-        }}
-        llmAnalysis={{ status: "clean", summary: "No ClawScan issues.", checkedAt: 1 }}
-      />,
-    );
-
-    expect(screen.getByRole("heading", { name: "VirusTotal" })).toBeTruthy();
-    expect(screen.getByText("Pass")).toBeTruthy();
-    expect(screen.getByText("No VirusTotal findings")).toBeTruthy();
-    expect(screen.queryByText("undetected-only-fallback")).toBeNull();
-  });
-
-  it("treats legacy non-engine VirusTotal text as neutral and hidden", () => {
-    render(
-      <SecurityAuditPage
-        entity={{
-          kind: "skill",
-          title: "SkillScan",
-          name: "skillscan",
-          version: "1.1.6",
-          detailPath: "/tokauthai/skillscan",
-        }}
-        sha256hash="abc123"
-        vtAnalysis={{
-          status: "suspicious",
-          analysis: "Type: OpenClaw Skill Name: skillscan Version: 1.1.6 raw AI context",
-          source: "legacy-ai",
-          checkedAt: Date.now(),
-        }}
-      />,
-    );
-
-    expect(
-      screen.getByText("Security checks across malware telemetry and agentic risk"),
-    ).toBeTruthy();
-    expect(screen.queryByText("Pass")).toBeNull();
-    expect(screen.getByRole("heading", { name: "Overview" })).toBeTruthy();
-    expect(screen.queryByText(/multi-engine malware detections/i)).toBeNull();
-    expect(screen.queryByRole("heading", { name: /Findings/ })).toBeNull();
-    expect(screen.queryByText(/raw AI context/i)).toBeNull();
-    expect(screen.getByText("No VirusTotal findings")).toBeTruthy();
-  });
+  it.each(["panel", "badge"] as const)(
+    "renders only ClawScan in the %s scan results",
+    (variant) => {
+      const { container } = render(
+        <SecurityScanResults variant={variant} llmAnalysis={{ status: "clean", checkedAt: 1 }} />,
+      );
+      expect(container.textContent).not.toMatch(/VirusTotal/i);
+      expect(container.querySelector('a[href*="virustotal.com"]')).toBeNull();
+      expect(screen.getByText("Pass")).toBeTruthy();
+      expect(screen.getByLabelText("ClawScan")).toBeTruthy();
+    },
+  );
 
   it("keeps static analysis reports out of the public scanner report shell", () => {
     const { container } = render(
@@ -1233,9 +1066,7 @@ describe("SecurityScanResults static guidance", () => {
     );
 
     expect(screen.getByRole("heading", { name: "Pattern Guard" })).toBeTruthy();
-    expect(
-      screen.getByText("Security checks across malware telemetry and agentic risk"),
-    ).toBeTruthy();
+    expect(screen.getByText("Security checks for vulnerabilities and agentic risk")).toBeTruthy();
     expect(screen.getByRole("heading", { name: "Overview" })).toBeTruthy();
     expect(screen.queryByText("Static analysis")).toBeNull();
     expect(screen.queryByText("Pattern checks found a network request.")).toBeNull();
@@ -1254,7 +1085,7 @@ describe("SecurityScanResults static guidance", () => {
       Array.from(container.querySelectorAll(".security-report-main > section h2")).map((node) =>
         node.textContent?.trim(),
       ),
-    ).toEqual(["Overview", "SkillSpector", "VirusTotal"]);
+    ).toEqual(["Overview", "SkillSpector"]);
   });
 
   it("builds a security audit ZIP with scanner outcome files", () => {
@@ -1327,9 +1158,7 @@ describe("SecurityScanResults static guidance", () => {
     );
 
     expect(screen.getByRole("heading", { name: "Plugin Guard" })).toBeTruthy();
-    expect(
-      screen.getByText("Security checks across malware telemetry and agentic risk"),
-    ).toBeTruthy();
+    expect(screen.getByText("Security checks for vulnerabilities and agentic risk")).toBeTruthy();
     expect(screen.getByText("Legacy plugin analysis summary.")).toBeTruthy();
     expect(screen.getByText("Legacy plugin guidance.")).toBeTruthy();
     expect(screen.getByRole("heading", { name: "Overview" })).toBeTruthy();
@@ -1347,7 +1176,7 @@ describe("SecurityScanResults static guidance", () => {
       Array.from(container.querySelectorAll(".security-report-main > section h2")).map((node) =>
         node.textContent?.trim(),
       ),
-    ).toEqual(["Overview", "VirusTotal", "Static analysis"]);
+    ).toEqual(["Overview", "Static analysis"]);
   });
 
   it("lets static scan risk override a clean legacy ClawScan outcome", () => {
@@ -1413,9 +1242,7 @@ describe("SecurityScanResults static guidance", () => {
     );
 
     expect(screen.getByRole("heading", { name: "Legacy Skill" })).toBeTruthy();
-    expect(
-      screen.getByText("Security checks across malware telemetry and agentic risk"),
-    ).toBeTruthy();
+    expect(screen.getByText("Security checks for vulnerabilities and agentic risk")).toBeTruthy();
     expect(screen.getByText("Legacy plugin analysis summary.")).toBeTruthy();
     expect(screen.getByRole("heading", { name: "Overview" })).toBeTruthy();
     expect(screen.queryByRole("heading", { name: "Risk analysis" })).toBeNull();
@@ -1428,7 +1255,7 @@ describe("SecurityScanResults static guidance", () => {
       Array.from(container.querySelectorAll(".security-report-main > section h2")).map((node) =>
         node.textContent?.trim(),
       ),
-    ).toEqual(["Overview", "SkillSpector", "VirusTotal"]);
+    ).toEqual(["Overview", "SkillSpector"]);
     expect(screen.getByRole("link", { name: "Back to skill" }).getAttribute("href")).toBe(
       "/local/legacy-skill",
     );
@@ -1449,14 +1276,12 @@ describe("SecurityScanResults static guidance", () => {
     );
 
     expect(screen.getByRole("heading", { name: "Pending Skill" })).toBeTruthy();
-    expect(
-      screen.getByText("Security checks across malware telemetry and agentic risk"),
-    ).toBeTruthy();
+    expect(screen.getByText("Security checks for vulnerabilities and agentic risk")).toBeTruthy();
     expect(screen.getAllByText("Pending").length).toBeGreaterThan(0);
     expect(screen.getByText("No security analysis has been recorded yet.")).toBeTruthy();
     expect(
-      screen.getByText("VirusTotal findings are pending for this skill version."),
-    ).toBeTruthy();
+      screen.queryByText("VirusTotal findings are pending for this skill version."),
+    ).toBeNull();
     expect(screen.queryByText("Static analysis")).toBeNull();
     expect(screen.queryByText("Static analysis findings are pending for this release.")).toBeNull();
     expect(screen.queryByText("No VirusTotal findings")).toBeNull();
@@ -1498,7 +1323,7 @@ describe("SecurityScanResults static guidance", () => {
       Array.from(container.querySelectorAll(".security-report-main > section h2")).map((node) =>
         node.textContent?.trim(),
       ),
-    ).toEqual(["Overview", "SkillSpector", "VirusTotal"]);
+    ).toEqual(["Overview", "SkillSpector"]);
   });
 
   it("lets skill managers enqueue a security rescan from the audit sidebar", async () => {

--- a/src/components/SkillSecurityScanResults.tsx
+++ b/src/components/SkillSecurityScanResults.tsx
@@ -138,32 +138,10 @@ type StaticFinding = {
 };
 
 type SecurityScanResultsProps = {
-  sha256hash?: string;
-  vtAnalysis?: VtAnalysis | null;
   llmAnalysis?: LlmAnalysis | null;
   staticFindings?: StaticFinding[];
   variant?: "panel" | "badge";
 };
-
-function VirusTotalIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      className={className}
-      width="1em"
-      height="1em"
-      xmlns="http://www.w3.org/2000/svg"
-      viewBox="0 0 100 89"
-      aria-label="VirusTotal"
-    >
-      <title>VirusTotal</title>
-      <path
-        fill="currentColor"
-        fillRule="evenodd"
-        d="M45.292 44.5 0 89h100V0H0l45.292 44.5zM90 80H22l35.987-35.2L22 9h68v71z"
-      />
-    </svg>
-  );
-}
 
 function ClawScanIcon({ className }: { className?: string }) {
   return <ShieldCheck className={className} aria-label="ClawScan" />;
@@ -266,33 +244,6 @@ export function getClawScanDisplayStatus(analysis?: LlmAnalysis | null) {
     return "review";
   }
   return status;
-}
-
-function getVtEngineStats(analysis?: VtAnalysis | null) {
-  return analysis?.engineStats ?? analysis?.metadata?.stats;
-}
-
-function hasNonEngineVirusTotalSource(analysis?: VtAnalysis | null) {
-  if (!analysis) return false;
-  const source = analysis.source?.trim().toLowerCase();
-  const scanner = analysis.scanner?.trim().toLowerCase();
-  return Boolean(
-    (source && !source.startsWith("engines")) || (scanner && !scanner.startsWith("engines")),
-  );
-}
-
-export function getVirusTotalDisplayStatus(analysis?: VtAnalysis | null) {
-  const stats = getVtEngineStats(analysis);
-  if (stats) {
-    if ((stats.malicious ?? 0) > 0) return "malicious";
-    if ((stats.suspicious ?? 0) > 0) return "suspicious";
-    return "benign";
-  }
-
-  if (hasNonEngineVirusTotalSource(analysis)) return "benign";
-  if (analysis?.verdict === "undetected-only-fallback") return "benign";
-
-  return analysis?.verdict ?? analysis?.status ?? "pending";
 }
 
 export function ScanResultBadge({
@@ -682,18 +633,11 @@ function LlmAnalysisDetail({ analysis }: { analysis: LlmAnalysis }) {
   );
 }
 
-export function SecurityScanResults({
-  sha256hash,
-  vtAnalysis,
-  llmAnalysis,
-  variant = "panel",
-}: SecurityScanResultsProps) {
-  if (!sha256hash && !llmAnalysis) {
+export function SecurityScanResults({ llmAnalysis, variant = "panel" }: SecurityScanResultsProps) {
+  if (!llmAnalysis) {
     return null;
   }
 
-  const vtStatus = getVirusTotalDisplayStatus(vtAnalysis);
-  const vtUrl = sha256hash ? `https://www.virustotal.com/gui/file/${sha256hash}` : null;
   const llmVerdict = llmAnalysis?.verdict ?? llmAnalysis?.status;
   const llmDisplayStatus = getClawScanDisplayStatus(llmAnalysis);
   const llmStatusInfo = llmVerdict ? getScanStatusInfo(llmDisplayStatus) : null;
@@ -701,23 +645,6 @@ export function SecurityScanResults({
   if (variant === "badge") {
     return (
       <div className="version-scan-badge-row">
-        {sha256hash ? (
-          <div className="version-scan-badge">
-            <VirusTotalIcon className="version-scan-icon version-scan-icon-vt" />
-            <ScanResultBadge status={vtStatus} className="version-scan-status-badge" />
-            {vtUrl ? (
-              <a
-                href={vtUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="version-scan-link"
-                onClick={(event) => event.stopPropagation()}
-              >
-                ↗
-              </a>
-            ) : null}
-          </div>
-        ) : null}
         {llmStatusInfo ? (
           <div className="version-scan-badge">
             <ClawScanIcon className="version-scan-icon version-scan-icon-oc" />
@@ -732,25 +659,6 @@ export function SecurityScanResults({
     <div className="scan-results-panel">
       <div className="scan-results-title">Security Scan</div>
       <div className="scan-results-list">
-        {sha256hash ? (
-          <div className="scan-result-row">
-            <div className="scan-result-scanner">
-              <VirusTotalIcon className="scan-result-icon scan-result-icon-vt" />
-              <span className="scan-result-scanner-name">VirusTotal</span>
-            </div>
-            <ScanResultBadge status={vtStatus} />
-            {vtUrl ? (
-              <a
-                href={vtUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="scan-result-link"
-              >
-                View report →
-              </a>
-            ) : null}
-          </div>
-        ) : null}
         {llmStatusInfo && llmAnalysis ? (
           <div className="scan-result-row">
             <div className="scan-result-scanner">

--- a/src/components/securityAuditModel.ts
+++ b/src/components/securityAuditModel.ts
@@ -6,9 +6,9 @@ import {
   type VtAnalysis,
 } from "./SkillSecurityScanResults";
 
-export type AuditScannerKind = "aig" | "static" | "virustotal" | "skillspector";
+export type AuditScannerKind = "aig" | "static" | "skillspector";
 
-export const SECURITY_AUDIT_SUBTEXT = "Security checks across malware telemetry and agentic risk";
+export const SECURITY_AUDIT_SUBTEXT = "Security checks for vulnerabilities and agentic risk";
 
 type SecurityAuditSignals = {
   vtAnalysis?: VtAnalysis | null;
@@ -27,10 +27,9 @@ export const AUDIT_SCANNER_LABELS: Record<AuditScannerKind, string> = {
   aig: "A.I.G",
   skillspector: "SkillSpector",
   static: "Static analysis",
-  virustotal: "VirusTotal",
 };
 
-const DEFAULT_AUDIT_SCANNER_ORDER: AuditScannerKind[] = ["skillspector", "virustotal", "static"];
+const DEFAULT_AUDIT_SCANNER_ORDER: AuditScannerKind[] = ["skillspector", "static"];
 
 const SUPPORTING_AUDIT_SCANNER_ORDER: AuditScannerKind[] = DEFAULT_AUDIT_SCANNER_ORDER.filter(
   (kind) => kind !== "skillspector",
@@ -64,11 +63,11 @@ export function getAuditScannerOrder(signals?: SecurityAuditSignals): AuditScann
   if (signals?.skillSpectorAnalysis) {
     order = hasStaticScanReview
       ? ["skillspector", ...SUPPORTING_AUDIT_SCANNER_ORDER]
-      : ["skillspector", "virustotal"];
+      : ["skillspector"];
   } else if (hasStaticScanReview) {
-    order = ["virustotal", "static"];
+    order = ["static"];
   } else {
-    order = ["skillspector", "virustotal"];
+    order = ["skillspector"];
   }
   return signals?.aigAnalysis ? ["aig", ...order] : order;
 }
@@ -78,7 +77,6 @@ export function getLatestAuditCheckedAt(signals: SecurityAuditSignals) {
     signals.aigAnalysis?.checkedAt,
     signals.llmAnalysis?.checkedAt,
     signals.skillSpectorAnalysis?.checkedAt,
-    signals.vtAnalysis?.checkedAt,
     signals.staticScan?.checkedAt,
   ].filter((value): value is number => typeof value === "number" && Number.isFinite(value));
   return values.length ? Math.max(...values) : null;

--- a/src/routes/audits.tsx
+++ b/src/routes/audits.tsx
@@ -5,7 +5,6 @@ import { MarketplaceIcon } from "../components/MarketplaceIcon";
 import {
   getClawScanDisplayStatus,
   getScanStatusInfo,
-  getVirusTotalDisplayStatus,
   ScanResultBadge,
   type LlmAnalysis,
   type VtAnalysis,
@@ -248,7 +247,6 @@ function AuditsPage() {
           <div className="audits-table-row audits-table-head" role="row">
             <div role="columnheader">{itemColumnLabel}</div>
             <div role="columnheader">ClawScan</div>
-            <div role="columnheader">VirusTotal</div>
             <div role="columnheader" className="audits-downloads-header">
               Downloads
             </div>
@@ -277,7 +275,6 @@ function AuditsPage() {
 function AuditTableRow({ row }: { row: AuditRow }) {
   const latest = row.kind === "plugin" ? row.latestRelease : row.latestVersion;
   const clawScanStatus = getClawScanDisplayStatus(latest?.llmAnalysis ?? null);
-  const vtStatus = getVirusTotalDisplayStatus(latest?.vtAnalysis ?? null);
   const ownerHandle = row.kind === "plugin" ? row.package.ownerHandle : row.ownerHandle;
   const displayName =
     row.kind === "plugin"
@@ -303,7 +300,6 @@ function AuditTableRow({ row }: { row: AuditRow }) {
         </div>
       </div>
       <AuditSignalCell status={clawScanStatus} />
-      <AuditSignalCell status={vtStatus} />
       <div role="cell" className="audits-downloads-cell">
         {formatCompactStat(downloadsForRow(row))}
       </div>
@@ -329,7 +325,6 @@ function AuditSkeletonRows({ count = 6 }: { count?: number }) {
             <span className="audits-skeleton-icon" />
             <span className="audits-skeleton-copy" />
           </div>
-          <span className="audits-skeleton-pill" />
           <span className="audits-skeleton-pill" />
           <span className="audits-skeleton-stat" />
         </div>

--- a/src/styles.css
+++ b/src/styles.css
@@ -12451,22 +12451,6 @@ a.skills-sh-security-audit-row:focus-visible {
   white-space: nowrap;
 }
 
-.skill-version-release .version-scan-link {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 12px;
-  min-width: 12px;
-  color: var(--ink-soft);
-  font-size: 0.72rem;
-  line-height: 1;
-  text-decoration: none;
-}
-
-.skill-version-release .version-scan-link:hover {
-  color: var(--accent);
-}
-
 .skill-version-release .version-scan-badge .scan-result-status.scan-status-clean {
   width: 22px;
   min-width: 22px;
@@ -16126,10 +16110,6 @@ a.skills-sh-security-audit-row:focus-visible {
   font-size: 1rem;
 }
 
-.scan-result-icon-vt {
-  color: var(--accent-deep);
-}
-
 .scan-result-icon-oc {
   color: var(--accent);
 }
@@ -16166,17 +16146,6 @@ a.skills-sh-security-audit-row:focus-visible {
 .scan-status-error {
   background: var(--oc-status-error-bg);
   color: var(--oc-status-error-fg);
-}
-
-.scan-result-link {
-  font-size: 0.82rem;
-  color: var(--accent);
-  text-decoration: none;
-  justify-self: end;
-}
-
-.scan-result-link:hover {
-  text-decoration: underline;
 }
 
 .version-scan-results {
@@ -16225,20 +16194,7 @@ a.skills-sh-security-audit-row:focus-visible {
   font-size: 0.9rem;
 }
 
-.version-scan-icon-vt {
-  color: var(--accent-deep);
-}
-
 .version-scan-icon-oc {
-  color: var(--accent);
-}
-
-.version-scan-link {
-  color: var(--ink-soft);
-  text-decoration: none;
-}
-
-.version-scan-link:hover {
   color: var(--accent);
 }
 
@@ -17011,11 +16967,6 @@ a.agentic-risk-finding-title:focus-visible {
   .scan-result-row {
     grid-template-columns: 1fr auto;
     gap: 6px 10px;
-  }
-
-  .scan-result-link {
-    grid-column: 1 / -1;
-    justify-self: start;
   }
 }
 
@@ -19586,9 +19537,7 @@ body:has(.browse-page-borderless-header) .navbar {
 
 .audits-table-row {
   display: grid;
-  grid-template-columns:
-    minmax(460px, 1.9fr) minmax(132px, 0.55fr) minmax(132px, 0.55fr)
-    minmax(108px, 0.35fr);
+  grid-template-columns: minmax(0, 1.9fr) minmax(132px, 0.55fr) minmax(108px, 0.35fr);
   column-gap: 32px;
   row-gap: 16px;
   align-items: center;
@@ -19612,8 +19561,7 @@ body:has(.browse-page-borderless-header) .navbar {
   background: color-mix(in srgb, var(--surface-muted) 50%, transparent);
 }
 
-.audits-table-head > div:nth-child(2),
-.audits-table-head > div:nth-child(3) {
+.audits-table-head > div:nth-child(2) {
   text-align: right;
 }
 
@@ -19771,10 +19719,6 @@ body:has(.browse-page-borderless-header) .navbar {
 
   .audits-table-row > .audits-signal-cell:nth-child(2)::before {
     content: "ClawScan";
-  }
-
-  .audits-table-row > .audits-signal-cell:nth-child(3)::before {
-    content: "VirusTotal";
   }
 
   .audits-downloads-cell {


### PR DESCRIPTION
Remove VirusTotal from ClawHub's security UI. Audit pages no longer show its section, pending placeholder, or report link; the audit directory and scan badges no longer show its status. Pending-scan copy and audit help text now describe the remaining security checks, and hidden VirusTotal updates no longer change the displayed latest-audit time.

Stored telemetry, moderation behavior, APIs, and downloadable audit JSON remain unchanged.

Validation: `bun run ci:static`, `bun run ci:unit` (6,583 passed), `bun run ci:types-build`, focused scan-component tests, and structured autoreview. Browser proof compares main at `feafb9ae91` with this change using real local Convex fixtures on `127.0.0.1:4329` (before) and `127.0.0.1:4330` (after), covering skill/plugin audits and both audit directory tabs at 390, 768, 1366, and 1440px widths. See the [40 paired screenshots and proof report](https://github.com/openclaw/clawhub/pull/3656#issuecomment-5612538542), including real loading states.
