### PR TITLE
fix(security): enforce current organization skill ownership

### DIFF
--- a/convex/skillOwnershipAuthorization.runtime.test.ts
+++ b/convex/skillOwnershipAuthorization.runtime.test.ts
@@ -1,0 +1,144 @@
+/// <reference types="vite/client" />
+/* @vitest-environment edge-runtime */
+import { convexTest } from "convex-test";
+import { expect, it } from "vitest";
+import { internal } from "./_generated/api";
+import schema from "./schema";
+
+const modules = import.meta.glob("./**/*.ts");
+
+async function setupOrganizationSkill() {
+  const t = convexTest(schema, modules);
+  const ids = await t.run(async (ctx) => {
+    const creatorId = await ctx.db.insert("users", { handle: "creator" });
+    const recipientId = await ctx.db.insert("users", { handle: "recipient" });
+    const publisherId = await ctx.db.insert("publishers", {
+      kind: "org",
+      handle: "organization",
+      displayName: "Organization",
+      createdAt: 1,
+      updatedAt: 1,
+    });
+    const membershipId = await ctx.db.insert("publisherMembers", {
+      publisherId,
+      userId: creatorId,
+      role: "admin",
+      createdAt: 1,
+      updatedAt: 1,
+    });
+    const skillId = await ctx.db.insert("skills", {
+      slug: "organization-skill",
+      displayName: "Organization skill",
+      ownerUserId: creatorId,
+      ownerPublisherId: publisherId,
+      tags: {},
+      badges: {},
+      moderationStatus: "active",
+      stats: { comments: 0, downloads: 0, stars: 0, versions: 0 },
+      createdAt: 1,
+      updatedAt: 1,
+    });
+    return { creatorId, recipientId, publisherId, membershipId, skillId };
+  });
+  return { t, ...ids };
+}
+
+it.each(["removed", "downgraded"])(
+  "rejects a transfer requested by a %s organization publisher",
+  async (change) => {
+    const { t, creatorId, membershipId, skillId } = await setupOrganizationSkill();
+    await t.run(async (ctx) => {
+      if (change === "removed") await ctx.db.delete(membershipId);
+      else await ctx.db.patch(membershipId, { role: "publisher" });
+    });
+    await expect(
+      t.mutation(internal.skillTransfers.requestTransferInternal, {
+        actorUserId: creatorId,
+        skillId,
+        toUserHandle: "recipient",
+      }),
+    ).rejects.toThrow("Forbidden");
+  },
+);
+
+it("allows current organization admins to complete a transfer", async () => {
+  const { t, creatorId, recipientId, skillId } = await setupOrganizationSkill();
+  const request = await t.mutation(internal.skillTransfers.requestTransferInternal, {
+    actorUserId: creatorId,
+    skillId,
+    toUserHandle: "recipient",
+  });
+  await expect(
+    t.mutation(internal.skillTransfers.acceptTransferInternal, {
+      actorUserId: recipientId,
+      transferId: request.transferId,
+    }),
+  ).resolves.toMatchObject({ ok: true, skillSlug: "organization-skill" });
+});
+
+it("allows current organization admins to delete and restore their skill", async () => {
+  const { t, creatorId } = await setupOrganizationSkill();
+  for (const deleted of [true, false]) {
+    await expect(
+      t.mutation(internal.skills.setSkillSoftDeletedInternal, {
+        userId: creatorId,
+        slug: "organization-skill",
+        ownerHandle: "organization",
+        deleted,
+      }),
+    ).resolves.toMatchObject({ ok: true });
+  }
+});
+
+it.each(["removed", "downgraded"])(
+  "cancels a pending transfer after its requester is %s",
+  async (change) => {
+    const { t, creatorId, recipientId, membershipId, skillId, publisherId } =
+      await setupOrganizationSkill();
+    const request = await t.mutation(internal.skillTransfers.requestTransferInternal, {
+      actorUserId: creatorId,
+      skillId,
+      toUserHandle: "recipient",
+    });
+    await t.run(async (ctx) => {
+      if (change === "removed") await ctx.db.delete(membershipId);
+      else await ctx.db.patch(membershipId, { role: "publisher" });
+    });
+    await expect(
+      t.mutation(internal.skillTransfers.acceptTransferInternal, {
+        actorUserId: recipientId,
+        transferId: request.transferId,
+      }),
+    ).resolves.toEqual({ ok: false, error: "Transfer is no longer valid" });
+    const state = await t.run(async (ctx) => ({
+      skill: await ctx.db.get(skillId),
+      transfer: await ctx.db.get(request.transferId),
+    }));
+    expect(state.skill?.ownerPublisherId).toBe(publisherId);
+    expect(state.transfer?.status).toBe("cancelled");
+  },
+);
+
+it.each([true, false])(
+  "rejects a former publisher's lifecycle change (deleted=%s)",
+  async (deleted) => {
+    const { t, creatorId, membershipId, skillId } = await setupOrganizationSkill();
+    await t.run(async (ctx) => {
+      await ctx.db.delete(membershipId);
+      if (!deleted)
+        await ctx.db.patch(skillId, {
+          softDeletedAt: 2,
+          moderationStatus: "hidden",
+          hiddenBy: creatorId,
+        });
+    });
+    await expect(
+      t.mutation(internal.skills.setSkillSoftDeletedInternal, {
+        userId: creatorId,
+        slug: "organization-skill",
+        ownerHandle: "organization",
+        deleted,
+      }),
+    ).rejects.toThrow("Forbidden");
+  },
+);

