### PR TITLE
fix(security): authorize previous content before changelog previews

### DIFF
--- a/convex/changelogPreview.runtime.test.ts
+++ b/convex/changelogPreview.runtime.test.ts
@@ -1,0 +1,128 @@
+/// <reference types="vite/client" />
+/* @vitest-environment edge-runtime */
+import { convexTest } from "convex-test";
+import { afterEach, expect, it, vi } from "vitest";
+import { api } from "./_generated/api";
+import schema from "./schema";
+
+const modules = import.meta.glob("./**/*.ts");
+const hiddenText = "Synthetic quarantined content, never send to the provider";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+});
+
+async function setupPreview() {
+  const t = convexTest(schema, modules);
+  const ids = await t.run(async (ctx) => {
+    const ownerId = await ctx.db.insert("users", { handle: "owner" });
+    const outsiderId = await ctx.db.insert("users", { handle: "outsider" });
+    const skillId = await ctx.db.insert("skills", {
+      slug: "quarantined",
+      displayName: "Quarantined",
+      ownerUserId: ownerId,
+      tags: {},
+      moderationStatus: "hidden",
+      moderationReason: "scanner.test.malicious",
+      stats: { comments: 0, downloads: 0, stars: 0, versions: 1 },
+      createdAt: 1,
+      updatedAt: 1,
+    });
+    const storageId = await ctx.storage.store(new Blob([hiddenText]));
+    const versionId = await ctx.db.insert("skillVersions", {
+      skillId,
+      version: "1.0.0",
+      changelog: "Initial",
+      parsed: { frontmatter: {} },
+      files: [{ path: "SKILL.md", size: hiddenText.length, storageId, sha256: "a".repeat(64) }],
+      createdBy: ownerId,
+      createdAt: 1,
+    });
+    await ctx.db.patch(skillId, { latestVersionId: versionId });
+    return { ownerId, outsiderId, skillId, versionId };
+  });
+  vi.stubEnv("OPENAI_API_KEY", "local-provider-fixture");
+  const provider = vi.fn(
+    async (_input: unknown, _init?: RequestInit) =>
+      new Response(
+        JSON.stringify({
+          output: [
+            { type: "message", content: [{ type: "output_text", text: "Provider answer" }] },
+          ],
+        }),
+        {
+          headers: { "Content-Type": "application/json" },
+        },
+      ),
+  );
+  vi.stubGlobal("fetch", provider);
+  return { t, provider, ...ids };
+}
+
+it("rejects an outsider's quarantined-content preview before calling the provider", async () => {
+  const { t, outsiderId, provider } = await setupPreview();
+  await expect(
+    t.withIdentity({ subject: outsiderId }).action(api.skills.generateChangelogPreview, {
+      slug: "quarantined",
+      version: "1.0.1",
+      readmeText: "New readme",
+      filePaths: ["SKILL.md"],
+    }),
+  ).rejects.toThrow("Version not available");
+  expect(provider).not.toHaveBeenCalled();
+});
+
+it.each(["pending", "blocked", "deleted"])(
+  "rejects an outsider's %s version without a provider call",
+  async (state) => {
+    const { t, outsiderId, provider, skillId, versionId } = await setupPreview();
+    await t.run(async (ctx) => {
+      await ctx.db.patch(skillId, { moderationStatus: "active", moderationReason: undefined });
+      if (state === "deleted") await ctx.db.patch(versionId, { softDeletedAt: 2 });
+      else await ctx.db.patch(versionId, { publicationStatus: state as "pending" | "blocked" });
+    });
+    await expect(
+      t.withIdentity({ subject: outsiderId }).action(api.skills.generateChangelogPreview, {
+        slug: "quarantined",
+        version: "1.0.1",
+        readmeText: "New readme",
+      }),
+    ).rejects.toThrow("Version not available");
+    expect(provider).not.toHaveBeenCalled();
+  },
+);
+
+it.each(["public", "owner"])("preserves previews with authorized %s content", async (access) => {
+  const { t, outsiderId, ownerId, provider, skillId } = await setupPreview();
+  if (access === "public")
+    await t.run((ctx) =>
+      ctx.db.patch(skillId, {
+        moderationStatus: "active",
+        moderationReason: undefined,
+      }),
+    );
+  await expect(
+    t
+      .withIdentity({ subject: access === "owner" ? ownerId : outsiderId })
+      .action(api.skills.generateChangelogPreview, {
+        slug: "quarantined",
+        version: "1.0.1",
+        readmeText: "New readme",
+      }),
+  ).resolves.toEqual({ changelog: "Provider answer", source: "auto" });
+  expect(provider).toHaveBeenCalledOnce();
+  expect(provider.mock.calls[0]?.[1]?.body).toContain(hiddenText);
+});
+
+it("allows an initial-release preview without loading another skill's content", async () => {
+  const { t, outsiderId, provider } = await setupPreview();
+  await expect(
+    t.withIdentity({ subject: outsiderId }).action(api.skills.generateChangelogPreview, {
+      slug: "new-skill",
+      version: "1.0.0",
+      readmeText: "New readme",
+    }),
+  ).resolves.toEqual({ changelog: "Provider answer", source: "auto" });
+  expect(provider.mock.calls[0]?.[1]?.body).not.toContain(hiddenText);
+});

