### PR TITLE
fix(security): upgrade ClawScan and SkillSpector workers

### DIFF
--- a/.github/workflows/prepublication-publish-checks.yml
+++ b/.github/workflows/prepublication-publish-checks.yml
@@ -95,7 +95,7 @@ jobs:
       - name: Install ClawScan CLI
         run: |
           set -euo pipefail
-          npm install -g @openclaw/clawscan@0.1.7
+          npm install -g @openclaw/clawscan@0.1.8
           clawscan --version
 
       - name: Install SkillSpector
@@ -104,7 +104,7 @@ jobs:
           python -m venv "$RUNNER_TEMP/skillspector-venv"
           source "$RUNNER_TEMP/skillspector-venv/bin/activate"
           python -m pip install --upgrade pip
-          python -m pip install 'git+https://github.com/NVIDIA/skillspector.git@8f37cfa'
+          python -m pip install 'git+https://github.com/NVIDIA/skillspector.git@69dcdfb74487d361ba4c811d088cfdea2ff3a9dc'
           echo "$RUNNER_TEMP/skillspector-venv/bin" >> "$GITHUB_PATH"
           skillspector --help >/dev/null
 

--- a/.github/workflows/security-scan-codex.yml
+++ b/.github/workflows/security-scan-codex.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Install ClawScan CLI
         run: |
           set -euo pipefail
-          npm install -g @openclaw/clawscan@0.1.7
+          npm install -g @openclaw/clawscan@0.1.8
           clawscan --version
 
       - name: Install A.I.G scanner
@@ -112,7 +112,7 @@ jobs:
           python -m venv "$RUNNER_TEMP/skillspector-venv"
           source "$RUNNER_TEMP/skillspector-venv/bin/activate"
           python -m pip install --upgrade pip
-          python -m pip install 'git+https://github.com/NVIDIA/skillspector.git@8f37cfa'
+          python -m pip install 'git+https://github.com/NVIDIA/skillspector.git@69dcdfb74487d361ba4c811d088cfdea2ff3a9dc'
           echo "$RUNNER_TEMP/skillspector-venv/bin" >> "$GITHUB_PATH"
           skillspector --help >/dev/null
 

