### PR TITLE
fix(import): cap GitHub zip expansion before inflate

### DIFF
--- a/convex/githubImport.test.ts
+++ b/convex/githubImport.test.ts
@@ -1,5 +1,6 @@
 /* @vitest-environment node */
 import { generateKeyPairSync } from "node:crypto";
+import { zipSync } from "fflate";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { internal } from "./_generated/api";
 import { __test } from "./githubImport";
@@ -84,6 +85,15 @@ describe("githubImport", () => {
       "demo-repo/skill/SKILL.md",
       "demo-repo/skill/notes.md",
     ]);
+  });
+
+  it("rejects oversized files so they are not inflated past import limits", () => {
+    const zip = zipSync({
+      "demo-repo/skill/SKILL.md": new TextEncoder().encode("# Demo\n"),
+      "demo-repo/skill/model.bin": new Uint8Array(10 * 1024 * 1024 + 1),
+    });
+
+    expect(() => __test.unzipToEntries(zip)).toThrow(/file that is too large/i);
   });
 
   it("rejects a public repo owned by another GitHub account before repo lookup", async () => {

--- a/convex/githubImport.ts
+++ b/convex/githubImport.ts
@@ -1,5 +1,5 @@
 import { ConvexError, v } from "convex/values";
-import { unzipSync } from "fflate";
+import { unzipSync, type UnzipFileInfo } from "fflate";
 import semver from "semver";
 import { api, internal } from "./_generated/api";
 import type { Id } from "./_generated/dataModel";
@@ -892,22 +892,45 @@ function normalizeRepoSearchQuery(query: string) {
 }
 
 function unzipToEntries(zipBytes: Uint8Array) {
-  const entries = unzipSync(zipBytes);
+  const limits = createZipEntryLimitFilter();
+  const entries = unzipSync(zipBytes, {
+    filter: (file) => limits.accept(file),
+  });
   const out: Record<string, Uint8Array> = {};
-  const rawPaths = Object.keys(entries);
-  if (rawPaths.length > MAX_FILE_COUNT) throw new ConvexError("Repo archive has too many files");
   let totalBytes = 0;
   for (const [rawPath, bytes] of Object.entries(entries)) {
     const normalizedPath = normalizeZipPath(rawPath);
     if (!normalizedPath) continue;
     if (isMacJunkPath(normalizedPath)) continue;
     if (!bytes) continue;
-    if (bytes.byteLength > MAX_SINGLE_FILE_BYTES) continue;
     totalBytes += bytes.byteLength;
     if (totalBytes > MAX_UNZIPPED_BYTES) throw new ConvexError("Repo archive is too large");
     out[normalizedPath] = bytes;
   }
   return out;
+}
+
+function createZipEntryLimitFilter() {
+  let fileCount = 0;
+  let totalBytes = 0;
+  return {
+    accept(file: UnzipFileInfo) {
+      fileCount += 1;
+      if (fileCount > MAX_FILE_COUNT) throw new ConvexError("Repo archive has too many files");
+      if (file.name.endsWith("/")) return false;
+
+      const normalizedPath = normalizeZipPath(file.name);
+      if (!normalizedPath) return false;
+      if (isMacJunkPath(normalizedPath)) return false;
+
+      if (file.originalSize > MAX_SINGLE_FILE_BYTES) {
+        throw new ConvexError("Repo archive contains a file that is too large");
+      }
+      totalBytes += file.originalSize;
+      if (totalBytes > MAX_UNZIPPED_BYTES) throw new ConvexError("Repo archive is too large");
+      return true;
+    },
+  };
 }
 
 function isCandidateUnderResolvedPath(candidatePath: string, resolvedPath: string) {


### PR DESCRIPTION
## What Problem This Solves

Authenticated Convex GitHub import (`previewGitHubImport`, `previewGitHubImportCandidate`, `importGitHubSkill`) calls `unzipSync(zipBytes)` with no filter, then checks file count / single-file / total size after the archive has already been inflated.

`fetchGitHubZipBytes` only caps the compressed download at 25MB. A highly compressible 25MB GitHub zip can expand far past the 80MB unzipped budget inside the Convex action before those post-checks run.

Sibling `convex/githubSkillSync.ts` already uses `createZipEntryLimitFilter` so `originalSize` is enforced before inflate. This change applies the same filter to `githubImport.ts` `unzipToEntries`.

## Evidence

Live `bun` against production `unzipToEntries` with a zip whose uncompressed `originalSize` is 10MB+1:

```console
$ bun -e "import { zipSync } from 'fflate'; import { __test } from './convex/githubImport.ts'; ..."
THREW ConvexError: Repo archive contains a file that is too large
```

Same-repo: `githubSkillSync` unzip filter (`createZipEntryLimitFilter`). F006 [#3612](https://github.com/openclaw/clawhub/pull/3612) is the same file's blob-store leak, not unzip bounds.

## Real behavior proof

- **Behavior or issue addressed:** GitHub import unzip rejects oversized entries from zip headers before fflate inflates them.
- **Real environment tested:** Windows 11, bun 1.4.1, worktree `C:\tmp\wt-ch-f012` at `786ce7d`.
- **Exact steps or command run after this patch:** Built an in-memory zip with `zipSync` containing `model.bin` of length `10 * 1024 * 1024 + 1` and called `__test.unzipToEntries`.
- **Evidence after fix:** terminal output `THREW ConvexError: Repo archive contains a file that is too large`.
- **Observed result after fix:** Import unzip fails closed on the single-file cap during the filter callback instead of inflating first and skipping later.
- **What was not tested:** A 25MB highly compressible archive on live Convex. File-count and 80MB total caps use the same filter and are not separately exercised in this live command.

## Tracker

Ref #3678

That issue stays open if this PR is closed without landing on main.
