### PR TITLE
fix(security): authenticate anonymous API quota identities

### DIFF
--- a/convex/catalogFeed.runtime.test.ts
+++ b/convex/catalogFeed.runtime.test.ts
@@ -3,6 +3,11 @@
 import { register as registerRateLimiter } from "@convex-dev/rate-limiter/test";
 import { convexTest } from "convex-test";
 import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Route behavior assumes verified ingress; trust validation is covered by httpRateLimit.edge.test.ts.
+vi.mock("./lib/verifiedClientIp", () => ({
+  getVerifiedClientIp: async () => "203.0.113.1",
+}));
 import { internal } from "./_generated/api";
 import schema from "./schema";
 

--- a/convex/downloadMetrics.test.ts
+++ b/convex/downloadMetrics.test.ts
@@ -97,7 +97,7 @@ describe("download metric helpers", () => {
     expect(__test.getDayStart(86_400_000)).toBe(86_400_000);
   });
 
-  it("prefers user identity and falls back to IP identity", () => {
+  it("prefers user identity and rejects unverified IP identity", () => {
     vi.stubEnv("TRUST_FORWARDED_IPS", "true");
     const request = new Request("https://example.com", {
       headers: { "cf-connecting-ip": "203.0.113.10" },
@@ -107,10 +107,7 @@ describe("download metric helpers", () => {
       identityKind: "user",
       identityValue: "users:one",
     });
-    expect(__test.getDownloadIdentity(request, null)).toEqual({
-      identityKind: "ip",
-      identityValue: "203.0.113.10",
-    });
+    expect(__test.getDownloadIdentity(request, null)).toBeNull();
   });
 
   it("does not create a metering identity when user and IP are missing", () => {

--- a/convex/downloads.test.ts
+++ b/convex/downloads.test.ts
@@ -2,6 +2,11 @@ import type { RateLimitArgs, RateLimitReturns } from "@convex-dev/rate-limiter";
 import { unzipSync } from "fflate";
 import { exportJWK, exportPKCS8, generateKeyPair } from "jose";
 import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Route behavior assumes verified ingress; trust validation is covered by httpRateLimit.edge.test.ts.
+vi.mock("./lib/verifiedClientIp", () => ({
+  getVerifiedClientIp: async () => "203.0.113.1",
+}));
 import type { ActionCtx } from "./_generated/server";
 import { __test, downloadZipHandler, recordArchiveDownloadMetricHandler } from "./downloads";
 import {
@@ -91,20 +96,20 @@ describe("downloads helpers", () => {
     expect(__test.getDownloadIdentityValue(request, "users_123")).toBe("user:users_123");
   });
 
-  it("uses cf-connecting-ip for anonymous identity when trusted headers are enabled", () => {
+  it("rejects unverified cf-connecting-ip for anonymous metrics", () => {
     vi.stubEnv("TRUST_FORWARDED_IPS", "true");
     const request = new Request("https://example.com", {
       headers: { "cf-connecting-ip": "1.2.3.4" },
     });
-    expect(__test.getDownloadIdentityValue(request, null)).toBe("ip:1.2.3.4");
+    expect(__test.getDownloadIdentityValue(request, null)).toBeNull();
   });
 
-  it("falls back to forwarded ip when explicitly enabled", () => {
+  it("rejects unverified forwarded addresses for metrics", () => {
     vi.stubEnv("TRUST_FORWARDED_IPS", "true");
     const request = new Request("https://example.com", {
       headers: { "x-forwarded-for": "10.0.0.1, 10.0.0.2" },
     });
-    expect(__test.getDownloadIdentityValue(request, null)).toBe("ip:10.0.0.1");
+    expect(__test.getDownloadIdentityValue(request, null)).toBeNull();
   });
 
   it("returns null when user and ip are missing", () => {

--- a/convex/http.test.ts
+++ b/convex/http.test.ts
@@ -125,12 +125,6 @@ describe("HTTP route rate limit defaults", () => {
     ["legacy download", LegacyApiRoutes.download, "downloadIp", RATE_LIMITS.download.ip],
     ["plugins export", ApiRoutes.pluginsExport, "exportIp", RATE_LIMITS.export.ip],
     [
-      "package inspector artifact",
-      "/api/v1/package-inspector/artifact",
-      "downloadIp",
-      RATE_LIMITS.download.ip,
-    ],
-    [
       "package artifact download",
       "/api/v1/packages/demo/versions/1.0.0/artifact/download",
       "downloadIp",
@@ -155,27 +149,6 @@ describe("HTTP route rate limit defaults", () => {
       bucket: "readIp",
       rate: RATE_LIMITS.read.ip,
     });
-  });
-
-  it("registers auth sign-in routes behind the router-level default limit", async () => {
-    const route = http.lookup("/api/auth/signin/github", "GET");
-    if (!route) throw new Error("Expected auth sign-in route");
-    const [action] = route;
-    const { ctx, runMutation } = makeDeniedRateLimitCtx();
-
-    const response = await (action as unknown as WrappedHttpAction)._handler(
-      ctx,
-      new Request("https://example.com/api/auth/signin/github"),
-    );
-
-    expect(response.status).toBe(429);
-    expect(runMutation).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({
-        name: "readIp",
-        config: expect.objectContaining({ rate: RATE_LIMITS.read.ip }),
-      }),
-    );
   });
 
   it.each([

--- a/convex/http.test.ts
+++ b/convex/http.test.ts
@@ -1,7 +1,11 @@
 import { ApiRoutes, LegacyApiRoutes } from "clawhub-schema";
 /* @vitest-environment node */
-import { afterEach, describe, expect, it } from "vitest";
-import { vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Route behavior assumes verified ingress; trust validation is covered by httpRateLimit.edge.test.ts.
+vi.mock("./lib/verifiedClientIp", () => ({
+  getVerifiedClientIp: async () => "203.0.113.1",
+}));
 import type { ActionCtx } from "./_generated/server";
 import http from "./http";
 import { RATE_LIMITS } from "./lib/httpRateLimit";

--- a/convex/httpApi.handlers.test.ts
+++ b/convex/httpApi.handlers.test.ts
@@ -1,6 +1,11 @@
 /* @vitest-environment node */
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+// Route behavior assumes verified ingress; trust validation is covered by httpRateLimit.edge.test.ts.
+vi.mock("./lib/verifiedClientIp", () => ({
+  getVerifiedClientIp: async () => "203.0.113.1",
+}));
+
 vi.mock("./lib/apiTokenAuth", () => ({
   getOptionalApiTokenUser: vi.fn(),
   requireApiTokenUser: vi.fn(),

--- a/convex/httpApiV1.ambiguousSkillSlug.test.ts
+++ b/convex/httpApiV1.ambiguousSkillSlug.test.ts
@@ -2,6 +2,11 @@
 
 import { describe, expect, it, vi } from "vitest";
 
+// Route behavior assumes verified ingress; trust validation is covered by httpRateLimit.edge.test.ts.
+vi.mock("./lib/verifiedClientIp", () => ({
+  getVerifiedClientIp: async () => "203.0.113.1",
+}));
+
 vi.mock("@convex-dev/auth/server", () => ({
   getAuthUserId: vi.fn(),
   authTables: {},

--- a/convex/httpApiV1.handlers.test.ts
+++ b/convex/httpApiV1.handlers.test.ts
@@ -2,6 +2,11 @@
 import type { RateLimitArgs, RateLimitReturns } from "@convex-dev/rate-limiter";
 import { gzipSync, strFromU8, unzipSync } from "fflate";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Route behavior assumes verified ingress; trust validation is covered by httpRateLimit.edge.test.ts.
+vi.mock("./lib/verifiedClientIp", () => ({
+  getVerifiedClientIp: async () => "203.0.113.1",
+}));
 import { api, internal } from "./_generated/api";
 import { RATE_LIMITS } from "./lib/httpRateLimit";
 import { MAX_PUBLISH_FILE_BYTES } from "./lib/publishLimits";
@@ -17499,7 +17504,7 @@ describe("httpApiV1 handlers", () => {
     expect(runMutation).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
-        key: "ip:unknown:trustedPublish",
+        key: "ip:203.0.113.1:trustedPublish",
         name: "trustedPublishIp",
         config: expect.objectContaining({ rate: RATE_LIMITS.trustedPublish.ip }),
       }),

--- a/convex/httpIngress.runtime.test.ts
+++ b/convex/httpIngress.runtime.test.ts
@@ -1,0 +1,206 @@
+/// <reference types="vite/client" />
+/* @vitest-environment edge-runtime */
+
+import { convexTest } from "convex-test";
+import { strFromU8, unzipSync } from "fflate";
+import { exportJWK, exportPKCS8, generateKeyPair } from "jose";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  ARCHIVE_METRIC_AUDIENCE,
+  ARCHIVE_METRIC_JWS_TYPE,
+  signArchivePayload,
+} from "./lib/archiveManifest";
+import schema from "./schema";
+
+const modules = import.meta.glob("./**/*.ts");
+const workerToken = "local-ingress-worker-fixture";
+const workerHeaders = { Authorization: `Bearer ${workerToken}` };
+
+beforeEach(() => {
+  vi.stubEnv("CLAWHUB_ENV", "production");
+  vi.stubEnv("CLAWHUB_PREVIEW", "");
+  vi.stubEnv("SITE_URL", "https://clawhub.ai");
+  vi.stubEnv("CONVEX_CLOUD_URL", "https://some.convex.cloud");
+  vi.stubEnv("CONVEX_SITE_URL", "https://some.convex.site");
+  vi.stubEnv("AUTH_GITHUB_ID", "local-oauth-client-fixture");
+  vi.stubEnv("AUTH_GITHUB_SECRET", "local-oauth-secret-fixture");
+  vi.stubEnv("CLAWHUB_PLUGIN_INSPECTOR_WORKER_TOKEN", workerToken);
+});
+
+afterEach(() => {
+  vi.clearAllTimers();
+  vi.useRealTimers();
+  vi.unstubAllEnvs();
+});
+
+describe("hosted HTTP ingress with endpoint-owned credentials", () => {
+  it("lets the worker claim, download, and acknowledge a real stored artifact directly", async () => {
+    const t = convexTest(schema, modules);
+    const releaseId = await t.run(async (ctx) => {
+      const ownerUserId = await ctx.db.insert("users", { handle: "inspector-fixture" });
+      const storageId = await ctx.storage.store(new Blob(["fixture plugin"]));
+      const packageId = await ctx.db.insert("packages", {
+        name: "inspector-fixture",
+        normalizedName: "inspector-fixture",
+        displayName: "Inspector fixture",
+        ownerUserId,
+        family: "code-plugin",
+        channel: "community",
+        isOfficial: false,
+        scanStatus: "clean",
+        tags: {},
+        stats: { downloads: 0, installs: 0, stars: 0, versions: 1 },
+        createdAt: 1,
+        updatedAt: 1,
+      });
+      const id = await ctx.db.insert("packageReleases", {
+        packageId,
+        version: "1.0.0",
+        publicationStatus: "published",
+        changelog: "Initial release",
+        distTags: ["latest"],
+        files: [{ path: "index.js", size: 14, storageId, sha256: "a".repeat(64) }],
+        integritySha256: "b".repeat(64),
+        createdAt: 1,
+        createdBy: ownerUserId,
+        verification: { tier: "source-linked", scope: "artifact-only", scanStatus: "clean" },
+      });
+      await ctx.db.patch(packageId, { latestReleaseId: id, tags: { latest: id } });
+      return id;
+    });
+
+    const claim = await t.fetch("/api/v1/package-inspector/claim?runId=ingress-fixture", {
+      method: "POST",
+      headers: workerHeaders,
+    });
+    expect(claim.status).toBe(200);
+    const batch = await claim.json();
+    expect(batch).toMatchObject({ leased: false, items: [{ releaseId }] });
+    const downloadUrl = new URL(batch.items[0].downloadUrl);
+    expect(downloadUrl.origin).toBe("https://some.convex.site");
+    const artifact = await t.fetch(downloadUrl.pathname + downloadUrl.search, {
+      headers: workerHeaders,
+    });
+    expect(artifact.status).toBe(200);
+    const files = unzipSync(new Uint8Array(await artifact.arrayBuffer()));
+    expect(Object.values(files).map((bytes) => strFromU8(bytes))).toContain("fixture plugin");
+    const acknowledge = await t.fetch(
+      "/api/v1/package-inspector/acknowledge?runId=ingress-fixture",
+      {
+        method: "POST",
+        headers: workerHeaders,
+      },
+    );
+    expect(acknowledge.status).toBe(200);
+    expect(await acknowledge.json()).toMatchObject({ ok: true, completed: true });
+  });
+
+  it.each(["claim", "acknowledge", "artifact", "results", "notify"])(
+    "still rejects missing and incorrect worker credentials on %s",
+    async (route) => {
+      const t = convexTest(schema, modules);
+      for (const authorization of [undefined, "Bearer incorrect-worker-fixture"]) {
+        const response = await t.fetch(`/api/v1/package-inspector/${route}`, {
+          method: route === "artifact" ? "GET" : "POST",
+          headers: authorization ? { Authorization: authorization } : {},
+        });
+        expect(response.status).toBe(401);
+        expect(response.headers.get("Location")).toBeNull();
+      }
+    },
+  );
+
+  it("starts OAuth with its verifier and cookies at the Convex origin", async () => {
+    const t = convexTest(schema, modules);
+    const verifier = await t.run((ctx) => ctx.db.insert("authVerifiers", {}));
+    const response = await t.fetch(`/api/auth/signin/github?code=${verifier}`);
+    expect(response.status).toBe(302);
+    const location = new URL(response.headers.get("Location")!);
+    expect(location.origin).toBe("https://github.com");
+    expect(location.searchParams.get("redirect_uri")).toBe(
+      "https://some.convex.site/api/auth/callback/github",
+    );
+    expect(response.headers.get("Set-Cookie")).toContain("HttpOnly");
+
+    // A denied provider callback must reach Auth's error handling at this origin.
+    const logError = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      for (const method of ["GET", "POST"]) {
+        const callback = await t.fetch("/api/auth/callback/github?error=access_denied", { method });
+        expect(callback.status).toBe(302);
+        expect(callback.headers.get("Location")).toBe("https://clawhub.ai/");
+      }
+    } finally {
+      logError.mockRestore();
+    }
+  });
+
+  it("accepts a signed metric receipt and rejects a forged one without an edge assertion", async () => {
+    vi.useFakeTimers();
+    const t = convexTest(schema, modules);
+    const skillId = await t.run(async (ctx) => {
+      const ownerUserId = await ctx.db.insert("users", { handle: "metric-fixture" });
+      return await ctx.db.insert("skills", {
+        slug: "metric-fixture",
+        displayName: "Metric fixture",
+        ownerUserId,
+        tags: {},
+        moderationStatus: "active",
+        stats: { comments: 0, downloads: 0, stars: 0, versions: 0 },
+        createdAt: 1,
+        updatedAt: 1,
+      });
+    });
+    const { publicKey, privateKey } = await generateKeyPair("RS256", { extractable: true });
+    vi.stubEnv("JWKS", JSON.stringify({ keys: [await exportJWK(publicKey)] }));
+    const now = Date.now();
+    const metric = {
+      target: { kind: "skill" as const, id: skillId },
+      identityKind: "ip" as const,
+      identityHash: "metric-fixture",
+      dayStart: Math.floor(now / 86_400_000) * 86_400_000,
+      occurredAt: now,
+    };
+    const token = await signArchivePayload(
+      {
+        schema: "clawhub.archive-download-metric.v1",
+        issuer: "https://some.convex.site",
+        audience: ARCHIVE_METRIC_AUDIENCE,
+        issuedAt: now,
+        expiresAt: now + 30_000,
+        metric,
+      },
+      ARCHIVE_METRIC_JWS_TYPE,
+      await exportPKCS8(privateKey),
+    );
+    const send = (body: string) =>
+      t.fetch("/api/internal/archive-download-metric", {
+        method: "POST",
+        headers: { "Content-Type": "application/jose" },
+        body,
+      });
+    expect((await send("forged-metric-fixture")).status).toBe(401);
+    expect((await send(token)).status).toBe(204);
+    const scheduled = await t.run((ctx) => ctx.db.system.query("_scheduled_functions").collect());
+    expect(scheduled).toHaveLength(1);
+    expect(scheduled[0].args).toEqual([metric]);
+  });
+
+  it("keeps ordinary anonymous API calls behind verified ingress, including worker bearer tokens", async () => {
+    const t = convexTest(schema, modules);
+    for (const headers of [{}, workerHeaders]) {
+      const response = await t.fetch("/api/v1/search?q=fixture", { headers });
+      expect(response.status).toBe(307);
+      expect(response.headers.get("Location")).toBe("https://clawhub.ai/api/v1/search?q=fixture");
+      expect(response.headers.get("RateLimit-Limit")).toBeNull();
+    }
+    const forged = await t.fetch("/api/v1/search?q=fixture", {
+      headers: {
+        "x-clawhub-vercel-oidc-token": "forged-edge-fixture",
+        "x-clawhub-client-ip": "203.0.113.42",
+      },
+    });
+    expect(forged.status).toBe(401);
+    expect(forged.headers.get("Location")).toBeNull();
+  });
+});

--- a/convex/lib/httpRateLimit.edge.test.ts
+++ b/convex/lib/httpRateLimit.edge.test.ts
@@ -1,0 +1,130 @@
+/* @vitest-environment node */
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { verifyClawHubVercelOidcToken } from "./clawhubVercelOidc";
+import { applyRateLimit, getClientIp } from "./httpRateLimit";
+
+vi.mock("./clawhubVercelOidc", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./clawhubVercelOidc")>()),
+  verifyClawHubVercelOidcToken: vi.fn(),
+}));
+
+beforeEach(() => {
+  vi.stubEnv("CLAWHUB_ENV", "production");
+  vi.stubEnv("SITE_URL", "https://clawhub.ai");
+  vi.mocked(verifyClawHubVercelOidcToken).mockImplementation(async (token) => {
+    if (token !== "local-verified-edge-fixture") throw new Error("Invalid edge token");
+    return {};
+  });
+});
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.resetAllMocks();
+});
+
+function request(ip: string, token = "local-verified-edge-fixture") {
+  return new Request("https://deployment.convex.site/api/v1/search", {
+    headers: {
+      "x-clawhub-client-ip": ip,
+      "x-clawhub-vercel-oidc-token": token,
+      "cf-connecting-ip": "198.51.100.99",
+      "x-forwarded-for": "198.51.100.98",
+    },
+  });
+}
+
+it("isolates verified visitor allowances and ignores other forwarded identity headers", async () => {
+  const consumed = new Set<string>();
+  const runMutation = vi.fn(async (_fn: unknown, args: { key: string; config?: unknown }) => {
+    if (!args.config) return { action: "updated" };
+    if (consumed.has(args.key)) return { ok: false, retryAfter: 60000 };
+    consumed.add(args.key);
+    return { ok: true };
+  });
+  const ctx = { runMutation } as unknown as Parameters<typeof applyRateLimit>[0];
+  const first = request("203.0.113.1");
+  expect((await applyRateLimit(ctx, first, "read")).ok).toBe(true);
+  const limited = await applyRateLimit(ctx, request("203.0.113.1"), "read");
+  expect(limited.ok).toBe(false);
+  if (!limited.ok) expect(limited.response.status).toBe(429);
+  expect((await applyRateLimit(ctx, request("203.0.113.2"), "read")).ok).toBe(true);
+  expect(getClientIp(first)).toBe("203.0.113.1");
+  expect([...consumed]).toEqual(["ip:203.0.113.1:read", "ip:203.0.113.2:read"]);
+  expect(verifyClawHubVercelOidcToken).toHaveBeenCalledWith(
+    "local-verified-edge-fixture",
+    "production",
+  );
+});
+
+it.each(["", "forged"])(
+  "rejects unverified identities (%s) before consuming any quota",
+  async (token) => {
+    vi.stubEnv("TRUST_FORWARDED_IPS", "true");
+    const runMutation = vi.fn();
+    const ctx = { runMutation } as unknown as Parameters<typeof applyRateLimit>[0];
+    const visitor = request("203.0.113.1", token);
+    const result = await applyRateLimit(ctx, visitor, "read");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.response.status).toBe(401);
+      expect(result.response.headers.get("Location")).toBeNull();
+    }
+    expect(getClientIp(visitor)).toBeNull();
+    expect(runMutation).not.toHaveBeenCalled();
+  },
+);
+
+it.each(["203.0.113.1, 203.0.113.2", "not-an-ip", "256.1.1.1", "001.2.3.4"])(
+  "rejects malformed edge addresses: %s",
+  async (ip) => {
+    const runMutation = vi.fn();
+    const result = await applyRateLimit(
+      { runMutation } as unknown as Parameters<typeof applyRateLimit>[0],
+      request(ip),
+      "read",
+    );
+    expect(result.ok).toBe(false);
+    expect(runMutation).not.toHaveBeenCalled();
+  },
+);
+
+it("keeps redirect destinations on the configured origin for network-path inputs", async () => {
+  const result = await applyRateLimit(
+    { runMutation: vi.fn() } as unknown as Parameters<typeof applyRateLimit>[0],
+    new Request("https://deployment.convex.site//attacker.example/api/v1/search?q=test"),
+    "read",
+  );
+  expect(result.ok).toBe(false);
+  if (!result.ok)
+    expect(result.response.headers.get("Location")).toBe(
+      "https://clawhub.ai//attacker.example/api/v1/search?q=test",
+    );
+});
+
+it("allows local development only when the server deployment URL is loopback", async () => {
+  vi.stubEnv("CLAWHUB_ENV", "");
+  vi.stubEnv("CLAWHUB_PREVIEW", "");
+  vi.stubEnv("CONVEX_CLOUD_URL", "http://127.0.0.1:3210");
+  const runMutation = vi.fn(async () => ({ ok: true }));
+  const ctx = { runMutation } as unknown as Parameters<typeof applyRateLimit>[0];
+  const local = new Request("http://127.0.0.1:3211/api/v1/search");
+  expect((await applyRateLimit(ctx, local, "read")).ok).toBe(true);
+  expect(getClientIp(local)).toBe("127.0.0.1");
+  vi.stubEnv("CONVEX_CLOUD_URL", "https://deployment.convex.cloud");
+  runMutation.mockClear();
+  expect((await applyRateLimit(ctx, new Request(local), "read")).ok).toBe(false);
+  expect(runMutation).not.toHaveBeenCalled();
+});
+
+it("rejects unverified requests when no distinct public edge is configured", async () => {
+  vi.stubEnv("CLAWHUB_ENV", "test");
+  vi.stubEnv("SITE_URL", "https://deployment.convex.site");
+  const runMutation = vi.fn();
+  const result = await applyRateLimit(
+    { runMutation } as unknown as Parameters<typeof applyRateLimit>[0],
+    request("203.0.113.1", ""),
+    "read",
+  );
+  expect(result.ok).toBe(false);
+  if (!result.ok) expect(result.response.status).toBe(401);
+  expect(runMutation).not.toHaveBeenCalled();
+});

--- a/convex/lib/httpRateLimit.test.ts
+++ b/convex/lib/httpRateLimit.test.ts
@@ -1,6 +1,12 @@
 /* @vitest-environment node */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { applyRateLimit, getClientIp, RATE_LIMITS } from "./httpRateLimit";
+import { getVerifiedClientIp } from "./verifiedClientIp";
+
+vi.mock("./verifiedClientIp", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./verifiedClientIp")>()),
+  getVerifiedClientIp: vi.fn(async () => null),
+}));
 
 type MockRateLimitStatus = {
   allowed: boolean;
@@ -113,27 +119,27 @@ describe("getClientIp", () => {
     expect(getClientIp(request)).toBeNull();
   });
 
-  it("returns first ip from cf-connecting-ip when trusted mode is enabled", () => {
+  it("rejects raw cf-connecting-ip even with the legacy flag", () => {
     const request = new Request("https://example.com", {
       headers: {
         "cf-connecting-ip": "203.0.113.1, 198.51.100.2",
       },
     });
     process.env.TRUST_FORWARDED_IPS = "true";
-    expect(getClientIp(request)).toBe("203.0.113.1");
+    expect(getClientIp(request)).toBeNull();
   });
 
-  it("uses forwarded headers when opt-in enabled", () => {
+  it("rejects raw forwarded headers even with the legacy flag", () => {
     const request = new Request("https://example.com", {
       headers: {
         "x-forwarded-for": "203.0.113.9, 198.51.100.2",
       },
     });
     process.env.TRUST_FORWARDED_IPS = "true";
-    expect(getClientIp(request)).toBe("203.0.113.9");
+    expect(getClientIp(request)).toBeNull();
   });
 
-  it("prefers x-forwarded-for over x-real-ip when trusted mode is enabled", () => {
+  it("rejects all unverified forwarded identity headers", () => {
     const request = new Request("https://example.com", {
       headers: {
         "x-forwarded-for": "203.0.113.9, 198.51.100.2",
@@ -141,7 +147,7 @@ describe("getClientIp", () => {
       },
     });
     process.env.TRUST_FORWARDED_IPS = "true";
-    expect(getClientIp(request)).toBe("203.0.113.9");
+    expect(getClientIp(request)).toBeNull();
   });
 });
 
@@ -168,6 +174,7 @@ describe("RATE_LIMITS", () => {
 });
 
 describe("applyRateLimit headers", () => {
+  beforeEach(() => vi.mocked(getVerifiedClientIp).mockResolvedValue("203.0.113.1"));
   afterEach(() => {
     vi.restoreAllMocks();
     vi.useRealTimers();
@@ -299,7 +306,7 @@ describe("applyRateLimit headers", () => {
     const [, args] = componentRateLimitCalls(runMutation)[0];
     expect(args).toMatchObject({
       name: "downloadIp",
-      key: "ip:unknown:download",
+      key: "ip:203.0.113.1:download",
       config: expect.objectContaining({
         kind: "fixed window",
         rate: RATE_LIMITS.download.ip,
@@ -335,7 +342,7 @@ describe("applyRateLimit headers", () => {
     expect(metadataTouchCalls(runMutation).map(([, args]) => args)).toContainEqual(
       expect.objectContaining({
         name: "downloadIp",
-        key: "ip:unknown:download",
+        key: "ip:203.0.113.1:download",
         now: 2_650_000,
         ttlMs: 86_400_000,
       }),
@@ -367,7 +374,7 @@ describe("applyRateLimit headers", () => {
     expect(metadataTouchCalls(runMutation).map(([, args]) => args)).toContainEqual(
       expect.objectContaining({
         name: "downloadIp",
-        key: "ip:unknown:download",
+        key: "ip:203.0.113.1:download",
         now: 2_660_000,
         ttlMs: 86_400_000,
       }),
@@ -396,7 +403,7 @@ describe("applyRateLimit headers", () => {
     const [, args] = componentRateLimitCalls(runMutation)[0];
     expect(args).toMatchObject({
       name: "exportIp",
-      key: "ip:unknown:export",
+      key: "ip:203.0.113.1:export",
       config: expect.objectContaining({
         kind: "fixed window",
         rate: RATE_LIMITS.export.ip,
@@ -543,7 +550,7 @@ describe("applyRateLimit headers", () => {
     expect(result.response.headers.get("Retry-After")).toBe("30");
   });
 
-  it("uses one anonymous download fallback bucket when client ip is missing", async () => {
+  it("shares the verified visitor download bucket across routes", async () => {
     vi.spyOn(Date, "now").mockReturnValue(4_500_000);
     const ctx = makeRateLimitCtx({
       ip: {
@@ -567,8 +574,8 @@ describe("applyRateLimit headers", () => {
 
     const runMutation = (ctx as unknown as { runMutation: ReturnType<typeof vi.fn> }).runMutation;
     expect(componentRateLimitCalls(runMutation).map(([, args]) => String(args.key))).toEqual([
-      "ip:unknown:download",
-      "ip:unknown:download",
+      "ip:203.0.113.1:download",
+      "ip:203.0.113.1:download",
     ]);
   });
 
@@ -642,7 +649,7 @@ describe("applyRateLimit headers", () => {
     );
   });
 
-  it("uses one anonymous read fallback bucket when client ip is missing", async () => {
+  it("shares the verified visitor read bucket across routes", async () => {
     vi.spyOn(Date, "now").mockReturnValue(4_600_000);
     const ctx = makeRateLimitCtx({
       ip: {
@@ -662,8 +669,8 @@ describe("applyRateLimit headers", () => {
 
     const runMutation = (ctx as unknown as { runMutation: ReturnType<typeof vi.fn> }).runMutation;
     expect(componentRateLimitCalls(runMutation).map(([, args]) => String(args.key))).toEqual([
-      "ip:unknown:read",
-      "ip:unknown:read",
+      "ip:203.0.113.1:read",
+      "ip:203.0.113.1:read",
     ]);
   });
 
@@ -691,5 +698,33 @@ describe("applyRateLimit headers", () => {
     expect(result.response.status).toBe(429);
     expect(result.response.headers.get("X-RateLimit-Limit")).toBe(String(RATE_LIMITS.download.ip));
     expect(result.response.headers.get("Retry-After")).toBe("30");
+  });
+});
+describe("anonymous request isolation", () => {
+  beforeEach(() => vi.mocked(getVerifiedClientIp).mockResolvedValue(null));
+  afterEach(() => vi.unstubAllEnvs());
+
+  it("routes unknown direct visitors through the edge without consuming a shared quota", async () => {
+    vi.stubEnv("SITE_URL", "https://clawhub.ai");
+    const ctx = makeRateLimitCtx({
+      ip: { allowed: true, remaining: 10, limit: 10, resetAt: Date.now() + 60000 },
+    });
+    const result = await applyRateLimit(
+      ctx,
+      new Request("https://example.convex.site/api/v1/search?q=test"),
+      "read",
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.response.status).toBe(307);
+    const runMutation = (ctx as unknown as { runMutation: ReturnType<typeof vi.fn> }).runMutation;
+    expect(runMutation).not.toHaveBeenCalled();
+  });
+
+  it("does not let an opt-in flag turn caller-supplied headers into quota identities", async () => {
+    vi.stubEnv("TRUST_FORWARDED_IPS", "true");
+    const request = new Request("https://example.convex.site/api/v1/search", {
+      headers: { "cf-connecting-ip": "203.0.113.8", "x-forwarded-for": "203.0.113.9" },
+    });
+    expect(getClientIp(request)).toBeNull();
   });
 });

--- a/convex/lib/httpRateLimit.ts
+++ b/convex/lib/httpRateLimit.ts
@@ -3,7 +3,9 @@ import { internal } from "../_generated/api";
 import type { Doc } from "../_generated/dataModel";
 import type { ActionCtx } from "../_generated/server";
 import { getOptionalApiTokenUser } from "./apiTokenAuth";
+import { ARCHIVE_REQUEST_IDENTITY_HEADER } from "./clawhubVercelOidc";
 import { corsHeaders, mergeHeaders } from "./httpHeaders";
+import { getVerifiedClientIp, VERIFIED_CLIENT_IP_HEADER } from "./verifiedClientIp";
 
 export const RATE_LIMITS = {
   read: { ip: 3000, key: 12000, adminKey: 120000 },
@@ -38,6 +40,7 @@ type HttpRateLimitName = `${RateLimitKind}${Capitalize<RateLimitSubject>}`;
 type FixedWindowRateLimitConfig = Extract<RateLimitConfig, { kind: "fixed window" }>;
 
 const preappliedRateLimitHeaders = new WeakMap<Request, HeadersInit>();
+const verifiedClientIps = new WeakMap<Request, string>();
 
 function fixedWindowRateLimit(rate: number): FixedWindowRateLimitConfig {
   const shards = Math.max(
@@ -84,8 +87,10 @@ export async function applyRateLimit(
   if (preappliedHeaders) return { ok: true, headers: preappliedHeaders };
 
   const auth = await getOptionalApiTokenUser(ctx, request);
-  const ip = getClientIp(request) ?? "unknown";
-  const ipSource = getClientIpSource(request);
+  const verifiedIp = await getVerifiedClientIp(request);
+  if (verifiedIp) verifiedClientIps.set(request, verifiedIp);
+  const ip = verifiedIp ?? "unknown";
+  const ipSource = verifiedIp ? "verified-edge" : "none";
   const hasClientIp = ip !== "unknown";
 
   // Authenticated requests are enforced and consumed by user bucket only to
@@ -128,7 +133,10 @@ export async function applyRateLimit(
     return { ok: true, headers };
   }
 
-  // Anonymous requests remain IP-enforced.
+  // Unknown direct callers must not consume a bucket shared by all visitors.
+  if (!verifiedIp) return anonymousEdgeResponse(request);
+
+  // Anonymous requests are enforced using the authenticated edge identity.
   const ipResult = await checkRateLimit(
     ctx,
     getAnonymousRateLimitKey(kind, ip),
@@ -167,8 +175,7 @@ export async function applyRateLimit(
 }
 
 function getAnonymousRateLimitKey(kind: RateLimitKind, ip: string) {
-  if (ip !== "unknown") return `ip:${ip}:${kind}`;
-  return `ip:unknown:${kind}`;
+  return `ip:${ip}:${kind}`;
 }
 
 function getAuthenticatedRateLimitKey(userId: string, kind: RateLimitKind) {
@@ -184,26 +191,67 @@ function getAuthenticatedRateLimit(kind: RateLimitKind, user: Pick<Doc<"users">,
 }
 
 export function getClientIp(request: Request): string | null {
-  if (!shouldTrustClientIpHeaders()) return null;
-
-  const cfHeader = request.headers.get("cf-connecting-ip");
-  if (cfHeader) return splitFirstIp(cfHeader);
-
-  const forwarded =
-    request.headers.get("x-forwarded-for") ??
-    request.headers.get("x-real-ip") ??
-    request.headers.get("fly-client-ip");
-
-  return splitFirstIp(forwarded);
+  return verifiedClientIps.get(request) ?? null;
 }
 
-function getClientIpSource(request: Request) {
-  if (!shouldTrustClientIpHeaders()) return "none";
-  if (request.headers.get("cf-connecting-ip")) return "cf-connecting-ip";
-  if (request.headers.get("x-forwarded-for")) return "x-forwarded-for";
-  if (request.headers.get("x-real-ip")) return "x-real-ip";
-  if (request.headers.get("fly-client-ip")) return "fly-client-ip";
-  return "none";
+function anonymousEdgeResponse(request: Request): ApplyRateLimitResult {
+  // An asserted but invalid edge identity must fail here: redirecting it back
+  // to the same misconfigured edge would produce an endless redirect loop.
+  if (
+    request.headers.has(ARCHIVE_REQUEST_IDENTITY_HEADER) ||
+    request.headers.has(VERIFIED_CLIENT_IP_HEADER)
+  ) {
+    return {
+      ok: false,
+      response: new Response("ClawHub edge identity could not be verified.", {
+        status: 401,
+        headers: mergeHeaders(
+          { "Cache-Control": "no-store", "Content-Type": "text/plain; charset=utf-8" },
+          corsHeaders(),
+        ),
+      }),
+    };
+  }
+  const source = new URL(request.url);
+  const configured = (process.env.SITE_URL ?? process.env.VITE_SITE_URL)?.trim();
+  const publicOrigin =
+    configured || (process.env.CLAWHUB_ENV === "production" ? "https://clawhub.ai" : null);
+  if (publicOrigin) {
+    try {
+      const target = new URL(publicOrigin);
+      target.pathname = source.pathname;
+      target.search = source.search;
+      target.hash = "";
+      if (
+        target.protocol === "https:" &&
+        target.origin !== source.origin &&
+        !target.hostname.endsWith(".convex.site")
+      ) {
+        return {
+          ok: false,
+          response: new Response(null, {
+            status: 307,
+            headers: mergeHeaders(
+              { Location: target.href, "Cache-Control": "no-store" },
+              corsHeaders(),
+            ),
+          }),
+        };
+      }
+    } catch {
+      /* Invalid deployment configuration fails closed below. */
+    }
+  }
+  return {
+    ok: false,
+    response: new Response("Use the ClawHub public API origin or an API token.", {
+      status: 401,
+      headers: mergeHeaders(
+        { "Cache-Control": "no-store", "Content-Type": "text/plain; charset=utf-8" },
+        corsHeaders(),
+      ),
+    }),
+  };
 }
 
 async function checkRateLimit(
@@ -321,22 +369,6 @@ export function parseBearerToken(request: Request) {
   if (!trimmed.toLowerCase().startsWith("bearer ")) return null;
   const token = trimmed.slice(7).trim();
   return token || null;
-}
-
-function splitFirstIp(header: string | null) {
-  if (!header) return null;
-  if (header.includes(",")) return header.split(",")[0]?.trim() || null;
-  const trimmed = header.trim();
-  return trimmed || null;
-}
-
-function shouldTrustClientIpHeaders() {
-  const value = (process.env.TRUST_FORWARDED_IPS ?? "").trim().toLowerCase();
-  // Direct Convex HTTP endpoints can be reached without ClawHub's edge. Trust
-  // client IP headers only when the deployment is explicitly behind that edge.
-  if (!value) return false;
-  if (value === "1" || value === "true" || value === "yes") return true;
-  return false;
 }
 
 function isRateLimitCounterWriteConflict(error: unknown) {

--- a/convex/lib/httpRouteRateLimit.test.ts
+++ b/convex/lib/httpRouteRateLimit.test.ts
@@ -1,6 +1,11 @@
 /* @vitest-environment node */
 import { httpRouter } from "convex/server";
 import { describe, expect, it, vi } from "vitest";
+
+// Route behavior assumes verified ingress; trust validation is covered by httpRateLimit.edge.test.ts.
+vi.mock("./verifiedClientIp", () => ({
+  getVerifiedClientIp: async () => "203.0.113.1",
+}));
 import type { ActionCtx } from "../_generated/server";
 import { httpAction } from "../functions";
 import { applyRateLimit, RATE_LIMITS } from "./httpRateLimit";

--- a/convex/lib/httpRouteRateLimit.ts
+++ b/convex/lib/httpRouteRateLimit.ts
@@ -25,6 +25,19 @@ type InstallRateLimitedRoutesOptions = {
 
 const authMetadataPaths = new Set(["/.well-known/openid-configuration", "/.well-known/jwks.json"]);
 
+// These handlers validate worker credentials, signed receipts, or the OAuth
+// verifier/state themselves. Redirecting them changes the credential/cookie origin.
+const handlerAuthenticatedPaths = new Set([
+  "/api/v1/package-inspector/claim",
+  "/api/v1/package-inspector/acknowledge",
+  "/api/v1/package-inspector/artifact",
+  "/api/v1/package-inspector/results",
+  "/api/v1/package-inspector/notify",
+  "/api/internal/archive-download-metric",
+  "/api/auth/signin/",
+  "/api/auth/callback/",
+]);
+
 export function installRateLimitedRoutes(
   http: HttpRouter,
   options: InstallRateLimitedRoutesOptions = {},
@@ -50,6 +63,7 @@ function resolveDefaultRouteRateLimit(spec: RouteSpec, request: Request): RouteR
 
   const routedPath = getRoutedPath(spec);
   if (authMetadataPaths.has(routedPath)) return { kind: "none" };
+  if (handlerAuthenticatedPaths.has(routedPath)) return { kind: "none" };
   // The Trending handler owns its rollout gate before rate limiting so the
   // dark route remains indistinguishable from an absent endpoint.
   if (routedPath === ApiRoutes.trending) return { kind: "none" };
@@ -63,7 +77,6 @@ function resolveDefaultRouteRateLimit(spec: RouteSpec, request: Request): RouteR
     if (routedPath === ApiRoutes.download || routedPath === LegacyApiRoutes.download) {
       return { kind: "download" };
     }
-    if (routedPath === "/api/v1/package-inspector/artifact") return { kind: "download" };
     if ("pathPrefix" in spec && spec.pathPrefix === `${ApiRoutes.packages}/`) {
       return packageReadRouteRateLimitKind(request);
     }

--- a/convex/lib/verifiedClientIp.ts
+++ b/convex/lib/verifiedClientIp.ts
@@ -1,0 +1,46 @@
+import {
+  ARCHIVE_REQUEST_IDENTITY_HEADER,
+  expectedVercelEnvironmentForConvexSite,
+  verifyClawHubVercelOidcToken,
+} from "./clawhubVercelOidc";
+
+export const VERIFIED_CLIENT_IP_HEADER = "x-clawhub-client-ip";
+
+export async function getVerifiedClientIp(request: Request): Promise<string | null> {
+  // A local Convex runtime has no hosted ingress. Gate this exception on the
+  // server-owned deployment URL, never the request Host or forwarded headers.
+  if (!process.env.CLAWHUB_ENV && !process.env.CLAWHUB_PREVIEW) {
+    try {
+      const deployment = new URL(process.env.CONVEX_CLOUD_URL ?? "");
+      if (
+        deployment.protocol === "http:" &&
+        ["localhost", "127.0.0.1", "[::1]"].includes(deployment.hostname)
+      )
+        return "127.0.0.1";
+    } catch {
+      /* Hosted or unconfigured runtimes require verified ingress. */
+    }
+  }
+  const token = request.headers.get(ARCHIVE_REQUEST_IDENTITY_HEADER)?.trim();
+  const ip = request.headers.get(VERIFIED_CLIENT_IP_HEADER)?.trim();
+  if (!token || token.length > 16384 || !ip || ip.length > 64 || ip.includes(",")) return null;
+  const environment = expectedVercelEnvironmentForConvexSite(request.url);
+  if (!environment) return null;
+  try {
+    await verifyClawHubVercelOidcToken(token, environment);
+    if (ip.includes(":")) {
+      if (!/^[0-9a-f:.]+$/i.test(ip)) return null;
+      // URL parsing validates and canonicalizes IPv6, including mapped addresses.
+      return new URL(`http://[${ip}]/`).hostname.slice(1, -1);
+    }
+    const octets = ip.split(".");
+    if (
+      octets.length !== 4 ||
+      octets.some((part) => !/^(0|[1-9]\d{0,2})$/.test(part) || Number(part) > 255)
+    )
+      return null;
+    return octets.join(".");
+  } catch {
+    return null;
+  }
+}

--- a/convex/packageIcons.runtime.test.ts
+++ b/convex/packageIcons.runtime.test.ts
@@ -2,7 +2,12 @@
 /* @vitest-environment edge-runtime */
 import { register as registerRateLimiter } from "@convex-dev/rate-limiter/test";
 import { convexTest } from "convex-test";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+// Route behavior assumes verified ingress; trust validation is covered by httpRateLimit.edge.test.ts.
+vi.mock("./lib/verifiedClientIp", () => ({
+  getVerifiedClientIp: async () => "203.0.113.1",
+}));
 import { internal } from "./_generated/api";
 import { derivePluginManifestSummary } from "./lib/packageRegistry";
 import { extractPackageDigestFields, upsertPackageSearchDigest } from "./lib/packageSearchDigest";

--- a/convex/packages.catalogVisibility.runtime.test.ts
+++ b/convex/packages.catalogVisibility.runtime.test.ts
@@ -3,7 +3,12 @@
 
 import { register as registerRateLimiter } from "@convex-dev/rate-limiter/test";
 import { convexTest } from "convex-test";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+// Route behavior assumes verified ingress; trust validation is covered by httpRateLimit.edge.test.ts.
+vi.mock("./lib/verifiedClientIp", () => ({
+  getVerifiedClientIp: async () => "203.0.113.1",
+}));
 import { api, internal } from "./_generated/api";
 import { extractPackageDigestFields, upsertPackageSearchDigest } from "./lib/packageSearchDigest";
 import { hashToken } from "./lib/tokens";

--- a/convex/packages.publisherBadges.runtime.test.ts
+++ b/convex/packages.publisherBadges.runtime.test.ts
@@ -3,7 +3,12 @@
 
 import { register as registerRateLimiter } from "@convex-dev/rate-limiter/test";
 import { convexTest } from "convex-test";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+// Route behavior assumes verified ingress; trust validation is covered by httpRateLimit.edge.test.ts.
+vi.mock("./lib/verifiedClientIp", () => ({
+  getVerifiedClientIp: async () => "203.0.113.1",
+}));
 import { extractPackageDigestFields, upsertPackageSearchDigest } from "./lib/packageSearchDigest";
 import schema from "./schema";
 

--- a/convex/scannerReports.runtime.test.ts
+++ b/convex/scannerReports.runtime.test.ts
@@ -3,6 +3,11 @@
 import { register as registerRateLimiter } from "@convex-dev/rate-limiter/test";
 import { convexTest } from "convex-test";
 import { afterEach, expect, it, vi } from "vitest";
+
+// Route behavior assumes verified ingress; trust validation is covered by httpRateLimit.edge.test.ts.
+vi.mock("./lib/verifiedClientIp", () => ({
+  getVerifiedClientIp: async () => "203.0.113.1",
+}));
 import { api, internal } from "./_generated/api";
 import schema from "./schema";
 

--- a/server/convexProxy.test.ts
+++ b/server/convexProxy.test.ts
@@ -117,10 +117,14 @@ describe("Convex HTTP proxy", () => {
     vi.stubGlobal("fetch", fetchMock);
     const event = mockEvent("https://preview.example/api/v1/skills/demo?include=latest");
 
-    const response = await proxyConvexRequest(event, {
-      VERCEL_ENV: "preview",
-      VITE_CONVEX_URL: "https://preview-branch-123.convex.cloud",
-    });
+    const response = await proxyConvexRequest(
+      event,
+      {
+        VERCEL_ENV: "preview",
+        VITE_CONVEX_URL: "https://preview-branch-123.convex.cloud",
+      },
+      TEST_ARCHIVE_DEPENDENCIES,
+    );
 
     expect(response).toBeInstanceOf(Response);
     await expect(response.json()).resolves.toEqual({ ok: true });
@@ -129,6 +133,56 @@ describe("Convex HTTP proxy", () => {
       expect.objectContaining({ method: "GET" }),
     );
     expect(response.headers.get("X-ClawHub-Preview-Backend")).toBe("preview-branch-123");
+  });
+
+  it.each(["production", "preview"])(
+    "replaces forged identity headers on %s API requests",
+    async (environment) => {
+      const fetchMock = vi.fn(
+        async (_input: RequestInfo | URL, _init?: RequestInit) => new Response("ok"),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+      const event = mockEvent("https://clawhub.ai/api/v1/search?q=test", {
+        headers: {
+          "x-vercel-forwarded-for": "203.0.113.7",
+          "x-forwarded-for": "198.51.100.8",
+          "x-clawhub-client-ip": "198.51.100.9",
+          "x-clawhub-vercel-oidc-token": "forged",
+        },
+      });
+      const response = await proxyConvexRequest(
+        event,
+        { VERCEL_ENV: environment, VITE_CONVEX_URL: "https://preview-branch-123.convex.cloud" },
+        TEST_ARCHIVE_DEPENDENCIES,
+      );
+      expect(response.status).toBe(200);
+      const init = fetchMock.mock.calls[0]?.[1] as RequestInit | undefined;
+      const headers = new Headers(init?.headers);
+      expect(headers.get("x-clawhub-client-ip")).toBe("203.0.113.7");
+      expect(headers.get("x-clawhub-vercel-oidc-token")).toBe("verified-vercel-oidc");
+    },
+  );
+
+  it("strips caller identity headers outside the Vercel runtime", async () => {
+    const fetchMock = vi.fn(
+      async (_input: RequestInfo | URL, _init?: RequestInit) => new Response("ok"),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const event = mockEvent("http://localhost:3000/api/v1/search", {
+      headers: {
+        "x-clawhub-client-ip": "198.51.100.9",
+        "x-clawhub-vercel-oidc-token": "forged",
+      },
+    });
+    await proxyConvexRequest(
+      event,
+      { VITE_CONVEX_URL: "http://127.0.0.1:3210" },
+      TEST_ARCHIVE_DEPENDENCIES,
+    );
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit | undefined;
+    const headers = new Headers(init?.headers);
+    expect(headers.get("x-clawhub-client-ip")).toBe("");
+    expect(headers.get("x-clawhub-vercel-oidc-token")).toBe("");
   });
 
   it("streams hosted downloads from a Convex manifest with the final attachment filename", async () => {

--- a/server/convexProxy.ts
+++ b/server/convexProxy.ts
@@ -24,6 +24,7 @@ import {
   validateFilePath,
   validateSlug,
 } from "../convex/lib/skillZip";
+import { VERIFIED_CLIENT_IP_HEADER } from "../convex/lib/verifiedClientIp";
 import { convexDeploymentName, resolveConvexSiteUrl } from "../src/lib/convexDeploymentUrl";
 
 const ARCHIVE_MANIFEST_REQUEST_HEADER = "x-clawhub-archive-manifest";
@@ -141,27 +142,32 @@ export async function proxyConvexRequest(
   const target = buildConvexProxyTarget(`${requestUrl.pathname}${requestUrl.search}`, env);
   const isArchiveRequest = isArchivePath(new URL(target).pathname);
   let archiveRequestToken: string | undefined;
-  if (isArchiveRequest) {
+  const isVercelRuntime = env.VERCEL_ENV === "production" || env.VERCEL_ENV === "preview";
+  if (isArchiveRequest || isVercelRuntime) {
     try {
       archiveRequestToken = await dependencies.getArchiveRequestToken();
     } catch {
-      return new Response("Archive streaming identity unavailable", {
+      return new Response("ClawHub edge identity unavailable", {
         status: 503,
         headers: { "Cache-Control": "no-store" },
       });
     }
   }
+  // Vercel overwrites this header at ingress. Never forward a visitor's chosen
+  // ClawHub IP/identity headers, including when running outside Vercel.
+  const clientIp = isVercelRuntime
+    ? (
+        event.req.headers.get("x-vercel-forwarded-for") ?? event.req.headers.get("x-forwarded-for")
+      )?.trim()
+    : undefined;
   const proxied = await proxyRequest(event, target, {
-    ...(isArchiveRequest
-      ? {
-          fetchOptions: {
-            headers: {
-              [ARCHIVE_MANIFEST_REQUEST_HEADER]: "v1",
-              [ARCHIVE_REQUEST_IDENTITY_HEADER]: archiveRequestToken!,
-            },
-          },
-        }
-      : {}),
+    fetchOptions: {
+      headers: {
+        [ARCHIVE_REQUEST_IDENTITY_HEADER]: archiveRequestToken ?? "",
+        [VERIFIED_CLIENT_IP_HEADER]: clientIp ?? "",
+        ...(isArchiveRequest ? { [ARCHIVE_MANIFEST_REQUEST_HEADER]: "v1" } : {}),
+      },
+    },
   });
   // H3's HTTPResponse is not guaranteed to share Nitro's bundled class identity.
   // Normalize it before crossing that boundary or Nitro can stringify the wrapper.

--- a/specs/deploy.md
+++ b/specs/deploy.md
@@ -137,10 +137,19 @@ Ensure Convex env is set (auth + embeddings):
 - Optional fallback: `GITHUB_TOKEN` (used when GitHub App auth is unavailable,
   and for arbitrary public repository lookups such as trusted-publisher setup)
 
-Do not set `TRUST_FORWARDED_IPS=true` while the Convex `*.convex.site` HTTP
-origin remains publicly reachable. That flag makes rate limits and download
-metrics trust forwarded client IP headers, so it is only safe behind a
-header-sanitizing edge that prevents direct origin requests.
+Hosted anonymous API requests require the ClawHub Vercel proxy. It attaches
+its OIDC service identity and replaces the visitor IP header with the Vercel
+controlled address. Convex verifies the project and environment before using
+that address for rate limits or download metrics. `TRUST_FORWARDED_IPS` no
+longer enables raw forwarded headers.
+
+Deploy the updated proxy before enabling backend enforcement. Set `SITE_URL`
+to the public HTTPS frontend origin so direct anonymous Convex requests can
+redirect there without consuming a shared quota. Invalid edge assertions return
+401 without redirecting, so a broken edge identity cannot cause a loop. Verify
+both anonymous API reads and downloads through that origin, as well as authenticated direct API
+requests. The existing ClawHub Vercel OIDC identity must be available in both
+Test and Production; this introduces no additional shared secret.
 
 ## 2) Deploy web app (Vercel)
 

--- a/specs/security-moderation.md
+++ b/specs/security-moderation.md
@@ -24,6 +24,11 @@ See also: [acceptable-usage.md](./acceptable-usage.md) for the marketplace polic
   The legacy `TRUST_FORWARDED_IPS` flag must never authorize raw IP headers.
 - API tokens retain per-user quotas. A server-owned loopback Convex deployment
   may use a local development bucket when no hosted environment is configured.
+- Inspector worker routes, signed archive metric receipts, and Convex Auth's
+  OAuth sign-in/callback routes retain their handler-owned credential checks at
+  the Convex origin. They do not use anonymous IP quotas or redirect credentials
+  to another origin. Worker credentials never exempt ordinary public API routes
+  from verified ingress.
 - Rollout requires the identity-forwarding edge before the backend starts
   enforcing verified anonymous ingress.
 

--- a/specs/security-moderation.md
+++ b/specs/security-moderation.md
@@ -10,6 +10,23 @@ read_when:
 
 See also: [acceptable-usage.md](./acceptable-usage.md) for the marketplace policy on prohibited skill categories.
 
+## Anonymous API ingress
+
+- Hosted anonymous HTTP requests must enter through the ClawHub Vercel edge.
+  The proxy replaces caller-supplied identity headers with its Vercel OIDC
+  service token and the platform-controlled visitor address. Convex verifies
+  the token's issuer, audience, project, owner and deployment environment
+  before using that address for quotas or download metrics.
+- Unverified direct requests consume no shared quota: redirect them to the
+  configured public HTTPS API origin, or reject if no safe origin is configured.
+  Invalid edge assertions are rejected without redirecting, to avoid loops
+  through a misconfigured proxy.
+  The legacy `TRUST_FORWARDED_IPS` flag must never authorize raw IP headers.
+- API tokens retain per-user quotas. A server-owned loopback Convex deployment
+  may use a local development bucket when no hosted environment is configured.
+- Rollout requires the identity-forwarding edge before the backend starts
+  enforcing verified anonymous ingress.
+
 ## Roles + permissions
 
 - Skill transfer, delete, and restore authorization follows the resource's current


### PR DESCRIPTION
Anonymous direct API requests previously shared one `ip:unknown` quota, while the optional forwarded-header flag let callers choose their own quota identity. Hosted anonymous requests now use an address vouched for by the ClawHub Vercel proxy: the proxy replaces caller identity headers, and Convex verifies its existing OIDC project/environment identity. Direct requests without edge assertions redirect to the configured public API origin without consuming quota, or fail closed when no safe origin exists. Invalid edge assertions return 401 without redirecting, preventing loops through a misconfigured edge.

API tokens retain per-user allowances. Local development is enabled only by the server-owned loopback deployment URL. Existing route tests explicitly model verified ingress, while dedicated boundary tests cover missing/forged identities, independent visitor allowances, proxy header replacement, redirect safety, and local-runtime isolation.

Addresses [GHSA-4c7q-g7xf-5628](https://github.com/openclaw/clawhub/security/advisories/GHSA-4c7q-g7xf-5628). The advisory is published with the deployed revision and regression evidence.

## Verification

- Before: regressions reproduced consumption of the shared anonymous allowance and acceptance of caller-selected identities under the legacy trust flag.
- After: the real local Convex backend at `http://127.0.0.1:3350`/`:3351`, configured with hosted ingress policy and the legacy flag enabled, returned 307 for a direct request without an assertion and 401 without Location for two forged assertions. Quota keys remained empty before and after. Redirects were not followed.
- `bun run ci:static` passed.
- `bun run ci:unit` passed: 6,634 tests; 497 passing files, 1 skipped.
- `bun run ci:types-build` passed, including schema, CLI, admin, app and backend TypeScript checks.
- `bun run ci:e2e-http` passed; its hosted read probes validate the existing public surface, not deployment of this private patch.
- Local Convex deployment/typecheck passed. Production credentials and data were not used.
- Final autoreview: clean, no actionable findings. Accepted and fixed the earlier redirect-loop finding; invalid assertions now return 401 without a Location header.

## Rollout

Deploy the identity-forwarding Vercel proxy before enforcing verified ingress in Convex. Check anonymous API reads/downloads through the public origin and authenticated direct API calls in Test and Production. No new shared secret is needed. See the updated deployment spec for the identity and origin requirements.

Best-fix verdict: best. Authenticate the existing edge boundary and eliminate the unknown shared bucket. Trusting another raw header or inventing a caller-controlled anonymous identifier would retain one of the reported failures.

## Final combined validation

Candidate `732dbf8ba6` includes all five fixes plus the ingress compatibility repair. Worker endpoints, signed archive receipts, and OAuth sign-in/callbacks retain their own credential checks at the Convex origin. Ordinary anonymous API requests still require verified ingress; a worker bearer token does not exempt ordinary routes.

Before the repair, new regression tests reproduced redirects before scanner/OAuth/receipt validation. After the repair, all 58 focused route and ingress tests pass. On disposable local Convex ports 3350/3351 with hosted ingress policy, the actual worker claim → stored ZIP download → acknowledgement flow passes, missing/incorrect credentials return 401 on all five worker endpoints, OAuth returns the provider URL with the correct callback origin, provider denial returns to the site, and valid/forged signed receipts return 204/401. Direct ordinary requests redirect to the public origin, forged assertions return 401, and quota keys remain empty.

`ci:unit` passes: 6,663 tests across 502 passing files, one skipped. `ci:static` and `ci:types-build` pass, including schema/CLI/admin checks. Local Convex code deployment with typechecking enabled passes. The compatibility patch's autoreview is clean; the remaining diff removes two obsolete assertions replaced by the runtime regressions. The proof helper and fixture credentials remain confined to the disposable local runtime and are not in the PR.

The previously verified Test edge frontend is already deployed. The stack is merged, Test and Production are deployed and verified, and all five advisories are published.

## Deployment verified

Merged and deployed in `8c2de6c506bb4efabe3f0c2ffb8370b9e23d4650`. [Test deployment](https://github.com/openclaw/clawhub/actions/runs/34637837491) and [Production deployment](https://github.com/openclaw/clawhub/actions/runs/34638222404) succeeded for that exact SHA. Live reads/downloads/image rendering and browser smoke tests pass; forged ingress is rejected. The active Production catalog rollout was restored after backend deployment. The superseded private security-fork PR is closed.
