### PR TITLE
fix(security): require moderator review before hiding reported skills

### DIFF
--- a/convex/lib/reporting.ts
+++ b/convex/lib/reporting.ts
@@ -1,3 +1,2 @@
 export const MAX_ACTIVE_REPORTS_PER_USER = 20;
-export const AUTO_HIDE_REPORT_THRESHOLD = 3;
 export const MAX_REPORT_REASON_LENGTH = 500;

--- a/convex/skillReports.runtime.test.ts
+++ b/convex/skillReports.runtime.test.ts
@@ -1,0 +1,71 @@
+/// <reference types="vite/client" />
+/* @vitest-environment edge-runtime */
+import { convexTest } from "convex-test";
+import { expect, it } from "vitest";
+import { api } from "./_generated/api";
+import schema from "./schema";
+
+const modules = import.meta.glob("./**/*.ts");
+
+it.each([false, true])(
+  "keeps a skill public after four reports (official=%s) until a moderator acts",
+  async (official) => {
+    const t = convexTest(schema, modules);
+    const { skillId, reporters } = await t.run(async (ctx) => {
+      const ownerUserId = await ctx.db.insert("users", { handle: "owner" });
+      const createdSkillId = await ctx.db.insert("skills", {
+        slug: "reported-skill",
+        displayName: "Reported skill",
+        ownerUserId,
+        tags: {},
+        badges: official ? { official: { byUserId: ownerUserId, at: 1 } } : {},
+        moderationStatus: "active",
+        stats: { comments: 0, downloads: 0, stars: 0, versions: 0 },
+        createdAt: 1,
+        updatedAt: 1,
+      });
+      const createdReporters = [];
+      for (let i = 0; i < 4; i++)
+        createdReporters.push(await ctx.db.insert("users", { handle: `reporter-${i}` }));
+      return { skillId: createdSkillId, reporters: createdReporters };
+    });
+    for (const userId of reporters) {
+      await expect(
+        t.withIdentity({ subject: userId }).mutation(api.skills.report, {
+          skillId,
+          reason: "Please review this skill",
+        }),
+      ).resolves.toMatchObject({ ok: true, reported: true });
+    }
+    const skill = await t.run((ctx) => ctx.db.get(skillId));
+    expect(skill?.reportCount).toBe(4);
+    expect(skill?.moderationStatus).toBe("active");
+    expect(skill?.softDeletedAt).toBeUndefined();
+    const reports = await t.run((ctx) => ctx.db.query("skillReports").collect());
+    expect(reports).toHaveLength(4);
+    expect(reports.every((report) => report.status === "open")).toBe(true);
+    await expect(
+      t.withIdentity({ subject: reporters[0] }).mutation(api.skills.report, {
+        skillId,
+        reason: "Repeated report",
+      }),
+    ).resolves.toMatchObject({ alreadyReported: true, reported: false });
+    expect((await t.run((ctx) => ctx.db.get(skillId)))?.reportCount).toBe(4);
+    await expect(
+      t.withIdentity({ subject: reporters[0] }).mutation(api.skills.setSoftDeleted, {
+        skillId,
+        deleted: true,
+        reason: "Reporter cannot make the moderation decision",
+      }),
+    ).rejects.toThrow("Forbidden");
+    const moderator = await t.run((ctx) =>
+      ctx.db.insert("users", { handle: "moderator", role: "moderator" }),
+    );
+    await t.withIdentity({ subject: moderator }).mutation(api.skills.setSoftDeleted, {
+      skillId,
+      deleted: true,
+      reason: "Moderator reviewed the reports",
+    });
+    expect((await t.run((ctx) => ctx.db.get(skillId)))?.moderationStatus).toBe("hidden");
+  },
+);

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -103,11 +103,7 @@ import {
   requirePublisherRole,
 } from "./lib/publishers";
 import { RECOMMENDATION_SCORE_VERSION } from "./lib/recommendationScore";
