### PR TITLE
fix: show bundled plugin icons in the catalog

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -109,6 +109,7 @@ import type * as lib_officialPublishers from "../lib/officialPublishers.js";
 import type * as lib_openClawPublishAuthorization from "../lib/openClawPublishAuthorization.js";
 import type * as lib_openaiResponse from "../lib/openaiResponse.js";
 import type * as lib_packageArtifacts from "../lib/packageArtifacts.js";
+import type * as lib_packageIcons from "../lib/packageIcons.js";
 import type * as lib_packagePublishRecovery from "../lib/packagePublishRecovery.js";
 import type * as lib_packageRegistry from "../lib/packageRegistry.js";
 import type * as lib_packageRuntimeIdentity from "../lib/packageRuntimeIdentity.js";
@@ -336,6 +337,7 @@ declare const fullApi: ApiFromModules<{
   "lib/openClawPublishAuthorization": typeof lib_openClawPublishAuthorization;
   "lib/openaiResponse": typeof lib_openaiResponse;
   "lib/packageArtifacts": typeof lib_packageArtifacts;
+  "lib/packageIcons": typeof lib_packageIcons;
   "lib/packagePublishRecovery": typeof lib_packagePublishRecovery;
   "lib/packageRegistry": typeof lib_packageRegistry;
   "lib/packageRuntimeIdentity": typeof lib_packageRuntimeIdentity;

--- a/convex/lib/packageIcons.test.ts
+++ b/convex/lib/packageIcons.test.ts
@@ -41,12 +41,11 @@ async function file(bytes = png, path = "assets/icon.png") {
 afterEach(() => vi.unstubAllGlobals());
 
 describe("package icons", () => {
-  it("prefers the portable PNG over legacy manifest URLs and serves it with the correct MIME type", async () => {
+  it("hosts the portable PNG with the correct MIME type", async () => {
     const ctx = context();
     expect(
       await resolvePackageIcon(ctx as never, {
         files: [await file()],
-        manifest: { icon: "https://old.example/icon.png" },
       }),
     ).toBe(`/api/v1/skill-icons/${await sha256Hex(png)}`);
     expect(ctx.storage.store.mock.calls[0]?.[0]).toHaveProperty("type", "image/png");
@@ -68,7 +67,7 @@ describe("package icons", () => {
     expect(ctx.storage.store).not.toHaveBeenCalled();
     expect(ctx.runMutation).not.toHaveBeenCalled();
   });
-  it("does not fetch manifest URLs, untrusted sources, moving refs, or traversal paths", async () => {
+  it("does not fetch untrusted sources, moving refs, or traversal paths", async () => {
     const fetcher = vi.fn();
     vi.stubGlobal("fetch", fetcher);
     for (const trustedSource of [
@@ -82,9 +81,8 @@ describe("package icons", () => {
         await resolvePackageIcon(context() as never, {
           files: [],
           trustedSource,
-          manifest: { icon: "https://example.com/icon.png" },
         }),
-      ).toBe("https://example.com/icon.png");
+      ).toBeUndefined();
     }
     expect(fetcher).not.toHaveBeenCalled();
   });

--- a/convex/lib/packageIcons.test.ts
+++ b/convex/lib/packageIcons.test.ts
@@ -1,0 +1,136 @@
+/* @vitest-environment node */
+import { getFunctionName } from "convex/server";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { sha256Hex } from "./clawpack";
+import { bundledPluginIconSourceUrl, resolvePackageIcon } from "./packageIcons";
+
+const png = new Uint8Array(
+  Buffer.from(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
+    "base64",
+  ),
+);
+const source = {
+  sourceRepo: "openclaw/openclaw",
+  sourceCommit: "a".repeat(40),
+  sourcePath: "extensions/whatsapp",
+};
+function context(bytes = png) {
+  return {
+    storage: {
+      get: vi.fn(async () => new Blob([new Uint8Array(bytes)])),
+      store: vi.fn(async (_blob: Blob) => "storage:hosted"),
+      delete: vi.fn(),
+    },
+    runQuery: vi.fn(async () => null),
+    runMutation: vi.fn(async (_ref, args) => args),
+    runAction: vi.fn(
+      async (ref) => getFunctionName(ref) === "skillPresentationImageNode:validateRasterInternal",
+    ),
+  };
+}
+async function file(bytes = png, path = "assets/icon.png") {
+  return {
+    path,
+    size: bytes.length,
+    sha256: await sha256Hex(bytes),
+    storageId: "storage:icon" as never,
+    contentType: "application/octet-stream",
+  };
+}
+afterEach(() => vi.unstubAllGlobals());
+
+describe("package icons", () => {
+  it("prefers the portable PNG over legacy manifest URLs and serves it with the correct MIME type", async () => {
+    const ctx = context();
+    expect(
+      await resolvePackageIcon(ctx as never, {
+        files: [await file()],
+        manifest: { icon: "https://old.example/icon.png" },
+      }),
+    ).toBe(`/api/v1/skill-icons/${await sha256Hex(png)}`);
+    expect(ctx.storage.store.mock.calls[0]?.[0]).toHaveProperty("type", "image/png");
+  });
+  it("recovers an omitted official asset from the immutable source without writes during dry run", async () => {
+    const fetcher = vi.fn(async () => new Response(png));
+    vi.stubGlobal("fetch", fetcher);
+    const ctx = context();
+    const icon = await resolvePackageIcon(ctx as never, {
+      files: [],
+      trustedSource: source,
+      dryRun: true,
+    });
+    expect(icon).toBe(`/api/v1/skill-icons/${await sha256Hex(png)}`);
+    expect(fetcher).toHaveBeenCalledWith(
+      `https://raw.githubusercontent.com/openclaw/openclaw/${source.sourceCommit}/extensions/whatsapp/assets/icon.png`,
+      expect.objectContaining({ redirect: "error" }),
+    );
+    expect(ctx.storage.store).not.toHaveBeenCalled();
+    expect(ctx.runMutation).not.toHaveBeenCalled();
+  });
+  it("does not fetch manifest URLs, untrusted sources, moving refs, or traversal paths", async () => {
+    const fetcher = vi.fn();
+    vi.stubGlobal("fetch", fetcher);
+    for (const trustedSource of [
+      undefined,
+      { ...source, sourceRepo: "attacker/openclaw" },
+      { ...source, sourceCommit: "main" },
+      { ...source, sourcePath: "extensions/../../secrets" },
+    ]) {
+      expect(bundledPluginIconSourceUrl(trustedSource)).toBeUndefined();
+      expect(
+        await resolvePackageIcon(context() as never, {
+          files: [],
+          trustedSource,
+          manifest: { icon: "https://example.com/icon.png" },
+        }),
+      ).toBe("https://example.com/icon.png");
+    }
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+  it("ignores nested lookalike paths and rejects tampered upload hashes", async () => {
+    expect(
+      await resolvePackageIcon(context() as never, {
+        files: [await file(png, "nested/assets/icon.png")],
+      }),
+    ).toBeUndefined();
+    await expect(
+      resolvePackageIcon(context() as never, {
+        files: [{ ...(await file()), sha256: "0".repeat(64) }],
+      }),
+    ).rejects.toThrow("changed during upload");
+  });
+  it("keeps fallback behavior for missing, malformed, oversized, or undecodable PNGs", async () => {
+    for (const bytes of [new Uint8Array([1, 2, 3]), new Uint8Array(512 * 1024 + 1)]) {
+      const ctx = context(bytes);
+      expect(
+        await resolvePackageIcon(ctx as never, { files: [await file(bytes)] }),
+      ).toBeUndefined();
+      expect(ctx.storage.store).not.toHaveBeenCalled();
+    }
+    const ctx = context();
+    ctx.runAction.mockResolvedValue(false);
+    expect(await resolvePackageIcon(ctx as never, { files: [await file()] })).toBeUndefined();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(null, { status: 404 })),
+    );
+    expect(
+      await resolvePackageIcon(ctx as never, { files: [], trustedSource: source }),
+    ).toBeUndefined();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(new Uint8Array(512 * 1024 + 1))),
+    );
+    expect(
+      await resolvePackageIcon(ctx as never, { files: [], trustedSource: source }),
+    ).toBeUndefined();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(null, { status: 503 })),
+    );
+    await expect(
+      resolvePackageIcon(ctx as never, { files: [], trustedSource: source }),
+    ).rejects.toThrow("503");
+  });
+});

--- a/convex/lib/packageIcons.ts
+++ b/convex/lib/packageIcons.ts
@@ -1,0 +1,104 @@
+import { ConvexError } from "convex/values";
+import type { Doc, Id } from "../_generated/dataModel";
+import type { ActionCtx } from "../_generated/server";
+import {
+  isDecodableSkillPresentationRaster,
+  storeSkillPresentationAsset,
+} from "../skillPresentationAssets";
+import { sha256Hex } from "./clawpack";
+import { normalizePluginManifestIcon } from "./packageRegistry";
+import {
+  buildSkillPresentationIconPath,
+  MAX_SKILL_PRESENTATION_ICON_BYTES,
+  validateSkillPresentationIcon,
+} from "./skillPresentation";
+
+const PORTABLE_PLUGIN_ICON = "assets/icon.png";
+type IconContext = Pick<ActionCtx, "storage" | "runAction" | "runQuery" | "runMutation">;
+type IconSource = Pick<
+  NonNullable<Doc<"packageReleases">["verification"]>,
+  "sourceRepo" | "sourceCommit" | "sourcePath"
+>;
+
+export function bundledPluginIconSourceUrl(source: IconSource | undefined) {
+  if (
+    source?.sourceRepo !== "openclaw/openclaw" ||
+    !/^[a-f\d]{40}$/i.test(source.sourceCommit ?? "") ||
+    !/^extensions\/[a-z0-9][a-z0-9-]*$/.test(source.sourcePath ?? "")
+  )
+    return undefined;
+  return `https://raw.githubusercontent.com/openclaw/openclaw/${source.sourceCommit}/${source.sourcePath}/${PORTABLE_PLUGIN_ICON}`;
+}
+
+/** Use the same fixed asset convention as OpenClaw; never interpret a manifest path as a URL. */
+export async function resolvePackageIcon(
+  ctx: IconContext,
+  args: {
+    files: Array<{ path: string; size: number; sha256: string; storageId: string }>;
+    manifest?: unknown;
+    trustedSource?: IconSource;
+    dryRun?: boolean;
+  },
+): Promise<string | undefined> {
+  const fallback = normalizePluginManifestIcon(args.manifest);
+  const file = args.files.find((entry) => entry.path === PORTABLE_PLUGIN_ICON);
+  let bytes: Uint8Array;
+  if (file) {
+    if (file.size > MAX_SKILL_PRESENTATION_ICON_BYTES) return fallback;
+    const blob = await ctx.storage.get(file.storageId as Id<"_storage">);
+    if (!blob) throw new ConvexError("Plugin icon could not be read. Please retry.");
+    if (blob.size > MAX_SKILL_PRESENTATION_ICON_BYTES) return fallback;
+    bytes = new Uint8Array(await blob.arrayBuffer());
+    if ((await sha256Hex(bytes)) !== file.sha256.toLowerCase()) {
+      throw new ConvexError("Plugin icon changed during upload. Please retry.");
+    }
+  } else {
+    // Older official npm archives omitted assets despite recording a source commit that has them.
+    const sourceUrl = bundledPluginIconSourceUrl(args.trustedSource);
+    if (!sourceUrl) return fallback;
+    const downloaded = await fetchBundledIcon(sourceUrl);
+    if (!downloaded) return fallback;
+    bytes = downloaded;
+  }
+
+  try {
+    // npm archives commonly label every entry application/octet-stream; validate the bytes.
+    validateSkillPresentationIcon({ path: PORTABLE_PLUGIN_ICON, bytes });
+  } catch {
+    return fallback;
+  }
+  if (!(await isDecodableSkillPresentationRaster(ctx, { bytes, contentType: "image/png" })))
+    return fallback;
+  const sha256 = await sha256Hex(bytes);
+  if (args.dryRun) return buildSkillPresentationIconPath(sha256);
+  // Reuse the content-addressed raster store and serving route already used for catalog icons.
+  return storeSkillPresentationAsset(ctx, { bytes, sha256, contentType: "image/png" });
+}
+
+async function fetchBundledIcon(url: string): Promise<Uint8Array | undefined> {
+  const response = await fetch(url, { redirect: "error", signal: AbortSignal.timeout(10_000) });
+  if (response.status === 404) return undefined;
+  if (!response.ok) throw new Error(`Bundled plugin icon fetch failed (${response.status}).`);
+  const reader = response.body?.getReader();
+  if (!reader) return undefined;
+  const chunks: Uint8Array[] = [];
+  let size = 0;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      size += value.byteLength;
+      if (size > MAX_SKILL_PRESENTATION_ICON_BYTES) return undefined;
+      chunks.push(value);
+    }
+  } finally {
+    await reader.cancel();
+  }
+  const bytes = new Uint8Array(size);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return bytes;
+}

--- a/convex/lib/packageIcons.ts
+++ b/convex/lib/packageIcons.ts
@@ -6,7 +6,6 @@ import {
   storeSkillPresentationAsset,
 } from "../skillPresentationAssets";
 import { sha256Hex } from "./clawpack";
-import { normalizePluginManifestIcon } from "./packageRegistry";
 import {
   buildSkillPresentationIconPath,
   MAX_SKILL_PRESENTATION_ICON_BYTES,
@@ -35,19 +34,17 @@ export async function resolvePackageIcon(
   ctx: IconContext,
   args: {
     files: Array<{ path: string; size: number; sha256: string; storageId: string }>;
-    manifest?: unknown;
     trustedSource?: IconSource;
     dryRun?: boolean;
   },
 ): Promise<string | undefined> {
-  const fallback = normalizePluginManifestIcon(args.manifest);
   const file = args.files.find((entry) => entry.path === PORTABLE_PLUGIN_ICON);
   let bytes: Uint8Array;
   if (file) {
-    if (file.size > MAX_SKILL_PRESENTATION_ICON_BYTES) return fallback;
+    if (file.size > MAX_SKILL_PRESENTATION_ICON_BYTES) return undefined;
     const blob = await ctx.storage.get(file.storageId as Id<"_storage">);
     if (!blob) throw new ConvexError("Plugin icon could not be read. Please retry.");
-    if (blob.size > MAX_SKILL_PRESENTATION_ICON_BYTES) return fallback;
+    if (blob.size > MAX_SKILL_PRESENTATION_ICON_BYTES) return undefined;
     bytes = new Uint8Array(await blob.arrayBuffer());
     if ((await sha256Hex(bytes)) !== file.sha256.toLowerCase()) {
       throw new ConvexError("Plugin icon changed during upload. Please retry.");
@@ -55,9 +52,9 @@ export async function resolvePackageIcon(
   } else {
     // Older official npm archives omitted assets despite recording a source commit that has them.
     const sourceUrl = bundledPluginIconSourceUrl(args.trustedSource);
-    if (!sourceUrl) return fallback;
+    if (!sourceUrl) return undefined;
     const downloaded = await fetchBundledIcon(sourceUrl);
-    if (!downloaded) return fallback;
+    if (!downloaded) return undefined;
     bytes = downloaded;
   }
 
@@ -65,10 +62,10 @@ export async function resolvePackageIcon(
     // npm archives commonly label every entry application/octet-stream; validate the bytes.
     validateSkillPresentationIcon({ path: PORTABLE_PLUGIN_ICON, bytes });
   } catch {
-    return fallback;
+    return undefined;
   }
   if (!(await isDecodableSkillPresentationRaster(ctx, { bytes, contentType: "image/png" })))
-    return fallback;
+    return undefined;
   const sha256 = await sha256Hex(bytes);
   if (args.dryRun) return buildSkillPresentationIconPath(sha256);
   // Reuse the content-addressed raster store and serving route already used for catalog icons.

--- a/convex/lib/packageRegistry.test.ts
+++ b/convex/lib/packageRegistry.test.ts
@@ -6,7 +6,6 @@ import {
   ensurePluginNameMatchesPackage,
   extractBundlePluginArtifacts,
   extractCodePluginArtifacts,
-  normalizePluginManifestIcon,
   normalizePackageName,
   summarizePackageForSearch,
   toConvexSafeJsonValue,
@@ -151,7 +150,6 @@ describe("packageRegistry", () => {
     expect(summary).toEqual({
       schemaVersion: 1,
       categories: ["tools", "runtime"],
-      icon: "https://cdn.example.test/icons/example-ai-plugin.svg",
       compatibility: { pluginApiRange: "^2.0.0" },
       manifestIdentity: {
         name: "example-ai-plugin",
@@ -436,28 +434,16 @@ describe("packageRegistry", () => {
     expect(result).not.toHaveProperty("capabilities");
   });
 
-  it("accepts only valid HTTPS plugin manifest icon URLs", () => {
-    expect(normalizePluginManifestIcon({ icon: "https://cdn.example.test/icons/demo.svg" })).toBe(
-      "https://cdn.example.test/icons/demo.svg",
-    );
-    expect(
-      normalizePluginManifestIcon({
-        icon: "  https://cdn.example.test/icons/demo.svg?color=111111  ",
-      }),
-    ).toBe("https://cdn.example.test/icons/demo.svg?color=111111");
-
+  it("ignores manifest icon URLs and paths in summaries", () => {
     for (const icon of [
+      "https://cdn.example.test/icons/demo.svg",
       "http://cdn.example.test/icons/demo.svg",
-      "/icons/demo.svg",
-      "icons/demo.svg",
-      "not a url",
-      "",
-      "   ",
-      123,
-      null,
-      { src: "https://cdn.example.test/icons/demo.svg" },
+      "assets/icon.png",
+      `/api/v1/skill-icons/${"a".repeat(64)}`,
     ]) {
-      expect(normalizePluginManifestIcon({ icon })).toBeUndefined();
+      expect(
+        derivePluginManifestSummary({ pluginManifest: { icon }, files: [] }),
+      ).not.toHaveProperty("icon");
     }
   });
 

--- a/convex/lib/packageRegistry.ts
+++ b/convex/lib/packageRegistry.ts
@@ -287,7 +287,6 @@ export function derivePluginManifestSummary(params: {
   compatibility?: PackageCompatibility;
   categories?: readonly string[];
 }) {
-  const icon = normalizePluginManifestIcon(params.pluginManifest);
   const compatibility = extractCompatibilityFromManifest(
     params.pluginManifest,
     params.compatibility,
@@ -321,7 +320,6 @@ export function derivePluginManifestSummary(params: {
   return {
     schemaVersion: 1 as const,
     ...(params.categories ? { categories: [...params.categories] } : {}),
-    ...(icon ? { icon } : {}),
     ...(compatibility ? { compatibility } : {}),
     ...(manifestIdentity ? { manifestIdentity } : {}),
     configFields: extractConfigFields(params.pluginManifest),
@@ -575,18 +573,6 @@ export function maybeParseJson(text: string | null | undefined) {
   const trimmed = text.trim();
   if (!trimmed) return undefined;
   return parseJsonFile(trimmed, "JSON file");
-}
-
-export function normalizePluginManifestIcon(manifest: unknown): string | undefined {
-  if (!isRecord(manifest) || typeof manifest.icon !== "string") return undefined;
-  const icon = manifest.icon.trim();
-  if (!icon) return undefined;
-  try {
-    const url = new URL(icon);
-    return url.protocol === "https:" ? icon : undefined;
-  } catch {
-    return undefined;
-  }
 }
 
 export function toConvexSafeJsonValue(

--- a/convex/maintenance.ts
+++ b/convex/maintenance.ts
@@ -10,6 +10,7 @@ import {
   syncPackageSearchDigestForPackageId,
 } from "./functions";
 import { assertRole, requireUserFromAction } from "./lib/access";
+import { resolvePackageIcon } from "./lib/packageIcons";
 import { extractPackageDigestFields } from "./lib/packageSearchDigest";
 import {
   derivePersonalPublisherHandle,
@@ -22,6 +23,7 @@ import {
 import { recomputePublisherStats } from "./lib/publisherStats";
 import { buildSkillSummaryBackfillPatch, type ParsedSkillData } from "./lib/skillBackfill";
 import { isSkillCardPath } from "./lib/skillCards";
+import { isHostedSkillPresentationIconPath } from "./lib/skillPresentation";
 import {
   computeQualitySignals,
   evaluateQuality,
@@ -38,6 +40,162 @@ const DEFAULT_BATCH_SIZE = 50;
 const MAX_BATCH_SIZE = 200;
 const DEFAULT_MAX_BATCHES = 20;
 const MAX_MAX_BATCHES = 200;
+
+type PluginIconCandidate = {
+  packageId: Id<"packages">;
+  name: string;
+  ownerPublisherId?: Id<"publishers">;
+  release: Doc<"packageReleases">;
+  trustedSource: boolean;
+};
+
+export const listPluginIconRepairCandidatesInternal = internalQuery({
+  args: {
+    family: v.union(v.literal("code-plugin"), v.literal("bundle-plugin")),
+    cursor: v.union(v.string(), v.null()),
+    limit: v.number(),
+  },
+  handler: async (ctx, args) => {
+    const page = await ctx.db
+      .query("packages")
+      .withIndex("by_active_family_recommended_score", (q) =>
+        q.eq("softDeletedAt", undefined).eq("family", args.family),
+      )
+      .paginate({ cursor: args.cursor, numItems: clampInt(args.limit, 1, 25) });
+    const candidates: PluginIconCandidate[] = [];
+    for (const pkg of page.page) {
+      if (pkg.icon || !pkg.latestReleaseId) continue;
+      const release = await ctx.db.get(pkg.latestReleaseId);
+      if (
+        !release ||
+        release.softDeletedAt !== undefined ||
+        (release.publicationStatus && release.publicationStatus !== "published")
+      )
+        continue;
+      const owner = pkg.ownerPublisherId ? await ctx.db.get(pkg.ownerPublisherId) : null;
+      candidates.push({
+        packageId: pkg._id,
+        name: pkg.normalizedName,
+        ownerPublisherId: pkg.ownerPublisherId,
+        release,
+        trustedSource:
+          pkg.normalizedName.startsWith("@openclaw/") &&
+          owner?.handle === "openclaw" &&
+          isPublisherActive(owner),
+      });
+    }
+    return {
+      candidates,
+      scanned: page.page.length,
+      cursor: page.continueCursor,
+      isDone: page.isDone,
+    };
+  },
+});
+
+export const applyPluginIconRepairInternal = internalMutation({
+  args: {
+    packageId: v.id("packages"),
+    releaseId: v.id("packageReleases"),
+    ownerPublisherId: v.optional(v.id("publishers")),
+    icon: v.string(),
+  },
+  handler: async (ctx, args) => {
+    if (!isHostedSkillPresentationIconPath(args.icon) && !args.icon.startsWith("https://"))
+      throw new ConvexError("Invalid plugin icon");
+    const pkg = await ctx.db.get(args.packageId);
+    const release = await ctx.db.get(args.releaseId);
+    // A concurrent publish, ownership change, or deletion invalidates the prepared repair.
+    if (
+      !pkg ||
+      pkg.icon ||
+      pkg.softDeletedAt !== undefined ||
+      pkg.latestReleaseId !== args.releaseId ||
+      pkg.ownerPublisherId !== args.ownerPublisherId ||
+      !release ||
+      release.packageId !== pkg._id ||
+      release.softDeletedAt !== undefined ||
+      (release.publicationStatus && release.publicationStatus !== "published")
+    )
+      return false;
+    await ctx.db.patch(release._id, {
+      icon: args.icon,
+      ...(release.pluginManifestSummary
+        ? { pluginManifestSummary: { ...release.pluginManifestSummary, icon: args.icon } }
+        : {}),
+    });
+    await ctx.db.patch(pkg._id, {
+      icon: args.icon,
+      ...(pkg.latestVersionSummary
+        ? { latestVersionSummary: { ...pkg.latestVersionSummary, icon: args.icon } }
+        : {}),
+    });
+    return true;
+  },
+});
+
+// Storage reads, GitHub fetches and raster decoding require an action. Keep this repair
+// bounded and cursor-resumable instead of scheduling untracked actions from migrateOne.
+export const repairPluginIconsInternal = internalAction({
+  args: {
+    family: v.optional(v.union(v.literal("code-plugin"), v.literal("bundle-plugin"))),
+    cursor: v.optional(v.union(v.string(), v.null())),
+    limit: v.optional(v.number()),
+    dryRun: v.optional(v.boolean()),
+  },
+  handler: async (
+    ctx,
+    args,
+  ): Promise<{
+    scanned: number;
+    matched: number;
+    patched: number;
+    cursor: string;
+    isDone: boolean;
+    dryRun: boolean;
+    samples: Array<{ name: string; icon: string }>;
+  }> => {
+    const dryRun = args.dryRun !== false;
+    const page = await ctx.runQuery(internal.maintenance.listPluginIconRepairCandidatesInternal, {
+      family: args.family ?? "code-plugin",
+      cursor: args.cursor ?? null,
+      limit: args.limit ?? 10,
+    });
+    const samples: Array<{ name: string; icon: string }> = [];
+    let patched = 0;
+    for (const candidate of page.candidates) {
+      const icon =
+        candidate.release.icon ??
+        (await resolvePackageIcon(ctx, {
+          files: candidate.release.files,
+          manifest: candidate.release.extractedPluginManifest,
+          ...(candidate.trustedSource ? { trustedSource: candidate.release.verification } : {}),
+          dryRun,
+        }));
+      if (!icon) continue;
+      samples.push({ name: candidate.name, icon });
+      if (
+        !dryRun &&
+        (await ctx.runMutation(internal.maintenance.applyPluginIconRepairInternal, {
+          packageId: candidate.packageId,
+          releaseId: candidate.release._id,
+          ownerPublisherId: candidate.ownerPublisherId,
+          icon,
+        }))
+      )
+        patched += 1;
+    }
+    return {
+      scanned: page.scanned,
+      matched: samples.length,
+      patched,
+      cursor: page.cursor,
+      isDone: page.isDone,
+      dryRun,
+      samples,
+    };
+  },
+});
 
 type StalePackagePublishAttempt = {
   attemptId: Id<"publishAttempts">;

--- a/convex/maintenance.ts
+++ b/convex/maintenance.ts
@@ -46,6 +46,7 @@ type PluginIconCandidate = {
   name: string;
   ownerPublisherId?: Id<"publishers">;
   release: Doc<"packageReleases">;
+  icon?: string;
   trustedSource: boolean;
 };
 
@@ -64,7 +65,7 @@ export const listPluginIconRepairCandidatesInternal = internalQuery({
       .paginate({ cursor: args.cursor, numItems: clampInt(args.limit, 1, 25) });
     const candidates: PluginIconCandidate[] = [];
     for (const pkg of page.page) {
-      if (pkg.icon || !pkg.latestReleaseId) continue;
+      if (isHostedSkillPresentationIconPath(pkg.icon) || !pkg.latestReleaseId) continue;
       const release = await ctx.db.get(pkg.latestReleaseId);
       if (
         !release ||
@@ -78,6 +79,7 @@ export const listPluginIconRepairCandidatesInternal = internalQuery({
         name: pkg.normalizedName,
         ownerPublisherId: pkg.ownerPublisherId,
         release,
+        icon: pkg.icon,
         trustedSource:
           pkg.normalizedName.startsWith("@openclaw/") &&
           owner?.handle === "openclaw" &&
@@ -99,16 +101,17 @@ export const applyPluginIconRepairInternal = internalMutation({
     releaseId: v.id("packageReleases"),
     ownerPublisherId: v.optional(v.id("publishers")),
     icon: v.string(),
+    expectedIcon: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    if (!isHostedSkillPresentationIconPath(args.icon) && !args.icon.startsWith("https://"))
-      throw new ConvexError("Invalid plugin icon");
+    if (!isHostedSkillPresentationIconPath(args.icon)) throw new ConvexError("Invalid plugin icon");
     const pkg = await ctx.db.get(args.packageId);
     const release = await ctx.db.get(args.releaseId);
     // A concurrent publish, ownership change, or deletion invalidates the prepared repair.
     if (
       !pkg ||
-      pkg.icon ||
+      isHostedSkillPresentationIconPath(pkg.icon) ||
+      pkg.icon !== args.expectedIcon ||
       pkg.softDeletedAt !== undefined ||
       pkg.latestReleaseId !== args.releaseId ||
       pkg.ownerPublisherId !== args.ownerPublisherId ||
@@ -164,14 +167,13 @@ export const repairPluginIconsInternal = internalAction({
     const samples: Array<{ name: string; icon: string }> = [];
     let patched = 0;
     for (const candidate of page.candidates) {
-      const icon =
-        candidate.release.icon ??
-        (await resolvePackageIcon(ctx, {
-          files: candidate.release.files,
-          manifest: candidate.release.extractedPluginManifest,
-          ...(candidate.trustedSource ? { trustedSource: candidate.release.verification } : {}),
-          dryRun,
-        }));
+      const icon = isHostedSkillPresentationIconPath(candidate.release.icon)
+        ? candidate.release.icon
+        : await resolvePackageIcon(ctx, {
+            files: candidate.release.files,
+            ...(candidate.trustedSource ? { trustedSource: candidate.release.verification } : {}),
+            dryRun,
+          });
       if (!icon) continue;
       samples.push({ name: candidate.name, icon });
       if (
@@ -180,6 +182,7 @@ export const repairPluginIconsInternal = internalAction({
           packageId: candidate.packageId,
           releaseId: candidate.release._id,
           ownerPublisherId: candidate.ownerPublisherId,
+          expectedIcon: candidate.icon,
           icon,
         }))
       )

--- a/convex/packageIcons.runtime.test.ts
+++ b/convex/packageIcons.runtime.test.ts
@@ -1,0 +1,158 @@
+/// <reference types="vite/client" />
+/* @vitest-environment edge-runtime */
+import { register as registerRateLimiter } from "@convex-dev/rate-limiter/test";
+import { convexTest } from "convex-test";
+import { describe, expect, it } from "vitest";
+import { internal } from "./_generated/api";
+import { derivePluginManifestSummary } from "./lib/packageRegistry";
+import { extractPackageDigestFields, upsertPackageSearchDigest } from "./lib/packageSearchDigest";
+import schema from "./schema";
+
+const modules = import.meta.glob("./**/*.ts");
+const icon = `/api/v1/skill-icons/${"a".repeat(64)}`;
+async function fixture() {
+  const t = convexTest(schema, modules);
+  registerRateLimiter(t);
+  const ids = await t.run(async (ctx) => {
+    const ownerUserId = await ctx.db.insert("users", { handle: "maintainer" });
+    const ownerPublisherId = await ctx.db.insert("publishers", {
+      kind: "org",
+      handle: "openclaw",
+      displayName: "OpenClaw",
+      createdAt: 1,
+      updatedAt: 1,
+    });
+    const packageId = await ctx.db.insert("packages", {
+      name: "@openclaw/whatsapp",
+      normalizedName: "@openclaw/whatsapp",
+      displayName: "WhatsApp",
+      ownerUserId,
+      ownerPublisherId,
+      family: "code-plugin",
+      channel: "official",
+      isOfficial: true,
+      scanStatus: "clean",
+      categories: ["channels"],
+      topics: ["WhatsApp"],
+      stats: { downloads: 100, installs: 1, stars: 0, versions: 1 },
+      tags: {},
+      createdAt: 1,
+      updatedAt: 1,
+    });
+    const releaseId = await ctx.db.insert("packageReleases", {
+      packageId,
+      version: "1.0.0",
+      publicationStatus: "published",
+      changelog: "Initial release",
+      distTags: ["latest"],
+      files: [],
+      integritySha256: "b".repeat(64),
+      createdAt: 1,
+      createdBy: ownerUserId,
+      pluginManifestSummary: derivePluginManifestSummary({
+        pluginManifest: { id: "whatsapp" },
+        files: [],
+      }),
+    });
+    await ctx.db.patch(packageId, {
+      latestReleaseId: releaseId,
+      latestVersionSummary: { version: "1.0.0", createdAt: 1, changelog: "Initial release" },
+      tags: { latest: releaseId },
+    });
+    const pkg = (await ctx.db.get(packageId))!;
+    await upsertPackageSearchDigest(ctx, {
+      ...extractPackageDigestFields(pkg),
+      ownerHandle: "openclaw",
+      ownerKind: "org",
+    });
+    return { packageId, releaseId, ownerPublisherId };
+  });
+  return { t, ...ids };
+}
+
+describe("plugin icon repair", () => {
+  it("updates the release, latest summary, and every public catalog projection atomically and idempotently", async () => {
+    const { t, ...ids } = await fixture();
+    const before = await t.fetch("/api/v1/plugins");
+    expect((await before.json()).items[0].icon).toBeNull();
+    expect(
+      await t.mutation(internal.maintenance.applyPluginIconRepairInternal, { ...ids, icon }),
+    ).toBe(true);
+    await t.run(async (ctx) => {
+      const pkg = await ctx.db.get(ids.packageId);
+      const release = await ctx.db.get(ids.releaseId);
+      expect(pkg?.icon).toBe(icon);
+      expect(pkg?.latestVersionSummary?.icon).toBe(icon);
+      expect(release?.icon).toBe(icon);
+      expect(release?.pluginManifestSummary?.icon).toBe(icon);
+      expect(pkg?.updatedAt).toBe(1);
+    });
+    for (const route of [
+      "/api/v1/plugins",
+      "/api/v1/plugins?category=channels",
+      "/api/v1/plugins?topic=whatsapp",
+      "/api/v1/plugins/search?q=whatsapp",
+    ]) {
+      const response = await t.fetch(route);
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(
+        (data.items ?? data.results.map((entry: { package: unknown }) => entry.package))[0].icon,
+      ).toBe(icon);
+    }
+    expect(
+      await t.mutation(internal.maintenance.applyPluginIconRepairInternal, { ...ids, icon }),
+    ).toBe(false);
+  });
+  it("previews without writing, applies, and skips already repaired records", async () => {
+    const { t, ...ids } = await fixture();
+    await t.run(async (ctx) => ctx.db.patch(ids.releaseId, { icon }));
+    expect(await t.action(internal.maintenance.repairPluginIconsInternal, {})).toMatchObject({
+      dryRun: true,
+      matched: 1,
+      patched: 0,
+    });
+    await t.run(async (ctx) => {
+      expect((await ctx.db.get(ids.packageId))?.icon).toBeUndefined();
+    });
+    expect(
+      await t.action(internal.maintenance.repairPluginIconsInternal, { dryRun: false }),
+    ).toMatchObject({ matched: 1, patched: 1 });
+    expect(
+      await t.action(internal.maintenance.repairPluginIconsInternal, { dryRun: false }),
+    ).toMatchObject({ matched: 0, patched: 0 });
+  });
+  it("paginates without skipping candidates and restricts source recovery to the active OpenClaw owner", async () => {
+    const { t, ...ids } = await fixture();
+    const args = { family: "code-plugin" as const, cursor: null, limit: 1 };
+    const page = await t.query(internal.maintenance.listPluginIconRepairCandidatesInternal, args);
+    expect(page.candidates).toMatchObject([{ trustedSource: true }]);
+    const end = await t.query(internal.maintenance.listPluginIconRepairCandidatesInternal, {
+      ...args,
+      cursor: page.cursor,
+    });
+    expect(end.candidates).toEqual([]);
+    expect(end.isDone).toBe(true);
+    await t.run(async (ctx) => ctx.db.patch(ids.ownerPublisherId, { deactivatedAt: 2 }));
+    expect(
+      (await t.query(internal.maintenance.listPluginIconRepairCandidatesInternal, args)).candidates,
+    ).toMatchObject([{ trustedSource: false }]);
+  });
+  it("does not overwrite icons or repair a deleted, pending, transferred, or superseded release", async () => {
+    for (const change of ["icon", "deleted", "pending", "owner", "latest"] as const) {
+      const { t, ...ids } = await fixture();
+      await t.run(async (ctx) => {
+        if (change === "icon")
+          await ctx.db.patch(ids.packageId, { icon: "https://example.com/new.png" });
+        if (change === "deleted") await ctx.db.patch(ids.packageId, { softDeletedAt: 2 });
+        if (change === "pending")
+          await ctx.db.patch(ids.releaseId, { publicationStatus: "pending" });
+        if (change === "owner") await ctx.db.patch(ids.packageId, { ownerPublisherId: undefined });
+        if (change === "latest") await ctx.db.patch(ids.packageId, { latestReleaseId: undefined });
+      });
+      expect(
+        await t.mutation(internal.maintenance.applyPluginIconRepairInternal, { ...ids, icon }),
+      ).toBe(false);
+    }
+  });
+});

--- a/convex/packageIcons.runtime.test.ts
+++ b/convex/packageIcons.runtime.test.ts
@@ -122,6 +122,46 @@ describe("plugin icon repair", () => {
       await t.action(internal.maintenance.repairPluginIconsInternal, { dryRun: false }),
     ).toMatchObject({ matched: 0, patched: 0 });
   });
+  it("does not accept external URLs or reuse legacy release icon URLs", async () => {
+    const { t, ...ids } = await fixture();
+    const externalIcon = "https://example.com/icon.png";
+    await expect(
+      t.mutation(internal.maintenance.applyPluginIconRepairInternal, {
+        ...ids,
+        icon: externalIcon,
+      }),
+    ).rejects.toThrow("Invalid plugin icon");
+    await t.run(async (ctx) =>
+      ctx.db.patch(ids.releaseId, {
+        icon: externalIcon,
+        extractedPluginManifest: { icon: externalIcon },
+      }),
+    );
+    expect(
+      await t.action(internal.maintenance.repairPluginIconsInternal, { dryRun: false }),
+    ).toMatchObject({ matched: 0, patched: 0 });
+    await t.run(async (ctx) => {
+      expect((await ctx.db.get(ids.packageId))?.icon).toBeUndefined();
+    });
+  });
+  it("replaces legacy package URLs with the hosted bundled asset", async () => {
+    const { t, ...ids } = await fixture();
+    const externalIcon = "https://example.com/icon.png";
+    await t.run(async (ctx) => {
+      await ctx.db.patch(ids.packageId, { icon: externalIcon });
+      await ctx.db.patch(ids.releaseId, { icon });
+    });
+    expect(await t.action(internal.maintenance.repairPluginIconsInternal, {})).toMatchObject({
+      matched: 1,
+      patched: 0,
+    });
+    expect(
+      await t.action(internal.maintenance.repairPluginIconsInternal, { dryRun: false }),
+    ).toMatchObject({ matched: 1, patched: 1 });
+    await t.run(async (ctx) => {
+      expect((await ctx.db.get(ids.packageId))?.icon).toBe(icon);
+    });
+  });
   it("paginates without skipping candidates and restricts source recovery to the active OpenClaw owner", async () => {
     const { t, ...ids } = await fixture();
     const args = { family: "code-plugin" as const, cursor: null, limit: 1 };

--- a/convex/packages.public.test.ts
+++ b/convex/packages.public.test.ts
@@ -12988,13 +12988,17 @@ describe("packages public queries", () => {
     );
     const hostedIcon = `/api/v1/skill-icons/${await sha256Hex(portableIcon)}`;
     await expect(
-      publishWithManifestIcon(undefined, undefined, undefined, portableIcon),
+      publishWithManifestIcon(
+        "https://ignored.example/icon.png",
+        undefined,
+        undefined,
+        portableIcon,
+      ),
     ).resolves.toMatchObject({ icon: hostedIcon, pluginManifestSummary: { icon: hostedIcon } });
 
     await expect(
       publishWithManifestIcon("https://cdn.example.test/icons/demo.svg"),
     ).resolves.toMatchObject({
-      icon: "https://cdn.example.test/icons/demo.svg",
       categories: ["scheduling"],
       pluginManifestSummary: { categories: ["scheduling"] },
       categoryClassification: {
@@ -13036,6 +13040,7 @@ describe("packages public queries", () => {
     });
 
     for (const icon of [
+      "https://cdn.example.test/icons/demo.svg",
       "http://cdn.example.test/icons/demo.svg",
       "/icons/demo.svg",
       "not a url",
@@ -13043,7 +13048,9 @@ describe("packages public queries", () => {
       123,
       { src: "https://cdn.example.test/icons/demo.svg" },
     ]) {
-      await expect(publishWithManifestIcon(icon)).resolves.not.toHaveProperty("icon");
+      const published = await publishWithManifestIcon(icon);
+      expect(published).not.toHaveProperty("icon");
+      expect(published.pluginManifestSummary).not.toHaveProperty("icon");
     }
   });
 

--- a/convex/packages.public.test.ts
+++ b/convex/packages.public.test.ts
@@ -12817,8 +12817,10 @@ describe("packages public queries", () => {
       icon: unknown,
       bundleManifest?: Record<string, unknown>,
       declaredCategories?: string[],
+      portableIcon?: Uint8Array,
     ) {
       const runMutation = vi.fn(async (_ref: unknown, args: Record<string, unknown>) => {
+        if ("sha256" in args && "contentType" in args) return args;
         if (args.minimumRole === "publisher") {
           return { publisherId: "publishers:owner", linkedUserId: "users:owner" };
         }
@@ -12880,12 +12882,22 @@ describe("packages public queries", () => {
             linkedUserId: "users:owner",
           }),
         runMutation,
-        runAction: makePublishRunActionMock(),
+        runAction: vi.fn(async function (
+          this: PublishScanStorage,
+          ref: FunctionReference<"action">,
+          args: unknown,
+        ) {
+          return getFunctionName(ref) === "skillPresentationImageNode:validateRasterInternal"
+            ? true
+            : makePublishRunActionMock().call(this, ref, args);
+        }),
         scheduler: {
           runAfter: vi.fn(),
         },
         storage: {
           get: vi.fn(async (storageId: string) => {
+            if (storageId === "storage:icon" && portableIcon)
+              return new Blob([new Uint8Array(portableIcon)]);
             const content = storedFiles.get(storageId);
             return content ? new Blob([content]) : null;
           }),
@@ -12943,6 +12955,17 @@ describe("packages public queries", () => {
               sha256: "code",
               contentType: "application/javascript",
             },
+            ...(portableIcon
+              ? [
+                  {
+                    path: "assets/icon.png",
+                    size: portableIcon.byteLength,
+                    storageId: "storage:icon",
+                    sha256: await sha256Hex(portableIcon),
+                    contentType: "application/octet-stream",
+                  },
+                ]
+              : []),
           ],
         },
       });
@@ -12956,6 +12979,17 @@ describe("packages public queries", () => {
       );
       return insertCall?.[1] as Record<string, unknown>;
     }
+
+    const portableIcon = new Uint8Array(
+      Buffer.from(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
+        "base64",
+      ),
+    );
+    const hostedIcon = `/api/v1/skill-icons/${await sha256Hex(portableIcon)}`;
+    await expect(
+      publishWithManifestIcon(undefined, undefined, undefined, portableIcon),
+    ).resolves.toMatchObject({ icon: hostedIcon, pluginManifestSummary: { icon: hostedIcon } });
 
     await expect(
       publishWithManifestIcon("https://cdn.example.test/icons/demo.svg"),

--- a/convex/packages.ts
+++ b/convex/packages.ts
@@ -9027,7 +9027,6 @@ async function publishPackageImpl(
       ? undefined
       : await resolvePackageIcon(ctx, {
           files,
-          manifest: pluginManifest,
           ...(trustedOpenClawPlugin ? { trustedSource: verification } : {}),
         });
   const integritySha256 = await hashSkillFiles(
@@ -9036,18 +9035,20 @@ async function publishPackageImpl(
   const pluginManifestSummary =
     family === "claw"
       ? undefined
-      : derivePluginManifestSummary({
-          pluginManifest:
-            pluginManifest ??
-            (() => {
-              throw new ConvexError("openclaw.plugin.json is required for plugin packages");
-            })(),
-          ...(bundleManifest ? { skillManifest: bundleManifest } : {}),
-          compatibility: codeArtifacts?.compatibility ?? bundleArtifacts?.compatibility,
-          ...(family === "code-plugin" || family === "bundle-plugin" ? { categories } : {}),
-          files: await withSkillMarkdownTextsForManifestSummary(ctx, files),
-        });
-  if (pluginManifestSummary && icon) pluginManifestSummary.icon = icon;
+      : {
+          ...derivePluginManifestSummary({
+            pluginManifest:
+              pluginManifest ??
+              (() => {
+                throw new ConvexError("openclaw.plugin.json is required for plugin packages");
+              })(),
+            ...(bundleManifest ? { skillManifest: bundleManifest } : {}),
+            compatibility: codeArtifacts?.compatibility ?? bundleArtifacts?.compatibility,
+            ...(family === "code-plugin" || family === "bundle-plugin" ? { categories } : {}),
+            files: await withSkillMarkdownTextsForManifestSummary(ctx, files),
+          }),
+          ...(icon ? { icon } : {}),
+        };
 
   const legacyZipStorageId =
     payload.artifact?.kind === "npm-pack"

--- a/convex/packages.ts
+++ b/convex/packages.ts
@@ -75,6 +75,7 @@ import type { StaticScanResult } from "./lib/moderationEngine";
 import { isOfficialPublisher, toPublicPublisherWithOfficial } from "./lib/officialPublishers";
 import { verifyOpenClawPublishAuthorization } from "./lib/openClawPublishAuthorization";
 import { getPackageReleaseArtifactSha256 } from "./lib/packageArtifacts";
+import { resolvePackageIcon } from "./lib/packageIcons";
 import {
   assertManualRecoveryFinalization,
   manualPackageRecovery,
@@ -86,7 +87,6 @@ import {
   extractBundlePluginArtifacts,
   extractCodePluginArtifacts,
   maybeParseJson,
-  normalizePluginManifestIcon,
   normalizePackageName,
   normalizePublishFiles,
   readStorageText,
@@ -8892,7 +8892,6 @@ async function publishPackageImpl(
     );
   }
   const validatedClaw = clawPackage?.ok ? clawPackage.value : undefined;
-  const icon = family === "claw" ? undefined : normalizePluginManifestIcon(pluginManifest);
   if (family === "code-plugin") {
     const validation = validateOpenClawExternalCodePluginPackageContents(
       packageJson,
@@ -9023,6 +9022,14 @@ async function publishPackageImpl(
         scanStatus: initialScanStatus,
       }
     : undefined;
+  const icon =
+    family === "claw"
+      ? undefined
+      : await resolvePackageIcon(ctx, {
+          files,
+          manifest: pluginManifest,
+          ...(trustedOpenClawPlugin ? { trustedSource: verification } : {}),
+        });
   const integritySha256 = await hashSkillFiles(
     files.map((file) => ({ path: file.path, sha256: file.sha256 })),
   );
@@ -9040,6 +9047,7 @@ async function publishPackageImpl(
           ...(family === "code-plugin" || family === "bundle-plugin" ? { categories } : {}),
           files: await withSkillMarkdownTextsForManifestSummary(ctx, files),
         });
+  if (pluginManifestSummary && icon) pluginManifestSummary.icon = icon;
 
   const legacyZipStorageId =
     payload.artifact?.kind === "npm-pack"

--- a/convex/publishers.ts
+++ b/convex/publishers.ts
@@ -107,10 +107,7 @@ type PublisherCatalogItem = {
   inferredCategories?: string[];
   latestVersionId?: Id<"skillVersions">;
   inferredFromVersionId?: Id<"skillVersions">;
-  /**
-   * Legacy skill icon field or public plugin manifest HTTPS icon URL retained
-   * while older frontend bundles are cached.
-   */
+  /** Hosted bundled icon path; older records may retain legacy icon values. */
   icon: string | null;
   href: string;
   installs: number;

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -164,8 +164,8 @@ to keep out of public issues.
   installation still uses one plugin for each runtime id.
 - Include `openclaw.plugin.json`. Code plugins also need `package.json` with
   `openclaw.compat.pluginApi` and `openclaw.build.openclawVersion`.
-- To show a custom plugin catalog icon on the homepage and plugin list pages,
-  add `icon` to `openclaw.plugin.json` with any HTTPS image URL.
+- To show a custom plugin catalog icon, include `assets/icon.png` at the package
+  root in the published archive. Use a valid PNG no larger than 512 KiB.
 - Include source repository and exact commit metadata, or use the CLI from a
   GitHub-backed checkout so it can detect them.
 - Run `clawhub package validate <source>` before publishing. For package,
@@ -181,6 +181,28 @@ inspection findings; it does not erase the primary error. These failures are
 distinct from plugin policy findings. Report the stage and Convex request id
 when asking maintainers to investigate; do not include credentials or package
 contents in diagnostic reports.
+
+### Plugin Icons
+
+ClawHub uses the bundled `assets/icon.png` for plugin catalog artwork. Manifest
+`icon` URLs and paths are ignored. If your npm package uses a `files` allowlist,
+include the asset there and check `npm pack --dry-run` to confirm it will ship.
+Missing or invalid artwork falls back to the plugin category glyph.
+
+Existing releases with only a manifest icon URL also use the category glyph.
+Publish a new release containing `assets/icon.png` to restore custom artwork.
+ClawHub validates and hosts the bundled PNG; an external image URL is not a
+supported substitute.
+
+Maintainers can repair existing latest releases with
+`maintenance:repairPluginIconsInternal` after deploying bundled icon support.
+The repair uses an asset already in the release, or, for official `@openclaw`
+packages owned by the active OpenClaw publisher, the asset at the release's
+recorded OpenClaw source commit. Run the default dry run for each of
+`family: "code-plugin"` and `family: "bundle-plugin"`, following each returned
+`cursor` until `isDone`. Apply from the initial cursor with `dryRun: false`, then
+repeat the dry run to verify no remaining matches. URL-only releases without a
+bundled asset cannot be restored by this repair.
 
 ### Plugin Catalog Metadata
 

--- a/specs/plans/plugins.md
+++ b/specs/plans/plugins.md
@@ -63,8 +63,8 @@ Additional product decision:
 
 ### Portable plugin icons
 
-Plugin publication resolves the fixed `assets/icon.png` path used by OpenClaw
-before falling back to the legacy HTTPS manifest `icon`. Validate the PNG bytes,
+Plugin publication resolves only the fixed `assets/icon.png` path used by OpenClaw.
+Manifest `icon` URLs and paths are ignored. Validate the PNG bytes,
 upload hash, size, and raster decoding; archive entries may be labeled
 `application/octet-stream`. Reuse the content-addressed presentation asset store
 and `/api/v1/skill-icons/<sha256>` endpoint for these catalog images. Persist the
@@ -75,7 +75,8 @@ recorded source commit. Only packages owned by the active `openclaw` publisher i
 the `@openclaw/` scope may recover it from `openclaw/openclaw`, using a full commit
 SHA and an `extensions/<plugin>` path. Never fetch a moving branch, arbitrary
 manifest URL, or caller-selected host for this recovery. Missing/invalid images
-retain the existing fallback; transient fetch failures remain retryable.
+use the category glyph; transient fetch failures remain retryable. Plugin UI
+accepts only hosted presentation assets, including when old records contain URLs.
 
 `maintenance:repairPluginIconsInternal` repairs existing latest releases in
 bounded pages (default 10, maximum 25). It defaults to `dryRun: true`; repeat with
@@ -85,7 +86,9 @@ verify no remaining matches. A dry run validates images without storing assets
 or patching records. The repair uses an action because storage reads, source
 fetches, and raster decoding cannot run inside a migration mutation. Replays are
 idempotent; failed pages can be retried from their input cursor. Concurrent
-publishes, ownership changes, existing icons, and deleted releases are preserved.
+publishes, ownership changes, hosted icons, and deleted releases are preserved.
+Legacy URL metadata is replaced when a bundled asset is available; a concurrent
+icon change invalidates the prepared repair.
 It changes presentation metadata only, without changing release artifacts,
 versions, moderation, or download statistics. Keep it as maintenance tooling for
 imports created before portable icon support.

--- a/specs/plans/plugins.md
+++ b/specs/plans/plugins.md
@@ -61,6 +61,35 @@ Additional product decision:
 
 ## Constraints
 
+### Portable plugin icons
+
+Plugin publication resolves the fixed `assets/icon.png` path used by OpenClaw
+before falling back to the legacy HTTPS manifest `icon`. Validate the PNG bytes,
+upload hash, size, and raster decoding; archive entries may be labeled
+`application/octet-stream`. Reuse the content-addressed presentation asset store
+and `/api/v1/skill-icons/<sha256>` endpoint for these catalog images. Persist the
+same URL on the release, manifest summary, current package, and catalog digests.
+
+Some official OpenClaw npm archives omit the icon even though it exists at their
+recorded source commit. Only packages owned by the active `openclaw` publisher in
+the `@openclaw/` scope may recover it from `openclaw/openclaw`, using a full commit
+SHA and an `extensions/<plugin>` path. Never fetch a moving branch, arbitrary
+manifest URL, or caller-selected host for this recovery. Missing/invalid images
+retain the existing fallback; transient fetch failures remain retryable.
+
+`maintenance:repairPluginIconsInternal` repairs existing latest releases in
+bounded pages (default 10, maximum 25). It defaults to `dryRun: true`; repeat with
+the returned `cursor` until `isDone` for each of `code-plugin` and `bundle-plugin`.
+Apply with `dryRun: false` from the initial cursor, then rerun the dry run to
+verify no remaining matches. A dry run validates images without storing assets
+or patching records. The repair uses an action because storage reads, source
+fetches, and raster decoding cannot run inside a migration mutation. Replays are
+idempotent; failed pages can be retried from their input cursor. Concurrent
+publishes, ownership changes, existing icons, and deleted releases are preserved.
+It changes presentation metadata only, without changing release artifacts,
+versions, moderation, or download statistics. Keep it as maintenance tooling for
+imports created before portable icon support.
+
 ### ClawHub today
 
 ClawHub is currently a text-bundle registry for skills.

--- a/src/__tests__/home-listing-section.test.tsx
+++ b/src/__tests__/home-listing-section.test.tsx
@@ -64,7 +64,7 @@ const featuredPlugin = {
   channel: "community" as const,
   isOfficial: false,
   summary: "Runs workflows.",
-  icon: "https://example.com/demo-plugin.png",
+  icon: `/api/v1/skill-icons/${"a".repeat(64)}`,
   createdAt: 1,
   updatedAt: 2,
   latestVersion: "1.0.0",

--- a/src/components/MarketplaceIcon.test.tsx
+++ b/src/components/MarketplaceIcon.test.tsx
@@ -28,6 +28,29 @@ describe("MarketplaceIcon", () => {
     ).toBe(true);
   });
 
+  it("renders only hosted bundled plugin icons, falling back for remote URLs", () => {
+    const hostedIcon = `/api/v1/skill-icons/${"c".repeat(64)}`;
+    const { container, rerender } = render(
+      <MarketplaceIcon
+        kind="plugin"
+        label="WhatsApp"
+        categorySlug="channels"
+        imageUrl={hostedIcon}
+      />,
+    );
+    expect(container.querySelector("img")?.getAttribute("src")).toBe(hostedIcon);
+    rerender(
+      <MarketplaceIcon
+        kind="plugin"
+        label="WhatsApp"
+        categorySlug="channels"
+        imageUrl="https://example.com/icon.png"
+      />,
+    );
+    expect(container.querySelector("img")).toBeNull();
+    expect(container.querySelector("svg.marketplace-icon-glyph")).toBeTruthy();
+  });
+
   it("ignores legacy skill custom-icon values", () => {
     const { container } = render(
       <MarketplaceIcon

--- a/src/components/MarketplaceIcon.tsx
+++ b/src/components/MarketplaceIcon.tsx
@@ -58,7 +58,9 @@ export function MarketplaceIcon({
         : MARKETPLACE_KIND_ICONS[kind];
   const hashedTone = hashTone(label);
   const supportedImageUrl =
-    kind !== "skill" || isHostedSkillPresentationIcon(imageUrl) ? imageUrl : null;
+    (kind !== "skill" && kind !== "plugin") || isHostedSkillPresentationIcon(imageUrl)
+      ? imageUrl
+      : null;
   const visibleImageUrl =
     supportedImageUrl && failedImageUrl !== supportedImageUrl ? supportedImageUrl : null;
 

--- a/src/components/PluginListItem.test.tsx
+++ b/src/components/PluginListItem.test.tsx
@@ -81,28 +81,28 @@ describe("PluginListItem", () => {
     expect(screen.getByLabelText("Categories")).toBeTruthy();
   });
 
-  it("renders a plugin manifest icon URL with safe image attributes", () => {
+  it("renders a hosted bundled plugin icon with safe image attributes", () => {
     render(
       <PluginListItem
-        item={makePlugin({ icon: "https://cdn.example.test/icons/demo.svg" })}
+        item={makePlugin({ icon: `/api/v1/skill-icons/${"a".repeat(64)}` })}
         variant="card"
       />,
     );
 
     const image = document.querySelector<HTMLImageElement>(".marketplace-icon-image");
     expect(image).toBeTruthy();
-    expect(image?.getAttribute("src")).toBe("https://cdn.example.test/icons/demo.svg");
+    expect(image?.getAttribute("src")).toBe(`/api/v1/skill-icons/${"a".repeat(64)}`);
     expect(image?.getAttribute("referrerpolicy")).toBe("no-referrer");
     expect(image?.getAttribute("loading")).toBe("lazy");
     expect(image?.getAttribute("decoding")).toBe("async");
   });
 
-  it("falls back to the default plugin glyph when a manifest icon fails to load", () => {
+  it("falls back to the category glyph when a bundled icon fails to load", () => {
     render(
       <PluginListItem
         item={makePlugin({
           categories: ["models"],
-          icon: "https://cdn.example.test/broken.svg",
+          icon: `/api/v1/skill-icons/${"b".repeat(64)}`,
         })}
       />,
     );

--- a/src/components/PublishedItemCard.test.tsx
+++ b/src/components/PublishedItemCard.test.tsx
@@ -78,21 +78,19 @@ describe("PublishedItemCard", () => {
     expect(document.querySelector("svg")?.classList.contains("lucide-slash")).toBe(true);
   });
 
-  it("always uses the default kind icon for plugins regardless of icon field (F7)", () => {
+  it("uses the default kind icon for plugins without a bundled icon", () => {
     render(<PublishedItemCard item={{ ...basePlugin, icon: null }} />);
     expect(document.querySelector(".marketplace-icon-glyph")).toBeTruthy();
   });
 
-  it("renders plugin manifest icons for publisher plugin rows", () => {
+  it("renders hosted bundled icons for publisher plugin rows", () => {
     render(
-      <PublishedItemCard
-        item={{ ...basePlugin, icon: "https://cdn.example.test/icons/plugin.svg" }}
-      />,
+      <PublishedItemCard item={{ ...basePlugin, icon: `/api/v1/skill-icons/${"a".repeat(64)}` }} />,
     );
 
     const image = document.querySelector<HTMLImageElement>(".marketplace-icon-image");
     expect(image).toBeTruthy();
-    expect(image?.getAttribute("src")).toBe("https://cdn.example.test/icons/plugin.svg");
+    expect(image?.getAttribute("src")).toBe(`/api/v1/skill-icons/${"a".repeat(64)}`);
     expect(document.querySelector(".marketplace-icon-glyph")).toBeNull();
   });
 

--- a/src/lib/publicUser.ts
+++ b/src/lib/publicUser.ts
@@ -66,7 +66,7 @@ export type PublicPublisherCatalogItem = {
   inferredCategories?: string[];
   latestVersionId?: string | null;
   inferredFromVersionId?: string | null;
-  /** Legacy skill icon field or plugin manifest HTTPS icon URL retained in responses. */
+  /** Hosted bundled icon path; older records may retain legacy icon values. */
   icon: string | null;
   href: string;
   installs?: number;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users browsing official plugins see generic category placeholders even though OpenClaw bundles artwork for those plugins.

## Why This Change Was Made

OpenClaw moved to the fixed `assets/icon.png` convention in [openclaw/openclaw#131510](https://github.com/openclaw/openclaw/pull/131510) and [#131511](https://github.com/openclaw/openclaw/pull/131511). ClawHub still read only a manifest HTTPS `icon` URL. The eight reported plugins also have published archives that omit their PNG despite recording source commits containing it.

Publication now validates and hosts only the bundled `assets/icon.png`. Manifest icon URLs and paths are ignored, and the UI renders only hosted bundled assets. For official packages owned by `@openclaw`, an omitted PNG can be recovered from that release's pinned OpenClaw source commit. Existing records have a bounded, cursor-resumable repair that defaults to a dry run and updates the release, latest package metadata, and catalog/search projections together. The publishing guide documents the bundled PNG requirement, ignored manifest fields, fallback for URL-only releases, and operator repair procedure.

## User Impact

Official plugin listings show their bundled artwork. Existing records need `maintenance:repairPluginIconsInternal` after deployment: preview, apply, and verify both `code-plugin` and `bundle-plugin`, continuing each returned cursor until `isDone`. The repair replaces legacy URL metadata when a bundled asset is available and preserves concurrent publishes, ownership or icon changes, existing hosted icons, release artifacts, moderation, and statistics. This PR has not changed production data.

## Evidence

| Before | After |
| --- | --- |
| ![Before: category placeholders](https://raw.githubusercontent.com/openclaw/clawhub/qa-artifacts/pr-3660/15f6108b71-plugin-icons/baseline/1-desktop-official-list-dark.png) | ![After: bundled plugin icons](https://raw.githubusercontent.com/openclaw/clawhub/qa-artifacts/pr-3660/15f6108b71-plugin-icons/candidate/1-desktop-official-list-dark.png) |

[All five paired browser captures](https://github.com/openclaw/clawhub/pull/3660#issuecomment-5621273144) · [Fixture and validation report](https://raw.githubusercontent.com/openclaw/clawhub/qa-artifacts/pr-3660/15f6108b71-plugin-icons/report.md)

Real local Convex + ClawHub + Chromium comparison, using the same eight public metadata fixtures on baseline `694ff719e9` and implementation commit `15f6108b71`; the subsequent commit changes only the publishing guide. Routes: `http://127.0.0.1:4377/plugins?official=true&view=list` before and port `4378` after, plus grid views.

| Check | Before | After |
| --- | --- | --- |
| Plugin image elements | 0 | 8; every visible PNG decodes |
| Repair dry run | 8 eligible, 0 writes | 0 remaining after applying 8 repairs |
| Desktop light/dark, laptop, tablet | Category placeholders | Bundled artwork |
| Compact mobile layout | Icons hidden by existing CSS | Layout preserved |

Validation passed:

- 443 targeted publishing, manifest, repair, and UI tests. Six regressions failed before the bundled-only correction and pass afterward.
- `bun run ci:unit`: 6,610 passed, 3 skipped.
- `bun run ci:static`.
- `bun run ci:types-build`.
- Convex codegen against the isolated candidate deployment.
- Real dry-run/apply/verify and five paired, visually inspected browser captures.
- Autoreview: final follow-up review exited cleanly with no accepted/actionable findings.

Pre-merge verification: schema, CLI, and Convex TypeScript checks passed; `bun run ci:static` and `git diff --check` passed after the documentation correction.