--- a/convex/lib/changelog.ts
+++ b/convex/lib/changelog.ts
@@ -273,18 +273,12 @@ export async function generateChangelogPreview(
     version: string;
     readmeText: string;
     filePaths?: string[];
+    previous: Doc<"skillVersions"> | null;
   },
 ): Promise<string> {
   try {
-    const skill = (await ctx.runQuery(internal.skills.getSkillBySlugInternal, {
-      slug: args.slug,
-    })) as Doc<"skills"> | null;
-    const previous: Doc<"skillVersions"> | null =
-      skill?.latestVersionId && !skill.softDeletedAt
-        ? ((await ctx.runQuery(internal.skills.getVersionByIdInternal, {
-            versionId: skill.latestVersionId,
-          })) as Doc<"skillVersions"> | null)
-        : null;
+    // The caller supplies only a version it has already authorized for file access.
+    const previous = args.previous;
 
     const oldReadmeText: string | null = previous
       ? await readReadmeFromVersion(ctx, previous)

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -10188,10 +10188,28 @@ export const generateChangelogPreview = action({
     readmeText: v.string(),
     filePaths: v.optional(v.array(v.string())),
   },
-  handler: async (ctx, args) => {
+  handler: async (ctx, args): Promise<{ changelog: string; source: "auto" }> => {
     await requireUserFromAction(ctx);
+    const slug = args.slug.trim().toLowerCase();
+    const skill: Doc<"skills"> | null = await ctx.runQuery(internal.skills.getSkillBySlugInternal, {
+      slug,
+    });
+    const previous: Doc<"skillVersions"> | null = skill?.latestVersionId
+      ? await ctx.runQuery(internal.skills.getVersionByIdInternal, {
+          versionId: skill.latestVersionId,
+        })
+      : null;
+    // Changelog generation reads files and sends them to an external provider.
+    // Apply the same access check as direct file reads before either can happen.
+    if (
+      previous &&
+      (previous.skillId !== skill?._id || !(await canReadSkillVersionFiles(ctx, previous)))
+    ) {
+      throw new ConvexError("Version not available");
+    }
     const changelog = await buildChangelogPreview(ctx, {
-      slug: args.slug.trim().toLowerCase(),
+      slug,
+      previous,
       version: args.version.trim(),
       readmeText: args.readmeText,
       filePaths: args.filePaths?.map((value) => value.trim()).filter(Boolean),

--- a/specs/security-moderation.md
+++ b/specs/security-moderation.md
@@ -20,6 +20,11 @@ See also: [acceptable-usage.md](./acceptable-usage.md) for the marketplace polic
   they originally published the skill. Removing or downgrading their membership
   invalidates pending requests. Personal and legacy skills retain personal-owner
   authorization through the shared publisher ownership check.
+- Changelog previews must authorize previous-version file access before reading
+  stored content or invoking an AI provider. They use the same ownership, staff,
+  moderation, deletion, and publication checks as direct skill file reads.
+  The changelog formatter receives an already-authorized version; it must not
+  resolve and load a different previous version from an untrusted slug.
 
 - user: upload skills (subject to GitHub age gate), report skills/packages.
 - moderator: hide/restore skills, view hidden skills, unhide, soft-delete, ban users (except admins).


### PR DESCRIPTION
A signed-in outsider could request a changelog preview for a quarantined skill and cause its previous content to be read and sent to the AI provider. The action now resolves and authorizes the previous version using the existing file-read rules before storage access or provider invocation; the formatter receives only that authorized version.

Addresses [GHSA-g3jp-jj55-jrcr](https://github.com/openclaw/clawhub/security/advisories/GHSA-g3jp-jj55-jrcr). The advisory is published with the deployed revision and regression evidence.

## Verification

- Before: the regression against `cbfee7343ddc867316dd9b3de6fa8856730f9f41` returned a changelog to an outsider for quarantined content instead of rejecting access.
- After: 10 focused tests pass, covering hidden content, pending/blocked/deleted versions, authorized owner and public access, initial releases, and zero provider calls on denied requests. The provider is a local stand-in using synthetic content.
- Real local Convex at `http://127.0.0.1:3340`: an authenticated synthetic outsider's public `skills:generateChangelogPreview` action rejects with `Version not available`. No production provider credentials or data were used.
- `bun run ci:static` passed.
- `bun run ci:unit` passed: 6,626 tests; 497 passing files, 1 skipped.
- `bun run ci:types-build` passed.
- Local Convex deployment and typecheck passed.
- `.agents/skills/autoreview/scripts/autoreview --mode local --no-web-search`: clean, no actionable findings.

Best-fix verdict: best. Authorize at the action boundary before the formatter's fallback/error handling. Checking after provider generation would be too late, and inventing a separate visibility rule would drift from direct file access.

Combined release validation: `ci:static`, `ci:unit` (6,656 passing tests), and `ci:types-build` passed on `f3cd9104981d1875cc2945418172837297afcb5d`. The protected Test frontend passed four HTTP checks, two browser checks, and an archive download check.

## Deployment verified

Merged and deployed in `8c2de6c506bb4efabe3f0c2ffb8370b9e23d4650`. [Test deployment](https://github.com/openclaw/clawhub/actions/runs/34637837491) and [Production deployment](https://github.com/openclaw/clawhub/actions/runs/34638222404) succeeded for that exact SHA. Live reads/downloads/image rendering and browser smoke tests pass; forged ingress is rejected. The active Production catalog rollout was restored after backend deployment. The superseded private security-fork PR is closed.
