### PR TITLE
fix(security): pin public image fetches to validated DNS addresses

### DIFF
--- a/server/og/fetchImageDataUrl.test.ts
+++ b/server/og/fetchImageDataUrl.test.ts
@@ -3,12 +3,16 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   fetchImageDataUrl,
+  fetchPublisherProfileImageDataUrl,
   isSafePublicHttpsOgImageUrl,
   isTrustedOgImageUrl,
 } from "./fetchImageDataUrl";
+import { requestPublicImage } from "./requestPublicImage";
+vi.mock("./requestPublicImage", () => ({ requestPublicImage: vi.fn() }));
 
 describe("fetchImageDataUrl", () => {
   afterEach(() => {
+    vi.mocked(requestPublicImage).mockReset();
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
   });
@@ -35,7 +39,7 @@ describe("fetchImageDataUrl", () => {
 
   it("does not fetch untrusted image URLs", async () => {
     const fetchMock = vi.fn();
-    vi.stubGlobal("fetch", fetchMock);
+    vi.mocked(requestPublicImage).mockImplementation(fetchMock);
 
     await expect(fetchImageDataUrl("https://127.0.0.1/avatar.png")).resolves.toBeNull();
 
@@ -49,13 +53,45 @@ describe("fetchImageDataUrl", () => {
         headers: { "content-type": "image/png" },
       });
     });
-    vi.stubGlobal("fetch", fetchMock);
+    vi.mocked(requestPublicImage).mockImplementation(fetchMock);
 
     await expect(
       fetchImageDataUrl("https://cdn.example.com/org-logo.png", {
         allowPublicHttps: true,
       }),
     ).resolves.toBe("data:image/png;base64,AQI=");
+  });
+
+  it("validates redirects and rejects a private redirect without fetching it", async () => {
+    vi.mocked(requestPublicImage).mockResolvedValueOnce(
+      new Response(null, {
+        status: 302,
+        headers: { Location: "https://127.0.0.1/internal" },
+      }),
+    );
+    await expect(
+      fetchPublisherProfileImageDataUrl("https://cdn.example.com/image.png"),
+    ).resolves.toBeNull();
+    expect(requestPublicImage).toHaveBeenCalledOnce();
+  });
+
+  it("runs every public redirect through the protected image transport", async () => {
+    vi.mocked(requestPublicImage)
+      .mockResolvedValueOnce(
+        new Response(null, {
+          status: 302,
+          headers: { Location: "https://other.example.com/image.png" },
+        }),
+      )
+      .mockRejectedValueOnce(new Error("Image destination is not public"));
+    await expect(
+      fetchPublisherProfileImageDataUrl("https://cdn.example.com/image.png"),
+    ).resolves.toBeNull();
+    expect(requestPublicImage).toHaveBeenNthCalledWith(
+      2,
+      new URL("https://other.example.com/image.png"),
+      expect.any(AbortSignal),
+    );
   });
 
   it("converts trusted image responses to data URLs", async () => {
@@ -65,7 +101,7 @@ describe("fetchImageDataUrl", () => {
         headers: { "content-type": "image/png" },
       });
     });
-    vi.stubGlobal("fetch", fetchMock);
+    vi.mocked(requestPublicImage).mockImplementation(fetchMock);
 
     await expect(fetchImageDataUrl("https://avatars.githubusercontent.com/u/1?v=4")).resolves.toBe(
       "data:image/png;base64,AQI=",
@@ -73,11 +109,7 @@ describe("fetchImageDataUrl", () => {
 
     expect(fetchMock).toHaveBeenCalledWith(
       new URL("https://avatars.githubusercontent.com/u/1?v=4"),
-      {
-        headers: { Accept: "image/avif,image/webp,image/png,image/jpeg,image/*" },
-        redirect: "manual",
-        signal: expect.any(AbortSignal),
-      },
+      expect.any(AbortSignal),
     );
   });
 
@@ -91,7 +123,7 @@ describe("fetchImageDataUrl", () => {
         },
       });
     });
-    vi.stubGlobal("fetch", fetchMock);
+    vi.mocked(requestPublicImage).mockImplementation(fetchMock);
 
     await expect(
       fetchImageDataUrl("https://avatars.githubusercontent.com/u/1?v=4"),
@@ -105,7 +137,7 @@ describe("fetchImageDataUrl", () => {
         headers: { "content-type": "image/png" },
       });
     });