-import {
-  AUTO_HIDE_REPORT_THRESHOLD,
-  MAX_ACTIVE_REPORTS_PER_USER,
-  MAX_REPORT_REASON_LENGTH,
-} from "./lib/reporting";
+import { MAX_ACTIVE_REPORTS_PER_USER, MAX_REPORT_REASON_LENGTH } from "./lib/reporting";
 import {
   canReleaseReservedSlugForPublisher,
   enforceReservedSlugCooldownForNewSkill,
@@ -4195,47 +4191,12 @@ export const report = mutation({
     });
 
     const nextReportCount = (skill.reportCount ?? 0) + 1;
-    const shouldAutoHide = nextReportCount > AUTO_HIDE_REPORT_THRESHOLD && !skill.softDeletedAt;
-    const updates: Partial<Doc<"skills">> = {
+    // Reports are moderator intake, not authority to hide another publisher's skill.
+    await ctx.db.patch(skill._id, {
       reportCount: nextReportCount,
       lastReportedAt: now,
       updatedAt: now,
-    };
-    if (shouldAutoHide) {
-      Object.assign(updates, {
-        softDeletedAt: now,
-        moderationStatus: "hidden",
-        moderationReason: "auto.reports",
-        moderationNotes: "Auto-hidden after 4 unique reports.",
-        isSuspicious: computeIsSuspicious({
-          moderationFlags: skill.moderationFlags,
-          moderationReason: "auto.reports",
-        }),
-        hiddenAt: now,
-        lastReviewedAt: now,
-        unpublishedSlugReservedUntil: undefined,
-        unpublishedSlugReleasedAt: undefined,
-        unpublishedOriginalSlug: undefined,
-      });
-    }
-
-    const nextSkill = { ...skill, ...updates };
-    await ctx.db.patch(skill._id, updates);
-    await adjustGlobalPublicCountForSkillChange(ctx, skill, nextSkill);
-    await adjustUserSkillStatsForSkillChange(ctx, skill, nextSkill);
-
-    if (shouldAutoHide) {
-      await setSkillEmbeddingsSoftDeleted(ctx, skill._id, true, now);
-
-      await ctx.db.insert("auditLogs", {
-        actorUserId: userId,
-        action: "skill.auto_hide",
-        targetType: "skill",
-        targetId: skill._id,
-        metadata: { reportCount: nextReportCount },
-        createdAt: now,
-      });
-    }
+    });
 
     await appendSkillModerationEventLog(ctx, {
       kind: "report",

--- a/specs/security-moderation.md
+++ b/specs/security-moderation.md
@@ -220,7 +220,7 @@ See also: [acceptable-usage.md](./acceptable-usage.md) for the marketplace polic
   abuse list from the filtered backend dashboard state instead of applying a
   separate client-side official-org filter.
 
-## Reporting + auto-hide
+## Reporting + moderation review
 
 - Reports are unique per user + target (skill/package).
 - Report reason required (trimmed, max 500 chars). Abuse of reporting may result in account bans.
@@ -229,13 +229,13 @@ See also: [acceptable-usage.md](./acceptable-usage.md) for the marketplace polic
     and the owner is not banned.
   - Active package report = package exists, not soft-deleted, and the owner is
     not banned/deactivated.
-- Auto-hide: when unique reports exceed 3 (4th report):
-  - skill report flow:
-    - soft-delete skill (`softDeletedAt`)
-    - set `moderationStatus = hidden`
-    - set `moderationReason = auto.reports`
-    - set embeddings visibility `deleted`
-    - audit log entry: `skill.auto_hide`
+- Reports never change skill visibility or installability automatically, regardless
+  of the number of distinct reporters or whether the skill is official. Report
+  submission records moderator intake and updates report counts only. Hiding a
+  skill requires an authorized moderator's explicit decision; this prevents a
+  small group of ordinary accounts from removing arbitrary catalog entries.
+- Existing report, scanner, and moderator hides retain their provenance; this
+  change does not automatically restore previously hidden skills.
 - Package reports feed `clawhub-admin package moderation-queue` and audit `package.report`,
   but do not auto-hide or block downloads. Moderators can review a formal report
   with an explicit final action to quarantine or revoke the affected release.


### PR DESCRIPTION
Four ordinary accounts could automatically hide any visible skill by reporting it once each. Report submission now updates moderator intake and counts only; an authorized moderator must explicitly decide to hide a skill. Official and ordinary skills follow the same rule.

Addresses [GHSA-5jj4-m8c9-gwcq](https://github.com/openclaw/clawhub/security/advisories/GHSA-5jj4-m8c9-gwcq). The advisory is published with the deployed revision and regression evidence.

## Verification

- Before: a regression against `cbfee7343ddc867316dd9b3de6fa8856730f9f41` observed `moderationStatus: hidden` after the fourth distinct report.
- After: authenticated runtime tests cover official and ordinary skills, four retained reports, duplicate-report rejection, denied reporter moderation privileges, and successful moderator hide.
- Real local Convex backend at `http://127.0.0.1:3330`: four distinct synthetic authenticated users reported an official skill through the public `skills:report` mutation. Result: `reportCount: 4`, `moderationStatus: active`, `deleted: false`.
- `bun run ci:static` passed.
- `bun run ci:unit` passed: 6,621 tests; 497 passing files, 1 skipped.
- `bun run ci:types-build` passed.
- Local Convex deployment and typecheck passed.
- `.agents/skills/autoreview/scripts/autoreview --mode local --no-web-search`: clean, no actionable findings.

Best-fix verdict: best. Report counts remain useful moderation evidence, while visibility decisions stay with moderators. Raising the threshold or exempting only official skills would retain the coordinated takedown mechanism. Existing hidden rows and historical audit labels remain intact.

Combined release validation: `ci:static`, `ci:unit` (6,656 passing tests), and `ci:types-build` passed on `f3cd9104981d1875cc2945418172837297afcb5d`. The protected Test frontend passed four HTTP checks, two browser checks, and an archive download check.

## Deployment verified

Merged and deployed in `8c2de6c506bb4efabe3f0c2ffb8370b9e23d4650`. [Test deployment](https://github.com/openclaw/clawhub/actions/runs/34637837491) and [Production deployment](https://github.com/openclaw/clawhub/actions/runs/34638222404) succeeded for that exact SHA. Live reads/downloads/image rendering and browser smoke tests pass; forged ingress is rejected. The active Production catalog rollout was restored after backend deployment. The superseded private security-fork PR is closed.