--- a/scripts/security/prepublication-worker-workflow.test.ts
+++ b/scripts/security/prepublication-worker-workflow.test.ts
@@ -154,10 +154,12 @@ describe("pre-publication publish worker workflow", () => {
     expect(runStep?.run).not.toContain("--version");
     expect(runStep?.run).not.toContain("--max-jobs");
     expect(steps.find((step) => step.name === "Install ClawScan CLI")?.run).toContain(
-      "npm install -g @openclaw/clawscan@0.1.7",
+      "npm install -g @openclaw/clawscan@0.1.8",
     );
     const skillspectorInstall = steps.find((step) => step.name === "Install SkillSpector")?.run;
-    expect(skillspectorInstall).toContain("git+https://github.com/NVIDIA/skillspector.git@8f37cfa");
+    expect(skillspectorInstall).toContain(
+      "git+https://github.com/NVIDIA/skillspector.git@69dcdfb74487d361ba4c811d088cfdea2ff3a9dc",
+    );
     expect(skillspectorInstall).toContain("skillspector --help");
     expect(steps).toContainEqual(
       expect.objectContaining({

--- a/scripts/security/security-scan-worker-workflow.test.ts
+++ b/scripts/security/security-scan-worker-workflow.test.ts
@@ -148,7 +148,7 @@ describe("security-scan-codex workflow", () => {
     const skillspectorInstall = steps.find((step) => step.name === "Install SkillSpector")?.run;
     expect(codexInstall).toContain("npm install -g @openai/codex@0.142.3");
     expect(codexInstall).not.toContain("@latest");
-    expect(clawScanInstall).toContain("npm install -g @openclaw/clawscan@0.1.7");
+    expect(clawScanInstall).toContain("npm install -g @openclaw/clawscan@0.1.8");
     expect(clawScanInstall).not.toContain("@latest");
     expect(aigInstall).toContain(
       "python -m pip install --require-hashes -r scripts/security/aig-worker-requirements.txt",
@@ -159,7 +159,9 @@ describe("security-scan-codex workflow", () => {
     expect(aigInstall).toContain("f18ae642d62be142192d6bd4c21c4ea7e098bbc8");
     expect(aigInstall).toContain('assert "temperature=" not in inspect.getsource(LLM.chat_stream)');
     expect(aigInstall).toContain("aig-skill-scan --help");
-    expect(skillspectorInstall).toContain("git+https://github.com/NVIDIA/skillspector.git@8f37cfa");
+    expect(skillspectorInstall).toContain(
+      "git+https://github.com/NVIDIA/skillspector.git@69dcdfb74487d361ba4c811d088cfdea2ff3a9dc",
+    );
     expect(skillspectorInstall).not.toContain("git+https://github.com/NVIDIA/skillspector.git'");
     expect(steps.find((step) => step.name === "Run Codex security worker")?.env).toEqual({
       CODEX_API_KEY: "${{ secrets.CODEX_API_KEY || secrets.OPENAI_API_KEY }}",


### PR DESCRIPTION
## Summary

Update both security worker workflows to ClawScan **0.1.8** and SkillSpector **2.11.2** at the full immutable release SHA. ClawHub runs scanners outside Docker, so its independent SkillSpector installation must be upgraded as well as ClawScan. The old host pin resolves to SkillSpector 2.3.5; the new release includes the configurable 600-second workflow budget.

Update the existing workflow contract tests to match. The outer 15-minute worker timeout already accommodates the new scanner budget.

## Validation

- `bunx vitest run scripts/security/prepublication-worker-workflow.test.ts scripts/security/security-scan-worker-workflow.test.ts`: passed.
- `bun run ci:static`: passed.
- `bun run ci:unit`: 6,583 passed, 3 skipped.
- `bun run ci:types-build`: passed, including schema and CLI TypeScript checks.
- Structured autoreview: no actionable findings.

Live proof on `byungkyu/api-gateway@1.2.0`, downloaded from the owner-qualified ClawHub API. Every published file matched its API SHA-256. The current export has 236 published files (the original 235 plus a generated `skill-card.md`); export-only `_meta.json` was excluded. All scans used `--no-llm` and an isolated environment with no model credentials.

| Run | Wall time | Coverage | Runtime-limit exceptions | AE1 findings |
| --- | ---: | ---: | ---: | ---: |
| SkillSpector 2.11.0 default | 27.17s | 99.6% | 0 | 0 |
| SkillSpector 2.11.2, forced 1s budget | 3.42s | 0% | 441 | 98 |
| SkillSpector 2.11.2 default 600s budget | 67.04s | 99.2% | 0 | 0 |

The timeout override works, and the default-budget run avoids runtime-limit/AE1 findings. The original 2.11.0 timeout did not reproduce on this Mac. The latest report remains partial with 186 unresolved-reference exceptions, one reference-extraction limit, and two obfuscated-text exceptions; it still reports 599 findings and CRITICAL / DO_NOT_INSTALL. This update does not claim to fix those independent scanner limits or ClawHub's completeness-reporting bug.

Packaged Linux/arm64 verification also passed using the built ClawScan 0.1.8 candidate and the complete runtime Dockerfile. The wrapper recorded SkillSpector 2.11.2 as `completed`, preserving its raw partial report (99.2% coverage, no runtime-limit exceptions) in 65.94s. The same container stack with only SkillSpector reverted to 2.11.0 completed in 17.73s with 99.6% coverage and no runtime-limit exceptions. Both wrapper runs exited 0; SkillSpector itself exited 1 for findings. Neither result is presented as a clean or complete security scan.

## Published dependency verification

[ClawScan 0.1.8](https://github.com/openclaw/clawscan/releases/tag/v0.1.8) is now published. The previously pending npm dependency is available and installable:

```text
$ npm install --prefix <isolated-prefix> --no-save --package-lock=false @openclaw/clawscan@0.1.8
# exit 0
$ <isolated-prefix>/node_modules/.bin/clawscan --version
clawscan v0.1.8 (commit 6190d96, built 2026-09-10T04:30:47Z)
$ npm view @openclaw/clawscan dist-tags --json
{ "latest": "0.1.8" }
```

This resolves the unpublished-package blocker in the initial automated review.