-    vi.stubGlobal("fetch", fetchMock);
+    vi.mocked(requestPublicImage).mockImplementation(fetchMock);
 
     await expect(
       fetchImageDataUrl("https://avatars.githubusercontent.com/u/1?v=4"),

--- a/server/og/fetchImageDataUrl.ts
+++ b/server/og/fetchImageDataUrl.ts
@@ -81,6 +81,7 @@ export async function fetchImageDataUrl(
       return `data:${contentType};base64,${buffer.toString("base64")}`;
     } finally {
       clearTimeout(timeout);
+      controller.abort();
     }
   } catch {
     return null;
@@ -98,17 +99,14 @@ async function fetchOgImageResponse(
 ) {
   let currentUrl = initialUrl;
   for (let hop = 0; hop <= MAX_IMAGE_REDIRECTS; hop += 1) {
-    const response = await fetch(currentUrl, {
-      headers: { Accept: "image/avif,image/webp,image/png,image/jpeg,image/*" },
-      redirect: "manual",
-      signal,
-    });
+    const response = await requestPublicImage(currentUrl, signal);
     if (
       options.followRedirects &&
       response.status >= 300 &&
       response.status < 400 &&
       hop < MAX_IMAGE_REDIRECTS
     ) {
+      await response.body?.cancel();
       const location = response.headers.get("location")?.trim();
       if (!location) return null;
       const nextUrl = new URL(location, currentUrl);
@@ -187,3 +185,4 @@ async function readLimitedImageBody(response: Response) {
     totalBytes,
   );
 }
+import { requestPublicImage } from "./requestPublicImage";

--- a/server/og/imageEgress.test.ts
+++ b/server/og/imageEgress.test.ts
@@ -1,0 +1,37 @@
+/* @vitest-environment node */
+import dns from "node:dns";
+import { createServer, type AddressInfo, type LookupFunction } from "node:net";
+import { expect, it, vi } from "vitest";
+import { fetchPublisherProfileImageDataUrl } from "./fetchImageDataUrl";
+
+it.each([
+  [{ address: "127.0.0.1", family: 4 }],
+  [{ address: "::ffff:127.0.0.1", family: 6 }],
+  [
+    { address: "127.0.0.1", family: 4 },
+    { address: "8.8.8.8", family: 4 },
+  ],
+])("rejects private or mixed DNS results before connecting: %j", async (...addresses) => {
+  let connections = 0;
+  const server = createServer((socket) => {
+    connections++;
+    socket.destroy();
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const port = (server.address() as AddressInfo).port;
+  const resolver: LookupFunction = (_host, options, callback) => {
+    callback(null, options.all ? addresses : addresses[0].address, addresses[0].family);
+  };
+  const lookup = vi.spyOn(dns, "lookup").mockImplementation(resolver as typeof dns.lookup);
+  try {
+    await expect(
+      fetchPublisherProfileImageDataUrl(`https://public-image.example:${port}/image.png`),
+    ).resolves.toBeNull();
+    expect(connections).toBe(0);
+  } finally {
+    lookup.mockRestore();
+    await new Promise<void>((resolve, reject) =>
+      server.close((error) => (error ? reject(error) : resolve())),
+    );
+  }
+});

--- a/server/og/requestPublicImage.ts
+++ b/server/og/requestPublicImage.ts
@@ -1,0 +1,94 @@
+import dns from "node:dns";
+import { request } from "node:https";
+import { BlockList, isIP, type LookupFunction } from "node:net";
+import { Readable } from "node:stream";
+
+const blockedAddresses = new BlockList();
+// Private, local, shared, documentation, transition, and reserved destinations
+// from the IANA special-purpose registries, plus multicast.
+for (const [address, prefix] of [
+  ["0.0.0.0", 8],
+  ["10.0.0.0", 8],
+  ["100.64.0.0", 10],
+  ["127.0.0.0", 8],
+  ["169.254.0.0", 16],
+  ["172.16.0.0", 12],
+  ["192.0.0.0", 24],
+  ["192.0.2.0", 24],
+  ["192.88.99.0", 24],
+  ["192.168.0.0", 16],
+  ["198.18.0.0", 15],
+  ["198.51.100.0", 24],
+  ["203.0.113.0", 24],
+  ["224.0.0.0", 4],
+  ["240.0.0.0", 4],
+] as const)
+  blockedAddresses.addSubnet(address, prefix, "ipv4");
+for (const [address, prefix] of [
+  ["2001::", 23],
+  ["2001:db8::", 32],
+  ["2002::", 16],
+  ["3fff::", 20],
+] as const)
+  blockedAddresses.addSubnet(address, prefix, "ipv6");
+const globalIpv6 = new BlockList();
+globalIpv6.addSubnet("2000::", 3, "ipv6");
+
+function isPublicAddress(address: string) {
+  const family = isIP(address);
+  if (family === 4) return !blockedAddresses.check(address, "ipv4");
+  // This also excludes IPv4-mapped, NAT64, link-local and unique-local addresses.
+  return (
+    family === 6 && globalIpv6.check(address, "ipv6") && !blockedAddresses.check(address, "ipv6")
+  );
+}
+
+const lookupPublicAddress: LookupFunction = (hostname, options, callback) => {
+  dns.lookup(hostname, { all: true, verbatim: true }, (error, addresses) => {
+    if (error) return callback(error, "");
+    if (!addresses.length || addresses.some(({ address }) => !isPublicAddress(address))) {
+      return callback(new Error("Image destination is not public"), "");
+    }
+    // Return the checked addresses directly to the socket. A separate validation
+    // lookup followed by ordinary fetch would allow DNS rebinding between them.
+    if (options.all) callback(null, addresses);
+    else callback(null, addresses[0].address, addresses[0].family);
+  });
+};
+
+export function requestPublicImage(url: URL, signal: AbortSignal): Promise<Response> {
+  return new Promise((resolve, reject) => {
+    const req = request(
+      url,
+      {
+        agent: false,
+        lookup: lookupPublicAddress,
+        signal,
+        headers: { Accept: "image/avif,image/webp,image/png,image/jpeg,image/*" },
+      },
+      (response) => {
+        try {
+          const headers = new Headers();
+          for (const [name, value] of Object.entries(response.headers)) {
+            if (value !== undefined)
+              headers.set(name, Array.isArray(value) ? value.join(", ") : value);
+          }
+          const status = response.statusCode ?? 502;
+          const noBody = status === 204 || status === 205 || status === 304;
+          if (noBody) response.destroy();
+          resolve(
+            new Response(noBody ? null : (Readable.toWeb(response) as ReadableStream<Uint8Array>), {
+              status,
+              headers,
+            }),
+          );
+        } catch (error) {
+          response.destroy();
+          reject(error);
+        }
+      },
+    );
+    req.on("error", reject);
+    req.end();
+  });
+}

--- a/specs/security-moderation.md
+++ b/specs/security-moderation.md
@@ -25,6 +25,11 @@ See also: [acceptable-usage.md](./acceptable-usage.md) for the marketplace polic
   moderation, deletion, and publication checks as direct skill file reads.
   The changelog formatter receives an already-authorized version; it must not
   resolve and load a different previous version from an untrusted slug.
+- Server-side OG image requests validate all resolved IPv4/IPv6 destinations at
+  the socket lookup boundary. Private, local, special-purpose, or mixed results
+  are rejected. The socket receives only those checked addresses, avoiding a
+  second DNS lookup; HTTPS still verifies the original hostname. Every redirect
+  repeats URL and destination checks. Timeout and byte limits remain enforced.
 
 - user: upload skills (subject to GitHub age gate), report skills/packages.
 - moderator: hide/restore skills, view hidden skills, unhide, soft-delete, ban users (except admins).


### PR DESCRIPTION
A public-looking profile image hostname could resolve to a private service during Open Graph rendering. Image retrieval now checks every DNS answer and pins the allowed addresses into the HTTPS socket, preserving TLS verification and checking every redirect through the same transport.

Addresses [GHSA-48gp-hx8w-wjvm](https://github.com/openclaw/clawhub/security/advisories/GHSA-48gp-hx8w-wjvm). The advisory is published with the deployed revision and regression evidence.

## Verification

- Before: a public-looking hostname resolving to loopback reached a real local TCP listener (one connection).
- After: the same regression records zero connections, including mapped IPv6 and mixed public/private DNS answers. All 12 focused image tests pass.
- A real public HTTPS GitHub avatar still loads through the patched transport with normal TLS verification under Node 24.
- `bun run ci:static`, `bun run ci:unit` (6,624 tests), and `bun run ci:types-build` passed.
- Autoreview: clean, no actionable findings.

Best-fix verdict: best. Enforcing and pinning addresses at socket creation closes both DNS rebinding and mixed-answer bypasses without replacing the existing image size, timeout, or redirect limits.

Combined release validation: `ci:static`, `ci:unit` (6,656 passing tests), and `ci:types-build` passed on `f3cd9104981d1875cc2945418172837297afcb5d`. The protected Test frontend passed four HTTP checks, two browser checks, and an archive download check.

## Deployment verified

Merged and deployed in `8c2de6c506bb4efabe3f0c2ffb8370b9e23d4650`. [Test deployment](https://github.com/openclaw/clawhub/actions/runs/34637837491) and [Production deployment](https://github.com/openclaw/clawhub/actions/runs/34638222404) succeeded for that exact SHA. Live reads/downloads/image rendering and browser smoke tests pass; forged ingress is rejected. The active Production catalog rollout was restored after backend deployment. The superseded private security-fork PR is closed.