--- a/convex/skillTransfers.ts
+++ b/convex/skillTransfers.ts
@@ -32,7 +32,7 @@ async function assertCanRequestSkillTransfer(
   actor: Doc<"users">,
   skill: Doc<"skills">,
 ) {
-  if (skill.ownerUserId === actor._id) return;
+  // Organization ownership follows current roles, not the original publisher.
   await assertCanManageOwnedResource(ctx, {
     actor,
     ownerUserId: skill.ownerUserId,
@@ -262,12 +262,11 @@ export const acceptTransferInternal = internalMutation({
     if (!requester || requester.deletedAt || requester.deactivatedAt) {
       return await cancelTransfer("Transfer is no longer valid");
     }
-    if (skill.ownerUserId !== transfer.fromUserId) {
-      try {
-        await assertCanRequestSkillTransfer(ctx, requester, skill);
-      } catch {
-        return await cancelTransfer("Transfer is no longer valid");
-      }
+    // Membership may have changed since the transfer was requested.
+    try {
+      await assertCanRequestSkillTransfer(ctx, requester, skill);
+    } catch {
+      return await cancelTransfer("Transfer is no longer valid");
     }
     const newPublisher = await ensurePersonalPublisherForUser(ctx, newOwner, {
       actorUserId: args.actorUserId,

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -13648,23 +13648,20 @@ async function setSkillSoftDeletedByActor(
   const slug = skill.slug;
 
   const isModeratorOrAdmin = user.role === "admin" || user.role === "moderator";
-  let isOwner = skill.ownerUserId === args.userId;
-
-  if (!isOwner) {
-    try {
-      await assertCanManageOwnedResource(ctx, {
-        actor: user,
-        ownerUserId: skill.ownerUserId,
-        ownerPublisherId: skill.ownerPublisherId,
-        allowedPublisherRoles: ["admin"],
-      });
-      isOwner = true;
-    } catch {
-      if (!isModeratorOrAdmin) {
-        // Preserve legacy behavior: delegate to assertModerator to produce the
-        // standard "Forbidden" error for non-owners without elevated roles.
-        assertModerator(user);
-      }
+  let isOwner = false;
+  // A historical publisher user ID does not confer current organization access.
+  try {
+    await assertCanManageOwnedResource(ctx, {
+      actor: user,
+      ownerUserId: skill.ownerUserId,
+      ownerPublisherId: skill.ownerPublisherId,
+      allowedPublisherRoles: ["admin"],
+    });
+    isOwner = true;
+  } catch {
+    if (!isModeratorOrAdmin) {
+      // Preserve the standard authorization error for non-owners.
+      assertModerator(user);
     }
   }
   if (args.deleted && skill.moderationStatus === "removed") {

--- a/specs/security-moderation.md
+++ b/specs/security-moderation.md
@@ -12,6 +12,15 @@ See also: [acceptable-usage.md](./acceptable-usage.md) for the marketplace polic
 
 ## Roles + permissions
 
+- Skill transfer, delete, and restore authorization follows the resource's current
+  publisher ownership. For organization skills, the historical `ownerUserId` is
+  not an authorization grant: current organization admin/owner membership is
+  required, subject to the operation's existing platform staff permissions.
+- Transfer acceptance rechecks the requester's current authority, including when
+  they originally published the skill. Removing or downgrading their membership
+  invalidates pending requests. Personal and legacy skills retain personal-owner
+  authorization through the shared publisher ownership check.
+
 - user: upload skills (subject to GitHub age gate), report skills/packages.
 - moderator: hide/restore skills, view hidden skills, unhide, soft-delete, ban users (except admins).
 - admin: all moderator actions + hard delete skills, change owners, change roles.


### PR DESCRIPTION
Former publishers retained authority over organization skills through the historical `ownerUserId`. Transfer requests and delete/restore now use current publisher authorization, and transfer acceptance rechecks the requester's authority after membership removal or downgrade.

Addresses [GHSA-9558-q4f9-324f](https://github.com/openclaw/clawhub/security/advisories/GHSA-9558-q4f9-324f). The advisory is published with the deployed revision and regression evidence.

## Verification

- Before: regression tests against `cbfee7343ddc867316dd9b3de6fa8856730f9f41` reproduced successful former-publisher transfer requests, acceptance after revocation/downgrade, and delete/restore.
- After: 40 focused tests pass, including current organization-admin and personal-owner compatibility coverage.
- Real local Convex backend at `http://127.0.0.1:3320`, using synthetic organization/member/recipient fixtures: transfer request denied; pending acceptance cancelled; delete denied; restore denied; organization ownership preserved. No production data or accounts were exercised.
- `bun run ci:static` passed.
- `bun run ci:unit` passed: 6,627 tests; 497 passing files, 1 skipped.
- `bun run ci:types-build` passed, including root, schema, CLI, admin TypeScript and production build.
- `bunx convex dev --once --codegen disable` pushed and typechecked the candidate successfully on the disposable local backend.
- `.agents/skills/autoreview/scripts/autoreview --mode local --no-web-search`: clean, no actionable findings.

Best-fix verdict: best. Reusing the shared publisher authorization keeps organization membership authoritative without changing personal-owner or staff permissions. Changing stored historical user IDs would not revalidate pending requests and would require a data migration.

Combined release validation: `ci:static`, `ci:unit` (6,656 passing tests), and `ci:types-build` passed on `f3cd9104981d1875cc2945418172837297afcb5d`. The protected Test frontend passed four HTTP checks, two browser checks, and an archive download check.

## Deployment verified

Merged and deployed in `8c2de6c506bb4efabe3f0c2ffb8370b9e23d4650`. [Test deployment](https://github.com/openclaw/clawhub/actions/runs/34637837491) and [Production deployment](https://github.com/openclaw/clawhub/actions/runs/34638222404) succeeded for that exact SHA. Live reads/downloads/image rendering and browser smoke tests pass; forged ingress is rejected. The active Production catalog rollout was restored after backend deployment. The superseded private security-fork PR is closed.
